### PR TITLE
Escalation advisor fails to launch, leaving the operator gate with option names and no advice

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -965,6 +965,11 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "selected_action": state.escalate_selected_action,
                 "advisory_generated": state.advisory_generated,
                 "advisory": state.advisory_report,
+                # A pre-turn advisor exit is a configuration defect that spent
+                # nothing — kept distinct in the audit from an advisor that ran
+                # and produced nothing usable (#2164).
+                "advisory_launch_failure": state.advisory_launch_failure,
+                "advisory_launch_reason": state.advisory_launch_reason,
                 "waited_seconds": (
                     round(state.human_review_waited_seconds, 1)
                     if state.human_review_waited_seconds is not None

--- a/src/theforge/coordinator/escalation_advisor_flow.py
+++ b/src/theforge/coordinator/escalation_advisor_flow.py
@@ -194,6 +194,25 @@ def build_evidence_packet(
     )
 
 
+def _classify_advisor_launch_failure(result: object) -> str | None:
+    """Return a one-line launch reason when the advisor never started, else None.
+
+    Reads the runner's own launch signal (``startup_failure`` / a launch
+    ``failure_code``) rather than pattern-matching provider text — classification
+    of what a subprocess did belongs to the runner; the coordinator only decides
+    what the classification means for the escalation.
+    """
+    if not getattr(result, "startup_failure", False):
+        code = str(getattr(result, "failure_code", "") or "").lower()
+        if code != "cli_launch_failure":
+            return None
+    output = str(getattr(result, "output", "") or "")
+    lines = [ln.strip() for ln in output.splitlines() if ln.strip()]
+    if lines:
+        return lines[-1][:500]
+    return str(getattr(result, "failure_code", "") or "") or "advisor process exited at launch"
+
+
 def run_escalation_advisor(
     state: "CoordinatorState",
     config: "ForgeConfig",
@@ -252,7 +271,22 @@ def run_escalation_advisor(
 
     log_agent_result(result, "ESCALATION_ADVISOR")
     if not getattr(result, "success", False):
-        _log("  ⚠ advisor agent returned failure — preserving escalation")
+        launch_reason = _classify_advisor_launch_failure(result)
+        if launch_reason is not None:
+            # The advisor never reached the model: this is a defect in the
+            # environment forge launched it into, not an investigation that
+            # reached no conclusion. Record it as such (and as a measured $0.00)
+            # so the operator checkpoint can say so and the run can be retried
+            # after the configuration is repaired.
+            state.advisory_launch_failure = True
+            state.advisory_launch_reason = launch_reason
+            _log(
+                "  ⚠ advisor agent FAILED TO LAUNCH — forge configuration/tool-invocation "
+                "defect; the model was never contacted and $0.00 was spent"
+            )
+            _log(f"     launch failure: {launch_reason}")
+        else:
+            _log("  ⚠ advisor agent returned failure — preserving escalation")
         state.advisory_generated = False
         return None
 

--- a/src/theforge/coordinator/pending_hitl.py
+++ b/src/theforge/coordinator/pending_hitl.py
@@ -145,11 +145,37 @@ def _pending_escalate_gate(
         # operator decision — surface the taxonomy plus the raw escalation context.
         options = list(ACTION_TAXONOMY)
         extra = {"decision_required": True, "advisory_unavailable": True}
+        launch_failed = bool(getattr(state, "advisory_launch_failure", False))
+        if launch_failed:
+            # An advisor that never started is a defect in forge's own
+            # configuration, not an investigation that reached no conclusion. Say
+            # which one happened, why, and that it cost nothing — the operator is
+            # choosing unaided either way, but only one of the two is worth
+            # repairing and retrying (#2164).
+            launch_reason = (
+                getattr(state, "advisory_launch_reason", None)
+                or "the advisor process exited before contacting the model"
+            )
+            extra["advisory_launch_failure"] = True
+            extra["advisory_launch_reason"] = launch_reason
+            extra["advisory_cost_usd"] = 0.0
+            headline = [
+                "ESCALATION — the advisory agent FAILED TO LAUNCH; select an action.",
+                (
+                    "This is a forge configuration / tool-invocation defect, NOT an "
+                    "advisor that ran and reached no conclusion: the model was never "
+                    "contacted and $0.00 was spent. Repairing the launch defect and "
+                    "re-running the escalation can still produce advice."
+                ),
+                f"launch failure: {launch_reason}",
+            ]
+        else:
+            headline = ["ESCALATION — advisory report unavailable; select an action."]
         reason = "\n".join(
             filter(
                 None,
                 [
-                    "ESCALATION — advisory report unavailable; select an action.",
+                    *headline,
                     verdict_line,
                     gate_line,
                     escalate_reason[:200],

--- a/src/theforge/coordinator/resume_persistence.py
+++ b/src/theforge/coordinator/resume_persistence.py
@@ -170,7 +170,11 @@ def _plan_review_block(state: "CoordinatorState") -> dict[str, Any] | None:
 
 def _escalation_block(state: "CoordinatorState") -> dict[str, Any] | None:
     """The escalate-gate decision and its advisory, or None when none was made."""
-    if state.escalate_decision is None and not state.advisory_generated:
+    if (
+        state.escalate_decision is None
+        and not state.advisory_generated
+        and not state.advisory_launch_failure
+    ):
         return None
     return {
         "decision": state.escalate_decision,
@@ -178,6 +182,8 @@ def _escalation_block(state: "CoordinatorState") -> dict[str, Any] | None:
         "reason": state.escalate_reason,
         "advisory_generated": bool(state.advisory_generated),
         "advisory_report": _jsonable(state.advisory_report),
+        "advisory_launch_failure": bool(state.advisory_launch_failure),
+        "advisory_launch_reason": state.advisory_launch_reason,
         "waited_seconds": state.human_review_waited_seconds,
     }
 
@@ -428,6 +434,13 @@ def _apply_escalation(state: "CoordinatorState", block: dict[str, Any]) -> bool:
     if block.get("advisory_generated") and not state.advisory_generated:
         state.advisory_generated = True
         applied = True
+    if block.get("advisory_launch_failure") and not state.advisory_launch_failure:
+        state.advisory_launch_failure = True
+        applied = True
+    applied = (
+        _set_if_unset(state, "advisory_launch_reason", block.get("advisory_launch_reason"))
+        or applied
+    )
     return applied
 
 

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -430,6 +430,17 @@ def _run_escalate_gate_inner(
                 "Escalation preserved: an advisory report was generated and an "
                 "operator action selection is still required (no auto-reject)."
             )
+        elif state.advisory_launch_failure:
+            # Distinct from "no advisory": the advisor never started, so the
+            # missing advice is a repairable forge configuration defect that cost
+            # nothing — not evidence that the escalation resists analysis (#2164).
+            preserve_message = (
+                "Escalation preserved: the escalation advisor FAILED TO LAUNCH "
+                f"({state.advisory_launch_reason or 'no reason captured'}) — a forge "
+                "configuration/tool-invocation defect that spent $0.00 and never "
+                "reached the model. An operator action selection is still required "
+                "(no auto-reject)."
+            )
         else:
             preserve_message = (
                 "Escalation preserved: an operator action selection is still "

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -763,6 +763,13 @@ class CoordinatorState:
     advisory_generated: bool = False  # True when a valid advisory report was produced
     advisory_packet: dict | None = None  # serialized EvidencePacket fed to the advisor
     advisory_report: dict | None = None  # serialized AdvisoryReport the advisor produced
+    # Set when the advisor process exited before it ever reached the model (a
+    # forge configuration / tool-invocation defect, e.g. a CLI refusing to start
+    # in the baseline checkout). Kept distinct from advisory_generated=False so
+    # the operator checkpoint can tell "the advisor never ran, and nothing was
+    # spent" apart from "the advisor ran and produced nothing usable" (#2164).
+    advisory_launch_failure: bool = False
+    advisory_launch_reason: str | None = None  # the tool's own explanation, one line
     # Structured escalation kind: "hygiene" (workspace mutation by a non-DEV phase),
     # "content" (review or gate found a real problem), or None when there is no
     # active escalation. Distinct from escalate_reason so resume can tell the two

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -79,6 +79,18 @@ def build_argv(
     — so every run was recorded cost-unknown and a multi-story sprint deadlocked
     on the fail-closed budget check (#2019). The ``-o`` last-message file is kept
     for agent text; ``--json`` only changes what stdout carries.
+
+    ``--skip-git-repo-check`` is mandatory, not opportunistic. Codex refuses to
+    run in any working directory it cannot verify as a trusted git repository
+    ("Not inside a trusted directory and --skip-git-repo-check was not
+    specified") and exits before contacting the model. Forge legitimately runs
+    agents against directories with no ``.git`` at all — the preflight /
+    escalation-advisor baseline checkout is built by ``git archive | tar -x``, a
+    plain file tree — so without this flag any role adaptive routing assigns to a
+    Codex CLI model against that baseline fails to launch 100% of the time
+    (#2164). Forge already selects its own containment via ``--sandbox``; the
+    trust gate is the CLI's interactive-user heuristic, not a security boundary
+    forge relies on.
     """
     cmd: list[str] = [
         "npx",
@@ -86,6 +98,7 @@ def build_argv(
         "exec",
         "--json",
         "--full-auto",
+        "--skip-git-repo-check",
         "-m",
         profile.model,
     ]
@@ -375,6 +388,86 @@ def _error_text_from_events(stdout: str) -> str | None:
     if not messages:
         return None
     return "\n".join(messages)
+
+
+# Event types that prove a turn actually began. ``turn.failed`` counts: the model
+# was engaged, so the run is NOT a pre-turn launch failure even though no usage
+# was reported for it.
+_TURN_ACTIVITY_EVENT_TYPES = frozenset(
+    {
+        "turn.started",
+        "turn.completed",
+        "turn.failed",
+        "item.started",
+        "item.updated",
+        "item.completed",
+        "agent_message",
+        "assistant_message",
+    }
+)
+
+# Stable failure identifier for "the CLI exited before any billable turn began".
+LAUNCH_FAILURE_CODE = "cli_launch_failure"
+
+
+def _exited_before_any_turn(stdout: str) -> bool:
+    """True when a codex stdout stream shows no turn ever began.
+
+    Under ``--json`` codex narrates every turn and item as it happens, so the
+    absence of ANY turn/item activity event means the process died before the
+    model was engaged — the trust-gate refusal, a bad flag, a config error. That
+    is a genuinely free run, distinct from a run that executed and whose usage
+    could not be parsed.
+
+    Deliberately fails closed on anything it cannot read: a stdout line that is
+    not a parseable event object means the process emitted output this parser
+    does not understand, so "nothing happened" is no longer an established fact
+    and the run keeps its cost-unknown classification. Only a stream that is
+    entirely pre-turn events (or empty) proves a zero.
+    """
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if not line.startswith("{"):
+            return False
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return False
+        if not isinstance(event, dict) or event.get("type") in _TURN_ACTIVITY_EVENT_TYPES:
+            return False
+    return True
+
+
+def _launch_failure_reason(stderr: str, stdout: str, returncode: int) -> str:
+    """Distil the CLI's own explanation for a pre-turn exit into one line.
+
+    Codex prefixes deprecation notices and progress chatter before the real
+    refusal, so ``warning:``/``Reading additional input`` lines are dropped and
+    the last substantive line wins.
+    """
+    for stream in (stderr, stdout):
+        lines = [ln.strip() for ln in (stream or "").splitlines() if ln.strip()]
+        substantive = [
+            ln
+            for ln in lines
+            if not ln.lower().startswith(("warning:", "reading additional input"))
+            and not ln.startswith("{")
+        ]
+        candidates = substantive or lines
+        if candidates:
+            return candidates[-1][:500]
+    return f"codex exited {returncode} before starting a turn (no output)"
+
+
+def _classify_codex_launch_failure(*, returncode: int, stdout: str, stderr: str) -> str | None:
+    """Return a launch-failure reason, or None when this was not a pre-turn exit."""
+    if returncode == 0:
+        return None
+    if not _exited_before_any_turn(stdout):
+        return None
+    return _launch_failure_reason(stderr, stdout, returncode)
 
 
 def _looks_like_codex_events(stdout: str) -> bool:
@@ -690,13 +783,32 @@ def _run_codex(
         # picking up a sibling invocation's entry from the global index.
         extracted_sid = None if is_pool else _get_codex_session_id(min_mtime=start_wall)
 
-        # Best-effort real cost from codex output. Unrecoverable → cost-unknown
-        # (None), surfaced loudly, never a fabricated $0.00.
-        cost_usd, model_usage = _extract_codex_cost(
-            profile=profile,
-            result_json=result_json,
+        # A pre-turn exit (trust gate, bad flag, config error) spent nothing —
+        # that is a MEASURED $0.00, not the cost-unknown a completed-but-
+        # unparseable run gets. Classify it before pricing so the cost-unmeasured
+        # warning is not emitted for a process that never reached the model.
+        launch_reason = _classify_codex_launch_failure(
+            returncode=proc.returncode,
             stdout=proc.stdout or "",
+            stderr=proc.stderr or "",
         )
+        if launch_reason is not None:
+            cost_usd: float | None = 0.0
+            model_usage: tuple[ModelUsage, ...] = ()
+            _log(
+                f"  {label} FAILED TO LAUNCH (exit {proc.returncode}, no turn began): "
+                f"{launch_reason} — recording measured $0.00, not cost-unknown."
+            )
+        else:
+            # Best-effort real cost from codex output. Unrecoverable → cost-unknown
+            # (None), surfaced loudly, never a fabricated $0.00.
+            cost_usd, model_usage = _extract_codex_cost(
+                profile=profile,
+                result_json=result_json,
+                stdout=proc.stdout or "",
+            )
+        _startup_failure = launch_reason is not None
+        _failure_code = LAUNCH_FAILURE_CODE if launch_reason is not None else None
 
         if result_json:
             _json_output = result_json.get("result", output_text)
@@ -710,6 +822,8 @@ def _run_codex(
                 profile_name=profile.name,
                 model_usage=model_usage,
                 dev_handoff=_try_parse_handoff(_json_output),
+                startup_failure=_startup_failure,
+                failure_code=_failure_code,
             )
 
         return AgentResult(
@@ -722,6 +836,8 @@ def _run_codex(
             profile_name=profile.name,
             model_usage=model_usage,
             dev_handoff=_try_parse_handoff(output_text),
+            startup_failure=_startup_failure,
+            failure_code=_failure_code,
         )
     finally:
         try:

--- a/tests/contract/test_codex_cli_contract.py
+++ b/tests/contract/test_codex_cli_contract.py
@@ -156,6 +156,25 @@ def test_codex_invoked_in_json_event_mode(shape: str, builder) -> None:
     assert "--json" in argv
 
 
+def test_fresh_exec_skips_the_git_repo_trust_gate() -> None:
+    """Forge must ask codex to skip its git-repo trust check (#2164).
+
+    Forge launches agents against the ``git archive | tar -x`` baseline checkout,
+    which has no ``.git`` at all. Without this flag codex refuses to start there
+    ("Not inside a trusted directory…") and exits before reaching the model, so
+    every escalation-advisor / preflight run routed to a Codex model produces no
+    output. Pinned on argv (no binary spawned) so it runs in the default gate; if
+    a future CLI renames the flag the cli_contract test above catches that.
+    """
+    argv = runner_codex.build_argv(
+        profile=_profile(),
+        working_dir=Path("/tmp"),
+        output_file=Path("/tmp/contract-out.txt"),
+        prompt="contract-check",
+    )
+    assert "--skip-git-repo-check" in argv
+
+
 # Codex `turn.completed.usage` fields observed on the real CLI. The parser must
 # accept this shape without depending on any human-readable summary text.
 _OBSERVED_TURN_COMPLETED = {

--- a/tests/fake_bin/npx
+++ b/tests/fake_bin/npx
@@ -29,6 +29,14 @@ Codex (FAKE_CODEX_MODE):
                   v0.142.x human summary (a bare `tokens used` total, no split)
                   to stdout, so tests can assert it is recorded cost-unknown
                   rather than fabricating a cost from a total alone
+  git_trust_gate — mimic the real CLI's trust gate: refuse with codex's own
+                  "Not inside a trusted directory" stderr and exit 1 UNLESS
+                  --skip-git-repo-check was passed; with the flag, behave like
+                  json_usage. Proves forge can run codex in the .git-less
+                  git-archive baseline checkout (#2164).
+  launch_refusal — always refuse at launch (deprecation warning + trust-gate
+                  stderr, exit 1, no JSONL events at all), so the pre-turn
+                  launch-failure classification can be exercised
   grandchild_hang
                 — spawn a long-sleeping grandchild in the same process group
                   (mirroring npm→node→codex), write its PID to
@@ -112,6 +120,23 @@ if "@openai/codex" in args:
         deadline = time.monotonic() + 30
         while time.monotonic() < deadline:
             time.sleep(0.1)
+        sys.exit(0)
+    if mode in ("git_trust_gate", "launch_refusal"):
+        # The real refusal, verbatim from Codex CLI v0.14x, preceded by the
+        # deprecation notice it emits first (see #2164's captured stderr).
+        if mode == "launch_refusal" or "--skip-git-repo-check" not in args:
+            sys.stderr.write(
+                "warning: `--full-auto` is deprecated; use `--sandbox workspace-write` instead.\n"
+            )
+            sys.stderr.write("Reading additional input from stdin...\n")
+            sys.stderr.write(
+                "Not inside a trusted directory and --skip-git-repo-check was not specified.\n"
+            )
+            sys.exit(1)
+        if output_file:
+            with open(output_file, "w") as fh:
+                fh.write("Task complete.\n")
+        _emit_events(turns=1)
         sys.exit(0)
     if mode == "usage":
         blob = {

--- a/tests/test_coord_escalation_advisor.py
+++ b/tests/test_coord_escalation_advisor.py
@@ -158,6 +158,40 @@ options:
         report = rp.run_escalation_advisor(state, config, task, tmp_path / "ws")
         assert report is None
         assert state.advisory_generated is False
+        # An advisor that RAN and produced nothing usable is not a launch defect.
+        assert state.advisory_launch_failure is False
+
+    def test_launch_failure_recorded_distinctly_from_advisory_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        """A pre-turn advisor exit is a configuration defect, not "no advice today" (#2164)."""
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+
+        launch_stderr = (
+            "warning: `--full-auto` is deprecated; use `--sandbox workspace-write` instead.\n"
+            "Not inside a trusted directory and --skip-git-repo-check was not specified."
+        )
+        monkeypatch.setattr(
+            flow,
+            "run_agent",
+            lambda **k: _make_agent_result(
+                success=False,
+                output=launch_stderr,
+                cost_usd=0.0,
+                profile_name="advisor",
+                startup_failure=True,
+                failure_code="cli_launch_failure",
+            ),
+        )
+        monkeypatch.setattr(flow, "log_agent_result", lambda *a, **k: None)
+
+        report = rp.run_escalation_advisor(state, config, task, tmp_path / "ws")
+        assert report is None
+        assert state.advisory_generated is False
+        assert state.advisory_launch_failure is True
+        assert "trusted directory" in state.advisory_launch_reason
 
 
 # ── Pending escalate gate: taxonomy options + no auto-reject on timeout ────────
@@ -256,6 +290,55 @@ class TestPendingEscalateGate:
 
         assert _pending.resolve_pending("run-preserve", "redirect", project_root=tmp_path)
         assert yaml.safe_load(pending_file.read_text())["decision"] == "redirect"
+
+    def _write_checkpoint_without_advisory(self, tmp_path, state, run_id: str) -> dict:
+        """Drive the gate with no usable advisory and return the pending payload."""
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        with patch("theforge.pending.poll_pending", return_value=("timeout", None)):
+            with patch("theforge.notify_backends.send_notifications"):
+                _pending_escalate_gate(
+                    state,
+                    task,
+                    config,
+                    state.error,
+                    {"reviewer-a": "REQUEST_CHANGES"},
+                    "PASS",
+                    run_id=run_id,
+                    advisory=None,
+                )
+        path = tmp_path / ".forge" / "pending" / f"{run_id}.yaml"
+        return yaml.safe_load(path.read_text())
+
+    def test_launch_failure_checkpoint_names_the_defect_and_zero_cost(self, tmp_path):
+        """The operator must be able to tell a launch defect from a no-conclusion run."""
+        state = _escalated_state()
+        state.advisory_launch_failure = True
+        state.advisory_launch_reason = (
+            "Not inside a trusted directory and --skip-git-repo-check was not specified."
+        )
+
+        data = self._write_checkpoint_without_advisory(tmp_path, state, "run-launchfail")
+
+        assert data["advisory_launch_failure"] is True
+        assert "trusted directory" in data["advisory_launch_reason"]
+        assert data["advisory_cost_usd"] == 0.0
+        assert "FAILED TO LAUNCH" in data["reason"]
+        assert "$0.00" in data["reason"]
+        # Options are still the full taxonomy — the operator must still choose.
+        assert data["options"] == list(rp.ACTION_TAXONOMY)
+
+    def test_advisory_unavailable_checkpoint_unchanged_without_launch_failure(self, tmp_path):
+        """An advisor that ran and produced nothing keeps the plain unavailable wording."""
+        data = self._write_checkpoint_without_advisory(
+            tmp_path, _escalated_state(), "run-nounavail"
+        )
+
+        assert data["advisory_unavailable"] is True
+        assert "advisory_launch_failure" not in data
+        assert "advisory_cost_usd" not in data
+        assert "FAILED TO LAUNCH" not in data["reason"]
+        assert "advisory report unavailable" in data["reason"]
 
     def test_decision_cleans_up_pending_file(self, tmp_path):
         # The complementary case: when the operator DOES select, the resolved
@@ -378,6 +461,40 @@ class TestRunEscalateGateDispositions:
         assert state.advisory_generated is False
         assert "advisory report was generated" not in result.message
         assert "operator action selection is still" in result.message
+
+    def test_timeout_preserve_message_names_an_advisor_launch_failure(self, tmp_path, monkeypatch):
+        """Preserve message must distinguish "never launched" from "no advisory"."""
+        config = _pending_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+
+        def _fake_advisor(*a, **k):
+            state.advisory_generated = False
+            state.advisory_launch_failure = True
+            state.advisory_launch_reason = "Not inside a trusted directory"
+            return None
+
+        monkeypatch.setattr(rp, "run_escalation_advisor", _fake_advisor)
+        monkeypatch.setattr(rp, "_pending_escalate_gate", lambda *a, **k: "timeout")
+        monkeypatch.setattr(rp, "_append_cycle_history", lambda *a, **k: None)
+        monkeypatch.setattr(rp, "_escalate_notify", lambda *a, **k: None)
+
+        result = _run_escalate_gate(
+            state,
+            config,
+            task,
+            tmp_path / "ws",
+            "forge/test",
+            0.0,
+            auto_merge=False,
+            notify=True,
+            logger=None,
+            run_id="run-lf",
+        )
+        assert state.escalate_decision == "advisory_pending"
+        assert "FAILED TO LAUNCH" in result.message
+        assert "Not inside a trusted directory" in result.message
+        assert "advisory report was generated" not in result.message
 
     def test_reject_policy_still_short_circuits_without_advisor(self, tmp_path, monkeypatch):
         # escalate_policy=reject must not even generate an advisory.

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -14,11 +14,13 @@ import pytest
 from theforge.config import ModelProfile
 from theforge.runners.runner_codex import (
     _agent_text_from_events,
+    _classify_codex_launch_failure,
     _CodexUsage,
     _error_text_from_events,
     _price_codex_usage,
     _run_codex,
     _usage_from_events,
+    build_argv,
 )
 
 # Spawn seam patched by the argv-construction tests below.
@@ -285,6 +287,93 @@ class TestCodexEventUsageParsing:
     def test_error_text_reads_nested_message(self) -> None:
         stream = '{"type":"turn.failed","error":{"message":"usage limit reached"}}\n'
         assert _error_text_from_events(stream) == "usage limit reached"
+
+
+class TestCodexGitRepoTrustGate:
+    """Forge runs codex against directories that are not git repos (#2164).
+
+    The preflight / escalation-advisor baseline checkout is built with
+    ``git archive | tar -x`` — a plain file tree with no ``.git``. Codex's trust
+    gate refuses such a directory unless ``--skip-git-repo-check`` is passed, and
+    exits before contacting the model.
+    """
+
+    def test_fresh_run_skips_the_git_repo_check(self, tmp_path: Path) -> None:
+        profile = _make_profile(sandbox_mode="workspace-write")
+        mock_proc = _make_subprocess_mock()
+        with patch("theforge.runners.runner_codex._get_codex_session_id", return_value=None):
+            with patch(_RUN_TARGET, return_value=mock_proc) as mock_run:
+                _run_codex(prompt="advise", profile=profile, working_dir=tmp_path)
+        cmd = _extract_codex_cmd(mock_run)
+        assert "--skip-git-repo-check" in cmd
+        # Must apply to the `exec` subcommand, not sit before it.
+        assert cmd.index("--skip-git-repo-check") > cmd.index("exec")
+
+    def test_build_argv_carries_the_flag_directly(self, tmp_path: Path) -> None:
+        argv = build_argv(
+            profile=_make_profile(sandbox_mode="none"),
+            working_dir=tmp_path,
+            output_file=tmp_path / "out.txt",
+            prompt="advise",
+        )
+        assert "--skip-git-repo-check" in argv
+
+
+class TestCodexLaunchFailureClassification:
+    """A pre-turn exit is a measured $0.00, not cost-unknown (#2164)."""
+
+    _TRUST_GATE_STDERR = (
+        "warning: `--full-auto` is deprecated; use `--sandbox workspace-write` instead.\n"
+        "Reading additional input from stdin...\n"
+        "Not inside a trusted directory and --skip-git-repo-check was not specified.\n"
+    )
+
+    def test_no_events_and_nonzero_exit_is_a_launch_failure(self) -> None:
+        reason = _classify_codex_launch_failure(
+            returncode=1, stdout="", stderr=self._TRUST_GATE_STDERR
+        )
+        assert (
+            reason == "Not inside a trusted directory and --skip-git-repo-check was not specified."
+        )
+
+    def test_deprecation_noise_is_not_mistaken_for_the_reason(self) -> None:
+        reason = _classify_codex_launch_failure(
+            returncode=1, stdout="", stderr="warning: `--full-auto` is deprecated;\n"
+        )
+        # No substantive line → falls back to the raw last line rather than None.
+        assert reason is not None
+        assert "deprecated" in reason
+
+    def test_zero_exit_is_never_a_launch_failure(self) -> None:
+        assert _classify_codex_launch_failure(returncode=0, stdout="", stderr="noise") is None
+
+    def test_turn_activity_rules_out_a_launch_failure(self) -> None:
+        stdout = (
+            '{"type":"thread.started","thread_id":"t1"}\n'
+            '{"type":"item.completed","item":{"type":"agent_message","text":"hi"}}\n'
+        )
+        assert _classify_codex_launch_failure(returncode=1, stdout=stdout, stderr="boom") is None
+
+    def test_turn_failed_counts_as_a_started_turn(self) -> None:
+        """The model was engaged: unmeasurable, not free."""
+        stdout = '{"type":"turn.failed","error":{"message":"upstream 500"}}\n'
+        assert _classify_codex_launch_failure(returncode=1, stdout=stdout, stderr="") is None
+
+    def test_thread_started_alone_still_counts_as_pre_turn(self) -> None:
+        stdout = '{"type":"thread.started","thread_id":"t1"}\n'
+        reason = _classify_codex_launch_failure(returncode=2, stdout=stdout, stderr="bad flag")
+        assert reason == "bad flag"
+
+    def test_unreadable_stdout_fails_closed_to_cost_unknown(self) -> None:
+        """Prose on stdout means something ran that this parser cannot account for.
+
+        Claiming $0.00 there would fabricate a zero — exactly what the
+        cost-unknown contract exists to prevent. Only an all-pre-turn (or empty)
+        event stream proves a free run.
+        """
+        assert (
+            _classify_codex_launch_failure(returncode=1, stdout="partial work", stderr="") is None
+        )
 
 
 class TestCodexCachedTokenPricing:
@@ -561,6 +650,56 @@ class TestCodexLifecycle:
         assert result.success is False
         assert result.cost_usd is None
         assert result.model_usage == ()
+
+    def test_runs_in_a_directory_with_no_git_repo(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Codex must start in the .git-less git-archive baseline checkout (#2164).
+
+        The fake CLI reproduces codex's trust gate: it refuses unless
+        ``--skip-git-repo-check`` is passed. ``tmp_path`` has no ``.git``, exactly
+        like the preflight/escalation-advisor baseline dir.
+        """
+        assert not (tmp_path / ".git").exists()
+        self._patch_env(monkeypatch, "git_trust_gate")
+        profile = _make_profile(sandbox_mode="none")
+        result = _run_codex(prompt="advise", profile=profile, working_dir=tmp_path)
+
+        assert result.success is True, result.output
+        assert "trusted directory" not in result.output
+        assert result.cost_usd is not None
+
+    def test_pre_turn_exit_is_measured_zero_cost_launch_failure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A process that dies before any turn spent nothing — $0.00, not unknown.
+
+        Distinct from ``test_real_total_only_summary_is_cost_unknown_not_fabricated``:
+        there the run executed and its usage could not be parsed (cost-unknown is
+        the honest answer); here no turn ever began, so zero is measured fact.
+        """
+        self._patch_env(monkeypatch, "launch_refusal")
+        profile = _make_profile(sandbox_mode="none")
+        result = _run_codex(prompt="advise", profile=profile, working_dir=tmp_path)
+
+        assert result.success is False
+        assert result.cost_usd == 0.0
+        assert result.model_usage == ()
+        assert result.startup_failure is True
+        assert result.failure_code == "cli_launch_failure"
+        assert "trusted directory" in result.output
+
+    def test_completed_run_with_unparseable_usage_stays_cost_unknown(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The launch-failure path must not swallow the cost-unknown contract."""
+        self._patch_env(monkeypatch, "total_only")
+        profile = _make_profile(sandbox_mode="none")
+        result = _run_codex(prompt="do the thing", profile=profile, working_dir=tmp_path)
+
+        assert result.cost_usd is None
+        assert result.startup_failure is False
+        assert result.failure_code is None
 
     def test_real_total_only_summary_is_cost_unknown_not_fabricated(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change satisfies the bug fix: Codex fresh runs skip the repo trust gate, pre-turn exits are recorded as zero-cost launch failures, and the escalation checkpoint/audit now surface that condition distinctly. | [google-gemini-3.5-flash-api] The implementation successfully resolves the escalation advisor launch failure by passing --skip-git-repo-check and correctly classifying pre-turn exits as zero-cost launch failures.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $1.63
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

Escalation advisor fails to launch, leaving the operator gate with option names and no advice (GitHub Issue #2164)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2164