### PR TITLE
Alias-backed price literals with no recorded provenance silently steer routing

### DIFF
--- a/docs/vision/self-adapting-router.md
+++ b/docs/vision/self-adapting-router.md
@@ -162,6 +162,16 @@ Attribution comes from pinning the entry to the version its figures describe,
 or from an operator declaring the price for that identity in `forge.yaml`.
 `forge check-config` lists any enabled model whose price is being ignored.
 
+The cost band (`cost_rank`, which decides the tier a role is filled from) is the
+other price-shaped routing input, so it is held to the same standard: every
+registry entry records what its band is derived from. A band that matches the
+entry's attributable price is attributed to that price; any other band has to
+name a non-price basis — the Claude shorthands' bands restate the vendor's own
+tier naming, which stays true when the shorthand resolves to a new version.
+Building an entry whose band can be traced to neither raises at import, so a
+band cannot quietly be a number copied off an untraceable literal.
+`forge check-config` prints each enabled model's band and its basis.
+
 ## What Stays in forge.yaml
 
 Only what forge cannot discover:

--- a/docs/vision/self-adapting-router.md
+++ b/docs/vision/self-adapting-router.md
@@ -152,6 +152,16 @@ starved by the accident of being listed second. That first dispatch is what
 lets a zero-history model accrue a profile entry, after which normal
 evidence-based ranking takes over (issue #1617).
 
+A price only participates in that tie-break — and in cost banding — when the
+registry records what identity it was true of. An entry named by a vendor
+shorthand (the Claude CLI's `opus`/`sonnet`) resolves to whichever concrete
+version the vendor currently ships, so its stored figure can describe a model
+that has since moved; those entries carry no pricing attribution and the router
+treats their price as unknown rather than authoritative (issue #2203).
+Attribution comes from pinning the entry to the version its figures describe,
+or from an operator declaring the price for that identity in `forge.yaml`.
+`forge check-config` lists any enabled model whose price is being ignored.
+
 ## What Stays in forge.yaml
 
 Only what forge cannot discover:

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -26,7 +26,7 @@ from .config import (
     ReasoningEffortConfig,
 )
 from .config.auth import check_agent_auth
-from .config.models import price_tiebreak_signal
+from .config.pricing import price_tiebreak_signal_for
 from .routing import (
     KNOB_EFFORT,
     KNOB_NONE,
@@ -516,7 +516,7 @@ def _agents_by_tier(agents: list[AgentDef], tier: str) -> list[AgentDef]:
         matches,
         key=lambda a: (
             a.budget_usd,
-            price_tiebreak_signal(a.input_cost_per_mtok, a.output_cost_per_mtok),
+            price_tiebreak_signal_for(a),
         ),
     )
 
@@ -538,7 +538,7 @@ def _rerank_by_profiles(
     Only role="dev" is profile-aware today; other roles pass through unchanged.
     Candidates without ``min_runs`` observations are ordered behind every
     observed model but among themselves fall back to the real per-MTok price
-    (via :func:`price_tiebreak_signal`), so the cheapest unobserved model is the
+    (via :func:`price_tiebreak_signal_for`), so the cheapest unobserved model is the
     first explored rather than whichever the pool happened to list first (#1617).
 
     Domain match (issue #155) is the *horizontal* preference axis. When
@@ -591,7 +591,7 @@ def _rerank_by_profiles(
         rows.append((agent, signal, dsignal))
 
     def _price(agent: AgentDef) -> float:
-        return price_tiebreak_signal(agent.input_cost_per_mtok, agent.output_cost_per_mtok)
+        return price_tiebreak_signal_for(agent)
 
     def _complexity_key(row: tuple[AgentDef, dict, dict | None]) -> tuple:
         agent, signal, _ = row

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -271,6 +271,27 @@ def _unattributed_pricing_models(
     return flagged
 
 
+def _cost_band_bases(
+    model_keys: list[str],
+    registry: dict | None = None,
+) -> list[tuple[str, int, str]]:
+    """Return ``(model_key, cost_rank, basis)`` for each resolvable enabled model.
+
+    ``cost_rank`` selects which tier a role is filled from, so it steers routing
+    the same way the price tie-break does. Reporting the basis alongside it makes
+    a band that came from a price distinguishable from one declared on non-price
+    grounds, without the operator having to read the registry (#2203).
+    """
+    rows: list[tuple[str, int, str]] = []
+    for model_key in model_keys:
+        try:
+            spec = resolve_agent_spec(model_key, registry=registry)
+        except ValueError:
+            continue  # unresolvable keys are already reported elsewhere
+        rows.append((model_key, spec.cost_rank, spec.routing.cost_rank_basis or "unrecorded"))
+    return rows
+
+
 def _ref_transport_label(
     provider: str | None,
     model: str,
@@ -463,6 +484,14 @@ def _format_config(
                     "    (recorded price is not attributable to the resolved model — "
                     "ignored for cost banding and price tie-breaks)"
                 )
+            # The cost band is the other price-shaped routing input, so show what
+            # each enabled model's band is derived from — an operator diagnosing a
+            # selection can otherwise only see the number, not its source (#2203).
+            bands = _cost_band_bases(config.models, registry=config.model_registry)
+            if bands:
+                lines.append("  cost band basis:")
+                for model_key, rank, basis in bands:
+                    lines.append(f"    {model_key:<32}rank {rank}  from {basis}")
         if config.custom_models:
             custom_details = []
             for model_id in config.custom_models:

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -249,6 +249,28 @@ def _provider_label(
     return f"{provider_label} {transport_label}"
 
 
+def _unattributed_pricing_models(
+    model_keys: list[str],
+    registry: dict | None = None,
+) -> list[str]:
+    """Return enabled models that record a price routing is not allowed to use.
+
+    These entries carry per-MTok figures whose attribution is unknown (typically
+    a vendor-shorthand identity that resolves elsewhere at invocation time), so
+    the cost band and price tie-break ignore them — see config/pricing.py.
+    """
+    flagged: list[str] = []
+    for model_key in model_keys:
+        try:
+            spec = resolve_agent_spec(model_key, registry=registry)
+        except ValueError:
+            continue  # unresolvable keys are already reported elsewhere
+        has_price = spec.input_cost_per_mtok is not None or spec.output_cost_per_mtok is not None
+        if has_price and not spec.pricing_attributable:
+            flagged.append(model_key)
+    return flagged
+
+
 def _ref_transport_label(
     provider: str | None,
     model: str,
@@ -429,6 +451,18 @@ def _format_config(
                 lines.append(f"  {'selected builtin:':<18}{', '.join(builtin_models)}")
             if forge_yaml_models:
                 lines.append(f"  {'selected forge.yaml:':<18}{', '.join(forge_yaml_models)}")
+            # Prices that cannot be attributed to the identity they describe do
+            # not band or break ties (#2203). Say so, or the operator reads the
+            # registry literal as the figure routing used.
+            unattributed = _unattributed_pricing_models(
+                config.models, registry=config.model_registry
+            )
+            if unattributed:
+                lines.append(f"  {'unattributed price:':<18}{', '.join(unattributed)}")
+                lines.append(
+                    "    (recorded price is not attributable to the resolved model — "
+                    "ignored for cost banding and price tie-breaks)"
+                )
         if config.custom_models:
             custom_details = []
             for model_id in config.custom_models:

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -44,9 +44,12 @@ from .models import (
     transport_for,
 )
 from .pricing import (
+    COST_BAND_BASIS_OPERATOR_DECLARED,
+    COST_BAND_BASIS_UNPRICED_DEFAULT,
     PRICING_PROVENANCE_OPERATOR_DECLARED,
     UNPRICED_COST_RANK,
     custom_model_cost_rank,
+    price_cost_band_basis,
 )
 from .profiles import (
     CLI_PROVIDER_MAP,
@@ -293,14 +296,23 @@ def _parse_enabled_mapping_entry(
         if input_cost is not None or output_cost is not None
         else None
     )
+    # The band travels with the reason it holds, in the same order of precedence:
+    # the operator's own declaration, then this entry's attributable price, then
+    # whatever the built-in entry already justified, then the unpriced default.
+    # Nothing here can reach the band of an unattributed literal — the middle
+    # branch is gated on `banded_cost_rank`, which is None in that case.
     if routing_raw.get("cost_rank") is not None:
         cost_rank = int(routing_raw["cost_rank"])
+        cost_rank_basis = COST_BAND_BASIS_OPERATOR_DECLARED
     elif banded_cost_rank is not None:
         cost_rank = banded_cost_rank
+        cost_rank_basis = price_cost_band_basis(str(pricing_provenance))
     elif builtin is not None:
         cost_rank = builtin.cost_rank
+        cost_rank_basis = builtin.routing.cost_rank_basis
     else:
         cost_rank = UNPRICED_COST_RANK
+        cost_rank_basis = COST_BAND_BASIS_UNPRICED_DEFAULT
     capability = routing_raw.get("capability")
     dev_capable = routing_raw.get("dev_capable")
     phases = routing_raw.get("phase_eligibility")
@@ -334,6 +346,7 @@ def _parse_enabled_mapping_entry(
                     else RoutingPolicy(tier=tier, capability=1, cost_rank=1).phase_eligibility
                 )
             ),
+            cost_rank_basis=cost_rank_basis,
         ),
         base_url=base_url if base_url is not None else (builtin.base_url if builtin else None),
         registry_source="forge.yaml",
@@ -479,6 +492,11 @@ def _parse_custom_model_registry(
                     overlay_cost_rank if overlay_cost_rank is not None else UNPRICED_COST_RANK
                 ),
                 dev_capable=custom_model_dev_capable(transport),
+                cost_rank_basis=(
+                    price_cost_band_basis(PRICING_PROVENANCE_OPERATOR_DECLARED)
+                    if overlay_cost_rank is not None
+                    else COST_BAND_BASIS_UNPRICED_DEFAULT
+                ),
             ),
             base_url=base_url,
             registry_source="forge.yaml",

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -36,13 +36,17 @@ from .models import (
     canonical_id_for_spec,
     canonical_model_id,
     custom_model_capability,
-    custom_model_cost_rank,
     custom_model_dev_capable,
     known_model_overlay_providers,
     normalize_model_key,
     overlay_transport,
     resolve_agent_spec,
     transport_for,
+)
+from .pricing import (
+    PRICING_PROVENANCE_OPERATOR_DECLARED,
+    UNPRICED_COST_RANK,
+    custom_model_cost_rank,
 )
 from .profiles import (
     CLI_PROVIDER_MAP,
@@ -271,14 +275,32 @@ def _parse_enabled_mapping_entry(
     output_cost = cost_raw.get(
         "output_per_mtok", builtin.output_cost_per_mtok if builtin is not None else None
     )
+    # Declaring any `cost:` figure here attributes the pair to this identity —
+    # the operator asserted it for this entry. Figures merely *inherited* from a
+    # built-in entry keep that entry's attribution, which for a vendor-shorthand
+    # identity is None: the literal is carried for reference but must not band.
+    pricing_provenance = (
+        PRICING_PROVENANCE_OPERATOR_DECLARED
+        if cost_raw
+        else (builtin.pricing_provenance if builtin is not None else None)
+    )
+    banded_cost_rank = (
+        custom_model_cost_rank(
+            float(input_cost or 0.0),
+            float(output_cost or 0.0),
+            pricing_provenance=pricing_provenance,
+        )
+        if input_cost is not None or output_cost is not None
+        else None
+    )
     if routing_raw.get("cost_rank") is not None:
         cost_rank = int(routing_raw["cost_rank"])
-    elif input_cost is not None or output_cost is not None:
-        cost_rank = custom_model_cost_rank(float(input_cost or 0.0), float(output_cost or 0.0))
+    elif banded_cost_rank is not None:
+        cost_rank = banded_cost_rank
     elif builtin is not None:
         cost_rank = builtin.cost_rank
     else:
-        cost_rank = custom_model_cost_rank(0.0, 0.0)
+        cost_rank = UNPRICED_COST_RANK
     capability = routing_raw.get("capability")
     dev_capable = routing_raw.get("dev_capable")
     phases = routing_raw.get("phase_eligibility")
@@ -317,6 +339,7 @@ def _parse_enabled_mapping_entry(
         registry_source="forge.yaml",
         input_cost_per_mtok=float(input_cost) if input_cost is not None else None,
         output_cost_per_mtok=float(output_cost) if output_cost is not None else None,
+        pricing_provenance=pricing_provenance,
     )
     return canonical_id, spec
 
@@ -438,6 +461,13 @@ def _parse_custom_model_registry(
             raise ValueError(
                 f"forge.yaml 'models.custom.{canonical_id}.base_url' must be a non-empty string"
             )
+        # A models.custom declaration states its own prices for its own identity,
+        # so the pair is attributed to the operator's declaration and bands.
+        overlay_cost_rank = custom_model_cost_rank(
+            float(input_cost),
+            float(output_cost),
+            pricing_provenance=PRICING_PROVENANCE_OPERATOR_DECLARED,
+        )
         spec = AgentSpec(
             provider=normalized_provider,
             model=model,
@@ -445,13 +475,16 @@ def _parse_custom_model_registry(
             routing=RoutingPolicy(
                 tier=tier,
                 capability=custom_model_capability(tier),
-                cost_rank=custom_model_cost_rank(float(input_cost), float(output_cost)),
+                cost_rank=(
+                    overlay_cost_rank if overlay_cost_rank is not None else UNPRICED_COST_RANK
+                ),
                 dev_capable=custom_model_dev_capable(transport),
             ),
             base_url=base_url,
             registry_source="forge.yaml",
             input_cost_per_mtok=float(input_cost),
             output_cost_per_mtok=float(output_cost),
+            pricing_provenance=PRICING_PROVENANCE_OPERATOR_DECLARED,
         )
         # The declaration key is operator-chosen; the identity is not. Register
         # the spec under its canonical id so nothing downstream can select the

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -29,9 +29,12 @@ from dataclasses import dataclass, fields, replace
 from typing import Any, TypeVar, overload
 
 from .pricing import (
+    COST_BAND_BASIS_DECLARED_POLICY,
+    COST_BAND_BASIS_VENDOR_TIER,
     PRICING_PROVENANCE_LOCAL_ENDPOINT,
     AttributablePricing,
     price_tiebreak_signal_for,
+    resolve_cost_band_basis,
 )
 
 # Re-exported: these moved to config/pricing.py, but callers (and the #1617
@@ -102,6 +105,12 @@ class RoutingPolicy:
     cost_rank: int  # 1=cheap, 2=moderate, 3=expensive
     dev_capable: bool = True  # whether this agent is allowed to own the dev role
     phase_eligibility: frozenset[str] = _DEFAULT_PHASE_ELIGIBILITY
+    # What ``cost_rank`` is derived from: ``price:<provenance>`` when the band is
+    # the entry's own attributable price band, otherwise a COST_BAND_BASIS_*
+    # marker naming a non-price basis. The band is a routing input in its own
+    # right, so it may not be a bare number copied off an untraceable literal —
+    # see config/pricing.resolve_cost_band_basis.
+    cost_rank_basis: str | None = None
 
 
 # ── Runner derivation from (provider, transport.kind) ────────────────────
@@ -486,6 +495,7 @@ def _entry(
     input_cost_per_mtok: float | None = None,
     output_cost_per_mtok: float | None = None,
     pricing_provenance: str | None = None,
+    cost_rank_basis: str | None = None,
 ) -> tuple[str, AgentSpec]:
     """Build a ``(canonical_id, AgentSpec)`` registry pair.
 
@@ -494,8 +504,21 @@ def _entry(
     entries identified by a vendor shorthand must do: the shorthand resolves to
     some other concrete version at invocation time, so nothing ties the stored
     literal to what is actually billed.
+
+    ``cost_rank`` is a routing input too, so it is held to the same standard:
+    omit ``cost_rank_basis`` only when the band *is* this entry's attributable
+    price band (it is then attributed to that price automatically). Every other
+    band — including every band on an entry whose price is unattributed — must
+    name its non-price basis, or construction raises.
     """
     transport = transport_for(provider, kind, runner=runner)
+    basis = resolve_cost_band_basis(
+        cost_rank,
+        input_cost_per_mtok=input_cost_per_mtok,
+        output_cost_per_mtok=output_cost_per_mtok,
+        pricing_provenance=pricing_provenance,
+        declared_basis=cost_rank_basis,
+    )
     spec = AgentSpec(
         provider=provider,
         model=model,
@@ -506,6 +529,7 @@ def _entry(
             cost_rank=cost_rank,
             dev_capable=dev_capable,
             phase_eligibility=phases,
+            cost_rank_basis=basis,
         ),
         base_url=base_url,
         input_cost_per_mtok=input_cost_per_mtok,
@@ -527,6 +551,15 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
         # no pricing_provenance: they are indicative only and routing ignores
         # them. Re-attributing them requires pinning the entry to the concrete
         # version the price is true of.
+        #
+        # Their cost bands are not derived from those literals either — they
+        # restate the vendor's own tier naming, which is what the shorthand
+        # *means* and stays true when it resolves to a new version: ``opus`` is
+        # whatever Anthropic currently sells as its flagship (strong band),
+        # ``sonnet`` whatever it sells as the mid-priced workhorse (cheap band,
+        # as the fleet's baseline). Note the bands already disagree with the
+        # literals — 3.00/15.00 would band sonnet at 2 — so the figures could
+        # move to any value without moving either band.
         _entry(
             "anthropic",
             "sonnet",
@@ -536,6 +569,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=1,
             input_cost_per_mtok=3.00,
             output_cost_per_mtok=15.00,
+            cost_rank_basis=COST_BAND_BASIS_VENDOR_TIER,
         ),
         _entry(
             "anthropic",
@@ -546,6 +580,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=3,
             input_cost_per_mtok=15.00,
             output_cost_per_mtok=75.00,
+            cost_rank_basis=COST_BAND_BASIS_VENDOR_TIER,
         ),
         # ── OpenAI (Codex CLI) ───────────────────────────────────────
         #
@@ -633,6 +668,10 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             input_cost_per_mtok=0.55,
             output_cost_per_mtok=2.19,
             pricing_provenance="deepseek-reasoner",
+            # Banded a step above its per-MTok rate on purpose: a reasoning model
+            # spends far more output tokens per task, so the rate alone (band 1)
+            # understates what filling a role with it costs.
+            cost_rank_basis=COST_BAND_BASIS_DECLARED_POLICY,
         ),
         _entry(
             "deepseek",

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -13,6 +13,14 @@ prefix (``openai-api/``, ``gemini-cli/``). Those spellings survive only as raw
 input aliases (see :data:`_LEGACY_MODEL_KEY_ALIASES` and
 :func:`normalize_model_key`) and are normalized to canonical identities the
 moment they are read.
+
+Per-MTok pricing on a registry entry is a *routing input*: it sets the cost band
+and breaks equal-band ties. A price may only act as one when it can be attributed
+to the identity it describes — see :attr:`AgentSpec.pricing_provenance` and
+:func:`price_tiebreak_signal_for`. An entry whose identity is a vendor shorthand
+that the vendor's own tooling resolves to some other concrete version at
+invocation time carries no attribution, and its literal price is treated as
+unknown rather than trusted.
 """
 
 from __future__ import annotations
@@ -20,6 +28,16 @@ from __future__ import annotations
 from dataclasses import dataclass, fields, replace
 from typing import Any, TypeVar, overload
 
+from .pricing import (
+    PRICING_PROVENANCE_LOCAL_ENDPOINT,
+    AttributablePricing,
+    price_tiebreak_signal_for,
+)
+
+# Re-exported: these moved to config/pricing.py, but callers (and the #1617
+# regression suite) import them from the registry module.
+from .pricing import custom_model_cost_rank as custom_model_cost_rank
+from .pricing import price_tiebreak_signal as price_tiebreak_signal
 from .types import (
     AssignmentConfig,
     ExplorationConfig,
@@ -163,7 +181,7 @@ _TRANSPORT_DEEPSEEK_API = transport_for("deepseek", "api")
 
 
 @dataclass(frozen=True)
-class AgentSpec:
+class AgentSpec(AttributablePricing):
     """First-class description of an agent: canonical identity + routing policy.
 
     Identity is exactly ``(provider, model, transport.kind)`` — see
@@ -184,6 +202,10 @@ class AgentSpec:
     registry_source: str = "builtin"  # "builtin" | "forge.yaml"
     input_cost_per_mtok: float | None = None
     output_cost_per_mtok: float | None = None
+    # What the prices above are attributed to (concrete billed identity or a
+    # PRICING_PROVENANCE_* marker). None = unattributed: routing treats the
+    # figures as unknown. See _AttributablePricing.
+    pricing_provenance: str | None = None
 
     @property
     def tier(self) -> str:
@@ -310,7 +332,7 @@ def transport_from_raw_fields(
 
 
 @dataclass(frozen=True)
-class ModelInfo:
+class ModelInfo(AttributablePricing):
     """Legacy flat view derived from an AgentSpec.
 
     Retained for backward compatibility: existing callers read `.cli`, `.provider`,
@@ -334,6 +356,7 @@ class ModelInfo:
     registry_source: str = "builtin"  # "builtin" | "forge.yaml"
     input_cost_per_mtok: float | None = None
     output_cost_per_mtok: float | None = None
+    pricing_provenance: str | None = None  # carried from the spec; None = unattributed
     transport: TransportSpec | None = None  # the canonical TransportSpec this view was built from
     # Provider family for *both* transports — unlike ``provider`` (which stays
     # None for CLI entries so legacy consumers keep their meaning), this is the
@@ -346,7 +369,7 @@ _CLI_TO_PROVIDER: dict[str, str] = dict(_LEGACY_CLI_TO_PROVIDER)
 
 
 @dataclass(frozen=True)
-class AgentDef:
+class AgentDef(AttributablePricing):
     """An agent available in the pool for adaptive model assignment."""
 
     name: str
@@ -366,9 +389,12 @@ class AgentDef:
     registry_source: str = "builtin"
     # Per-MTok pricing carried through from the registry so ranking helpers can
     # break equal-tier ties by real cost rather than pool list order. See
-    # price_tiebreak_signal and issue #1617.
+    # price_tiebreak_signal_for and issue #1617. ``pricing_provenance`` travels
+    # with the figures so the tie-break can tell a traceable price from a
+    # literal nothing can vouch for.
     input_cost_per_mtok: float | None = None
     output_cost_per_mtok: float | None = None
+    pricing_provenance: str | None = None
 
     @property
     def effective_provider(self) -> str | None:
@@ -459,8 +485,16 @@ def _entry(
     base_url: str | None = None,
     input_cost_per_mtok: float | None = None,
     output_cost_per_mtok: float | None = None,
+    pricing_provenance: str | None = None,
 ) -> tuple[str, AgentSpec]:
-    """Build a ``(canonical_id, AgentSpec)`` registry pair."""
+    """Build a ``(canonical_id, AgentSpec)`` registry pair.
+
+    ``pricing_provenance`` names the concrete billed identity the price figures
+    were recorded for. Omitting it marks the figures unattributed, which is what
+    entries identified by a vendor shorthand must do: the shorthand resolves to
+    some other concrete version at invocation time, so nothing ties the stored
+    literal to what is actually billed.
+    """
     transport = transport_for(provider, kind, runner=runner)
     spec = AgentSpec(
         provider=provider,
@@ -476,6 +510,7 @@ def _entry(
         base_url=base_url,
         input_cost_per_mtok=input_cost_per_mtok,
         output_cost_per_mtok=output_cost_per_mtok,
+        pricing_provenance=pricing_provenance,
     )
     return canonical_id_for_spec(spec), spec
 
@@ -483,6 +518,15 @@ def _entry(
 AGENT_REGISTRY: dict[str, AgentSpec] = dict(
     [
         # ── Anthropic ────────────────────────────────────────────────
+        #
+        # ``sonnet``/``opus`` are Claude-CLI shorthands, not billed identities:
+        # the CLI resolves each to whichever concrete version it currently ships
+        # (the vendor bills ``claude-sonnet-4-6`` / ``claude-opus-4-6``-style
+        # names — see runners/schema_utils.PRICING_TABLE). The entry identity can
+        # therefore move while the literal below does not, so these figures carry
+        # no pricing_provenance: they are indicative only and routing ignores
+        # them. Re-attributing them requires pinning the entry to the concrete
+        # version the price is true of.
         _entry(
             "anthropic",
             "sonnet",
@@ -504,6 +548,11 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             output_cost_per_mtok=75.00,
         ),
         # ── OpenAI (Codex CLI) ───────────────────────────────────────
+        #
+        # Unlike the Claude-CLI shorthands above, these model strings are the
+        # identity the vendor bills under — they are passed through verbatim and
+        # priced under the same name (runners/schema_utils.PRICING_TABLE keys
+        # them identically), so the figures are attributable to the entry.
         _entry(
             "openai",
             "gpt-5.4",
@@ -513,6 +562,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=2,
             input_cost_per_mtok=1.25,
             output_cost_per_mtok=10.00,
+            pricing_provenance="gpt-5.4",
         ),
         _entry(
             "openai",
@@ -523,6 +573,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=1,
             input_cost_per_mtok=0.25,
             output_cost_per_mtok=2.00,
+            pricing_provenance="gpt-5.4-mini",
         ),
         _entry(
             "openai",
@@ -533,6 +584,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=3,
             input_cost_per_mtok=15.00,
             output_cost_per_mtok=120.00,
+            pricing_provenance="gpt-5.4-pro",
         ),
         # ── OpenAI (API) ─────────────────────────────────────────────
         _entry(
@@ -544,6 +596,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=2,
             input_cost_per_mtok=1.25,
             output_cost_per_mtok=10.00,
+            pricing_provenance="gpt-5.4",
         ),
         _entry(
             "openai",
@@ -554,6 +607,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=1,
             input_cost_per_mtok=0.25,
             output_cost_per_mtok=2.00,
+            pricing_provenance="gpt-5.4-mini",
         ),
         _entry(
             "openai",
@@ -564,6 +618,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=3,
             input_cost_per_mtok=15.00,
             output_cost_per_mtok=120.00,
+            pricing_provenance="gpt-5.4-pro",
             # Reasoning-heavy — intentionally excluded from the preflight role.
             phases=frozenset({"dev", "plan", "review"}),
         ),
@@ -577,6 +632,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=2,
             input_cost_per_mtok=0.55,
             output_cost_per_mtok=2.19,
+            pricing_provenance="deepseek-reasoner",
         ),
         _entry(
             "deepseek",
@@ -587,6 +643,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=1,
             input_cost_per_mtok=0.27,
             output_cost_per_mtok=1.10,
+            pricing_provenance="deepseek-chat",
         ),
         # ── Google (API) ─────────────────────────────────────────────
         _entry(
@@ -606,6 +663,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=2,
             input_cost_per_mtok=2.00,
             output_cost_per_mtok=12.00,
+            pricing_provenance="gemini-3.1-pro-preview",
         ),
         _entry(
             "google",
@@ -616,6 +674,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             cost_rank=2,
             input_cost_per_mtok=1.25,
             output_cost_per_mtok=10.00,
+            pricing_provenance="gemini-2.5-pro",
         ),
         # ── Google (Gemini CLI — explicit opt-in) ────────────────────
         _entry(
@@ -628,6 +687,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             dev_capable=False,
             input_cost_per_mtok=1.25,
             output_cost_per_mtok=10.00,
+            pricing_provenance="gemini-2.5-pro",
         ),
         _entry(
             "google",
@@ -648,6 +708,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             dev_capable=False,
             input_cost_per_mtok=2.00,
             output_cost_per_mtok=12.00,
+            pricing_provenance="gemini-3.1-pro-preview",
         ),
         # ── Local OpenAI-compatible models ───────────────────────────
         # API transport + a localhost base_url. Not a provider prefix, not a
@@ -662,6 +723,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             base_url=LOCAL_OPENAI_COMPATIBLE_BASE_URL,
             input_cost_per_mtok=0.0,
             output_cost_per_mtok=0.0,
+            pricing_provenance=PRICING_PROVENANCE_LOCAL_ENDPOINT,
         ),
         _entry(
             "openai",
@@ -673,6 +735,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             base_url=LOCAL_OPENAI_COMPATIBLE_BASE_URL,
             input_cost_per_mtok=0.0,
             output_cost_per_mtok=0.0,
+            pricing_provenance=PRICING_PROVENANCE_LOCAL_ENDPOINT,
         ),
         _entry(
             "openai",
@@ -684,6 +747,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             base_url=LOCAL_OPENAI_COMPATIBLE_BASE_URL,
             input_cost_per_mtok=0.0,
             output_cost_per_mtok=0.0,
+            pricing_provenance=PRICING_PROVENANCE_LOCAL_ENDPOINT,
         ),
         _entry(
             "openai",
@@ -695,6 +759,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = dict(
             base_url=LOCAL_OPENAI_COMPATIBLE_BASE_URL,
             input_cost_per_mtok=0.0,
             output_cost_per_mtok=0.0,
+            pricing_provenance=PRICING_PROVENANCE_LOCAL_ENDPOINT,
         ),
     ]
 )
@@ -787,48 +852,6 @@ def custom_model_capability(tier: str) -> int:
     return by_tier[tier]
 
 
-def custom_model_cost_rank(input_cost_per_mtok: float, output_cost_per_mtok: float) -> int:
-    """Map per-MTok pricing to the routing cost bands used by the registry."""
-    price_signal = max(float(input_cost_per_mtok), float(output_cost_per_mtok))
-    if price_signal <= 5.0:
-        return 1
-    if price_signal <= 25.0:
-        return 2
-    return 3
-
-
-# Sentinel returned by ``price_tiebreak_signal`` when a candidate carries no
-# pricing data. It sorts *after* every priced candidate so unpriced models keep
-# their original relative order (list-order fallback) among themselves rather
-# than jumping ahead of a model whose real cost is known.
-_UNPRICED_SIGNAL: float = float("inf")
-
-
-def price_tiebreak_signal(
-    input_cost_per_mtok: float | None,
-    output_cost_per_mtok: float | None,
-) -> float:
-    """Return a per-MTok price signal for breaking equal-``cost_rank`` ties.
-
-    Two models can share a ``cost_rank`` band (and even a ``capability`` score) yet
-    differ substantially in real price — e.g. the cheap-tier bucket holds both
-    ``claude/sonnet`` and ``openai/gpt-5.4-mini``. Ranking helpers previously broke
-    that tie by ``models.enabled`` list order, permanently starving whichever model
-    was listed second. This collapses the two per-MTok costs into one comparable
-    number (``max`` of input/output, mirroring :func:`custom_model_cost_rank`'s
-    price banding) so the cheaper candidate wins the tie deterministically.
-
-    Candidates with no pricing data return :data:`_UNPRICED_SIGNAL` so they rank
-    behind any priced peer while preserving list order among unpriced models.
-    """
-    if input_cost_per_mtok is None and output_cost_per_mtok is None:
-        return _UNPRICED_SIGNAL
-    return max(
-        float(input_cost_per_mtok) if input_cost_per_mtok is not None else 0.0,
-        float(output_cost_per_mtok) if output_cost_per_mtok is not None else 0.0,
-    )
-
-
 def custom_model_dev_capable(transport: TransportSpec) -> bool:
     """Return whether a custom model transport can own the dev role."""
     return not (transport.kind == "cli" and transport.runner == "gemini")
@@ -866,6 +889,7 @@ def _spec_to_model_info(
         registry_source=spec.registry_source,
         input_cost_per_mtok=spec.input_cost_per_mtok,
         output_cost_per_mtok=spec.output_cost_per_mtok,
+        pricing_provenance=spec.pricing_provenance,
         transport=spec.transport,
     )
 
@@ -1008,7 +1032,7 @@ def _planner_candidate_models(agents: list[AgentDef]) -> set[str]:
             [a for a in agents if a.tier == tier],
             key=lambda a: (
                 a.budget_usd,
-                price_tiebreak_signal(a.input_cost_per_mtok, a.output_cost_per_mtok),
+                price_tiebreak_signal_for(a),
             ),
         )
         if tier_agents:

--- a/src/theforge/config/pricing.py
+++ b/src/theforge/config/pricing.py
@@ -32,6 +32,78 @@ PRICING_PROVENANCE_LOCAL_ENDPOINT = "local-endpoint"
 # derived from an untraceable price.
 UNPRICED_COST_RANK = 1
 
+# ── Cost-band attribution ────────────────────────────────────────────────
+#
+# ``RoutingPolicy.cost_rank`` is the *other* price-shaped routing input: it
+# selects the tier a role is filled from (1=cheap, 2=mid, 3=strong), so a band
+# copied off an untraceable literal steers selection just as the tie-break does.
+# Every band therefore records what it is derived from. A band that matches the
+# entry's *attributable* price is attributed to that price automatically; any
+# other band has to name a non-price basis, which is what stops an entry from
+# silently inheriting a band from figures it is not allowed to trust.
+
+# The band restates the vendor's own tier naming (Claude's ``opus`` is the
+# flagship tier, ``sonnet`` the mid tier). That claim is true of the shorthand
+# identity itself and survives the shorthand resolving to a new version, which
+# is exactly what the literal price does not do.
+COST_BAND_BASIS_VENDOR_TIER = "vendor-tier"
+# A deliberate routing decision that is not the entry's price band — e.g. a
+# reasoning model whose token *volume* puts it a band above its per-MTok rate.
+COST_BAND_BASIS_DECLARED_POLICY = "declared-policy"
+# The operator set ``routing.cost_rank`` for this entry in forge.yaml.
+COST_BAND_BASIS_OPERATOR_DECLARED = "forge.yaml"
+# No usable price and no band to inherit: :data:`UNPRICED_COST_RANK` applies.
+COST_BAND_BASIS_UNPRICED_DEFAULT = "default-unpriced"
+
+
+def price_cost_band_basis(pricing_provenance: str) -> str:
+    """Name the basis of a band that was derived from an attributed price."""
+    return f"price:{pricing_provenance}"
+
+
+def resolve_cost_band_basis(
+    cost_rank: int,
+    *,
+    input_cost_per_mtok: float | None,
+    output_cost_per_mtok: float | None,
+    pricing_provenance: str | None,
+    declared_basis: str | None,
+) -> str:
+    """Return the basis to record for ``cost_rank``, or raise if there is none.
+
+    An explicit ``declared_basis`` always wins — the author stated why the band
+    is what it is. Otherwise the band may only be attributed to the entry's own
+    price, and only when that price is attributable *and* actually produces this
+    band. Anything else (an unattributed literal, no price at all, or a band that
+    disagrees with the price it would sit next to) raises: the band has no
+    traceable source, and inventing one is the defect this module exists to stop.
+    """
+    if declared_basis is not None:
+        return declared_basis
+    derived = (
+        custom_model_cost_rank(
+            float(input_cost_per_mtok or 0.0),
+            float(output_cost_per_mtok or 0.0),
+            pricing_provenance=pricing_provenance,
+        )
+        if input_cost_per_mtok is not None or output_cost_per_mtok is not None
+        else None
+    )
+    if derived is None and cost_rank == UNPRICED_COST_RANK:
+        # No price recorded at all and the band is the unpriced default — that
+        # default *is* the basis, and it cannot have come from a literal because
+        # there is none.
+        return COST_BAND_BASIS_UNPRICED_DEFAULT
+    if derived is None or derived != cost_rank or pricing_provenance is None:
+        raise ValueError(
+            f"cost_rank={cost_rank} cannot be attributed to this entry's pricing "
+            f"(provenance={pricing_provenance!r}, derived band={derived!r}). "
+            "State a non-price basis explicitly — see COST_BAND_BASIS_* in "
+            "config/pricing.py."
+        )
+    return price_cost_band_basis(pricing_provenance)
+
+
 # Sentinel returned by ``price_tiebreak_signal`` when a candidate carries no
 # usable pricing. It sorts *after* every priced candidate so unpriced models keep
 # their original relative order (list-order fallback) among themselves rather

--- a/src/theforge/config/pricing.py
+++ b/src/theforge/config/pricing.py
@@ -1,0 +1,138 @@
+"""Pricing attribution and the routing signals derived from price.
+
+A stored per-MTok price is a *routing input*: it sets a model's cost band and
+breaks ties between equal-band candidates. It may only act as one when the
+record says what identity the figures were true of — an entry identified by a
+vendor shorthand (the Claude CLI's ``opus``/``sonnet``) resolves to whichever
+concrete version the vendor currently ships, so its literal can describe an
+identity that has since moved (issue #2203).
+
+``pricing_provenance`` carries that attribution: the concrete billed identity
+the figures were recorded for, or one of the ``PRICING_PROVENANCE_*`` markers
+below. ``None`` means *unattributed* — the figures may be present, but nothing
+ties them to what is actually billed, so every routing path here treats them as
+unknown rather than authoritative.
+
+Stdlib-only and dependency-free by design: this is consumed by the registry
+types (:mod:`theforge.config.models`) and by every selection path that ranks
+them.
+"""
+
+from __future__ import annotations
+
+# The operator declared these figures for this identity in forge.yaml.
+PRICING_PROVENANCE_OPERATOR_DECLARED = "forge.yaml"
+# A locally served endpoint: there is no vendor bill, so 0.0 is true by
+# construction rather than by observation.
+PRICING_PROVENANCE_LOCAL_ENDPOINT = "local-endpoint"
+
+# Cost band used when an entry has no usable price at all (none declared, none
+# attributable, no built-in band to inherit). Unchanged from the previous
+# ``custom_model_cost_rank(0.0, 0.0)`` spelling — it is a default, not a figure
+# derived from an untraceable price.
+UNPRICED_COST_RANK = 1
+
+# Sentinel returned by ``price_tiebreak_signal`` when a candidate carries no
+# usable pricing. It sorts *after* every priced candidate so unpriced models keep
+# their original relative order (list-order fallback) among themselves rather
+# than jumping ahead of a model whose real cost is known.
+_UNPRICED_SIGNAL: float = float("inf")
+
+
+class AttributablePricing:
+    """Attribution gate shared by every view that carries registry pricing.
+
+    ``AgentSpec``, ``ModelInfo`` and ``AgentDef`` all carry the same
+    ``input_cost_per_mtok`` / ``output_cost_per_mtok`` / ``pricing_provenance``
+    triple. The ``effective_*`` properties are what routing reads: they collapse
+    to ``None`` — the same shape as "no price recorded" — whenever the figures
+    cannot be attributed, so an untraceable literal cannot silently participate
+    in selection.
+    """
+
+    input_cost_per_mtok: float | None
+    output_cost_per_mtok: float | None
+    pricing_provenance: str | None
+
+    @property
+    def pricing_attributable(self) -> bool:
+        """True when the recorded prices are attributed to a concrete identity."""
+        return bool(self.pricing_provenance)
+
+    @property
+    def effective_input_cost_per_mtok(self) -> float | None:
+        """Input price as a routing input — ``None`` when unattributable."""
+        return self.input_cost_per_mtok if self.pricing_attributable else None
+
+    @property
+    def effective_output_cost_per_mtok(self) -> float | None:
+        """Output price as a routing input — ``None`` when unattributable."""
+        return self.output_cost_per_mtok if self.pricing_attributable else None
+
+
+def custom_model_cost_rank(
+    input_cost_per_mtok: float,
+    output_cost_per_mtok: float,
+    *,
+    pricing_provenance: str | None,
+) -> int | None:
+    """Map per-MTok pricing to the routing cost bands used by the registry.
+
+    ``pricing_provenance`` is keyword-only and has no default so every caller has
+    to state what the figures are attributed to. When it is ``None`` the prices
+    cannot be tied to the identity being banded, so this returns ``None`` —
+    "no band derivable" — and the caller falls back to a declared or built-in
+    band rather than inventing one from an untraceable literal.
+    """
+    if pricing_provenance is None:
+        return None
+    price_signal = max(float(input_cost_per_mtok), float(output_cost_per_mtok))
+    if price_signal <= 5.0:
+        return 1
+    if price_signal <= 25.0:
+        return 2
+    return 3
+
+
+def price_tiebreak_signal(
+    input_cost_per_mtok: float | None,
+    output_cost_per_mtok: float | None,
+) -> float:
+    """Return a per-MTok price signal for breaking equal-``cost_rank`` ties.
+
+    Two models can share a ``cost_rank`` band (and even a ``capability`` score) yet
+    differ substantially in real price — e.g. the cheap-tier bucket holds both
+    ``claude/sonnet`` and ``openai/gpt-5.4-mini``. Ranking helpers previously broke
+    that tie by ``models.enabled`` list order, permanently starving whichever model
+    was listed second. This collapses the two per-MTok costs into one comparable
+    number (``max`` of input/output, mirroring :func:`custom_model_cost_rank`'s
+    price banding) so the cheaper candidate wins the tie deterministically.
+
+    Candidates with no pricing data return :data:`_UNPRICED_SIGNAL` so they rank
+    behind any priced peer while preserving list order among unpriced models.
+
+    This is the numeric primitive. Selection paths call
+    :func:`price_tiebreak_signal_for` instead, which feeds it the *attributable*
+    prices only.
+    """
+    if input_cost_per_mtok is None and output_cost_per_mtok is None:
+        return _UNPRICED_SIGNAL
+    return max(
+        float(input_cost_per_mtok) if input_cost_per_mtok is not None else 0.0,
+        float(output_cost_per_mtok) if output_cost_per_mtok is not None else 0.0,
+    )
+
+
+def price_tiebreak_signal_for(entry: AttributablePricing) -> float:
+    """Attribution-gated tie-break signal for a registry entry or pool agent.
+
+    Every selection path (assignment, role derivation, profile auto-assignment,
+    the coordinator preflight pool) breaks equal-band ties through this function
+    rather than reading the raw price fields, so an entry whose figures carry no
+    ``pricing_provenance`` ranks exactly like an unpriced one instead of steering
+    the tie with a literal nothing can vouch for.
+    """
+    return price_tiebreak_signal(
+        entry.effective_input_cost_per_mtok,
+        entry.effective_output_cost_per_mtok,
+    )

--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -16,7 +16,8 @@ from .defaults import (
     PROVIDER_SDK_MAP,
     SUPPORTED_CLIS,
 )
-from .models import AgentDef, AgentSpec, _resolve_model_info, price_tiebreak_signal
+from .models import AgentDef, AgentSpec, _resolve_model_info
+from .pricing import price_tiebreak_signal_for
 from .types import SUPPORTED_PROVIDERS, ModelProfile, TransportFallbackConfig
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -117,6 +118,7 @@ def _agents_from_models(
                 registry_source=info.registry_source,
                 input_cost_per_mtok=info.input_cost_per_mtok,
                 output_cost_per_mtok=info.output_cost_per_mtok,
+                pricing_provenance=info.pricing_provenance,
             )
         )
     return agents
@@ -366,7 +368,7 @@ def _auto_assign_models(
         key=lambda x: (
             x[1].cost_rank,
             -x[1].capability,
-            price_tiebreak_signal(x[1].input_cost_per_mtok, x[1].output_cost_per_mtok),
+            price_tiebreak_signal_for(x[1]),
         ),
     )
 

--- a/src/theforge/config/role_derivation.py
+++ b/src/theforge/config/role_derivation.py
@@ -13,7 +13,8 @@ from typing import Any
 
 from ..routing import DEV_COMPLEXITY_TIER, score_to_dev_tier
 from .defaults import DEFAULT_DEV_PROFILE, DEFAULT_PREFLIGHT_PROFILE, DEFAULT_REVIEW_PROFILE
-from .models import AgentSpec, ModelInfo, _resolve_model_info, price_tiebreak_signal
+from .models import AgentSpec, ModelInfo, _resolve_model_info
+from .pricing import price_tiebreak_signal_for
 from .schema import (
     DevRoleConfig,
     ModelRef,
@@ -257,7 +258,7 @@ def derive_roles(
         key=lambda x: (
             x[1].cost_rank,
             -x[1].capability,
-            price_tiebreak_signal(x[1].input_cost_per_mtok, x[1].output_cost_per_mtok),
+            price_tiebreak_signal_for(x[1]),
         ),
     )
 
@@ -317,7 +318,7 @@ def derive_roles(
                     key=lambda x: (
                         x[1].cost_rank,
                         -x[1].capability,
-                        price_tiebreak_signal(x[1].input_cost_per_mtok, x[1].output_cost_per_mtok),
+                        price_tiebreak_signal_for(x[1]),
                     ),
                 )
             ]

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -284,10 +284,8 @@ def _build_pool_entries(
     from ``ForgeConfig.model_registry``. When None, only built-ins are visible
     and custom-overlay model keys raise ValueError.
     """
-    from theforge.config.models import (  # noqa: PLC0415
-        _resolve_model_info,
-        price_tiebreak_signal,
-    )
+    from theforge.config.models import _resolve_model_info  # noqa: PLC0415
+    from theforge.config.pricing import price_tiebreak_signal_for  # noqa: PLC0415
 
     info_view = model_info_view(registry)
     entries: list[tuple[int, str, ModelInfo]] = []
@@ -302,7 +300,7 @@ def _build_pool_entries(
         key=lambda x: (
             x[0],
             -x[2].capability,
-            price_tiebreak_signal(x[2].input_cost_per_mtok, x[2].output_cost_per_mtok),
+            price_tiebreak_signal_for(x[2]),
         )
     )
     return entries

--- a/tests/test_config_transport_identity.py
+++ b/tests/test_config_transport_identity.py
@@ -434,6 +434,7 @@ class TestRoutingPolicyIsSeparateFromIdentity:
             "cost_rank",
             "dev_capable",
             "phase_eligibility",
+            "cost_rank_basis",
         }
         assert not policy_fields & {"provider", "model", "transport", "base_url"}
 

--- a/tests/test_pricing_provenance.py
+++ b/tests/test_pricing_provenance.py
@@ -1,0 +1,310 @@
+"""Pricing attribution gates the routing inputs derived from price (issue #2203).
+
+A per-MTok price on a registry entry is a routing input: it sets the cost band
+and breaks equal-band ties. Entries identified by a vendor shorthand (the Claude
+CLI's ``opus``/``sonnet``) resolve to some other concrete version at invocation
+time, so their stored literal describes an identity that can move underneath it.
+These tests pin the fix: a price that carries no ``pricing_provenance`` is
+treated exactly like a missing price — it never bands and never breaks a tie —
+while attributed prices keep the #1617 behaviour intact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from theforge.config import load_config
+from theforge.config.models import (
+    AGENT_REGISTRY,
+    MODEL_REGISTRY,
+    AgentSpec,
+    RoutingPolicy,
+    _spec_to_model_info,
+    transport_for,
+)
+from theforge.config.pricing import (
+    PRICING_PROVENANCE_LOCAL_ENDPOINT,
+    PRICING_PROVENANCE_OPERATOR_DECLARED,
+    custom_model_cost_rank,
+    price_tiebreak_signal,
+    price_tiebreak_signal_for,
+)
+from theforge.config.profiles import _agents_from_models
+from theforge.config.role_derivation import derive_roles
+from theforge.coordinator.preflight import _build_pool_entries
+
+_UNPRICED = float("inf")
+
+
+def _spec(
+    model: str,
+    *,
+    provider: str = "openai",
+    kind: str = "api",
+    capability: int = 7,
+    cost_rank: int = 1,
+    input_cost: float | None = None,
+    output_cost: float | None = None,
+    provenance: str | None = None,
+) -> AgentSpec:
+    return AgentSpec(
+        provider=provider,
+        model=model,
+        transport=transport_for(provider, kind),
+        routing=RoutingPolicy(tier="cheap", capability=capability, cost_rank=cost_rank),
+        input_cost_per_mtok=input_cost,
+        output_cost_per_mtok=output_cost,
+        pricing_provenance=provenance,
+    )
+
+
+# ── The attribution gate itself ────────────────────────────────────────
+
+
+def test_unattributed_prices_are_unknown_to_routing():
+    """Present figures with no provenance read as "no price" on the routing path."""
+    spec = _spec("shorthand", input_cost=1.0, output_cost=4.0)
+    # The literals are still recorded — they just cannot be vouched for.
+    assert (spec.input_cost_per_mtok, spec.output_cost_per_mtok) == (1.0, 4.0)
+    assert spec.pricing_attributable is False
+    assert spec.effective_input_cost_per_mtok is None
+    assert spec.effective_output_cost_per_mtok is None
+    assert price_tiebreak_signal_for(spec) == _UNPRICED
+
+
+def test_attributed_prices_still_steer_the_tiebreak():
+    spec = _spec("pinned", input_cost=1.0, output_cost=4.0, provenance="pinned-2026-07")
+    assert spec.pricing_attributable is True
+    assert spec.effective_input_cost_per_mtok == 1.0
+    assert spec.effective_output_cost_per_mtok == 4.0
+    # Unchanged from the numeric primitive: max(input, output).
+    assert price_tiebreak_signal_for(spec) == price_tiebreak_signal(1.0, 4.0) == 4.0
+
+
+def test_attributed_but_unpriced_entry_still_reads_as_unpriced():
+    spec = _spec("no-figures", provenance="pinned-2026-07")
+    assert price_tiebreak_signal_for(spec) == _UNPRICED
+
+
+def test_cost_rank_needs_attribution_to_band():
+    """An unattributable price yields no band rather than a fabricated one."""
+    assert custom_model_cost_rank(15.0, 75.0, pricing_provenance=None) is None
+    # With attribution the existing banding is untouched.
+    assert custom_model_cost_rank(1.0, 5.0, pricing_provenance="x") == 1
+    assert custom_model_cost_rank(15.0, 25.0, pricing_provenance="x") == 2
+    assert custom_model_cost_rank(15.0, 75.0, pricing_provenance="x") == 3
+
+
+def test_provenance_survives_the_projections_routing_reads():
+    """ModelInfo and AgentDef carry the attribution, not just AgentSpec."""
+    opus = _spec_to_model_info("anthropic/opus/cli", AGENT_REGISTRY["anthropic/opus/cli"])
+    assert opus.input_cost_per_mtok == 15.00  # literal preserved for reference
+    assert opus.pricing_provenance is None
+    assert price_tiebreak_signal_for(opus) == _UNPRICED
+
+    agents = _agents_from_models(["anthropic/opus/cli", "openai/gpt-5.4/cli"], budget_usd=10.0)
+    by_model = {a.model: a for a in agents}
+    assert by_model["opus"].pricing_provenance is None
+    assert price_tiebreak_signal_for(by_model["opus"]) == _UNPRICED
+    assert by_model["gpt-5.4"].pricing_provenance == "gpt-5.4"
+    assert price_tiebreak_signal_for(by_model["gpt-5.4"]) == 10.00
+
+
+# ── Built-in registry attribution ──────────────────────────────────────
+
+
+@pytest.mark.parametrize("key", ["anthropic/opus/cli", "anthropic/sonnet/cli"])
+def test_cli_shorthand_entries_are_unattributed(key):
+    """The Claude CLI resolves these identities at invocation, so their stored
+    literal cannot be attributed to what is billed."""
+    assert AGENT_REGISTRY[key].pricing_provenance is None
+    assert MODEL_REGISTRY[key].pricing_provenance is None
+
+
+def test_every_other_priced_builtin_entry_records_its_attribution():
+    unattributed = {
+        key
+        for key, spec in AGENT_REGISTRY.items()
+        if spec.input_cost_per_mtok is not None and spec.pricing_provenance is None
+    }
+    assert unattributed == {"anthropic/opus/cli", "anthropic/sonnet/cli"}
+
+
+def test_local_endpoint_entries_are_attributed_to_the_endpoint():
+    spec = AGENT_REGISTRY["openai/codestral/api"]
+    assert spec.pricing_provenance == PRICING_PROVENANCE_LOCAL_ENDPOINT
+    assert price_tiebreak_signal_for(spec) == 0.0
+
+
+# ── Selection seams: the literal no longer steers ──────────────────────
+
+
+def _rigged_registry() -> dict[str, AgentSpec]:
+    """Two same-band, same-capability candidates. The *unattributed* one is much
+    cheaper on paper, so under the old behaviour it won every tie-break."""
+    cheap_literal = _spec("shorthand", input_cost=1.0, output_cost=1.0)
+    attributed = _spec("pinned", input_cost=9.0, output_cost=9.0, provenance="pinned-2026-07")
+    return {
+        "openai/shorthand/api": cheap_literal,
+        "openai/pinned/api": attributed,
+    }
+
+
+@pytest.mark.parametrize(
+    "models",
+    [
+        ["openai/shorthand/api", "openai/pinned/api"],
+        ["openai/pinned/api", "openai/shorthand/api"],
+    ],
+)
+def test_build_pool_entries_ignores_the_unattributed_literal(models):
+    """Coordinator preflight seam: the attributed candidate leads regardless of
+    the cheaper unattributable figure (and regardless of list order)."""
+    entries = _build_pool_entries(models, registry=_rigged_registry())
+    assert [key for _rank, key, _info in entries][0] == "openai/pinned/api"
+
+
+@pytest.mark.parametrize(
+    "models",
+    [
+        ["openai/shorthand/api", "openai/pinned/api"],
+        ["openai/pinned/api", "openai/shorthand/api"],
+    ],
+)
+def test_derive_roles_ignores_the_unattributed_literal(models):
+    """Role-derivation seam: same ordering rule at config-load time."""
+    assignment = derive_roles(models, registry=_rigged_registry())
+    assert assignment.dev.ref.model == "pinned"
+
+
+def test_attributed_pool_still_breaks_ties_by_price():
+    """Control: with both candidates attributed, the cheaper one wins as before."""
+    registry = _rigged_registry()
+    registry["openai/shorthand/api"] = _spec(
+        "shorthand", input_cost=1.0, output_cost=1.0, provenance="pinned-2026-07"
+    )
+    entries = _build_pool_entries(["openai/pinned/api", "openai/shorthand/api"], registry=registry)
+    assert [key for _rank, key, _info in entries][0] == "openai/shorthand/api"
+
+
+# ── Config-load seam ───────────────────────────────────────────────────
+
+
+def _write_config(data: dict, tmp_dir: Path) -> Path:
+    config_path = tmp_dir / "forge.yaml"
+    config_path.write_text(yaml.dump(data), encoding="utf-8")
+    return config_path
+
+
+def test_inherited_unattributed_price_does_not_reband_the_entry(tmp_path):
+    """An enabled-mapping override that only touches routing inherits the
+    built-in band — it does not re-derive one from the inherited literal."""
+    config_path = _write_config(
+        {
+            "models": {
+                "enabled": [
+                    {
+                        "provider": "anthropic",
+                        "model": "opus",
+                        "transport": {"kind": "cli"},
+                        "routing": {"capability": 8},
+                    }
+                ]
+            },
+            "budget_usd": 50.0,
+        },
+        tmp_path,
+    )
+    config = load_config(config_path)
+    spec = config.model_registry["anthropic/opus/cli"]
+    assert spec.pricing_provenance is None
+    # 15.00/75.00 would band 3 anyway; the point is the band came from the
+    # built-in policy, and the figures stay out of the tie-break.
+    assert spec.cost_rank == AGENT_REGISTRY["anthropic/opus/cli"].cost_rank
+    assert price_tiebreak_signal_for(spec) == _UNPRICED
+
+
+def test_operator_declared_cost_is_attributed_and_bands(tmp_path):
+    """A `cost:` block is the operator attributing figures to this identity."""
+    config_path = _write_config(
+        {
+            "models": {
+                "enabled": [
+                    {
+                        "provider": "anthropic",
+                        "model": "opus",
+                        "transport": {"kind": "cli"},
+                        "cost": {"input_per_mtok": 5.0, "output_per_mtok": 25.0},
+                    }
+                ]
+            },
+            "budget_usd": 50.0,
+        },
+        tmp_path,
+    )
+    config = load_config(config_path)
+    spec = config.model_registry["anthropic/opus/cli"]
+    assert spec.pricing_provenance == PRICING_PROVENANCE_OPERATOR_DECLARED
+    assert spec.cost_rank == 2  # re-banded from the declared figures, not the literal
+    assert price_tiebreak_signal_for(spec) == 25.0
+
+
+def test_check_config_names_the_models_whose_price_is_ignored(tmp_path, capsys):
+    """Operator-visible: the registry section says which enabled entries carry a
+    price that routing refuses to use, so the literal isn't read as the figure
+    selection ran on."""
+    from unittest.mock import patch
+
+    from theforge.cli.check_config import _unattributed_pricing_models, cmd_check_config
+
+    assert _unattributed_pricing_models(
+        ["anthropic/opus/cli", "openai/gpt-5.4/cli", "openai/gpt-5.4-mini/cli"]
+    ) == ["anthropic/opus/cli"]
+
+    config_path = _write_config(
+        {
+            "models": {"enabled": ["anthropic/opus/cli", "openai/gpt-5.4-mini/cli"]},
+            "budget_usd": 50.0,
+        },
+        tmp_path,
+    )
+    config = load_config(config_path)
+    args = type("Args", (), {"config": str(config_path), "verbose": False, "json": False})()
+    with (
+        patch("theforge.cli.check_config._find_config", return_value=config_path),
+        patch("theforge.cli.check_config.load_config", return_value=config),
+        patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+    ):
+        cmd_check_config(args)
+    out = capsys.readouterr().out
+    assert "unattributed price:" in out
+    assert "anthropic/opus/cli" in out.split("unattributed price:")[1].splitlines()[0]
+
+
+def test_models_custom_declaration_is_attributed(tmp_path):
+    config_path = _write_config(
+        {
+            "models": {
+                "enabled": ["anthropic/sonnet/cli", "gpt-5.5"],
+                "custom": {
+                    "gpt-5.5": {
+                        "provider": "openai",
+                        "model": "gpt-5.5",
+                        "tier": "strong",
+                        "input_cost_per_mtok": 5,
+                        "output_cost_per_mtok": 30,
+                    }
+                },
+            },
+            "budget_usd": 50.0,
+        },
+        tmp_path,
+    )
+    config = load_config(config_path)
+    spec = config.model_registry["openai/gpt-5.5/cli"]
+    assert spec.pricing_provenance == PRICING_PROVENANCE_OPERATOR_DECLARED
+    assert spec.cost_rank == 3
+    assert price_tiebreak_signal_for(spec) == 30.0

--- a/tests/test_pricing_provenance.py
+++ b/tests/test_pricing_provenance.py
@@ -11,6 +11,7 @@ while attributed prices keep the #1617 behaviour intact.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -22,15 +23,19 @@ from theforge.config.models import (
     MODEL_REGISTRY,
     AgentSpec,
     RoutingPolicy,
+    _entry,
     _spec_to_model_info,
     transport_for,
 )
 from theforge.config.pricing import (
+    COST_BAND_BASIS_OPERATOR_DECLARED,
+    COST_BAND_BASIS_VENDOR_TIER,
     PRICING_PROVENANCE_LOCAL_ENDPOINT,
     PRICING_PROVENANCE_OPERATOR_DECLARED,
     custom_model_cost_rank,
     price_tiebreak_signal,
     price_tiebreak_signal_for,
+    resolve_cost_band_basis,
 )
 from theforge.config.profiles import _agents_from_models
 from theforge.config.role_derivation import derive_roles
@@ -282,6 +287,272 @@ def test_check_config_names_the_models_whose_price_is_ignored(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "unattributed price:" in out
     assert "anthropic/opus/cli" in out.split("unattributed price:")[1].splitlines()[0]
+
+
+# ── The cost band is attributed too ────────────────────────────────────
+#
+# ``cost_rank`` selects which tier a role is filled from, so a band copied off an
+# untraceable literal steers selection exactly as the tie-break did. These pin
+# the second half of the fix: every band names what it is derived from, and the
+# alias entries' bands are not a function of their literals.
+
+
+_ALIAS_KEYS = ["anthropic/opus/cli", "anthropic/sonnet/cli"]
+
+
+def test_every_builtin_band_records_what_it_is_derived_from():
+    assert [
+        key for key, spec in AGENT_REGISTRY.items() if spec.routing.cost_rank_basis is None
+    ] == []
+
+
+def test_alias_bands_are_declared_on_non_price_grounds():
+    """The entries whose price cannot be attributed must not be banding off it."""
+    for key in _ALIAS_KEYS:
+        basis = AGENT_REGISTRY[key].routing.cost_rank_basis
+        assert basis == COST_BAND_BASIS_VENDOR_TIER
+        assert not basis.startswith("price:")
+
+
+@pytest.mark.parametrize("key", _ALIAS_KEYS)
+@pytest.mark.parametrize(
+    ("input_cost", "output_cost"),
+    [
+        (15.00, 75.00),  # what the registry records today
+        (5.00, 25.00),  # what forge.yaml annotates as actually billed — bands 2
+        (0.01, 0.01),  # bands 1
+        (999.0, 999.0),  # bands 3
+    ],
+)
+def test_alias_band_does_not_move_when_the_literal_moves(key, input_cost, output_cost):
+    """No value of the unattributable literal changes the band — including the
+    5.00/25.00 forge.yaml annotates, which is a band below the 15.00/75.00 the
+    registry records and is where the reported one-band divergence came from."""
+    spec = AGENT_REGISTRY[key]
+    repriced = replace(spec, input_cost_per_mtok=input_cost, output_cost_per_mtok=output_cost)
+    assert repriced.cost_rank == spec.cost_rank
+    assert repriced.routing.cost_rank_basis == spec.routing.cost_rank_basis
+    assert price_tiebreak_signal_for(repriced) == _UNPRICED
+
+
+def test_sonnets_band_already_disagrees_with_its_literal():
+    """Evidence the band is not price-derived rather than merely coinciding:
+    3.00/15.00 would band 2, and the entry is banded 1."""
+    spec = AGENT_REGISTRY["anthropic/sonnet/cli"]
+    would_be = custom_model_cost_rank(
+        spec.input_cost_per_mtok, spec.output_cost_per_mtok, pricing_provenance="hypothetical"
+    )
+    assert would_be == 2
+    assert spec.cost_rank == 1
+
+
+def test_the_defects_exact_entry_shape_no_longer_builds():
+    """The shape the bug was reported in: a vendor-shorthand entry carrying an
+    unattributable 15.00/75.00 and banded 3 — the band those figures produce, with
+    nothing recording whether that was a derivation or a coincidence. Building it
+    now raises; the entry only exists once it says why band 3 holds without them."""
+    args = ("anthropic", "opus", "cli")
+    kwargs = dict(
+        tier="strong",
+        capability=10,
+        cost_rank=3,
+        input_cost_per_mtok=15.00,
+        output_cost_per_mtok=75.00,
+    )
+    with pytest.raises(ValueError, match="cannot be attributed"):
+        _entry(*args, **kwargs)
+
+    _key, spec = _entry(*args, **kwargs, cost_rank_basis=COST_BAND_BASIS_VENDOR_TIER)
+    assert spec.cost_rank == 3
+    assert spec.routing.cost_rank_basis == COST_BAND_BASIS_VENDOR_TIER
+    # And that band still owes nothing to the figures beside it.
+    assert price_tiebreak_signal_for(spec) == _UNPRICED
+
+
+def test_an_untraceable_band_is_refused_at_construction():
+    """The mechanical guard: a band with no attributable price and no declared
+    basis cannot be built, so a future entry cannot quietly acquire one."""
+    with pytest.raises(ValueError, match="cannot be attributed"):
+        resolve_cost_band_basis(
+            3,
+            input_cost_per_mtok=15.0,
+            output_cost_per_mtok=75.0,
+            pricing_provenance=None,
+            declared_basis=None,
+        )
+    # Attributed, but the band disagrees with the price it claims to come from.
+    with pytest.raises(ValueError, match="cannot be attributed"):
+        resolve_cost_band_basis(
+            3,
+            input_cost_per_mtok=1.0,
+            output_cost_per_mtok=2.0,
+            pricing_provenance="pinned-2026-07",
+            declared_basis=None,
+        )
+    # A band that *is* the attributable price band is attributed to that price.
+    assert (
+        resolve_cost_band_basis(
+            1,
+            input_cost_per_mtok=1.0,
+            output_cost_per_mtok=2.0,
+            pricing_provenance="pinned-2026-07",
+            declared_basis=None,
+        )
+        == "price:pinned-2026-07"
+    )
+
+
+def _alias_repriced_registry(input_cost: float, output_cost: float) -> dict[str, AgentSpec]:
+    """The real registry with both Claude shorthand literals moved."""
+    registry = dict(AGENT_REGISTRY)
+    for key in _ALIAS_KEYS:
+        registry[key] = replace(
+            registry[key],
+            input_cost_per_mtok=input_cost,
+            output_cost_per_mtok=output_cost,
+        )
+    return registry
+
+
+_FLEET = [
+    "anthropic/sonnet/cli",
+    "anthropic/opus/cli",
+    "openai/gpt-5.4/cli",
+    "openai/gpt-5.4-mini/cli",
+]
+
+
+@pytest.mark.parametrize(
+    ("input_cost", "output_cost"), [(5.00, 25.00), (0.01, 0.01), (999.0, 999.0)]
+)
+def test_selection_is_identical_whatever_the_alias_literal_says(input_cost, output_cost):
+    """End-to-end at both selection seams: moving the unattributable figures —
+    including to the billed 5.00/25.00 that would have re-banded opus — changes
+    neither the preflight pool order nor any derived role."""
+    baseline_pool = _build_pool_entries(_FLEET, registry=AGENT_REGISTRY)
+    moved_pool = _build_pool_entries(
+        _FLEET, registry=_alias_repriced_registry(input_cost, output_cost)
+    )
+    assert [(rank, key) for rank, key, _info in moved_pool] == [
+        (rank, key) for rank, key, _info in baseline_pool
+    ]
+
+    for complexity in ("LOW", "MEDIUM", "HIGH"):
+        baseline = derive_roles(_FLEET, registry=AGENT_REGISTRY, complexity=complexity)
+        moved = derive_roles(
+            _FLEET,
+            registry=_alias_repriced_registry(input_cost, output_cost),
+            complexity=complexity,
+        )
+        for role in ("preflight", "plan", "dev"):
+            assert getattr(moved, role).ref.model == getattr(baseline, role).ref.model
+        assert [r.ref.model for r in moved.review_pool] == [
+            r.ref.model for r in baseline.review_pool
+        ]
+
+
+def test_check_config_reports_each_bands_basis(tmp_path, capsys):
+    """Operator-visible: the band and its source are printed together, so a
+    selection can be traced without reading the registry."""
+    from unittest.mock import patch
+
+    from theforge.cli.check_config import _cost_band_bases, cmd_check_config
+
+    assert _cost_band_bases(["anthropic/opus/cli", "openai/gpt-5.4/cli"]) == [
+        ("anthropic/opus/cli", 3, COST_BAND_BASIS_VENDOR_TIER),
+        ("openai/gpt-5.4/cli", 2, "price:gpt-5.4"),
+    ]
+
+    config_path = _write_config(
+        {
+            "models": {"enabled": ["anthropic/opus/cli", "openai/gpt-5.4-mini/cli"]},
+            "budget_usd": 50.0,
+        },
+        tmp_path,
+    )
+    config = load_config(config_path)
+    args = type("Args", (), {"config": str(config_path), "verbose": False, "json": False})()
+    with (
+        patch("theforge.cli.check_config._find_config", return_value=config_path),
+        patch("theforge.cli.check_config.load_config", return_value=config),
+        patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")),
+    ):
+        cmd_check_config(args)
+    out = capsys.readouterr().out
+    assert "cost band basis:" in out
+    assert f"rank 3  from {COST_BAND_BASIS_VENDOR_TIER}" in out
+
+
+def test_operator_declared_band_is_attributed_to_the_operator(tmp_path):
+    """A `routing.cost_rank` in forge.yaml is the operator declaring the band."""
+    config_path = _write_config(
+        {
+            "models": {
+                "enabled": [
+                    {
+                        "provider": "anthropic",
+                        "model": "opus",
+                        "transport": {"kind": "cli"},
+                        "routing": {"cost_rank": 2},
+                    }
+                ]
+            },
+            "budget_usd": 50.0,
+        },
+        tmp_path,
+    )
+    config = load_config(config_path)
+    spec = config.model_registry["anthropic/opus/cli"]
+    assert spec.cost_rank == 2
+    assert spec.routing.cost_rank_basis == COST_BAND_BASIS_OPERATOR_DECLARED
+
+
+def test_inherited_band_keeps_the_builtin_basis(tmp_path):
+    """Inheriting a built-in band inherits its justification too — it does not
+    become a price-derived band on the way through the loader."""
+    config_path = _write_config(
+        {
+            "models": {
+                "enabled": [
+                    {
+                        "provider": "anthropic",
+                        "model": "opus",
+                        "transport": {"kind": "cli"},
+                        "routing": {"capability": 8},
+                    }
+                ]
+            },
+            "budget_usd": 50.0,
+        },
+        tmp_path,
+    )
+    config = load_config(config_path)
+    spec = config.model_registry["anthropic/opus/cli"]
+    assert spec.routing.cost_rank_basis == COST_BAND_BASIS_VENDOR_TIER
+
+
+def test_operator_declared_cost_bands_from_the_declared_price(tmp_path):
+    """The `cost:` path bands *and* records that the band came from that price."""
+    config_path = _write_config(
+        {
+            "models": {
+                "enabled": [
+                    {
+                        "provider": "anthropic",
+                        "model": "opus",
+                        "transport": {"kind": "cli"},
+                        "cost": {"input_per_mtok": 5.0, "output_per_mtok": 25.0},
+                    }
+                ]
+            },
+            "budget_usd": 50.0,
+        },
+        tmp_path,
+    )
+    config = load_config(config_path)
+    spec = config.model_registry["anthropic/opus/cli"]
+    assert spec.cost_rank == 2
+    assert spec.routing.cost_rank_basis == f"price:{PRICING_PROVENANCE_OPERATOR_DECLARED}"
 
 
 def test_models_custom_declaration_is_attributed(tmp_path):


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior P1 is resolved: the Claude alias price no longer steers the tie-break, and its retained cost band now records a non-price basis. | [google-gemini-3.5-flash-api] The cost band and price tie-break are now fully gated on pricing attribution, resolving the prior P1 finding.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $11.78
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Alias-backed price literals with no recorded provenance silently steer routing (GitHub Issue #2203)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2203