### PR TITLE
Audit redaction removes numeric usage counts, so per-token cost cannot be derived from any record

### DIFF
--- a/src/theforge/coordinator/redact.py
+++ b/src/theforge/coordinator/redact.py
@@ -4,7 +4,8 @@ Applies three scrubbing passes before any audit record reaches disk:
 
 1. Key-pattern scrub: dict keys matching secret-shaped names (secret, token,
    password, api_key, authorization, …) have their values replaced with
-   "[REDACTED]".
+   "[REDACTED]".  Numeric values are exempt — see "Numeric values are telemetry"
+   below.
 2. Env-file value scrub: values loaded from a .env file are replaced wherever
    they appear as substrings inside string values.  Values shorter than 8
    characters are skipped to avoid replacing common innocuous strings like
@@ -14,6 +15,28 @@ Applies three scrubbing passes before any audit record reaches disk:
 
 Redaction is best-effort.  Arbitrary story or plan text can still embed secrets
 the scrubber cannot recognise.
+
+## Numeric values are telemetry, not credentials
+
+The key pattern classifies by *name*, but a credential is always a string: no
+API key, bearer token, or password is representable as a JSON number.  A field
+whose value is a bounded numeric measurement therefore carries no secret,
+whatever word was used to name it — and scrubbing it destroys evidence while
+protecting nothing.
+
+This matters because per-invocation usage counts are keyed with the word
+"token" (`input_tokens`, `output_tokens`, `cache_read_tokens`,
+`cache_creation_tokens`).  Redacting them left audit records holding what an
+invocation cost but not what it bought, so cost per unit of work was not
+derivable from the substrate (#2202).
+
+`_redact_obj` therefore retains numeric values on secret-shaped keys.  This is a
+narrowing of a trust boundary, so it is guarded mechanically rather than by
+comment alone: `TELEMETRY_NUMERIC_KEYS` catalogues the audit keys that depend on
+the carve-out and `tests/test_coord_redact.py` asserts every one of them
+survives redaction with a numeric value *and* is still scrubbed with a string
+value.  A later widening of `_SECRET_KEY_RE`, or a removal of the numeric
+carve-out, fails those tests instead of silently discarding telemetry again.
 """
 
 from __future__ import annotations
@@ -25,6 +48,21 @@ from typing import Any
 
 _SECRET_KEY_RE = re.compile(r"(?i)(secret|token|password|api[_-]?key|authorization)")
 _MIN_SECRET_LEN = 8
+
+#: Audit keys that match `_SECRET_KEY_RE` but hold numeric telemetry, not
+#: credentials.  These are the fields the numeric carve-out in `_redact_obj`
+#: exists to protect; `tests/test_coord_redact.py` pins each one so a future
+#: edit to the pattern or to the carve-out cannot silently start scrubbing them
+#: again.  Add an entry here (and its test coverage follows automatically) when
+#: a new numeric audit field lands under a secret-shaped name.
+TELEMETRY_NUMERIC_KEYS = frozenset(
+    {
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_creation_tokens",
+    }
+)
 
 
 def _load_env_secrets(env_file: Path) -> set[str]:
@@ -67,6 +105,19 @@ def _redact_value(val: str, secrets: set[str]) -> str:
     return val
 
 
+def _carries_no_credential(val: Any) -> bool:
+    """Return True when *val* cannot possibly hold a credential.
+
+    Credentials are strings.  A numeric value — a token count, a byte count, a
+    duration — is a measurement, so retaining it on a secret-shaped key leaks
+    nothing while preserving evidence.  `bool` is included (it subclasses `int`
+    and is equally incapable of carrying a secret); `None` is left to the normal
+    redaction path so an explicitly-null credential field still reads as
+    scrubbed rather than as "no credential was present".
+    """
+    return isinstance(val, (int, float))
+
+
 def _redact_obj(obj: Any, secrets: set[str]) -> Any:
     """Recursively walk and scrub a JSON-serialisable object."""
     if isinstance(obj, dict):
@@ -76,8 +127,9 @@ def _redact_obj(obj: Any, secrets: set[str]) -> Any:
             if k == "environment" and isinstance(v, dict):
                 result[k] = sorted(v.keys())
                 continue
-            # Pass 1: secret-shaped key → redact value
-            if _SECRET_KEY_RE.search(str(k)):
+            # Pass 1: secret-shaped key → redact value, unless the value is
+            # numeric and so cannot carry a credential (see module docstring).
+            if _SECRET_KEY_RE.search(str(k)) and not _carries_no_credential(v):
                 result[k] = "[REDACTED]"
                 continue
             result[k] = _redact_obj(v, secrets)

--- a/tests/test_coord_redact.py
+++ b/tests/test_coord_redact.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from theforge.coordinator.redact import redact
+import pytest
+
+from theforge.coordinator.redact import TELEMETRY_NUMERIC_KEYS, redact
 
 # ── redact() unit tests ─────────────────────────────────────────────────────
 
@@ -112,6 +114,129 @@ class TestRedactSecretKeys:
         result = redact({"status": "ok", "message": "all good"}, None)
         assert result["status"] == "ok"
         assert result["message"] == "all good"
+
+
+class TestRedactNumericTelemetry:
+    """Numeric values on secret-shaped keys are measurements, not credentials.
+
+    These tests are the mechanical guard on the carve-out in `_redact_obj`: a
+    widening of `_SECRET_KEY_RE`, or a removal of the numeric exemption, fails
+    here instead of silently discarding usage counts again (#2202).
+    """
+
+    @pytest.mark.parametrize("key", sorted(TELEMETRY_NUMERIC_KEYS))
+    def test_catalogued_telemetry_key_survives_with_numeric_value(self, key: str) -> None:
+        result = redact({key: 1234}, None)
+        assert result[key] == 1234
+
+    @pytest.mark.parametrize("key", sorted(TELEMETRY_NUMERIC_KEYS))
+    def test_catalogued_telemetry_key_still_scrubbed_with_string_value(self, key: str) -> None:
+        # The carve-out is value-shaped, not key-shaped: a string on the same
+        # key could carry a credential and must still be removed.
+        result = redact({key: "tok_abc123"}, None)
+        assert result[key] == "[REDACTED]"
+
+    def test_zero_count_survives(self) -> None:
+        result = redact({"cache_read_tokens": 0}, None)
+        assert result["cache_read_tokens"] == 0
+
+    def test_float_value_on_secret_key_survives(self) -> None:
+        result = redact({"token_ratio": 0.25}, None)
+        assert result["token_ratio"] == 0.25
+
+    def test_string_secret_keys_unaffected_by_carve_out(self) -> None:
+        result = redact(
+            {"api_key": "ak_12345", "authorization": "Bearer x", "password": "hunter2"},
+            None,
+        )
+        assert result == {
+            "api_key": "[REDACTED]",
+            "authorization": "[REDACTED]",
+            "password": "[REDACTED]",
+        }
+
+    def test_null_secret_value_still_scrubbed(self) -> None:
+        # None is not a measurement; leave it reading as scrubbed rather than
+        # as "no credential was present".
+        result = redact({"token": None}, None)
+        assert result["token"] == "[REDACTED]"
+
+    def test_container_on_secret_key_still_scrubbed(self) -> None:
+        result = redact({"tokens": {"raw": "tok_abc"}, "token_list": ["tok_a"]}, None)
+        assert result["tokens"] == "[REDACTED]"
+        assert result["token_list"] == "[REDACTED]"
+
+    def test_model_usage_entry_keeps_counts_and_cost(self) -> None:
+        entry = {
+            "model": "claude-opus-5",
+            "input_tokens": 1500,
+            "output_tokens": 320,
+            "cache_read_tokens": 90_000,
+            "cache_creation_tokens": 12,
+            "cost_usd": 0.42,
+        }
+        result = redact({"cost": {"agents": [{"model_usage": [entry]}]}}, None)
+        assert result["cost"]["agents"][0]["model_usage"][0] == entry
+
+
+class TestRedactAuditRenderSeam:
+    """Counts rendered by audit_render survive the scrubber applied to them.
+
+    Unit coverage above pins redact() in isolation; this exercises the actual
+    render → redact seam, so a change to either side that reintroduces the loss
+    is caught.
+    """
+
+    def test_rendered_model_usage_survives_redaction(self, tmp_path: Path) -> None:
+        from theforge.agent_types import AgentResult, ModelUsage
+        from theforge.coordinator.audit_render import _model_usage_entries
+
+        env = tmp_path / ".env"
+        env.write_text("ANTHROPIC_API_KEY=sk-ant-realsecretvalue\n")
+
+        result = AgentResult(
+            success=True,
+            output="done",
+            session_id="s1",
+            cost_usd=0.42,
+            exit_code=0,
+            raw={},
+            model_usage=(
+                ModelUsage(
+                    model="claude-opus-5",
+                    input_tokens=1500,
+                    output_tokens=320,
+                    cache_read_tokens=90_000,
+                    cache_creation_tokens=12,
+                    cost_usd=0.42,
+                ),
+            ),
+        )
+        rendered = _model_usage_entries(result)
+        scrubbed = redact({"cost": {"agents": [{"model_usage": rendered}]}}, env)
+
+        usage = scrubbed["cost"]["agents"][0]["model_usage"][0]
+        assert usage["input_tokens"] == 1500
+        assert usage["output_tokens"] == 320
+        assert usage["cache_read_tokens"] == 90_000
+        assert usage["cache_creation_tokens"] == 12
+        assert usage["cost_usd"] == 0.42
+        assert usage["model"] == "claude-opus-5"
+        # Cost per unit of work is derivable from the stored record.
+        assert usage["cost_usd"] / usage["output_tokens"] > 0
+
+    def test_credential_alongside_usage_still_scrubbed(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("ANTHROPIC_API_KEY=sk-ant-realsecretvalue\n")
+        record = {
+            "api_key": "sk-ant-realsecretvalue",
+            "command": "run --key sk-ant-realsecretvalue",
+            "model_usage": [{"input_tokens": 10, "output_tokens": 2}],
+        }
+        scrubbed = redact(record, env)
+        assert scrubbed["api_key"] == "[REDACTED]"
+        assert "sk-ant-realsecretvalue" not in scrubbed["command"]
+        assert scrubbed["model_usage"][0] == {"input_tokens": 10, "output_tokens": 2}
 
 
 class TestRedactEnvironmentDict:


### PR DESCRIPTION
## Summary

The patch preserves numeric model usage counts through the production redaction path while keeping string credentials scrubbed; focused redaction tests pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $2.44
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Audit redaction removes numeric usage counts, so per-token cost cannot be derived from any record (GitHub Issue #2202)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2202