### PR TITLE
Indexed model identity is derived from record keys the audit renderer never writes

### DIFF
--- a/src/theforge/coordinator/agent_identity.py
+++ b/src/theforge/coordinator/agent_identity.py
@@ -1,0 +1,130 @@
+"""Model identity projected out of audit ``cost.agents`` entries.
+
+This module owns *one* reading of the agent-entry identity contract. The
+writer is :func:`theforge.coordinator.audit_render._agent_entry`; the readers
+are the ``audit_substrate`` derivations that project a run record to the model
+that ran (indexed ``dev_model``, escalation history, assignment history).
+
+Issue #2201: those readers had each been written against ``provider`` /
+``model`` / ``cli`` / ``name`` keys the renderer never emits, so every
+derivation returned nothing on live records. Keeping the read in one place
+means a future renderer/reader divergence breaks one seam-pinned helper rather
+than silently emptying three projections.
+
+Provenance matters as much as the value. ``model_used`` is the identity the
+runner recorded at invocation time (:data:`SOURCE_DIRECT`). Anything
+reconstructed afterwards — an invocation's configured preference list, or the
+legacy identity keys older records carry — is a best-effort recovery
+(:data:`SOURCE_RECOVERED`) and consumers must be able to tell the two apart.
+
+Per-component ``model_usage`` billing is deliberately *not* a source: a model
+billed inside an invocation is not the identity of the invocation.
+
+Stdlib only, plus a lazy, failure-tolerant hop to ``model_profiles`` for
+canonicalization.
+"""
+
+from __future__ import annotations
+
+SOURCE_DIRECT = "direct"
+"""Identity was recorded by the runner at invocation time (``model_used``)."""
+
+SOURCE_RECOVERED = "recovered"
+"""Identity was reconstructed after the fact (config block / legacy keys)."""
+
+
+def _canonicalize(raw: str) -> str:
+    """Return the canonical ``provider/model/transport`` id for ``raw``.
+
+    Falls back to ``raw`` unchanged when the key cannot be resolved
+    unambiguously — an unresolvable identity is still a truthful record of
+    what ran, and guessing at it would be worse than reporting it verbatim.
+    """
+    try:
+        from theforge.model_profiles import canonical_id_for_legacy_key  # noqa: PLC0415
+
+        return canonical_id_for_legacy_key(raw) or raw
+    except Exception:  # noqa: BLE001 - identity projection must never break indexing
+        return raw
+
+
+def is_dev_entry(entry: object) -> bool:
+    """Return True when this ``cost.agents`` entry describes the dev agent.
+
+    ``role`` is what :func:`audit_render._agent_entry` writes; ``phase`` is the
+    key older records used.
+    """
+    if not isinstance(entry, dict):
+        return False
+    return entry.get("role") == "dev" or entry.get("phase") == "dev"
+
+
+def entry_model_identity(entry: object) -> tuple[str, str] | None:
+    """Return ``(identity, source)`` for one ``cost.agents`` entry, or None.
+
+    Resolution order:
+      1. ``model_used`` — the model the runner reports having invoked
+         (:data:`SOURCE_DIRECT`).
+      2. ``model_config`` — the configured preference list for the invocation.
+         Which entry actually served is not recorded, so the preferred (first)
+         entry is reported as a :data:`SOURCE_RECOVERED` reconstruction.
+      3. Legacy ``provider``/``model``/``cli`` or ``name`` keys, kept only as
+         compatibility for records written before the current renderer
+         (:data:`SOURCE_RECOVERED`).
+    """
+    if not isinstance(entry, dict):
+        return None
+
+    model_used = str(entry.get("model_used") or "").strip()
+    if model_used:
+        return (_canonicalize(model_used), SOURCE_DIRECT)
+
+    model_config = entry.get("model_config")
+    if isinstance(model_config, list):
+        for candidate in model_config:
+            configured = str(candidate or "").strip()
+            if configured:
+                return (_canonicalize(configured), SOURCE_RECOVERED)
+
+    provider = str(entry.get("provider") or "").strip()
+    model = str(entry.get("model") or "").strip()
+    cli = str(entry.get("cli") or "").strip()
+    if provider and model:
+        return (f"{provider}/{model}/{'cli' if cli else 'api'}", SOURCE_RECOVERED)
+    name = str(entry.get("name") or "").strip()
+    if name:
+        return (name, SOURCE_RECOVERED)
+    return None
+
+
+def dev_model_identity(record: object) -> tuple[str | None, str | None]:
+    """Return ``(identity, source)`` for the dev agent of an audit record.
+
+    A directly recorded identity wins over a reconstructed one regardless of
+    entry order, so a run whose later dev attempt recorded ``model_used`` is
+    not reported as recovered. Returns ``(None, None)`` when no dev-role entry
+    carries a trustworthy invocation identity.
+    """
+    if not isinstance(record, dict):
+        return (None, None)
+    cost_block = record.get("cost")
+    if not isinstance(cost_block, dict):
+        return (None, None)
+    agents = cost_block.get("agents")
+    if not isinstance(agents, list):
+        return (None, None)
+
+    recovered: tuple[str, str] | None = None
+    for entry in agents:
+        if not is_dev_entry(entry):
+            continue
+        resolved = entry_model_identity(entry)
+        if resolved is None:
+            continue
+        if resolved[1] == SOURCE_DIRECT:
+            return resolved
+        if recovered is None:
+            recovered = resolved
+    if recovered is not None:
+        return recovered
+    return (None, None)

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -29,7 +29,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-SUBSTRATE_SCHEMA_VERSION = 4
+from .agent_identity import dev_model_identity
+
+# Substrate (SQLite) schema version. Bumped to 5 by #2201, which added
+# ``audit_records.dev_model_source`` and repaired the dev-model projection:
+# substrates written under version <= 4 carry an empty ``dev_model`` on every
+# row, so opening an older one re-derives both columns from the stored
+# ``raw_json`` (see :func:`_reindex_dev_model_identity`) instead of leaving the
+# repaired projection unapplied to already-indexed history.
+SUBSTRATE_SCHEMA_VERSION = 5
 # Current per-record schema version. Records pre-dating the indexed-dimensions
 # slice (#1522) are treated as version 1. The reader-side migration helper
 # (`_migrate_record`) is the seam future breaking changes hang off — a version
@@ -153,6 +161,7 @@ CREATE TABLE IF NOT EXISTS audit_records (
     milestone TEXT,
     issue_id INTEGER,
     dev_model TEXT,
+    dev_model_source TEXT,
     verdict TEXT,
     raw_json TEXT NOT NULL
 );
@@ -255,6 +264,7 @@ CREATE INDEX IF NOT EXISTS idx_inline_remediation_events_action
 
 def _apply_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(_SCHEMA)
+    prior_version = _stored_schema_version(conn)
     # Idempotent column adds for substrates created under an older schema.
     # SQLite < 3.35 lacks ADD COLUMN IF NOT EXISTS, so swallow the duplicate
     # error from re-runs.
@@ -267,6 +277,7 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
         "ALTER TABLE audit_records ADD COLUMN milestone TEXT",
         "ALTER TABLE audit_records ADD COLUMN issue_id INTEGER",
         "ALTER TABLE audit_records ADD COLUMN dev_model TEXT",
+        "ALTER TABLE audit_records ADD COLUMN dev_model_source TEXT",
         "ALTER TABLE audit_records ADD COLUMN verdict TEXT",
         "ALTER TABLE readiness_events ADD COLUMN staleness_verdict TEXT",
         "ALTER TABLE readiness_events ADD COLUMN diagnosis_baseline_sha TEXT",
@@ -293,12 +304,74 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
             conn.execute(idx_stmt)
         except sqlite3.OperationalError:
             pass
+    # A substrate indexed under an older schema carries values derived by the
+    # older projection — for dev_model that meant "empty on every row" (#2201).
+    # Re-derive from the stored raw_json so the repair reaches history rather
+    # than only new writes.
+    if prior_version is not None and prior_version < SUBSTRATE_SCHEMA_VERSION:
+        _reindex_dev_model_identity(conn)
     conn.execute(
         "INSERT INTO meta(key, value) VALUES (?, ?) "
         "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
         ("schema_version", str(SUBSTRATE_SCHEMA_VERSION)),
     )
     conn.commit()
+
+
+def _stored_schema_version(conn: sqlite3.Connection) -> int | None:
+    """Return the substrate schema version recorded in ``meta``, if any.
+
+    ``None`` means a freshly created substrate (nothing indexed under an older
+    projection), which needs no re-derivation.
+    """
+    try:
+        row = conn.execute("SELECT value FROM meta WHERE key = 'schema_version'").fetchone()
+    except sqlite3.OperationalError:
+        return None
+    if row is None:
+        return None
+    value = row[0] if not isinstance(row, sqlite3.Row) else row["value"]
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _reindex_dev_model_identity(conn: sqlite3.Connection) -> int:
+    """Re-derive ``dev_model``/``dev_model_source`` from each row's raw_json.
+
+    The canonical per-run JSON is not needed — ``raw_json`` is the record, so
+    rows imported from legacy history are repaired alongside native ones. Rows
+    whose record carries no trustworthy invocation identity are left alone:
+    the projection has nothing truthful to write for them, and clearing an
+    existing value would destroy data the record still justifies.
+
+    Returns the number of rows updated (used by tests and callers that want to
+    report the repair).
+    """
+    try:
+        rows = conn.execute("SELECT run_id, raw_json FROM audit_records").fetchall()
+    except sqlite3.OperationalError:
+        return 0
+    updated = 0
+    for row in rows:
+        run_id = row[0] if not isinstance(row, sqlite3.Row) else row["run_id"]
+        raw = row[1] if not isinstance(row, sqlite3.Row) else row["raw_json"]
+        try:
+            record = json.loads(raw)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        identity, source = dev_model_identity(record)
+        if not identity:
+            continue
+        conn.execute(
+            "UPDATE audit_records SET dev_model = ?, dev_model_source = ? WHERE run_id = ?",
+            (identity, source, run_id),
+        )
+        updated += 1
+    return updated
 
 
 # ── Connection management ────────────────────────────────────────────────
@@ -625,6 +698,8 @@ def _flat_fields(record: dict) -> dict:
     else:
         issue_id = None
 
+    dev_model, dev_model_source = dev_model_identity(record)
+
     return {
         "slug": task.get("slug"),
         "started_at": timing.get("started_at"),
@@ -638,7 +713,8 @@ def _flat_fields(record: dict) -> dict:
         "record_schema_version": record_schema_version,
         "milestone": milestone,
         "issue_id": issue_id,
-        "dev_model": _derive_dev_model(record),
+        "dev_model": dev_model,
+        "dev_model_source": dev_model_source,
         "verdict": _derive_record_verdict(record),
     }
 
@@ -667,31 +743,6 @@ def _derive_record_verdict(record: dict) -> str | None:
         return None
     verdict = last.get("verdict")
     return verdict if isinstance(verdict, str) and verdict else None
-
-
-def _derive_dev_model(record: dict) -> str | None:
-    """Return the canonical dev model identity recorded for this run.
-
-    Mirrors the `cost.agents` parsing logic in :func:`_derive_escalation` so
-    the indexed `dev_model` column matches the model the adaptive router
-    treats as authoritative (the one that actually ran).
-    """
-    cost_block = record.get("cost") if isinstance(record.get("cost"), dict) else {}
-    agents = cost_block.get("agents") if isinstance(cost_block.get("agents"), list) else []
-    for entry in agents:
-        if not isinstance(entry, dict):
-            continue
-        if entry.get("phase") != "dev" and entry.get("role") != "dev":
-            continue
-        provider = (entry.get("provider") or "").strip()
-        model = (entry.get("model") or "").strip()
-        cli = (entry.get("cli") or "").strip()
-        if model and provider:
-            transport = "cli" if cli else "api"
-            return f"{provider}/{model}/{transport}"
-        if entry.get("name"):
-            return str(entry["name"])
-    return None
 
 
 # ── Per-record schema migration ──────────────────────────────────────────
@@ -1302,6 +1353,7 @@ def upsert_run_record(
         flat["milestone"],
         flat["issue_id"],
         flat["dev_model"],
+        flat["dev_model_source"],
         flat["verdict"],
         raw_json,
     )
@@ -1310,8 +1362,8 @@ def upsert_run_record(
         "(run_id, slug, started_at, finished_at, total_cost_usd, final_phase, "
         "outcome_success, branch, landing_status, provenance, source_path, "
         "source_mtime, complexity_score, record_schema_version, milestone, "
-        "issue_id, dev_model, verdict, raw_json) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+        "issue_id, dev_model, dev_model_source, verdict, raw_json) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
         "ON CONFLICT(run_id) DO UPDATE SET "
         "slug=excluded.slug, started_at=excluded.started_at, "
         "finished_at=excluded.finished_at, total_cost_usd=excluded.total_cost_usd, "
@@ -1322,7 +1374,8 @@ def upsert_run_record(
         "complexity_score=excluded.complexity_score, "
         "record_schema_version=excluded.record_schema_version, "
         "milestone=excluded.milestone, issue_id=excluded.issue_id, "
-        "dev_model=excluded.dev_model, verdict=excluded.verdict, "
+        "dev_model=excluded.dev_model, "
+        "dev_model_source=excluded.dev_model_source, verdict=excluded.verdict, "
         "raw_json=excluded.raw_json",
         params,
     )
@@ -1877,26 +1930,11 @@ def derive_assignment_history(
         # Fallback: when the audit record lacks the preflight.complexity_routing
         # block (older audits, or audits seeded by tests that bypass routing),
         # derive the canonical dev model from cost.agents — the model that
-        # actually ran. provider/model/transport gives the same canonical_id
-        # shape the routing block would have provided.
+        # actually ran, canonicalized to the same provider/model/transport shape
+        # the routing block would have provided. Shares the one reading of the
+        # agent-entry identity contract (#2201).
         if not (isinstance(dev_model, str) and dev_model):
-            cost_block = record.get("cost") if isinstance(record.get("cost"), dict) else {}
-            agents = cost_block.get("agents") if isinstance(cost_block.get("agents"), list) else []
-            for entry in agents:
-                if not isinstance(entry, dict):
-                    continue
-                if entry.get("phase") != "dev" and entry.get("role") != "dev":
-                    continue
-                provider = (entry.get("provider") or "").strip()
-                model = (entry.get("model") or "").strip()
-                cli = (entry.get("cli") or "").strip()
-                if model and provider:
-                    transport = "cli" if cli else "api"
-                    dev_model = f"{provider}/{model}/{transport}"
-                    break
-                if entry.get("name"):
-                    dev_model = str(entry["name"])
-                    break
+            dev_model = dev_model_identity(record)[0]
         if not isinstance(dev_model, str) or not dev_model:
             continue
         timing = record.get("timing") or {}
@@ -1996,25 +2034,8 @@ def _derive_escalation(record: dict) -> dict | None:
     complexity = _normalize_complexity_band(raw_complexity)
 
     # Canonical dev model identity, derived from the cost.agents block when
-    # present (carries provider/model/cli identity per phase).
-    dev_model = ""
-    cost_block = record.get("cost") if isinstance(record.get("cost"), dict) else {}
-    agents = cost_block.get("agents") if isinstance(cost_block.get("agents"), list) else []
-    for entry in agents:
-        if not isinstance(entry, dict):
-            continue
-        if entry.get("phase") != "dev" and entry.get("role") != "dev":
-            continue
-        provider = (entry.get("provider") or "").strip()
-        model = (entry.get("model") or "").strip()
-        cli = (entry.get("cli") or "").strip()
-        if model and provider:
-            transport = "cli" if cli else "api"
-            dev_model = f"{provider}/{model}/{transport}"
-            break
-        if entry.get("name"):
-            dev_model = str(entry["name"])
-            break
+    # present, through the one shared reading of that contract (#2201).
+    dev_model = dev_model_identity(record)[0] or ""
 
     raw_score = preflight.get("complexity_score") if isinstance(preflight, dict) else None
     if isinstance(raw_score, bool):

--- a/tests/test_agent_identity.py
+++ b/tests/test_agent_identity.py
@@ -1,0 +1,62 @@
+"""Unit tests for the agent-entry → model identity projection (#2201)."""
+
+from __future__ import annotations
+
+from theforge.coordinator import agent_identity as ai
+
+
+def test_model_used_is_a_direct_identity() -> None:
+    assert ai.entry_model_identity({"role": "dev", "model_used": "sonnet"}) == (
+        "anthropic/sonnet/cli",
+        ai.SOURCE_DIRECT,
+    )
+
+
+def test_unresolvable_identity_is_kept_verbatim() -> None:
+    """Canonicalization failure must not discard what the runner recorded."""
+    identity, source = ai.entry_model_identity({"role": "dev", "model_used": "some-new-model"})
+    assert (identity, source) == ("some-new-model", ai.SOURCE_DIRECT)
+
+
+def test_model_config_is_a_recovered_identity() -> None:
+    assert ai.entry_model_identity({"role": "dev", "model_config": ["opus", "sonnet"]}) == (
+        "anthropic/opus/cli",
+        ai.SOURCE_RECOVERED,
+    )
+
+
+def test_legacy_keys_are_a_recovered_identity() -> None:
+    assert ai.entry_model_identity(
+        {"phase": "dev", "provider": "openai", "model": "gpt-5", "cli": ""}
+    ) == ("openai/gpt-5/api", ai.SOURCE_RECOVERED)
+    assert ai.entry_model_identity({"phase": "dev", "name": "dev-profile"}) == (
+        "dev-profile",
+        ai.SOURCE_RECOVERED,
+    )
+
+
+def test_model_usage_alone_is_not_an_identity() -> None:
+    """Per-component billing is not the identity of the invocation."""
+    assert (
+        ai.entry_model_identity(
+            {"role": "dev", "model_usage": [{"model": "claude-haiku-4-5", "cost_usd": 0.01}]}
+        )
+        is None
+    )
+
+
+def test_non_dev_entries_are_ignored() -> None:
+    record = {"cost": {"agents": [{"role": "review", "model_used": "sonnet"}]}}
+    assert ai.dev_model_identity(record) == (None, None)
+
+
+def test_dev_entry_matches_role_or_legacy_phase_key() -> None:
+    assert ai.is_dev_entry({"role": "dev"})
+    assert ai.is_dev_entry({"phase": "dev"})
+    assert not ai.is_dev_entry({"role": "synthesis"})
+    assert not ai.is_dev_entry("dev")
+
+
+def test_malformed_records_project_to_nothing() -> None:
+    for record in (None, {}, {"cost": "nope"}, {"cost": {"agents": "nope"}}, {"cost": {}}):
+        assert ai.dev_model_identity(record) == (None, None)

--- a/tests/test_assignment_history_derived.py
+++ b/tests/test_assignment_history_derived.py
@@ -415,3 +415,76 @@ def test_export_assignment_history_parser_wired_under_audits(tmp_path: Path, cap
     rc = audits_cli.cmd_audits(args)
     assert rc == 0
     assert out_path.exists()
+
+
+# ── #2201: cost.agents fallback reads the keys the renderer writes ───────
+
+
+def _record_without_routing(*, run_id: str, slug: str, agent_entry: dict) -> dict:
+    """Audit record with no preflight routing block — forces the cost.agents fallback."""
+    return {
+        "run_id": run_id,
+        "task": {"slug": slug},
+        "outcome": {"success": True, "final_phase": "DONE"},
+        "timing": {"started_at": "2026-05-08T09:00:00+00:00"},
+        "preflight": {"verdict": "PROCEED", "complexity": "medium", "complexity_score": 5},
+        "cost": {"total_usd": 1.0, "agents": [agent_entry]},
+    }
+
+
+def test_assignment_history_fallback_reads_renderer_model_used(tmp_path: Path) -> None:
+    """The fallback must read ``model_used`` — the key ``_agent_entry`` actually writes.
+
+    Pre-#2201 it read provider/model/cli/name, which the renderer never emits,
+    so a record with a recorded dev identity dropped out of the history entirely.
+    """
+    from theforge.agent_types import AgentResult
+    from theforge.coordinator import audit_render
+
+    entry = audit_render._agent_entry(
+        AgentResult(
+            success=True,
+            output="ok",
+            session_id=None,
+            cost_usd=1.0,
+            exit_code=0,
+            raw={},
+            profile_name="dev",
+            model_used="sonnet",
+        ),
+        "dev",
+        "dev",
+        12.0,
+    )
+    _seed_substrate(
+        tmp_path,
+        [_record_without_routing(run_id="r-fallback", slug="fallback", agent_entry=entry)],
+    )
+    conn = sub.require_substrate(tmp_path)
+    try:
+        derived = sub.derive_assignment_history(conn)
+    finally:
+        conn.close()
+
+    assert [(d["story"], d["dev_model"]) for d in derived] == [
+        ("fallback", "anthropic/sonnet/cli")
+    ]
+
+
+def test_assignment_history_prefers_routing_assignment_over_executed_identity(
+    tmp_path: Path,
+) -> None:
+    """The CLI/export view still reports the *assigned* model when routing recorded one."""
+    rec = _audit_record(run_id="r-assigned", slug="assigned", success=True)
+    rec["cost"] = {
+        "total_usd": 1.0,
+        "agents": [{"role": "dev", "model_used": "opus"}],
+    }
+    _seed_substrate(tmp_path, [rec])
+    conn = sub.require_substrate(tmp_path)
+    try:
+        derived = sub.derive_assignment_history(conn)
+    finally:
+        conn.close()
+
+    assert [d["dev_model"] for d in derived] == ["anthropic/sonnet/cli"]

--- a/tests/test_audit_substrate.py
+++ b/tests/test_audit_substrate.py
@@ -1099,3 +1099,190 @@ def test_migrate_record_chains_up_to_v14() -> None:
 
     assert migrated["iterations"]["gate_runs"] is None
     assert migrated["iterations"]["gate_debug"][0]["trace_index"] == 1
+
+
+class TestRendererIndexerModelIdentitySeam:
+    """#2201: the fields the renderer writes are the fields the indexer reads.
+
+    These build the ``cost.agents`` entry with the *real* writer
+    (:func:`audit_render._agent_entry`) rather than a hand-shaped dict, so a
+    future rename on either side of the seam fails here instead of silently
+    emptying the ``dev_model`` column on every indexed record.
+    """
+
+    def _agent_result(self, **overrides) -> object:
+        from theforge.agent_types import AgentResult
+
+        kwargs = {
+            "success": True,
+            "output": "done",
+            "session_id": None,
+            "cost_usd": 1.0,
+            "exit_code": 0,
+            "raw": {},
+            "profile_name": "dev",
+        }
+        kwargs.update(overrides)
+        return AgentResult(**kwargs)
+
+    def _record_with_agent_entry(self, entry: dict, run_id: str = "seam-1") -> dict:
+        rec = _make_record(run_id=run_id)
+        rec["cost"]["agents"] = [entry]
+        return rec
+
+    def _index(self, tmp_path: Path, record: dict) -> tuple:
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, record, provenance="native")
+            conn.commit()
+            return tuple(
+                conn.execute(
+                    "SELECT dev_model, dev_model_source FROM audit_records WHERE run_id = ?",
+                    (record["run_id"],),
+                ).fetchone()
+            )
+        finally:
+            conn.close()
+
+    def test_model_used_from_renderer_indexes_as_direct_identity(self, tmp_path: Path) -> None:
+        from theforge.coordinator import audit_render
+
+        entry = audit_render._agent_entry(
+            self._agent_result(model_used="sonnet"), "dev", "dev", 12.0
+        )
+        assert "model_used" in entry, "renderer no longer emits the key the indexer reads"
+
+        assert self._index(tmp_path, self._record_with_agent_entry(entry)) == (
+            "anthropic/sonnet/cli",
+            "direct",
+        )
+
+    def test_unresolvable_model_used_is_recorded_verbatim_not_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        """An identity the profile registry cannot canonicalize is still what ran."""
+        from theforge.coordinator import audit_render
+
+        entry = audit_render._agent_entry(
+            self._agent_result(model_used="claude-opus-4-1-20250805"), "dev", "dev", 12.0
+        )
+
+        assert self._index(tmp_path, self._record_with_agent_entry(entry)) == (
+            "claude-opus-4-1-20250805",
+            "direct",
+        )
+
+    def test_model_config_only_entry_indexes_as_recovered_identity(self, tmp_path: Path) -> None:
+        """No recorded model_used → reconstruct from invocation config, marked recovered."""
+        from theforge.coordinator import audit_render
+
+        entry = audit_render._agent_entry(
+            self._agent_result(model_config=("opus", "sonnet")), "dev", "dev", 12.0
+        )
+        assert "model_used" not in entry
+
+        assert self._index(tmp_path, self._record_with_agent_entry(entry)) == (
+            "anthropic/opus/cli",
+            "recovered",
+        )
+
+    def test_component_billing_is_not_treated_as_invocation_identity(self, tmp_path: Path) -> None:
+        """A model billed inside an invocation is not the model that was invoked.
+
+        ``_agent_entry`` back-fills ``model_used`` from ``model_usage`` itself,
+        so the indexer must not reach into per-component billing on its own —
+        an entry carrying only ``model_usage`` has no invocation identity.
+        """
+        entry = {
+            "role": "dev",
+            "profile": "dev",
+            "cost_usd": 1.0,
+            "duration_seconds": 12.0,
+            "success": True,
+            "exit_code": 0,
+            "model_usage": [{"model": "claude-haiku-4-5", "cost_usd": 0.01}],
+        }
+
+        assert self._index(tmp_path, self._record_with_agent_entry(entry)) == (None, None)
+
+    def test_direct_identity_wins_over_a_recovered_one(self, tmp_path: Path) -> None:
+        """A later dev attempt that recorded model_used is not reported as recovered."""
+        rec = _make_record(run_id="seam-multi")
+        rec["cost"]["agents"] = [
+            {"role": "dev", "model_config": ["opus", "sonnet"]},
+            {"role": "dev", "model_used": "sonnet"},
+        ]
+
+        assert self._index(tmp_path, rec) == ("anthropic/sonnet/cli", "direct")
+
+    def test_legacy_identity_keys_still_index_as_recovered(self, tmp_path: Path) -> None:
+        """Older records carry provider/model/cli; keep reading them, marked recovered."""
+        rec = _make_record(run_id="seam-legacy")
+        rec["cost"]["agents"] = [
+            {"phase": "dev", "provider": "openai", "model": "gpt-5", "cli": ""}
+        ]
+
+        assert self._index(tmp_path, rec) == ("openai/gpt-5/api", "recovered")
+
+    def test_escalation_projection_uses_the_same_identity(self, tmp_path: Path) -> None:
+        """The adaptive-routing view reads the renderer's keys, not the stale ones."""
+        from theforge.coordinator import audit_render
+
+        entry = audit_render._agent_entry(
+            self._agent_result(model_used="sonnet"), "dev", "dev", 12.0
+        )
+        rec = self._record_with_agent_entry(entry, run_id="esc-seam")
+        rec["outcome"] = {"success": False, "final_phase": "ESCALATE"}
+        rec["preflight"] = {"complexity": "medium", "complexity_score": 5}
+
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            projected = list(sub.iter_escalation_records(conn))
+        finally:
+            conn.close()
+
+        assert [p["dev_model"] for p in projected] == ["anthropic/sonnet/cli"]
+
+    def test_reindex_repairs_rows_indexed_under_the_broken_projection(
+        self, tmp_path: Path
+    ) -> None:
+        """Opening a pre-#2201 substrate re-derives dev_model from raw_json.
+
+        Simulates the observed failure: rows present, identity in the record,
+        column empty. The substrate schema version is what marks them stale.
+        """
+        from theforge.coordinator import audit_render
+
+        entry = audit_render._agent_entry(
+            self._agent_result(model_used="sonnet"), "dev", "dev", 12.0
+        )
+        rec = self._record_with_agent_entry(entry, run_id="stale-1")
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.execute(
+                "UPDATE audit_records SET dev_model = NULL, dev_model_source = NULL "
+                "WHERE run_id = 'stale-1'"
+            )
+            conn.execute("UPDATE meta SET value = '4' WHERE key = 'schema_version'")
+            conn.commit()
+        finally:
+            conn.close()
+
+        conn = sub.create_or_open(tmp_path)
+        try:
+            row = tuple(
+                conn.execute(
+                    "SELECT dev_model, dev_model_source FROM audit_records WHERE run_id='stale-1'"
+                ).fetchone()
+            )
+            version = conn.execute(
+                "SELECT value FROM meta WHERE key = 'schema_version'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert row == ("anthropic/sonnet/cli", "direct")
+        assert version == str(sub.SUBSTRATE_SCHEMA_VERSION)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change satisfies the model identity projection, provenance, seam coverage, and historical repair requirements; targeted tests passed. | [google-gemini-3.5-flash-api] Successfully unified the audit model-identity projection behind a new agent_identity helper, added provenance tracking, and implemented historical reindexing.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $6.14
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Indexed model identity is derived from record keys the audit renderer never writes (GitHub Issue #2201)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2201