### PR TITLE
A story reconciled from a prior generation inherits DONE even when that generation left it in flight

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -280,7 +280,7 @@ def _cmd_sprint(args: object) -> int:
     # On the re-exec path, resolve the prior generation's recorded outcomes so the
     # launch guard can distinguish an already-completed worktree from a fresh
     # collision. Mirror the runner's sprint-name resolution (manifest ``name``).
-    prior_outcomes: dict[str, str] | None = None
+    prior_outcomes: dict[str, dict] | None = None
     if reexec:
         try:
             from theforge.sprint.manifest import load_sprint_manifest  # noqa: PLC0415
@@ -414,7 +414,7 @@ def _acquire_launch_locks(
     *,
     allow_drop: bool = False,
     force: bool = False,
-    prior_outcomes: dict[str, str] | None = None,
+    prior_outcomes: dict[str, str | dict] | None = None,
     live_slugs: set[str] | None = None,
     unresolved_slugs: set[str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
@@ -455,29 +455,40 @@ def _resolve_story_liveness(config: object, slugs: list[str]) -> LivenessResolut
         return unresolved_liveness(slugs, reason=f"liveness lookup unavailable: {exc}")
 
 
-def _resolve_prior_outcomes(config: object, sprint_name: str) -> dict[str, str]:
-    """Best-effort map of slug -> prior-generation outcome for the re-exec guard.
+def _resolve_prior_outcomes(config: object, sprint_name: str) -> dict[str, dict]:
+    """Best-effort map of slug -> prior-generation story record for the guard.
 
     Resolves the logical sprint id the same way the runner does (from the
     manifest ``name``) and reads the prior generation's accumulated story
-    outcomes from ``.forge/sprints/<id>/state.yaml``. Returns an empty map on any
+    entries from ``.forge/sprints/<id>/state.yaml``. Returns an empty map on any
     failure so a lookup miss degrades to today's collision behavior — this must
     never fail the launch.
+
+    The whole recorded entry is carried forward, not just its ``outcome``: the
+    guard's reconciliation decision needs the landing evidence recorded beside
+    the outcome (``landing_status`` / ``landing`` / ``merge``), because a
+    coordinator ``DONE`` is persisted before the sprint's landing step runs and
+    on its own says nothing about whether the story actually landed (#2189).
+    The policy that reads those fields lives in
+    :mod:`theforge.sprint.prior_landing`; this is only the data hand-off.
     """
     try:
         from theforge.sprint.audit import (  # noqa: PLC0415
             _get_or_create_sprint_id,
             _load_accumulated_stories,
         )
+        from theforge.sprint.prior_landing import as_prior_record  # noqa: PLC0415
 
         sprint_id = _get_or_create_sprint_id(sprint_name, config.project_root)
-        outcomes: dict[str, str] = {}
+        records: dict[str, dict] = {}
         for story in _load_accumulated_stories(sprint_id, config.project_root):
+            if not isinstance(story, dict):
+                continue
             slug = story.get("slug")
             if not slug:
                 continue
-            outcomes[slug] = str(story.get("outcome") or "").upper()
-        return outcomes
+            records[slug] = as_prior_record(story)
+        return records
     except Exception:
         return {}
 

--- a/src/theforge/cli/sprint_digest.py
+++ b/src/theforge/cli/sprint_digest.py
@@ -419,7 +419,14 @@ def _story_row(story: dict) -> str:
     """`#NNNN  $cost  elapsed  <title>` for a landed/failed row."""
     ref = _story_ref(story)
     cost = story.get("cost_usd")
-    cost_str = f"${cost:.2f}" if isinstance(cost, (int, float)) and cost else "—"
+    # A measured $0.00 is a number, not a missing value. Rendering it as the
+    # absent marker collapsed three distinct states — "cost was zero", "cost is
+    # unknown", and "no cost recorded" — into one dash, which is how a story
+    # whose real spend was overwritten with 0.0 read as having no cost at all
+    # (#2189). Only None / a missing key renders as absent.
+    cost_str = (
+        f"${cost:.2f}" if isinstance(cost, (int, float)) and not isinstance(cost, bool) else "—"
+    )
     elapsed = _elapsed_seconds_from_bounds(story.get("started_at"), story.get("finished_at"))
     elapsed_str = f"{int(elapsed // 60)}m" if isinstance(elapsed, (int, float)) else "—"
     title = str(story.get("path") or story.get("slug") or "")

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -17,6 +17,11 @@ from theforge.sprint.preflight import (
     drop_conflicting_running_stories,
     warn_for_running_stories,
 )
+from theforge.sprint.prior_landing import (
+    PRIOR_SUCCEEDED_OUTCOMES,
+    as_prior_record,
+    reconcilable_prior_success,
+)
 
 # Reason codes used as the value in the ``dropped_slugs`` mapping.  These are
 # consumed by the sprint runner for audit visibility and by tests.
@@ -45,10 +50,14 @@ REASON_IN_FLIGHT = "in-flight-current-sprint"
 # remediation is to delete the worktree (#2079).
 REASON_IN_FLIGHT_UNRESOLVED = "in-flight-liveness-unresolved"
 
-# Prior-generation outcome strings (upper-cased) that mean the story succeeded
-# and its worktree should be reconciled/preserved rather than treated as a fresh
-# collision.
-_PRIOR_SUCCEEDED_OUTCOMES = frozenset({"DONE", "ALREADY_DONE"})
+# Prior-generation outcome strings (upper-cased) that *claim* the story
+# succeeded. Claiming it is not sufficient: a succeeded outcome is only
+# reconcilable when the record also shows its landing obligation resolved (see
+# ``prior_landing.reconcilable_prior_success``). A coordinator ``DONE`` is
+# persisted the moment review approves, before the sprint's landing step runs,
+# so a re-exec in that window leaves a DONE behind for a story still sitting
+# unmerged on a branch (#2189).
+_PRIOR_SUCCEEDED_OUTCOMES = PRIOR_SUCCEEDED_OUTCOMES
 
 
 def acquire_launch_story_locks(
@@ -58,7 +67,7 @@ def acquire_launch_story_locks(
     resume: bool,
     allow_drop: bool = False,
     force: bool = False,
-    prior_outcomes: dict[str, str] | None = None,
+    prior_outcomes: dict[str, str | dict] | None = None,
     live_slugs: set[str] | None = None,
     unresolved_slugs: set[str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
@@ -209,8 +218,11 @@ def acquire_launch_story_locks(
     # collision after a re-exec: the *prior generation* may have already
     # finished this story (DONE) or left it partially complete (stranded).
     # Classify each active worktree against the prior generation's recorded
-    # outcomes (``prior_outcomes``, slug -> upper-cased outcome) so a completed
-    # story is reconciled instead of being flattened into a launch collision.
+    # outcomes (``prior_outcomes``, slug -> recorded story entry, or a bare
+    # upper-cased outcome string) so a completed story is reconciled instead of
+    # being flattened into a launch collision. A succeeded outcome whose landing
+    # was owed and never completed is NOT a completed story: it is reported as
+    # stranded, so a later generation can resume it to actual landing (#2189).
     prior_outcomes = prior_outcomes or {}
     active_worktrees = check_active_worktrees(
         [s for s in schedulable if s not in in_flight_slugs],
@@ -226,12 +238,14 @@ def acquire_launch_story_locks(
             # Already classified (escalated), or live work of this same run. A
             # later, coarser classification must never overwrite either.
             continue
-        prior_outcome = prior_outcomes.get(slug)
-        if prior_outcome in _PRIOR_SUCCEEDED_OUTCOMES:
+        prior_raw = prior_outcomes.get(slug)
+        prior_outcome = as_prior_record(prior_raw)["outcome"]
+        if reconcilable_prior_success(prior_raw):
             dropped[slug] = REASON_RECONCILE_PRIOR_DONE
             reconciled_slugs.append(slug)
         elif prior_outcome:
-            # A prior-generation record exists but the story did not succeed —
+            # A prior-generation record exists but the story did not succeed, or
+            # claimed success while its landing was still owed and unresolved —
             # recoverable stranded sprint state, not a fresh collision.
             dropped[slug] = REASON_STRANDED_WORKTREE
             stranded_slugs.append(slug)

--- a/src/theforge/sprint/prior_landing.py
+++ b/src/theforge/sprint/prior_landing.py
@@ -1,0 +1,92 @@
+"""Landing evidence in a recorded sprint story entry.
+
+A sprint's accumulated story entry (``.forge/sprints/<id>/state.yaml``) records
+the coordinator phase a story reached. That phase is written the moment the
+coordinator returns — which for an approved story is *before* the sprint's
+separate landing step runs. A generation that re-execs in that window leaves a
+durable ``outcome: DONE`` behind for a story that never landed, and the re-exec
+launch guard used to read that as proof of completion: the story was reconciled
+as a finished success, never re-entered dispatch, and was counted as landed while
+its issue stayed open with unmerged commits on a branch (#2189).
+
+The predicates here are the shared answer to "does this record show a landing
+that was owed *and* never resolved?". They are deliberately conservative in one
+direction only: a record with no landing information at all is not evidence of
+an unresolved landing, so it keeps the historical behaviour. Only an explicitly
+recorded unresolved landing demotes a succeeded outcome.
+
+Stdlib-only imports (per project convention 4: pure-data types in low-dependency
+modules).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+# Recorded outcome strings (upper-cased) that claim the story succeeded.
+PRIOR_SUCCEEDED_OUTCOMES = frozenset({"DONE", "ALREADY_DONE"})
+
+# ``landing_status`` values that mean a landing was owed and has not completed.
+#
+#   pending_integration — approved, landing deferred to the sprint scheduler's
+#     integration step. Recorded before that step runs (and re-recorded if it
+#     could not run), so it is exactly the pre-landing state #2189 mistook for a
+#     completed one.
+#   failed — the landing ran and did not land the work.
+#
+# ``None`` is deliberately NOT in this set: it is the recorded status of a story
+# with no landing obligation of its own (``on_approve`` ``pr`` / ``none``), which
+# reaches its configured terminal without any merge. Demoting those would strand
+# every story in a PR-only or branch-only sprint.
+UNRESOLVED_LANDING_STATUSES = frozenset({"pending_integration", "failed"})
+
+
+def as_prior_record(value: object) -> dict:
+    """Normalise a prior-generation outcome value into a record dict.
+
+    Accepts either a bare outcome string (the pre-#2189 shape, still used by
+    callers that have nothing but the outcome) or a full story-entry mapping.
+    ``outcome`` is upper-cased so callers can compare against
+    :data:`PRIOR_SUCCEEDED_OUTCOMES` without re-normalising.
+    """
+    if isinstance(value, Mapping):
+        record = dict(value)
+        record["outcome"] = str(record.get("outcome") or "").upper()
+        return record
+    return {"outcome": str(value or "").upper()}
+
+
+def landing_settled(record: object) -> bool:
+    """True unless the record shows a landing that was owed and never completed.
+
+    Positive evidence of a completed landing (a confirmed merge, a queued
+    auto-merge, a created PR) settles it, as does the absence of any landing
+    obligation. Only a recorded :data:`UNRESOLVED_LANDING_STATUSES` status with
+    no such evidence reads as unsettled.
+    """
+    if not isinstance(record, Mapping):
+        # No record at all is not evidence that a landing is outstanding.
+        return True
+    if record.get("landed") is True or record.get("merge") is True:
+        return True
+    landing = record.get("landing")
+    if isinstance(landing, Mapping) and (
+        landing.get("merged") or landing.get("merge_queued") or landing.get("pr_url")
+    ):
+        return True
+    return str(record.get("landing_status") or "") not in UNRESOLVED_LANDING_STATUSES
+
+
+def reconcilable_prior_success(record: object) -> bool:
+    """True when the record is a succeeded outcome whose landing is settled.
+
+    This is the gate a re-exec'd generation applies before preserving a prior
+    generation's outcome instead of re-running the story. A ``DONE`` whose
+    landing was owed and never completed is *not* reconcilable: the story has no
+    completed outcome to carry forward, and asserting one reports work as landed
+    that is still sitting unmerged on a branch (#2189).
+    """
+    normalized = as_prior_record(record)
+    if normalized["outcome"] not in PRIOR_SUCCEEDED_OUTCOMES:
+        return False
+    return landing_settled(record if isinstance(record, Mapping) else None)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -35,6 +35,7 @@ from ..coordinator.agent_failure import (
 from ..coordinator.config_snapshot import SprintConfigSnapshot, capture_or_load
 from ..coordinator.engine import run_from_dev, run_from_review, run_review_only, run_task
 from ..coordinator.gate import run_gate_full
+from ..coordinator.landing_record import build_landing_record
 from ..coordinator.log_tee import _make_story_log_dir, set_worker_slug
 from ..coordinator.logging import StructuredLogger
 from ..coordinator.notify import _notify
@@ -109,6 +110,7 @@ from .manifest import (
     _build_task_from_story,
     resolve_from_manifest,
 )
+from .prior_landing import landing_settled
 from .query import NormalizedDependencyPlan, normalize_dependency_plan
 from .sources import StorySource
 from .state_writer import (
@@ -3698,13 +3700,28 @@ def run_sprint(
         accumulated entry itself. DONE is the only succeeded outcome that means
         "a generation of this sprint ran the story"; ALREADY_DONE means the
         opposite, so it is deliberately not accepted here.
+
+        A recorded DONE is accepted only when the same record shows its landing
+        obligation resolved. The coordinator reaches Phase.DONE when review
+        approves — before the sprint's landing step runs — so a DONE persisted by
+        a generation that then re-exec'd describes a story that was approved and
+        never landed. Reading that as a completed story is what reported #1108 as
+        landed while its issue stayed open with unmerged commits (#2189). The
+        dict record is preferred where one exists, because only it carries the
+        landing fields; the canonical entry is consulted for the in-run case,
+        where a confirmed landing is marked with ``landed``.
         """
-        entry = _story_state.get(slug)
-        if entry is not None and entry.outcome is StoryOutcome.DONE:
-            return True
         ref = canonical_ref or slug_to_context.get(slug, (None, None, None))[2]
-        prior = recovered_prior_entries_by_ref.get(ref) if ref else None
-        return isinstance(prior, dict) and str(prior.get("outcome") or "").upper() == "DONE"
+        record = current_story_entries_by_ref.get(ref) if ref else None
+        if record is None:
+            _prior = recovered_prior_entries_by_ref.get(ref) if ref else None
+            record = _prior if isinstance(_prior, dict) else None
+        if record is not None:
+            return str(record.get("outcome") or "").upper() == "DONE" and landing_settled(record)
+        entry = _story_state.get(slug)
+        if entry is None or entry.outcome is not StoryOutcome.DONE:
+            return False
+        return landing_settled(dict(entry.extras))
 
     def _skip_merged_outcome(slug: str, canonical_ref: str) -> tuple[StoryOutcome, str | None]:
         """Outcome and ``outcome_source`` to record for a ``skip_merged`` triage.
@@ -3861,6 +3878,44 @@ def run_sprint(
             block["status"] = "allocation_exhausted"
         return block
 
+    def _landing_evidence_fields(result: CoordinatorResult) -> dict:
+        """The accumulated entry's account of this story's landing.
+
+        ``landing_status`` is the coordinator/scheduler's own three-state answer
+        (``None`` = no landing owed, ``pending_integration`` = owed and not yet
+        resolved, ``landed`` / ``failed`` = resolved), and ``landing`` carries the
+        structured record once a landing attempt actually happened. Together they
+        are what lets a later generation tell a completed story from one that
+        merely reached Phase.DONE before its landing step ran (#2189).
+        """
+        _merge = result.merge if isinstance(result.merge, dict) else None
+        return {
+            "landing_status": getattr(result, "landing_status", None),
+            "landing": build_landing_record(_merge),
+            "merge": bool(_merge and _merge.get("merged", False)),
+        }
+
+    def _persist_story_landing(slug: str, result: CoordinatorResult) -> None:
+        """Re-persist a dispatched story's landing evidence once it resolves.
+
+        ``_persist_current_story_result`` runs before the landing step, so the
+        entry it writes records the landing as *owed*. Every site that later
+        resolves a landing — immediate integration, the pending-integration
+        sweep, queued-PR polling, sprint wrap-up — calls this so the durable
+        record matches reality before the next re-exec can read it. Without it a
+        story that genuinely landed would stay recorded as landing-owed and be
+        stranded on the next generation instead of reconciled.
+        """
+        task_ctx = slug_to_context.get(slug)
+        if task_ctx is None:
+            return
+        canonical_ref = task_ctx[2]
+        entry = current_story_entries_by_ref.get(canonical_ref)
+        if entry is None:
+            return
+        entry.update(_landing_evidence_fields(result))
+        _persist_accumulated_story_entries()
+
     def _persist_current_story_result(
         slug: str,
         result: CoordinatorResult,
@@ -3915,7 +3970,15 @@ def run_sprint(
             "error": result.state.error,
             "error_type": result.state.error_type,
             "outcome_code": result.state.error_type or outcome.lower(),
-            "merge": result.merge is not None and result.merge.get("merged", False),
+            # Landing evidence recorded beside the phase, because the phase alone
+            # cannot say whether the story landed: this entry is written the
+            # moment the coordinator returns, and for an approved story that is
+            # BEFORE _attempt_integration runs. A re-exec in that window used to
+            # leave a bare ``outcome: DONE`` that the next generation read as
+            # proof of completion for a story still unmerged on its branch
+            # (#2189). ``landing_status`` names the obligation and its state;
+            # _persist_story_landing rewrites these once landing resolves.
+            **_landing_evidence_fields(result),
             "batch_group": getattr(result.state, "preflight_batch_group", None),
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -4459,6 +4522,57 @@ def run_sprint(
             return StoryOutcome.DONE
         return StoryOutcome.ALREADY_DONE
 
+    def _prior_generation_record(slug: str) -> dict | None:
+        """The prior generation's accumulated entry for ``slug``, if recovered."""
+        ref = slug_to_context.get(slug, (None, None, None))[2]
+        prior = recovered_prior_entries_by_ref.get(ref) if ref else None
+        return prior if isinstance(prior, dict) else None
+
+    def _reconcilable_prior_record(slug: str) -> bool:
+        """True when the prior generation's record is a *settled* success.
+
+        The launch guard already applies this test, but the runner must not take
+        the drop reason on faith: the guard classifies from whatever prior-outcome
+        map the CLI managed to resolve, and a record that claims DONE while its
+        landing was owed and unresolved has no completed outcome to preserve. A
+        story reconciled on that basis is reported as landed, its DAG node marked
+        complete, and it is dropped from dispatch on every subsequent re-exec —
+        with approved work still sitting unmerged on its branch (#2189). Absence
+        of any record is not treated as a demotion: an ALREADY_DONE reconciled
+        with no surviving record stays reconcilable, as before.
+        """
+        record = _prior_generation_record(slug)
+        if record is None:
+            return True
+        outcome = str(record.get("outcome") or "").upper()
+        if outcome not in {"DONE", "ALREADY_DONE"}:
+            return True
+        return landing_settled(record)
+
+    def _measured_recorded_cost(slug: str) -> float | None:
+        """Cost already measured for a story whose row this generation rewrites.
+
+        A reconciled or stranded story is recorded without a coordinator result,
+        and defaulting its row to ``0.0`` overwrites the spend the generation that
+        actually ran it recorded — dropping it from the run total and rendering a
+        known amount as absent (#2189). The prior accumulated entry is preferred;
+        its ``None`` (cost-unknown) is a real value and is carried through as-is.
+        Returns ``0.0`` only when no record of spend exists at all.
+        """
+        record = _prior_generation_record(slug)
+        if record is not None and "cost_usd" in record:
+            raw = record.get("cost_usd")
+            if raw is None:
+                return None
+            try:
+                return float(raw)
+            except (TypeError, ValueError):
+                return None
+        entry = _story_state.get(slug)
+        if entry is not None:
+            return entry.cost_usd
+        return 0.0
+
     def _record_dropped_story_audit(slug: str, cause_text: str) -> dict:
         """Write the per-run audit record for a story dropped before dispatch.
 
@@ -4514,10 +4628,26 @@ def run_sprint(
             _log(f"WARN {slug}: could not write drop audit record: {exc}")
             return {}
 
-    for slug, reason in _dropped_slugs.items():
+    for slug, reason in list(_dropped_slugs.items()):
         if slug not in slug_to_context:
             continue
         _reclaim_dropped_agents(slug)
+        if reason == REASON_RECONCILE_PRIOR_DONE and not _reconcilable_prior_record(slug):
+            # A prior-generation success whose landing never completed. Rewrite
+            # the reason in place so every downstream reader — the initial live
+            # status rows below, sprint audit, RCA — reports the same recoverable
+            # stranded state, instead of one surface preserving a success the
+            # story never reached (#2189).
+            _recorded_outcome = str(
+                (_prior_generation_record(slug) or {}).get("outcome") or "success"
+            ).upper()
+            _log(
+                f"UNLANDED {slug}: prior generation recorded {_recorded_outcome} before its "
+                "landing completed; treating as stranded prior-generation state, "
+                "not a preserved success"
+            )
+            reason = REASON_STRANDED_WORKTREE
+            _dropped_slugs[slug] = reason
         if reason == "preserved-escalated":
             _log(f"PRESERVED {slug} (escalated worktree held for review)")
             dag.mark_skipped(slug)
@@ -4540,7 +4670,15 @@ def run_sprint(
                 # Only a genuine no-op carries the ALREADY_DONE source tag; a
                 # reconciled DONE must not be tagged as one.
                 _reconcile_extras["outcome_source"] = "reexec_reconcile"
-            _record_current_story_entry(slug, _reconciled.name, extras=_reconcile_extras)
+            # Carry the spend the generation that ran this story measured. The
+            # 0.0 default would overwrite it, dropping real spend from the run
+            # total and rendering a known amount as absent (#2189).
+            _record_current_story_entry(
+                slug,
+                _reconciled.name,
+                cost_usd=_measured_recorded_cost(slug),
+                extras=_reconcile_extras,
+            )
         elif reason == REASON_STRANDED_WORKTREE:
             # A prior-generation worktree exists but the story did not succeed:
             # recoverable stranded sprint state. Keep it DROPPED but retain the
@@ -4549,14 +4687,25 @@ def run_sprint(
             _log(f"DROPPED {slug} (stranded prior-generation sprint state)")
             dag.mark_skipped(slug)
             _stranded_cause = _record_dropped_story_audit(slug, reason)
+            _stranded_cost = _measured_recorded_cost(slug)
+            if _stranded_cost is None:
+                unmeasured_spend.append(f"stranded-unmeasured:{slug}")
             _set_outcome(
-                slug, StoryOutcome.DROPPED, reason=reason, failure_cause=_stranded_cause or None
+                slug,
+                StoryOutcome.DROPPED,
+                reason=reason,
+                cost_usd=_stranded_cost,
+                failure_cause=_stranded_cause or None,
             )
+            # Same reasoning as the reconciled branch: the prior generation's
+            # measured spend is this sprint's spend, whatever outcome the story
+            # ended at. It must not be replaced by the 0.0 default (#2189).
             _record_current_story_entry(
                 slug,
                 "DROPPED",
                 error=reason,
                 error_type="dropped",
+                cost_usd=_stranded_cost,
                 extras={"drop_reason": reason},
                 failure_cause=_stranded_cause or None,
             )
@@ -5082,6 +5231,11 @@ def run_sprint(
                 inherited_dev_residue=bool(merge_info.get("inherited_dev_residue")),
             )
 
+        # The accumulated entry was written before this landing ran and records
+        # the landing as owed. Now that it has resolved either way, rewrite it so
+        # the durable record a later re-exec reads matches what happened (#2189).
+        _persist_story_landing(slug, result)
+
         if merge_info.get("merged"):
             merged_slugs.add(slug)
             dag.mark_complete(slug)
@@ -5535,6 +5689,7 @@ def run_sprint(
                         # while another story occupies the only worker slot. The
                         # marker guarantees this DONE cannot later be clobbered.
                         _set_outcome(_qp_slug, StoryOutcome.DONE, landed=True)
+                        _persist_story_landing(_qp_slug, _qp_result)
                         del queued_prs[_qp_slug]
                         _write_story_audit(config, _qp_task, _qp_result, sprint_id=_sprint_id)
                         _resolve_batch_leader_landing(_qp_slug, "landed")
@@ -5551,6 +5706,7 @@ def run_sprint(
                         _set_outcome(
                             _qp_slug, StoryOutcome.MERGE_FAILED, phase=_qp_result.phase.name
                         )
+                        _persist_story_landing(_qp_slug, _qp_result)
                         del queued_prs[_qp_slug]
                         # Defensive/idempotent: the parent is normally already in
                         # _finished (added when its PR was queued), so its collision
@@ -6053,6 +6209,7 @@ def run_sprint(
                 _set_outcome(slug, StoryOutcome.MERGE_FAILED, phase=result.phase.name)
                 _resolve_batch_leader_landing(slug, "failed")
                 _log(f"✗ {slug}: queued PR {poll_result['status']} during sprint wrap-up")
+            _persist_story_landing(slug, result)
             _write_story_audit(config, task, result, sprint_id=_sprint_id)
             del queued_prs[slug]
 

--- a/tests/test_sprint_reexec_unlanded_done.py
+++ b/tests/test_sprint_reexec_unlanded_done.py
@@ -1,0 +1,474 @@
+"""Seam tests: a prior generation's DONE is only inherited when it landed.
+
+Issue #2189. The coordinator reaches ``Phase.DONE`` the moment review approves,
+and the sprint runner persists that phase as the accumulated story outcome
+*before* the separate landing step runs. A mid-sprint ``os.execv`` ("source
+updated after pull") in that window leaves ``outcome: DONE`` durably on disk for
+a story that never landed. The re-exec'd generation's launch guard read that as
+proof of completion, reconciled the worktree collision as a success, marked the
+DAG node complete, and reported the story as landed — while its issue stayed open
+with approved, unmerged commits on a branch. Its measured $20.56 was also
+overwritten with the 0.0 default, dropping the spend from the run total and
+rendering a known amount as absent.
+
+These tests pin the three seams that produced that: the launch guard's
+classification, the runner's drop handling and cost carry, and the durable record
+the guard reads (which must state the landing obligation and its resolution).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.sprint import run_sprint
+from theforge.sprint.audit import persist_accumulated_story_state
+from theforge.sprint.dag import StoryTriage
+from theforge.sprint.launch_guard import (
+    REASON_RECONCILE_PRIOR_DONE,
+    REASON_STRANDED_WORKTREE,
+)
+from theforge.sprint.prior_landing import (
+    as_prior_record,
+    landing_settled,
+    reconcilable_prior_success,
+)
+
+# ── prior-landing predicate (the shared policy) ───────────────────────────────
+
+
+class TestLandingEvidencePredicates:
+    def test_pre_landing_done_is_not_reconcilable(self) -> None:
+        """The exact record #2189 was built on: approved, landing owed, unrun."""
+        record = {"outcome": "DONE", "landing_status": "pending_integration", "merge": False}
+        assert landing_settled(record) is False
+        assert reconcilable_prior_success(record) is False
+
+    def test_landed_done_is_reconcilable(self) -> None:
+        record = {"outcome": "DONE", "landing_status": "landed", "merge": True}
+        assert reconcilable_prior_success(record) is True
+
+    def test_done_with_no_landing_obligation_is_reconcilable(self) -> None:
+        """``on_approve: pr`` / ``none`` reach DONE with landing_status None.
+
+        Those stories owe no landing of their own, so demoting them would strand
+        every story in a PR-only or branch-only sprint.
+        """
+        record = {"outcome": "DONE", "landing_status": None, "merge": False}
+        assert reconcilable_prior_success(record) is True
+
+    def test_queued_pr_counts_as_completed_landing(self) -> None:
+        """A queued auto-merge is recorded landing, not an unresolved one."""
+        record = {
+            "outcome": "DONE",
+            "landing_status": "pending_integration",
+            "landing": {"merge_queued": True, "pr_url": "https://github.com/o/r/pull/1"},
+        }
+        assert reconcilable_prior_success(record) is True
+
+    def test_failed_landing_is_not_reconcilable(self) -> None:
+        record = {"outcome": "DONE", "landing_status": "failed", "merge": False}
+        assert reconcilable_prior_success(record) is False
+
+    def test_bare_outcome_string_keeps_prior_behaviour(self) -> None:
+        """A record with no landing fields is not evidence of an owed landing."""
+        assert as_prior_record("done")["outcome"] == "DONE"
+        assert reconcilable_prior_success("DONE") is True
+        assert reconcilable_prior_success({"outcome": "DONE"}) is True
+        assert reconcilable_prior_success("FAILED") is False
+        assert reconcilable_prior_success(None) is False
+
+
+# ── launch guard classification ───────────────────────────────────────────────
+
+
+def _guard_config(tmp_path: Path) -> MagicMock:
+    config = MagicMock()
+    config.project_root = tmp_path
+    config.workspace.path_pattern = "worktrees/{slug}"
+    config.workspace.branch_pattern = "forge/{slug}"
+    config.workspace.base_branch = "main"
+    return config
+
+
+def _make_active_worktree(tmp_path: Path, slug: str) -> None:
+    wt = tmp_path / "worktrees" / slug
+    wt.mkdir(parents=True, exist_ok=True)
+    (wt / "file.txt").write_text("work", encoding="utf-8")
+
+
+def _classify(tmp_path: Path, prior_outcomes: dict) -> dict[str, str]:
+    from theforge.sprint.launch_guard import acquire_launch_story_locks
+    from theforge.sprint.lock import release_story_locks
+
+    _make_active_worktree(tmp_path, "issue-1108")
+    config = _guard_config(tmp_path)
+    completed = MagicMock(returncode=0, stdout="2\n")
+    with patch("theforge.sprint.lock.subprocess.run", return_value=completed):
+        locked_fds, launch_error, dropped = acquire_launch_story_locks(
+            slugs=["issue-1108"],
+            config=config,
+            resume=False,
+            allow_drop=True,
+            prior_outcomes=prior_outcomes,
+        )
+    release_story_locks(locked_fds)
+    assert launch_error is None
+    return dropped
+
+
+class TestLaunchGuardRejectsUnlandedPriorDone:
+    def test_pre_landing_done_is_stranded_not_reconciled(self, tmp_path: Path, capsys) -> None:
+        dropped = _classify(
+            tmp_path,
+            {
+                "issue-1108": {
+                    "slug": "issue-1108",
+                    "outcome": "DONE",
+                    "landing_status": "pending_integration",
+                    "merge": False,
+                }
+            },
+        )
+        assert dropped["issue-1108"] == REASON_STRANDED_WORKTREE
+        assert dropped["issue-1108"] != REASON_RECONCILE_PRIOR_DONE
+        assert "STRANDED" in capsys.readouterr().err
+
+    def test_landed_done_still_reconciles(self, tmp_path: Path) -> None:
+        dropped = _classify(
+            tmp_path,
+            {
+                "issue-1108": {
+                    "slug": "issue-1108",
+                    "outcome": "DONE",
+                    "landing_status": "landed",
+                    "merge": True,
+                }
+            },
+        )
+        assert dropped["issue-1108"] == REASON_RECONCILE_PRIOR_DONE
+
+    def test_done_without_landing_obligation_still_reconciles(self, tmp_path: Path) -> None:
+        dropped = _classify(
+            tmp_path,
+            {"issue-1108": {"slug": "issue-1108", "outcome": "DONE", "landing_status": None}},
+        )
+        assert dropped["issue-1108"] == REASON_RECONCILE_PRIOR_DONE
+
+
+# ── runner drop handling + cost carry ─────────────────────────────────────────
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+    )
+
+
+def _make_spec_file(tmp_path: Path, name: str, slug: str) -> Path:
+    spec = tmp_path / f"{slug}.md"
+    spec.write_text(
+        f"---\nname: {name}\nslug: {slug}\n---\n# {name}\nDo the thing.",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def _make_manifest(tmp_path: Path, specs: list[str], budget: float = 200.0) -> Path:
+    manifest_path = tmp_path / "sprint.yaml"
+    manifest_path.write_text(
+        yaml.dump({"name": "Test Sprint", "budget_usd": budget, "specs": specs}),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _set_sprint_id(tmp_path: Path, sprint_id: str = "sprint-2189") -> str:
+    sprint_dir = tmp_path / ".forge" / "logs" / "Test Sprint"
+    sprint_dir.mkdir(parents=True, exist_ok=True)
+    (sprint_dir / ".sprint_id").write_text(sprint_id, encoding="utf-8")
+    return sprint_id
+
+
+def _make_result(
+    *,
+    success: bool = True,
+    cost: float = 1.0,
+    phase: Phase = Phase.DONE,
+    landing_status: str | None = None,
+) -> CoordinatorResult:
+    state = CoordinatorState()
+    state.preflight_verdict = "PROCEED"
+    mock_preflight = MagicMock()
+    mock_preflight.cost_usd = cost
+    state.preflight_result = mock_preflight
+    state.branch_name = "forge/feature-a"
+    return CoordinatorResult(
+        success=success,
+        phase=phase,
+        state=state,
+        message="Done." if success else "Failed.",
+        landing_status=landing_status,
+    )
+
+
+def _triage_full(spec_path, config, project_root, *, task=None, **_progress):
+    return StoryTriage(
+        story_path=spec_path,
+        action="full",
+        reason="x",
+        worktree_path=None,
+        slug=Path(spec_path).stem,
+    )
+
+
+def _accumulated_by_slug(tmp_path: Path, sprint_id: str) -> dict[str, dict]:
+    state_path = tmp_path / ".forge" / "sprints" / sprint_id / "state.yaml"
+    data = yaml.safe_load(state_path.read_text(encoding="utf-8")) or {}
+    return {s["slug"]: s for s in data.get("stories", [])}
+
+
+def _summary_by_slug(tmp_path: Path) -> dict[str, dict]:
+    summary = yaml.safe_load(
+        (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text()
+    )
+    return {s["slug"]: s for s in summary["stories"]}
+
+
+def _run_reexec_with_unlanded_prior_done(tmp_path: Path, writes: list | None = None):
+    """A re-exec whose prior generation left feature-a DONE-but-unlanded.
+
+    When ``writes`` is given, every accumulated-state write for feature-a is
+    appended to it. Those intermediate writes matter on their own: each one is
+    what the *next* re-exec reads, and the reported symptom compounded across
+    three of them (the first generation to write ``cost_usd: 0.0`` is what made
+    the later generation's summary report $0 for a story that spent $20.56).
+    """
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
+    config = _make_config(tmp_path)
+    sprint_id = _set_sprint_id(tmp_path)
+    persist_accumulated_story_state(
+        sprint_id,
+        "Test Sprint",
+        tmp_path,
+        [
+            {
+                "canonical_ref": "feature-a.md",
+                "slug": "feature-a",
+                "path": "feature-a.md",
+                # Phase.DONE persisted before the landing step ran.
+                "outcome": "DONE",
+                "landing_status": "pending_integration",
+                "landing": None,
+                "merge": False,
+                "cost_usd": 20.556,
+                "story_run_id": "run-prev",
+                "depends_on": [],
+            }
+        ],
+    )
+
+    def _capture(_sprint_id, sprint_name, project_root, stories):
+        if writes is not None:
+            for story in stories:
+                if story.get("slug") == "feature-a":
+                    writes.append(dict(story))
+        persist_accumulated_story_state(_sprint_id, sprint_name, project_root, stories)
+
+    fresh = _make_result(landing_status="landed")
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=fresh) as mock_run_task,
+        patch(
+            "theforge.sprint.runner.persist_accumulated_story_state",
+            side_effect=_capture,
+        ),
+        patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev"}, clear=False),
+    ):
+        result = run_sprint(
+            config,
+            manifest_path,
+            reexec=True,
+            dropped_slugs={"feature-a": REASON_RECONCILE_PRIOR_DONE},
+        )
+    return result, sprint_id, mock_run_task
+
+
+class TestRunnerRefusesUnlandedPriorDone:
+    def test_unlanded_prior_done_is_not_recorded_as_done_or_landed(self, tmp_path: Path) -> None:
+        """The reported symptom: ``LANDED (9 of 9)`` counting an unlanded story.
+
+        Even when the drop reason still says ``reconciled-prior-generation-done``
+        (a stale prior-outcome map, or the guard classifying from a record without
+        landing fields), the runner must not settle the story on DONE.
+        """
+        result, sprint_id, _ = _run_reexec_with_unlanded_prior_done(tmp_path)
+
+        summary = _summary_by_slug(tmp_path)["feature-a"]
+        assert summary["outcome"] != "DONE"
+        assert summary["outcome"] == "DROPPED"
+        assert summary["drop_reason"] == REASON_STRANDED_WORKTREE
+
+        accumulated = _accumulated_by_slug(tmp_path, sprint_id)["feature-a"]
+        assert accumulated["outcome"] == "DROPPED"
+
+        # It is not counted as a succeeded/landed story. Only the story that
+        # actually ran and landed this generation is.
+        assert result.specs_succeeded == 1
+        assert result.specs_failed == 1
+
+    def test_measured_cost_survives_the_reroute(self, tmp_path: Path) -> None:
+        """$20.56 already measured must stay a number, and stay in the total.
+
+        Every durable write is checked, not just the last one: the row this
+        generation persists is what the next re-exec seeds from, so a single
+        intermediate write of ``cost_usd: 0.0`` is enough to lose the spend for
+        good — which is how the reported run's summary came to claim $75.04
+        against an actual $95.60.
+        """
+        writes: list[dict] = []
+        result, sprint_id, _ = _run_reexec_with_unlanded_prior_done(tmp_path, writes)
+
+        assert writes, "no accumulated-state write was captured for feature-a"
+        for write in writes:
+            assert write["cost_usd"] == pytest.approx(20.556), (
+                f"a durable write replaced the measured spend: {write['cost_usd']!r}"
+            )
+
+        accumulated = _accumulated_by_slug(tmp_path, sprint_id)["feature-a"]
+        assert accumulated["cost_usd"] == pytest.approx(20.556)
+        assert _summary_by_slug(tmp_path)["feature-a"]["cost_usd"] == pytest.approx(20.556)
+        # The run total reports the spend it recorded (prior $20.556 + fresh $1).
+        assert result.total_cost_usd == pytest.approx(21.556)
+
+    def test_landed_prior_done_still_reconciles_as_done(self, tmp_path: Path) -> None:
+        """The other half of the rule: a real landing is still inherited."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "DONE",
+                    "landing_status": "landed",
+                    "merge": True,
+                    "cost_usd": 0.33,
+                    "story_run_id": "run-prev",
+                    "depends_on": [],
+                }
+            ],
+        )
+
+        fresh = _make_result(landing_status="landed")
+        with (
+            patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+            patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.run_task", return_value=fresh),
+            patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev"}, clear=False),
+        ):
+            result = run_sprint(
+                config,
+                manifest_path,
+                reexec=True,
+                dropped_slugs={"feature-a": REASON_RECONCILE_PRIOR_DONE},
+            )
+
+        assert _summary_by_slug(tmp_path)["feature-a"]["outcome"] == "DONE"
+        assert result.specs_succeeded == 2
+        assert result.specs_failed == 0
+
+
+class TestPersistedRecordStatesLandingObligation:
+    def test_pre_landing_record_is_not_reconcilable_and_is_corrected(self, tmp_path: Path) -> None:
+        """The durable record must never read as a landed success before it is one.
+
+        Captures every write of the accumulated state during a normal run whose
+        landing succeeds. The write that happens *before* the landing step must
+        say the landing is owed (so a re-exec reading it strands the story rather
+        than inheriting a DONE), and the write after it must say it landed (so a
+        story that really did land is still reconciled, not stranded).
+        """
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
+        config = _make_config(tmp_path)
+        _set_sprint_id(tmp_path)
+
+        writes: list[dict] = []
+
+        def _capture(sprint_id, sprint_name, project_root, stories):
+            for story in stories:
+                if story.get("slug") == "feature-a":
+                    writes.append(dict(story))
+
+        result_a = _make_result(landing_status="pending_integration")
+        with (
+            patch("theforge.sprint.runner.persist_accumulated_story_state", side_effect=_capture),
+            patch("theforge.sprint.runner.run_task", return_value=result_a),
+            patch(
+                "theforge.coordinator.completion.land_story",
+                return_value=({"action": "merge", "merged": True}, "landed"),
+            ),
+        ):
+            run_sprint(config, manifest_path)
+
+        assert len(writes) >= 2, f"expected a pre- and post-landing write, got {writes}"
+        pre_landing = writes[0]
+        assert pre_landing["outcome"] == "DONE"
+        assert pre_landing["landing_status"] == "pending_integration"
+        assert reconcilable_prior_success(pre_landing) is False
+
+        post_landing = writes[-1]
+        assert post_landing["landing_status"] == "landed"
+        assert post_landing["merge"] is True
+        assert reconcilable_prior_success(post_landing) is True
+
+
+# ── digest rendering ─────────────────────────────────────────────────────────
+
+
+class TestDigestCostRendering:
+    def test_zero_renders_as_a_number_and_missing_renders_absent(self) -> None:
+        from theforge.cli.sprint_digest import _story_row
+
+        assert "$0.00" in _story_row({"slug": "issue-1", "cost_usd": 0.0})
+        assert "$20.56" in _story_row({"slug": "issue-1", "cost_usd": 20.556})
+        # Cost-unknown and no-cost-recorded stay the explicit absent marker.
+        assert "—" in _story_row({"slug": "issue-1", "cost_usd": None})
+        assert "—" in _story_row({"slug": "issue-1"})


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change satisfies the reconciliation, summary, cost, rendering, and seam-test criteria; focused tests pass. | [google-gemini-3.5-flash-api] The implementation successfully gates prior-generation reconciliation on completed landing rather than on a persisted coordinator DONE phase, carries measured costs correctly, and renders 0.0 cost as $0.00.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $17.87
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A story reconciled from a prior generation inherits DONE even when that generation left it in flight (GitHub Issue #2189)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2189