### PR TITLE
Seam-test coverage batch: adaptive routing and model registry (5 findings)

### DIFF
--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -672,6 +672,80 @@ def test_numeric_complexity_score_splits_same_legacy_band_assignments():
     assert len(upper_medium.code_reviewers) == 2
 
 
+def test_complexity_score_boundaries_reach_lowest_and_highest_routing():
+    """Score 1 and score 10 land on the extreme ends of every score-driven axis."""
+    # Extra same-provider agents so the max reviewer target is actually reachable
+    # after the self-exclusion of the dev/planner picks.
+    agents = _make_agents_one_per_tier() + [
+        AgentDef(
+            name="opus-2",
+            provider="anthropic",
+            model="opus-2",
+            budget_usd=8.0,
+            timeout_seconds=1200,
+            tier="strong",
+        ),
+        AgentDef(
+            name="opus-3",
+            provider="anthropic",
+            model="opus-3",
+            budget_usd=8.0,
+            timeout_seconds=1200,
+            tier="strong",
+        ),
+    ]
+    cfg = _make_cfg(min_reviewers=1, max_reviewers=3, prefer_cross_provider=False)
+
+    lowest = assign_models(agents, cfg, "medium", complexity_score=1)
+    highest = assign_models(agents, cfg, "medium", complexity_score=10)
+
+    # score 1: dev tier "cheap", plan tier "mid", reviewer target "min"
+    assert lowest.dev.model == "haiku"
+    assert lowest.planner.model == "sonnet"
+    assert len(lowest.code_reviewers) == 1
+    # score 10: dev + plan tier "strong", reviewer target "max"
+    assert highest.dev.model == "opus"
+    assert highest.planner.model == "opus"
+    assert len(highest.code_reviewers) == 3
+
+
+def test_out_of_range_complexity_score_clamps_to_boundary_assignment():
+    """Scores outside 1-10 clamp rather than falling through to the legacy band."""
+    agents = _make_agents_one_per_tier()
+    cfg = _make_cfg(min_reviewers=1, max_reviewers=3, prefer_cross_provider=False)
+
+    def _shape(decision):
+        return (
+            decision.dev.model,
+            decision.planner.model,
+            len(decision.code_reviewers),
+            len(decision.plan_reviewers),
+        )
+
+    below = assign_models(agents, cfg, "medium", complexity_score=0)
+    at_min = assign_models(agents, cfg, "medium", complexity_score=1)
+    above = assign_models(agents, cfg, "medium", complexity_score=99)
+    at_max = assign_models(agents, cfg, "medium", complexity_score=10)
+
+    assert _shape(below) == _shape(at_min)
+    assert _shape(above) == _shape(at_max)
+    # And the clamp is observable: the two ends differ from each other.
+    assert _shape(below) != _shape(above)
+
+
+def test_missing_complexity_score_falls_back_to_legacy_band():
+    """complexity_score=None is the fallback path: routing comes from the band."""
+    agents = _make_agents_one_per_tier()
+    cfg = _make_cfg(min_reviewers=1, max_reviewers=3, prefer_cross_provider=False)
+
+    no_score = assign_models(agents, cfg, "medium", complexity_score=None)
+
+    # MEDIUM band: dev tier "mid", plan tier "strong", reviewer midpoint.
+    assert no_score.dev.model == "sonnet"
+    assert no_score.planner.model == "opus"
+    assert len(no_score.code_reviewers) == _reviewer_count("MEDIUM", 1, 3)
+
+
 def test_adaptive_disabled_ignores_complexity_score():
     """With adaptive_enabled=False, two scores in the same band yield identical assignments."""
     agents = _make_agents_one_per_tier()

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -589,6 +589,37 @@ class TestCheckConfigAgentsSection:
         out = capsys.readouterr().out
         assert "Per-story routing cost target: $20.00/story" in out
 
+    def test_unset_per_story_cap_reported_in_header_and_settings(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Adaptive routing with no per-story cap says so in both places it appears."""
+        assignment = AssignmentConfig(
+            enabled=True,
+            min_reviewers=1,
+            max_reviewers=3,
+            max_cost_per_story_usd=None,
+        )
+        config = _make_forge_config(tmp_path, assignment=assignment)
+        with (
+            patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.check_config.load_config", return_value=config),
+            patch(
+                "theforge.cli.check_config.check_agent_auth",
+                return_value=(True, ""),
+            ),
+        ):
+            cmd_check_config(_make_args())
+        out = capsys.readouterr().out
+        assert (
+            "Per-story routing cost target: unset "
+            "(adaptive routes by complexity; only budget_usd enforces spend)" in out
+        )
+        assert (
+            "assignment:    enabled  (min=1, max=3, "
+            "no per-story routing cost target configured)" in out
+        )
+        assert "/story" not in out
+
     def test_no_budget_header_when_assignment_disabled(self, tmp_path: Path, capsys) -> None:
         config = _make_forge_config(tmp_path)  # assignment disabled
         with (

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -832,7 +832,35 @@ class TestDefaultFlags:
         assert config.custom_models == ("openai/gpt-5.5/cli",)
         assert config.model_registry_sources["openai/gpt-5.5/cli"] == "forge.yaml"
         assert config.model_registry["openai/gpt-5.5/cli"].model == "gpt-5.5"
-        assert config.dev_profile.registry_source in {"builtin", "forge.yaml"}
+        # The dev role resolves to the builtin anthropic/sonnet/cli entry in this
+        # fixture, so name that source exactly: a silent switch to the forge.yaml
+        # declaration (or vice versa, guarded above) now fails the test.
+        assert config.dev_profile.registry_id == "anthropic/sonnet/cli"
+        assert config.dev_profile.registry_source == "builtin"
+
+    def test_models_custom_only_makes_dev_profile_report_forge_yaml_source(self, tmp_path):
+        """When the sole enabled model is forge.yaml-declared, dev names that source."""
+        config_path = _write_config(
+            {
+                "models": {
+                    "enabled": ["gpt-5.5"],
+                    "custom": {
+                        "gpt-5.5": {
+                            "provider": "openai",
+                            "model": "gpt-5.5",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 5,
+                            "output_cost_per_mtok": 30,
+                        }
+                    },
+                },
+                "budget_usd": 50.0,
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.dev_profile.registry_id == "openai/gpt-5.5/cli"
+        assert config.dev_profile.registry_source == "forge.yaml"
 
     def test_models_custom_unknown_provider_rejected(self, tmp_path):
         config_path = _write_config(

--- a/tests/test_coord_model_profiles_seam.py
+++ b/tests/test_coord_model_profiles_seam.py
@@ -242,6 +242,54 @@ def test_preflight_records_assignment_rationale_in_audit_state(tmp_path, monkeyp
     assert "target_usd" in audit["per_story_routing_cost_target"]
 
 
+def test_preflight_audit_records_forge_yaml_registry_source(tmp_path, monkeypatch):
+    """Seam: a forge.yaml-declared model's registry source reaches the routing audit."""
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+
+    from theforge.coordinator import preflight as _pf
+
+    config = replace(
+        _make_config(tmp_path),
+        agents=[
+            AgentDef(
+                name="gpt-5.5",
+                provider="openai",
+                model="gpt-5.5",
+                budget_usd=10.0,
+                timeout_seconds=300,
+                tier="strong",
+                cli=None,
+                registry_id="openai/gpt-5.5/api",
+                registry_source="forge.yaml",
+            )
+        ],
+        assignment=AssignmentConfig(
+            enabled=True,
+            escalation_memory=False,
+            max_cost_per_story_usd=100.0,
+            min_reviewers=1,
+            max_reviewers=1,
+        ),
+    )
+
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.preflight_complexity_score = 7
+
+    _pf._apply_preflight_config(config, state)
+
+    audit = state.complexity_routing_audit
+    assert audit is not None
+    assert audit["assignments"]["dev"]["model"] == "gpt-5.5"
+    assert audit["assignments"]["dev"]["source"] == "forge.yaml"
+    assert audit["assignments"]["preflight"]["source"] == "forge.yaml"
+    assert [entry["source"] for entry in audit["assignments"]["plan_reviewers"]] == ["forge.yaml"]
+    assert audit["role_sources"]["dev"] == "adaptive"
+    # The planner is an explicit override in this config and keeps its own
+    # (builtin) source — the audit records per-role provenance, not one value.
+    assert audit["assignments"]["planner"]["source"] == "builtin"
+
+
 def test_preflight_audit_keeps_strong_planner_when_strong_dev_forces_budget_pressure(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The added seam tests cover the requested routing, registry-source, audit, and unset cost-cap behaviours, with no blocking review findings. | [google-gemini-3.5-flash-api] All five seam-test coverage findings are fully implemented with robust, high-quality tests that pass successfully. | [anthropic-sonnet-cli] Test-only seam-coverage batch; all 5 new tests verified against actual source logic and pass, no production code changed.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $7.23
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Seam-test coverage batch: adaptive routing and model registry (5 findings) (GitHub Issue #1587)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1587