### PR TITLE
One data-backed model catalog on a single schema, replacing registry literals and models.custom (#2204)

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -370,8 +370,10 @@ complexity. Use `forge check-config` to inspect the derived role table.
 A model is identified by exactly three things: **provider**, **model**, and
 **transport kind** (`cli` or `api`). Runner/executor is derived from
 `(provider, transport.kind)` — `(openai, cli)` is the Codex CLI, `(anthropic,
-cli)` is the Claude CLI, `(google, api)` is the Google API adapter — so no
-config names a runner.
+cli)` is the Claude CLI, `(google, api)` is the Google API adapter — so config
+normally does not name a runner. The one exception is a `(provider, kind)` pair
+that has more than one executor, where `transport.runner` picks between them; a
+runner that contradicts the pair is rejected at load.
 
 The mapping form spells the same identity out, and is the place to attach
 endpoint and routing metadata:
@@ -457,6 +459,32 @@ price-attributable nor explained is a load error rather than a silent guess.
 shipped one refines it: fields you state win, fields you omit keep the shipped
 value. `forge check-config` reports which source supplied each field.
 
+**Where a definition can go.** Either surface accepts the canonical schema:
+inline in `models.enabled` (defines and selects in one place), or under
+`models.custom` (a reusable declaration, selected by its key). They are the same
+shape and the same parser:
+
+```yaml
+models:
+  enabled: [anthropic/sonnet/cli, fast-reviewer]
+  custom:
+    fast-reviewer:                  # operator-chosen key — the selector
+      provider: google
+      model: gemini-4-flash
+      transport: {kind: api}
+      routing:
+        tier: cheap
+        capability: 7
+        phase_eligibility: [review]
+      cost:
+        input_per_mtok: 0.30
+        output_per_mtok: 2.50
+```
+
+A `models.custom` declaration stands alone: it does not inherit from a shipped
+entry, and replacing a shipped identity requires `override: true` alongside the
+definition.
+
 **Existing configuration keeps loading.** The flat `models.custom` form below
 and inline `models.enabled` mappings written before this schema existed are
 translated into it at the parse boundary — adopting the canonical shape is
@@ -475,7 +503,9 @@ models:
 ```
 
 The flat form still derives `capability` from `tier` and cannot set
-`phase_eligibility`; use the canonical shape when you need those.
+`phase_eligibility`; use the canonical shape when you need those. A declaration
+that mixes the two — flat `tier` next to a `routing:` block — is rejected rather
+than resolved under one reading.
 
 **Rejected/migration-only spellings.** `openai-api/gpt-5.4`,
 `gemini-cli/gemini-2.5-pro` and `claude/opus` are legacy aliases. They still

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -408,6 +408,75 @@ models:
 selection *policy*, not identity — two entries differing only in `routing` are
 the same model.
 
+### Model definitions
+
+That mapping is the **canonical model definition schema**, and it is the only
+one. The models TheForge ships with are written in it too: they live in
+`src/theforge/config/data/models.yaml` inside the package and are read by the
+same parser that reads your `forge.yaml`, so a project-declared model is not a
+second-class one — anything the shipped set can express, yours can:
+
+```yaml
+models:
+  enabled:
+    - provider: google              # adapter family (required)
+      model: gemini-4-pro           # model id passed to that adapter (required)
+      transport:
+        kind: api                   # cli | api (required)
+        # runner: ghaw              # only for (provider, kind) tuples with
+                                    # more than one executor
+      base_url: https://…/v1        # endpoint metadata (local/compatible servers)
+      routing:
+        tier: strong                # cheap | fast | strong
+        capability: 10              # 1–10 relative capability
+        cost_rank: 3                # 1=cheap, 2=moderate, 3=expensive
+        dev_capable: false          # may this model own the dev role?
+        phase_eligibility: [dev, plan, review]
+        cost_rank_basis: declared-policy
+      cost:
+        input_per_mtok: 2.00
+        output_per_mtok: 12.00
+        pricing_provenance: gemini-4-pro-2026-08
+```
+
+**Adding a model needs no code and no release** as long as it runs on an adapter
+that already exists (`anthropic`, `openai`, `google`, `deepseek`). Adding a
+*provider* does need code, because a provider needs a runner module — declaring
+one that has no adapter fails at load with a message naming the adapters that
+do exist.
+
+**Cost attribution.** `pricing_provenance` names the concrete billed identity
+the figures were recorded for. Omit it and the figures are *unattributed*:
+carried for reference, ignored by cost banding and price tie-breaks. Write
+`pricing_provenance: null` explicitly for a vendor shorthand whose price you
+record but cannot vouch for. `cost_rank_basis` states why the band holds when it
+is not simply this entry's own attributable price band; a band that is neither
+price-attributable nor explained is a load error rather than a silent guess.
+
+**Overlaying a shipped definition.** A declaration whose identity matches a
+shipped one refines it: fields you state win, fields you omit keep the shipped
+value. `forge check-config` reports which source supplied each field.
+
+**Existing configuration keeps loading.** The flat `models.custom` form below
+and inline `models.enabled` mappings written before this schema existed are
+translated into it at the parse boundary — adopting the canonical shape is
+optional, not forced:
+
+```yaml
+models:
+  enabled: [anthropic/sonnet/cli, gpt-5.5]   # a custom declaration may still be
+  custom:                                     # selected by its declaration key
+    gpt-5.5:
+      provider: openai                        # alias tokens (openai-api,
+      model: gpt-5.5                          # gemini-cli) still normalize
+      tier: strong
+      input_cost_per_mtok: 1.50
+      output_cost_per_mtok: 12.00
+```
+
+The flat form still derives `capability` from `tier` and cannot set
+`phase_eligibility`; use the canonical shape when you need those.
+
 **Rejected/migration-only spellings.** `openai-api/gpt-5.4`,
 `gemini-cli/gemini-2.5-pro` and `claude/opus` are legacy aliases. They still
 load, but they are rewritten to their canonical identity at the parse boundary

--- a/docs/guides/model-reference.md
+++ b/docs/guides/model-reference.md
@@ -10,6 +10,20 @@ TheForge's adaptive assignment maps complexity to routing tiers
 [`routing-policy.md`](routing-policy.md). The tables below show which concrete
 model fits each tier cell.
 
+The shipped model set itself is **data**: `src/theforge/config/data/models.yaml`
+inside the package, written in the canonical model-definition schema documented
+in [`inputs-reference.md`](inputs-reference.md#model-definitions) and read by the
+same parser that reads a project's `forge.yaml`. Adding or re-pinning a model
+that runs on an existing adapter is an edit to that file — or to your own
+`forge.yaml`, with no code change at all. Adding a *provider* still requires
+code, because a provider needs a runner module.
+
+> **TheForge's own `forge.yaml` is deliberately unchanged.** Moving this
+> repository's config onto the canonical schema is separate operator work,
+> sequenced after a release containing the schema has been cut and deployed:
+> sprints here run against an *installed release*, which cannot read a schema it
+> does not yet contain.
+
 ---
 
 ## OpenAI (GPT-5.4 family)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,11 @@ openai = ["openai>=1.0"]
 anthropic = ["anthropic>=0.30"]
 google = ["google-genai>=1.0"]
 all = ["openai>=1.0", "anthropic>=0.30", "google-genai>=1.0"]
-dev = ["pytest", "pytest-xdist", "ruff"]
+# hatchling is the build backend below; it is also a test dependency because the
+# packaging guard in tests/test_model_catalog.py builds a real wheel and looks
+# inside it. Nothing importable can stand in for that — the source tree always
+# has the catalog whether or not the build would ship it.
+dev = ["pytest", "pytest-xdist", "ruff", "hatchling"]
 
 [project.scripts]
 forge = "theforge.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,13 @@ forge = "theforge.cli:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# The shipped model catalog (src/theforge/config/data/models.yaml) is data, not
+# code, and must travel in the wheel: without it there is no default model set.
+# Naming the package directory explicitly is what states that non-Python package
+# data is part of the distribution rather than relying on auto-detection.
+[tool.hatch.build.targets.wheel]
+packages = ["src/theforge"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 norecursedirs = [".forge"]

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -506,6 +506,17 @@ def _format_config(
                 )
             if custom_details:
                 lines.append(f"  {'declared forge.yaml:':<18}{', '.join(custom_details)}")
+        # Where a project declaration refines a shipped definition, the entry is
+        # neither wholly builtin nor wholly forge.yaml. Name the fields the
+        # project actually supplied, or the overlay reads as a replacement.
+        for model_id in config.custom_models:
+            field_sources = config.model_registry_field_sources.get(model_id, {})
+            overlaid = sorted(f for f, src in field_sources.items() if src == "builtin")
+            if overlaid:
+                declared = sorted(f for f, src in field_sources.items() if src != "builtin")
+                lines.append(f"  field provenance for {model_id}:")
+                lines.append(f"    {'forge.yaml:':<12}{', '.join(declared) or '(none)'}")
+                lines.append(f"    {'builtin:':<12}{', '.join(overlaid)}")
         lines.append("")
 
     # ── DERIVED ROLES (v0.8 simple mode) ─────────────────────────────────

--- a/src/theforge/config/CONVENTIONS.md
+++ b/src/theforge/config/CONVENTIONS.md
@@ -24,6 +24,12 @@ and secrets handling.
   disk and environment.
 - `defaults.py`, `profiles.py`, and `models.py` define how omitted values are
   filled and how model/provider capabilities are represented.
+- Model definitions are layered so the shipped set and project-declared models
+  share one schema: `model_identity.py` (leaf — canonical identity, transport,
+  routing policy, `AgentSpec`) ← `model_catalog.py` (the one parser, plus the
+  packaged `data/models.yaml` catalog) ← `models.py` (`AGENT_REGISTRY`, legacy
+  views, lookups) ← `load.py`. Keep that direction: a back-edge would put the
+  parser and the registry it builds in an import cycle.
 - `types.py` contains typed config structures used throughout the codebase.
 - `auth.py` and `secrets.py` are the main places to inspect when credentials or
   provider authentication behavior changes.

--- a/src/theforge/config/data/models.yaml
+++ b/src/theforge/config/data/models.yaml
@@ -1,0 +1,307 @@
+# TheForge shipped model catalog.
+#
+# This file *is* the default model set. Every entry is written in the canonical
+# model-definition schema — the same schema a project uses under `models.custom`
+# / `models.enabled` in forge.yaml — and is read by the same parser
+# (config/model_catalog.py). Nothing here is behaviour: an entry is a canonical
+# identity (provider + model + transport kind) plus routing policy, endpoint
+# metadata and cost seeds.
+#
+# Adding or re-pinning a model that runs on an already-supported adapter is an
+# edit to this file (or to a project's forge.yaml) — no code change, no release.
+# Adding a *provider* still requires code, because a provider needs a runner
+# module; declaring one that has no adapter fails at load time with a message
+# naming the adapters that do exist.
+#
+# Schema (see docs/guides/inputs-reference.md § Model definitions):
+#   provider:   adapter family — anthropic | openai | google | deepseek
+#   model:      model identifier passed to that adapter
+#   transport:  {kind: cli|api, runner: <optional explicit runner>}
+#   routing:    tier, capability, cost_rank, dev_capable, phase_eligibility,
+#               cost_rank_basis
+#   base_url:   endpoint metadata (locally served OpenAI-compatible servers)
+#   cost:       input_per_mtok, output_per_mtok, pricing_provenance
+#
+# `cost.pricing_provenance` names the concrete billed identity the figures were
+# recorded for. Omitting it marks them *unattributed*: routing ignores them.
+# `routing.cost_rank_basis` must be stated whenever the band is not this entry's
+# own attributable price band — an unstated, underivable band is a load error.
+
+version: 1
+
+models:
+  # ── Anthropic ────────────────────────────────────────────────────────
+  #
+  # `sonnet`/`opus` are Claude-CLI shorthands, not billed identities: the CLI
+  # resolves each to whichever concrete version it currently ships (the vendor
+  # bills `claude-sonnet-4-6` / `claude-opus-4-6`-style names — see
+  # runners/schema_utils.PRICING_TABLE). The entry identity can therefore move
+  # while the literal below does not, so these figures carry no
+  # pricing_provenance: they are indicative only and routing ignores them.
+  # Re-attributing them requires pinning the entry to the concrete version the
+  # price is true of.
+  #
+  # Their cost bands are not derived from those literals either — they restate
+  # the vendor's own tier naming, which is what the shorthand *means* and stays
+  # true when it resolves to a new version: `opus` is whatever Anthropic
+  # currently sells as its flagship (strong band), `sonnet` whatever it sells as
+  # the mid-priced workhorse (cheap band, as the fleet's baseline). Note the
+  # bands already disagree with the literals — 3.00/15.00 would band sonnet at
+  # 2 — so the figures could move to any value without moving either band.
+  - provider: anthropic
+    model: sonnet
+    transport: {kind: cli}
+    routing:
+      tier: fast
+      capability: 7
+      cost_rank: 1
+      cost_rank_basis: vendor-tier
+    cost:
+      input_per_mtok: 3.00
+      output_per_mtok: 15.00
+
+  - provider: anthropic
+    model: opus
+    transport: {kind: cli}
+    routing:
+      tier: strong
+      capability: 10
+      cost_rank: 3
+      cost_rank_basis: vendor-tier
+    cost:
+      input_per_mtok: 15.00
+      output_per_mtok: 75.00
+
+  # ── OpenAI (Codex CLI) ───────────────────────────────────────────────
+  #
+  # Unlike the Claude-CLI shorthands above, these model strings are the identity
+  # the vendor bills under — they are passed through verbatim and priced under
+  # the same name (runners/schema_utils.PRICING_TABLE keys them identically), so
+  # the figures are attributable to the entry.
+  - provider: openai
+    model: gpt-5.4
+    transport: {kind: cli}
+    routing:
+      tier: strong
+      capability: 9
+      cost_rank: 2
+    cost:
+      input_per_mtok: 1.25
+      output_per_mtok: 10.00
+      pricing_provenance: gpt-5.4
+
+  - provider: openai
+    model: gpt-5.4-mini
+    transport: {kind: cli}
+    routing:
+      tier: cheap
+      capability: 7
+      cost_rank: 1
+    cost:
+      input_per_mtok: 0.25
+      output_per_mtok: 2.00
+      pricing_provenance: gpt-5.4-mini
+
+  - provider: openai
+    model: gpt-5.4-pro
+    transport: {kind: cli}
+    routing:
+      tier: strong
+      capability: 10
+      cost_rank: 3
+    cost:
+      input_per_mtok: 15.00
+      output_per_mtok: 120.00
+      pricing_provenance: gpt-5.4-pro
+
+  # ── OpenAI (API) ─────────────────────────────────────────────────────
+  - provider: openai
+    model: gpt-5.4
+    transport: {kind: api}
+    routing:
+      tier: strong
+      capability: 9
+      cost_rank: 2
+    cost:
+      input_per_mtok: 1.25
+      output_per_mtok: 10.00
+      pricing_provenance: gpt-5.4
+
+  - provider: openai
+    model: gpt-5.4-mini
+    transport: {kind: api}
+    routing:
+      tier: cheap
+      capability: 7
+      cost_rank: 1
+    cost:
+      input_per_mtok: 0.25
+      output_per_mtok: 2.00
+      pricing_provenance: gpt-5.4-mini
+
+  - provider: openai
+    model: gpt-5.4-pro
+    transport: {kind: api}
+    routing:
+      tier: strong
+      capability: 10
+      cost_rank: 3
+      # Reasoning-heavy — intentionally excluded from the preflight role.
+      phase_eligibility: [dev, plan, review]
+    cost:
+      input_per_mtok: 15.00
+      output_per_mtok: 120.00
+      pricing_provenance: gpt-5.4-pro
+
+  # ── DeepSeek (API) ───────────────────────────────────────────────────
+  - provider: deepseek
+    model: deepseek-reasoner
+    transport: {kind: api}
+    routing:
+      tier: strong
+      capability: 9
+      cost_rank: 2
+      # Banded a step above its per-MTok rate on purpose: a reasoning model
+      # spends far more output tokens per task, so the rate alone (band 1)
+      # understates what filling a role with it costs.
+      cost_rank_basis: declared-policy
+    cost:
+      input_per_mtok: 0.55
+      output_per_mtok: 2.19
+      pricing_provenance: deepseek-reasoner
+
+  - provider: deepseek
+    model: deepseek-chat
+    transport: {kind: api}
+    routing:
+      tier: fast
+      capability: 7
+      cost_rank: 1
+    cost:
+      input_per_mtok: 0.27
+      output_per_mtok: 1.10
+      pricing_provenance: deepseek-chat
+
+  # ── Google (API) ─────────────────────────────────────────────────────
+  - provider: google
+    model: gemini-3-flash-preview
+    transport: {kind: api}
+    routing:
+      tier: cheap
+      capability: 7
+      cost_rank: 1
+
+  - provider: google
+    model: gemini-3.1-pro-preview
+    transport: {kind: api}
+    routing:
+      tier: strong
+      capability: 9
+      cost_rank: 2
+    cost:
+      input_per_mtok: 2.00
+      output_per_mtok: 12.00
+      pricing_provenance: gemini-3.1-pro-preview
+
+  - provider: google
+    model: gemini-2.5-pro
+    transport: {kind: api}
+    routing:
+      tier: strong
+      capability: 8
+      cost_rank: 2
+    cost:
+      input_per_mtok: 1.25
+      output_per_mtok: 10.00
+      pricing_provenance: gemini-2.5-pro
+
+  # ── Google (Gemini CLI — explicit opt-in) ────────────────────────────
+  - provider: google
+    model: gemini-2.5-pro
+    transport: {kind: cli}
+    routing:
+      tier: strong
+      capability: 8
+      cost_rank: 2
+      dev_capable: false
+    cost:
+      input_per_mtok: 1.25
+      output_per_mtok: 10.00
+      pricing_provenance: gemini-2.5-pro
+
+  - provider: google
+    model: gemini-3-flash-preview
+    transport: {kind: cli}
+    routing:
+      tier: cheap
+      capability: 7
+      cost_rank: 1
+      dev_capable: false
+
+  - provider: google
+    model: gemini-3.1-pro-preview
+    transport: {kind: cli}
+    routing:
+      tier: strong
+      capability: 9
+      cost_rank: 2
+      dev_capable: false
+    cost:
+      input_per_mtok: 2.00
+      output_per_mtok: 12.00
+      pricing_provenance: gemini-3.1-pro-preview
+
+  # ── Local OpenAI-compatible models ───────────────────────────────────
+  # API transport + a localhost base_url. Not a provider prefix, not a
+  # transport kind — just an endpoint.
+  - provider: openai
+    model: codestral
+    transport: {kind: api}
+    base_url: http://localhost:11434/v1
+    routing:
+      tier: fast
+      capability: 7
+      cost_rank: 1
+    cost:
+      input_per_mtok: 0.0
+      output_per_mtok: 0.0
+      pricing_provenance: local-endpoint
+
+  - provider: openai
+    model: deepseek-coder
+    transport: {kind: api}
+    base_url: http://localhost:11434/v1
+    routing:
+      tier: fast
+      capability: 7
+      cost_rank: 1
+    cost:
+      input_per_mtok: 0.0
+      output_per_mtok: 0.0
+      pricing_provenance: local-endpoint
+
+  - provider: openai
+    model: llama3.1
+    transport: {kind: api}
+    base_url: http://localhost:11434/v1
+    routing:
+      tier: fast
+      capability: 6
+      cost_rank: 1
+    cost:
+      input_per_mtok: 0.0
+      output_per_mtok: 0.0
+      pricing_provenance: local-endpoint
+
+  - provider: openai
+    model: qwen2.5-coder
+    transport: {kind: api}
+    base_url: http://localhost:11434/v1
+    routing:
+      tier: fast
+      capability: 7
+      cost_rank: 1
+    cost:
+      input_per_mtok: 0.0
+      output_per_mtok: 0.0
+      pricing_provenance: local-endpoint

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -27,30 +27,23 @@ from .defaults import (
     PROVIDER_SDK_MAP,
     SUPPORTED_CLIS,
 )
+from .model_catalog import (
+    PROVENANCE_FIELDS,
+    ResolvedModel,
+    parse_definition,
+    parse_transport_block,
+    resolve_project,
+)
 from .models import (
     AGENT_REGISTRY,
-    TRANSPORT_KINDS,
     AgentSpec,
-    RoutingPolicy,
     _parse_assignment,
-    canonical_id_for_spec,
-    canonical_model_id,
-    custom_model_capability,
-    custom_model_dev_capable,
     known_model_overlay_providers,
     normalize_model_key,
     overlay_transport,
     resolve_agent_spec,
-    transport_for,
 )
-from .pricing import (
-    COST_BAND_BASIS_OPERATOR_DECLARED,
-    COST_BAND_BASIS_UNPRICED_DEFAULT,
-    PRICING_PROVENANCE_OPERATOR_DECLARED,
-    UNPRICED_COST_RANK,
-    custom_model_cost_rank,
-    price_cost_band_basis,
-)
+from .pricing import PRICING_PROVENANCE_OPERATOR_DECLARED
 from .profiles import (
     CLI_PROVIDER_MAP,
     _agents_from_models,
@@ -153,19 +146,28 @@ def _parse_sandbox_config(sandbox_raw: Any) -> SandboxConfig:
 
 def _parse_models_section(
     raw_models: Any,
-) -> tuple[list[str] | None, dict[str, AgentSpec], dict[str, Any], bool]:
+) -> tuple[
+    list[str] | None,
+    dict[str, AgentSpec],
+    dict[str, dict[str, str]],
+    dict[str, Any],
+    bool,
+]:
     """Normalize the top-level models section.
 
-    Returns ``(enabled_models, inline_specs, custom_raw, simple_mode_enabled)`` where:
+    Returns ``(enabled_models, inline_specs, inline_field_sources, custom_raw,
+    simple_mode_enabled)`` where:
     - ``enabled_models`` is the selected model list, as canonical
       ``provider/model/transport-kind`` identities
     - ``inline_specs`` holds AgentSpecs declared inline under ``models.enabled``
+    - ``inline_field_sources`` reports, per inline declaration, which source
+      supplied each resolved field
     - ``custom_raw`` is the raw ``models.custom`` mapping (possibly empty)
     - ``simple_mode_enabled`` indicates whether the config opted into simple mode
     """
     if isinstance(raw_models, list):
-        ids, inline = _normalize_enabled_entries(raw_models)
-        return ids, inline, {}, True
+        ids, inline, inline_sources = _normalize_enabled_entries(raw_models)
+        return ids, inline, inline_sources, {}, True
     if raw_models is None:
         raise ValueError("'models' must be a non-empty list")
     if not isinstance(raw_models, dict):
@@ -188,178 +190,36 @@ def _parse_models_section(
     if not isinstance(custom_raw, dict):
         raise ValueError("forge.yaml 'models.custom' must be a mapping")
 
-    enabled_ids, inline_specs = (
-        _normalize_enabled_entries(enabled_raw) if enabled_raw is not None else (None, {})
+    enabled_ids, inline_specs, inline_sources = (
+        _normalize_enabled_entries(enabled_raw) if enabled_raw is not None else (None, {}, {})
     )
-    return enabled_ids, inline_specs, custom_raw, enabled_raw is not None
-
-
-def _parse_transport_block(raw: Any, where: str) -> str:
-    """Read the bounded ``transport: {kind: cli|api}`` object off a raw entry."""
-    if not isinstance(raw, dict):
-        raise ValueError(f"forge.yaml '{where}.transport' must be a mapping with a 'kind' key")
-    unknown = set(raw) - {"kind"}
-    if unknown:
-        raise ValueError(
-            f"forge.yaml '{where}.transport' only supports 'kind'; got {sorted(unknown)}"
-        )
-    kind = raw.get("kind")
-    if kind not in TRANSPORT_KINDS:
-        raise ValueError(
-            f"forge.yaml '{where}.transport.kind' must be one of {sorted(TRANSPORT_KINDS)}, "
-            f"got {kind!r}"
-        )
-    return str(kind)
-
-
-_ENABLED_ENTRY_KEYS = {"provider", "model", "transport", "routing", "base_url", "cost"}
-_ROUTING_KEYS = {"tier", "capability", "cost_rank", "dev_capable", "phase_eligibility"}
+    return enabled_ids, inline_specs, inline_sources, custom_raw, enabled_raw is not None
 
 
 def _parse_enabled_mapping_entry(
     entry: dict[str, Any], index: int
-) -> tuple[str, AgentSpec | None]:
+) -> tuple[str, ResolvedModel | None]:
     """Normalize one canonical ``models.enabled`` mapping entry.
 
-    Returns ``(canonical_id, spec_or_None)``. The spec is None when the entry
-    only selects a model the built-in registry already knows — declaring
+    Returns ``(canonical_id, resolved_or_None)``. The resolution is None when the
+    entry only selects a model the built-in registry already knows — declaring
     ``provider``/``model``/``transport`` is enough to name it, and the built-in
     routing policy and pricing apply unchanged.
+
+    An entry that *does* carry ``routing``/``cost``/``base_url`` is a definition,
+    and goes through the same canonical parser as the packaged catalog.
     """
     where = f"models.enabled[{index}]"
-    unknown = set(entry) - _ENABLED_ENTRY_KEYS
-    if unknown:
-        raise ValueError(
-            f"forge.yaml '{where}' only supports {sorted(_ENABLED_ENTRY_KEYS)}; "
-            f"unknown key(s): {sorted(unknown)}"
-        )
-    for required in ("provider", "model", "transport"):
-        if required not in entry:
-            raise ValueError(f"forge.yaml '{where}' is missing required field {required!r}")
-    provider = entry["provider"]
-    model = entry["model"]
-    if not isinstance(provider, str) or not provider:
-        raise ValueError(f"forge.yaml '{where}.provider' must be a non-empty string")
-    if not isinstance(model, str) or not model:
-        raise ValueError(f"forge.yaml '{where}.model' must be a non-empty string")
-    kind = _parse_transport_block(entry["transport"], where)
-    transport = transport_for(provider, kind)
-    canonical_id = canonical_model_id(provider, model, kind)
-
-    routing_raw = entry.get("routing") or {}
-    if not isinstance(routing_raw, dict):
-        raise ValueError(f"forge.yaml '{where}.routing' must be a mapping")
-    unknown_routing = set(routing_raw) - _ROUTING_KEYS
-    if unknown_routing:
-        raise ValueError(
-            f"forge.yaml '{where}.routing' only supports {sorted(_ROUTING_KEYS)}; "
-            f"unknown key(s): {sorted(unknown_routing)}"
-        )
-    base_url = entry.get("base_url")
-    if base_url is not None and (not isinstance(base_url, str) or not base_url):
-        raise ValueError(f"forge.yaml '{where}.base_url' must be a non-empty string")
-    cost_raw = entry.get("cost") or {}
-    if not isinstance(cost_raw, dict):
-        raise ValueError(f"forge.yaml '{where}.cost' must be a mapping")
-
-    builtin = AGENT_REGISTRY.get(canonical_id)
-    if builtin is not None and not routing_raw and base_url is None and not cost_raw:
-        return canonical_id, None
-
-    tier = routing_raw.get("tier") or (builtin.tier if builtin is not None else None)
-    if not isinstance(tier, str) or not tier:
-        raise ValueError(
-            f"forge.yaml '{where}.routing.tier' is required for a model that is not "
-            "in the built-in registry"
-        )
-    input_cost = cost_raw.get(
-        "input_per_mtok", builtin.input_cost_per_mtok if builtin is not None else None
-    )
-    output_cost = cost_raw.get(
-        "output_per_mtok", builtin.output_cost_per_mtok if builtin is not None else None
-    )
-    # Declaring any `cost:` figure here attributes the pair to this identity —
-    # the operator asserted it for this entry. Figures merely *inherited* from a
-    # built-in entry keep that entry's attribution, which for a vendor-shorthand
-    # identity is None: the literal is carried for reference but must not band.
-    pricing_provenance = (
-        PRICING_PROVENANCE_OPERATOR_DECLARED
-        if cost_raw
-        else (builtin.pricing_provenance if builtin is not None else None)
-    )
-    banded_cost_rank = (
-        custom_model_cost_rank(
-            float(input_cost or 0.0),
-            float(output_cost or 0.0),
-            pricing_provenance=pricing_provenance,
-        )
-        if input_cost is not None or output_cost is not None
-        else None
-    )
-    # The band travels with the reason it holds, in the same order of precedence:
-    # the operator's own declaration, then this entry's attributable price, then
-    # whatever the built-in entry already justified, then the unpriced default.
-    # Nothing here can reach the band of an unattributed literal — the middle
-    # branch is gated on `banded_cost_rank`, which is None in that case.
-    if routing_raw.get("cost_rank") is not None:
-        cost_rank = int(routing_raw["cost_rank"])
-        cost_rank_basis = COST_BAND_BASIS_OPERATOR_DECLARED
-    elif banded_cost_rank is not None:
-        cost_rank = banded_cost_rank
-        cost_rank_basis = price_cost_band_basis(str(pricing_provenance))
-    elif builtin is not None:
-        cost_rank = builtin.cost_rank
-        cost_rank_basis = builtin.routing.cost_rank_basis
-    else:
-        cost_rank = UNPRICED_COST_RANK
-        cost_rank_basis = COST_BAND_BASIS_UNPRICED_DEFAULT
-    capability = routing_raw.get("capability")
-    dev_capable = routing_raw.get("dev_capable")
-    phases = routing_raw.get("phase_eligibility")
-    spec = AgentSpec(
-        provider=provider,
-        model=model,
-        transport=transport,
-        routing=RoutingPolicy(
-            tier=tier,
-            capability=(
-                int(capability)
-                if capability is not None
-                else (builtin.capability if builtin is not None else custom_model_capability(tier))
-            ),
-            cost_rank=cost_rank,
-            dev_capable=(
-                bool(dev_capable)
-                if dev_capable is not None
-                else (
-                    builtin.dev_capable
-                    if builtin is not None
-                    else custom_model_dev_capable(transport)
-                )
-            ),
-            phase_eligibility=(
-                frozenset(str(p) for p in phases)
-                if phases is not None
-                else (
-                    builtin.phase_eligibility
-                    if builtin is not None
-                    else RoutingPolicy(tier=tier, capability=1, cost_rank=1).phase_eligibility
-                )
-            ),
-            cost_rank_basis=cost_rank_basis,
-        ),
-        base_url=base_url if base_url is not None else (builtin.base_url if builtin else None),
-        registry_source="forge.yaml",
-        input_cost_per_mtok=float(input_cost) if input_cost is not None else None,
-        output_cost_per_mtok=float(output_cost) if output_cost is not None else None,
-        pricing_provenance=pricing_provenance,
-    )
-    return canonical_id, spec
+    defn = parse_definition(entry, where=where)
+    builtin = AGENT_REGISTRY.get(defn.canonical_id)
+    if builtin is not None and not defn.declared:
+        return defn.canonical_id, None
+    return defn.canonical_id, resolve_project(defn, where=where, builtin=builtin)
 
 
 def _normalize_enabled_entries(
     enabled_raw: list[Any],
-) -> tuple[list[str], dict[str, AgentSpec]]:
+) -> tuple[list[str], dict[str, AgentSpec], dict[str, dict[str, str]]]:
     """Normalize ``models.enabled`` into canonical ids plus any inline declarations.
 
     Two spellings are accepted at this boundary and both leave it as canonical
@@ -369,148 +229,134 @@ def _normalize_enabled_entries(
       plus optional ``routing``/``base_url``/``cost`` metadata;
     - a canonical id string, or one of the legacy provider-prefix spellings
       (``openai-api/…``, ``gemini-cli/…``), which is rewritten here.
+
+    The third element carries per-field provenance for the inline declarations.
     """
     ids: list[str] = []
     inline: dict[str, AgentSpec] = {}
+    field_sources: dict[str, dict[str, str]] = {}
     for index, entry in enumerate(enabled_raw):
         if isinstance(entry, dict):
-            canonical_id, spec = _parse_enabled_mapping_entry(entry, index)
-            if spec is not None:
-                inline[canonical_id] = spec
+            canonical_id, resolved = _parse_enabled_mapping_entry(entry, index)
+            if resolved is not None:
+                inline[canonical_id] = resolved.spec
+                field_sources[canonical_id] = resolved.field_sources
             ids.append(canonical_id)
         else:
             ids.append(normalize_model_key(str(entry)))
-    return ids, inline
+    return ids, inline, field_sources
+
+
+_CUSTOM_REQUIRED_KEYS = (
+    "provider",
+    "model",
+    "tier",
+    "input_cost_per_mtok",
+    "output_cost_per_mtok",
+)
+
+
+def _custom_declaration_to_definition(canonical_id: str, decl: dict[str, Any]) -> dict[str, Any]:
+    """Translate a legacy flat ``models.custom`` declaration into the canonical shape.
+
+    The flat form predates the canonical schema and stays loadable unchanged:
+    the fields are rearranged here (``tier`` under ``routing``,
+    ``input_cost_per_mtok``/``output_cost_per_mtok`` under ``cost``) and the
+    provider-like alias tokens (``openai-api``, ``gemini-cli``) are resolved to a
+    provider family plus a transport kind, so the declaration is validated and
+    resolved by the same parser everything else goes through.
+
+    Field-level validation stays here rather than being delegated, so the
+    messages keep naming the keys the operator actually wrote.
+    """
+    where = f"models.custom.{canonical_id}"
+    if not isinstance(decl, dict):
+        raise ValueError(f"forge.yaml '{where}' must be a mapping")
+    missing = [key for key in _CUSTOM_REQUIRED_KEYS if key not in decl]
+    if missing:
+        raise ValueError(f"forge.yaml '{where}' is missing required field(s): {missing}")
+
+    provider = decl["provider"]
+    model = decl["model"]
+    tier = decl["tier"]
+    if not isinstance(provider, str) or not provider:
+        raise ValueError(f"forge.yaml '{where}.provider' must be a non-empty string")
+    if not isinstance(model, str) or not model:
+        raise ValueError(f"forge.yaml '{where}.model' must be a non-empty string")
+    if not isinstance(tier, str) or not tier:
+        raise ValueError(f"forge.yaml '{where}.tier' must be a non-empty string")
+    if provider not in known_model_overlay_providers():
+        known = ", ".join(known_model_overlay_providers())
+        raise ValueError(
+            f"Unknown provider {provider!r} in {where}. Known providers/adapters: {known}"
+        )
+
+    for cost_key in ("input_cost_per_mtok", "output_cost_per_mtok"):
+        value = decl[cost_key]
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or float(value) < 0:
+            raise ValueError(
+                f"forge.yaml '{where}.{cost_key}' must be a non-negative number, got {value!r}"
+            )
+
+    transport_kind = (
+        parse_transport_block(decl["transport"], where)[0] if "transport" in decl else None
+    )
+    # Alias tokens carry an implied kind; an explicit transport block wins.
+    normalized_provider, transport = overlay_transport(provider, transport_kind)
+    definition: dict[str, Any] = {
+        "provider": normalized_provider,
+        "model": model,
+        "transport": {"kind": transport.kind},
+        "routing": {"tier": tier},
+        # A models.custom declaration states its own prices for its own
+        # identity, so the pair is attributed to the operator's declaration.
+        "cost": {
+            "input_per_mtok": float(decl["input_cost_per_mtok"]),
+            "output_per_mtok": float(decl["output_cost_per_mtok"]),
+            "pricing_provenance": PRICING_PROVENANCE_OPERATOR_DECLARED,
+        },
+    }
+    base_url = decl.get("base_url")
+    if base_url is not None:
+        if not isinstance(base_url, str) or not base_url:
+            raise ValueError(f"forge.yaml '{where}.base_url' must be a non-empty string")
+        definition["base_url"] = base_url
+    return definition
 
 
 def _parse_custom_model_registry(
     custom_raw: dict[str, Any],
-) -> tuple[dict[str, AgentSpec], dict[str, str]]:
+) -> tuple[dict[str, AgentSpec], dict[str, str], dict[str, dict[str, str]]]:
     """Parse and validate user-declared model overlays from forge.yaml.
 
-    Returns ``(registry, declaration_aliases)``. The registry is keyed by
-    canonical identity (``provider/model/transport-kind``); the alias map
+    Returns ``(registry, declaration_aliases, field_sources)``. The registry is
+    keyed by canonical identity (``provider/model/transport-kind``); the alias map
     translates the operator-chosen declaration key into that identity so a
     ``models.enabled`` entry may still refer to the declaration by name. The
     declaration key is raw input and never reaches the registry.
+
+    A ``models.custom`` entry is a standalone declaration, not a refinement of a
+    built-in one (replacing a built-in identity requires ``override: true``), so
+    it resolves without a built-in fallback and every field is its own.
     """
     registry: dict[str, AgentSpec] = {}
     aliases: dict[str, str] = {}
+    field_sources: dict[str, dict[str, str]] = {}
     for canonical_id, decl in custom_raw.items():
         if not isinstance(canonical_id, str) or not canonical_id:
             raise ValueError("forge.yaml 'models.custom' keys must be non-empty strings")
-        if not isinstance(decl, dict):
-            raise ValueError(f"forge.yaml 'models.custom.{canonical_id}' must be a mapping")
-
-        missing = [
-            key
-            for key in (
-                "provider",
-                "model",
-                "tier",
-                "input_cost_per_mtok",
-                "output_cost_per_mtok",
-            )
-            if key not in decl
-        ]
-        if missing:
-            raise ValueError(
-                "forge.yaml "
-                f"'models.custom.{canonical_id}' is missing required field(s): {missing}"
-            )
-
-        provider = decl["provider"]
-        model = decl["model"]
-        tier = decl["tier"]
-        if not isinstance(provider, str) or not provider:
-            raise ValueError(
-                f"forge.yaml 'models.custom.{canonical_id}.provider' must be a non-empty string"
-            )
-        if not isinstance(model, str) or not model:
-            raise ValueError(
-                f"forge.yaml 'models.custom.{canonical_id}.model' must be a non-empty string"
-            )
-        if not isinstance(tier, str) or not tier:
-            raise ValueError(
-                f"forge.yaml 'models.custom.{canonical_id}.tier' must be a non-empty string"
-            )
-
-        if provider not in known_model_overlay_providers():
-            known = ", ".join(known_model_overlay_providers())
-            raise ValueError(
-                f"Unknown provider {provider!r} in models.custom.{canonical_id}. "
-                f"Known providers/adapters: {known}"
-            )
-
-        input_cost = decl["input_cost_per_mtok"]
-        output_cost = decl["output_cost_per_mtok"]
-        if (
-            isinstance(input_cost, bool)
-            or not isinstance(input_cost, (int, float))
-            or float(input_cost) < 0
-        ):
-            raise ValueError(
-                f"forge.yaml 'models.custom.{canonical_id}.input_cost_per_mtok' must be a "
-                f"non-negative number, got {input_cost!r}"
-            )
-        if (
-            isinstance(output_cost, bool)
-            or not isinstance(output_cost, (int, float))
-            or float(output_cost) < 0
-        ):
-            raise ValueError(
-                f"forge.yaml 'models.custom.{canonical_id}.output_cost_per_mtok' must be a "
-                f"non-negative number, got {output_cost!r}"
-            )
-
-        transport_kind = (
-            _parse_transport_block(decl["transport"], f"models.custom.{canonical_id}")
-            if "transport" in decl
-            else None
-        )
-        normalized_provider, transport = overlay_transport(provider, transport_kind)
-        base_url = decl.get("base_url")
-        if base_url is not None and (not isinstance(base_url, str) or not base_url):
-            raise ValueError(
-                f"forge.yaml 'models.custom.{canonical_id}.base_url' must be a non-empty string"
-            )
-        # A models.custom declaration states its own prices for its own identity,
-        # so the pair is attributed to the operator's declaration and bands.
-        overlay_cost_rank = custom_model_cost_rank(
-            float(input_cost),
-            float(output_cost),
-            pricing_provenance=PRICING_PROVENANCE_OPERATOR_DECLARED,
-        )
-        spec = AgentSpec(
-            provider=normalized_provider,
-            model=model,
-            transport=transport,
-            routing=RoutingPolicy(
-                tier=tier,
-                capability=custom_model_capability(tier),
-                cost_rank=(
-                    overlay_cost_rank if overlay_cost_rank is not None else UNPRICED_COST_RANK
-                ),
-                dev_capable=custom_model_dev_capable(transport),
-                cost_rank_basis=(
-                    price_cost_band_basis(PRICING_PROVENANCE_OPERATOR_DECLARED)
-                    if overlay_cost_rank is not None
-                    else COST_BAND_BASIS_UNPRICED_DEFAULT
-                ),
-            ),
-            base_url=base_url,
-            registry_source="forge.yaml",
-            input_cost_per_mtok=float(input_cost),
-            output_cost_per_mtok=float(output_cost),
-            pricing_provenance=PRICING_PROVENANCE_OPERATOR_DECLARED,
+        where = f"models.custom.{canonical_id}"
+        definition = _custom_declaration_to_definition(canonical_id, decl)
+        resolved = resolve_project(
+            parse_definition(definition, where=where), where=where, builtin=None
         )
         # The declaration key is operator-chosen; the identity is not. Register
         # the spec under its canonical id so nothing downstream can select the
         # same model twice under two different names.
-        identity = canonical_id_for_spec(spec)
-        registry[identity] = spec
-        aliases[canonical_id] = identity
-    return registry, aliases
+        registry[resolved.canonical_id] = resolved.spec
+        field_sources[resolved.canonical_id] = resolved.field_sources
+        aliases[canonical_id] = resolved.canonical_id
+    return registry, aliases, field_sources
 
 
 def _merge_model_registry(
@@ -1090,14 +936,32 @@ def load_config(config_path: Path) -> ForgeConfig:
     _raw_overrides: dict[str, Any] | None = None
     model_registry = dict(AGENT_REGISTRY)
     model_registry_sources = {key: "builtin" for key in AGENT_REGISTRY}
+    # Entry-level source (above) says which file an entry came from; this says
+    # which file supplied each *field* of it, which is the only way to read a
+    # partial project overlay of a shipped definition.
+    model_registry_field_sources: dict[str, dict[str, str]] = {
+        key: {field: "builtin" for field in PROVENANCE_FIELDS} for key in AGENT_REGISTRY
+    }
     custom_models: tuple[str, ...] = ()
     if "models" in raw:
-        models_list, inline_specs, custom_raw, simple_mode_enabled = _parse_models_section(
-            raw["models"]
-        )
+        (
+            models_list,
+            inline_specs,
+            inline_field_sources,
+            custom_raw,
+            simple_mode_enabled,
+        ) = _parse_models_section(raw["models"])
     else:
-        models_list, inline_specs, custom_raw, simple_mode_enabled = (None, {}, {}, False)
-    overlay_registry, overlay_aliases = _parse_custom_model_registry(custom_raw)
+        models_list, inline_specs, inline_field_sources, custom_raw, simple_mode_enabled = (
+            None,
+            {},
+            {},
+            {},
+            False,
+        )
+    overlay_registry, overlay_aliases, overlay_field_sources = _parse_custom_model_registry(
+        custom_raw
+    )
     custom_registry = {**overlay_registry, **inline_specs}
     if models_list is not None and overlay_aliases:
         models_list = [overlay_aliases.get(key, key) for key in models_list]
@@ -1110,6 +974,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         model_registry = _merge_model_registry(custom_registry, override_ids)
         custom_models = tuple(sorted(custom_registry))
         model_registry_sources.update({key: "forge.yaml" for key in custom_registry})
+        model_registry_field_sources.update({**overlay_field_sources, **inline_field_sources})
 
     if simple_mode_enabled:
         assert models_list is not None
@@ -1811,6 +1676,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         models_overrides=_raw_overrides,
         model_registry=model_registry,
         model_registry_sources=model_registry_sources,
+        model_registry_field_sources=model_registry_field_sources,
         custom_models=custom_models,
         diagnose=diagnose_cfg,
     )

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -254,6 +254,13 @@ _CUSTOM_REQUIRED_KEYS = (
     "input_cost_per_mtok",
     "output_cost_per_mtok",
 )
+# Top-level keys that exist only in the legacy flat shape. Their presence is what
+# tells the two shapes apart: ``provider``/``model``/``transport``/``base_url``
+# are spelled the same in both, so they cannot discriminate.
+_CUSTOM_LEGACY_ONLY_KEYS = frozenset({"tier", "input_cost_per_mtok", "output_cost_per_mtok"})
+# Operator control keys that ride alongside a declaration without being part of
+# the definition itself, and so are stripped before the definition is parsed.
+_CUSTOM_CONTROL_KEYS = frozenset({"override"})
 
 
 def _custom_declaration_to_definition(canonical_id: str, decl: dict[str, Any]) -> dict[str, Any]:
@@ -270,8 +277,6 @@ def _custom_declaration_to_definition(canonical_id: str, decl: dict[str, Any]) -
     messages keep naming the keys the operator actually wrote.
     """
     where = f"models.custom.{canonical_id}"
-    if not isinstance(decl, dict):
-        raise ValueError(f"forge.yaml '{where}' must be a mapping")
     missing = [key for key in _CUSTOM_REQUIRED_KEYS if key not in decl]
     if missing:
         raise ValueError(f"forge.yaml '{where}' is missing required field(s): {missing}")
@@ -324,6 +329,43 @@ def _custom_declaration_to_definition(canonical_id: str, decl: dict[str, Any]) -
     return definition
 
 
+def _custom_definition(canonical_id: str, decl: Any) -> dict[str, Any]:
+    """Return the canonical definition for one ``models.custom`` declaration.
+
+    Two shapes are accepted under this key, and which one was written is decided
+    by the legacy-only top-level fields (``tier``, ``input_cost_per_mtok``,
+    ``output_cost_per_mtok``):
+
+    - none present → the declaration is already canonical and goes to the shared
+      parser untouched, so a reusable ``models.custom`` entry can express every
+      field the shipped catalog can;
+    - any present → the legacy flat shape, translated field by field.
+
+    A declaration carrying both is rejected rather than silently resolved under
+    one reading: config loading is an integrity boundary, and guessing which
+    ``tier`` (flat or ``routing.tier``) the operator meant would decide routing
+    on a coin flip.
+    """
+    where = f"models.custom.{canonical_id}"
+    if not isinstance(decl, dict):
+        raise ValueError(f"forge.yaml '{where}' must be a mapping")
+    legacy_keys = sorted(_CUSTOM_LEGACY_ONLY_KEYS & decl.keys())
+    canonical_keys = sorted({"routing", "cost"} & decl.keys())
+    if legacy_keys and canonical_keys:
+        raise ValueError(
+            f"forge.yaml '{where}' mixes the flat declaration shape ({legacy_keys}) with the "
+            f"canonical one ({canonical_keys}). Use one: move {legacy_keys} under "
+            "'routing'/'cost', or drop the canonical block(s)."
+        )
+    if legacy_keys:
+        return _custom_declaration_to_definition(canonical_id, decl)
+    # Canonical: strip the operator control keys, which are not part of the
+    # definition, and let the shared parser validate the rest — including the
+    # adapter, so an unsupported provider fails here naming the adapters that do
+    # exist.
+    return {key: value for key, value in decl.items() if key not in _CUSTOM_CONTROL_KEYS}
+
+
 def _parse_custom_model_registry(
     custom_raw: dict[str, Any],
 ) -> tuple[dict[str, AgentSpec], dict[str, str], dict[str, dict[str, str]]]:
@@ -334,6 +376,14 @@ def _parse_custom_model_registry(
     translates the operator-chosen declaration key into that identity so a
     ``models.enabled`` entry may still refer to the declaration by name. The
     declaration key is raw input and never reaches the registry.
+
+    Both declaration shapes are accepted here. A declaration written in the
+    canonical schema (``routing``/``cost`` blocks) is handed to the shared parser
+    as-is, so ``models.custom`` is a fully expressive *reusable* definition
+    surface rather than a lesser one — a definition no longer has to be inlined
+    into ``models.enabled`` to set capability or phase eligibility. The legacy
+    flat shape is translated into the canonical one first
+    (:func:`_custom_declaration_to_definition`) and keeps loading unchanged.
 
     A ``models.custom`` entry is a standalone declaration, not a refinement of a
     built-in one (replacing a built-in identity requires ``override: true``), so
@@ -346,7 +396,7 @@ def _parse_custom_model_registry(
         if not isinstance(canonical_id, str) or not canonical_id:
             raise ValueError("forge.yaml 'models.custom' keys must be non-empty strings")
         where = f"models.custom.{canonical_id}"
-        definition = _custom_declaration_to_definition(canonical_id, decl)
+        definition = _custom_definition(canonical_id, decl)
         resolved = resolve_project(
             parse_definition(definition, where=where), where=where, builtin=None
         )

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -34,6 +34,7 @@ from .model_catalog import (
     parse_transport_block,
     resolve_project,
 )
+from .model_identity import MODEL_TIERS
 from .models import (
     AGENT_REGISTRY,
     AgentSpec,
@@ -290,6 +291,13 @@ def _custom_declaration_to_definition(canonical_id: str, decl: dict[str, Any]) -
         raise ValueError(f"forge.yaml '{where}.model' must be a non-empty string")
     if not isinstance(tier, str) or not tier:
         raise ValueError(f"forge.yaml '{where}.tier' must be a non-empty string")
+    # Checked here as well as in the canonical parser: this shape spells it at the
+    # top level, so delegating would report it as '<id>.routing.tier' — a key this
+    # operator did not write.
+    if tier not in MODEL_TIERS:
+        raise ValueError(
+            f"forge.yaml '{where}.tier' must be one of {sorted(MODEL_TIERS)}, got {tier!r}"
+        )
     if provider not in known_model_overlay_providers():
         known = ", ".join(known_model_overlay_providers())
         raise ValueError(

--- a/src/theforge/config/model_catalog.py
+++ b/src/theforge/config/model_catalog.py
@@ -60,6 +60,10 @@ import yaml
 
 from .model_identity import (
     _DEFAULT_PHASE_ELIGIBILITY,
+    CAPABILITY_RANGE,
+    COST_RANK_RANGE,
+    KNOWN_PHASES,
+    MODEL_TIERS,
     TRANSPORT_KINDS,
     AgentSpec,
     RoutingPolicy,
@@ -173,6 +177,31 @@ def _require_price(value: Any, *, where: str) -> float:
     return float(value)
 
 
+def _require_tier(value: Any, *, where: str) -> str:
+    tier = _require_str(value, where=where)
+    if tier not in MODEL_TIERS:
+        raise ValueError(
+            f"forge.yaml '{where}' must be one of {sorted(MODEL_TIERS)}, got {tier!r}"
+        )
+    return tier
+
+
+def _require_in_range(value: Any, bounds: tuple[int, int], *, where: str) -> int:
+    """Bound a routing integer to the scale its consumer actually reads.
+
+    Type alone is not enough for these: ``capability: 999`` and ``cost_rank: -8``
+    are well-typed and load, then sort a model to the top or bottom of every
+    candidate list forever. Out-of-scale is never a meaningful declaration, so it
+    is a load error rather than a value to clamp — clamping would resolve a
+    definition to something the operator did not write.
+    """
+    number = _require_int(value, where=where)
+    low, high = bounds
+    if not low <= number <= high:
+        raise ValueError(f"forge.yaml '{where}' must be between {low} and {high}, got {number}")
+    return number
+
+
 def parse_transport_block(raw: Any, where: str) -> tuple[str, str | None]:
     """Read the bounded ``transport: {kind: cli|api, runner: …}`` object.
 
@@ -249,14 +278,14 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
 
     routing: dict[str, Any] = {}
     if "tier" in routing_raw:
-        routing["tier"] = _require_str(routing_raw["tier"], where=f"{where}.routing.tier")
+        routing["tier"] = _require_tier(routing_raw["tier"], where=f"{where}.routing.tier")
     if "capability" in routing_raw:
-        routing["capability"] = _require_int(
-            routing_raw["capability"], where=f"{where}.routing.capability"
+        routing["capability"] = _require_in_range(
+            routing_raw["capability"], CAPABILITY_RANGE, where=f"{where}.routing.capability"
         )
     if "cost_rank" in routing_raw:
-        routing["cost_rank"] = _require_int(
-            routing_raw["cost_rank"], where=f"{where}.routing.cost_rank"
+        routing["cost_rank"] = _require_in_range(
+            routing_raw["cost_rank"], COST_RANK_RANGE, where=f"{where}.routing.cost_rank"
         )
     if "dev_capable" in routing_raw:
         routing["dev_capable"] = _require_bool(
@@ -268,9 +297,16 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
             raise ValueError(
                 f"forge.yaml '{where}.routing.phase_eligibility' must be a non-empty list"
             )
-        routing["phase_eligibility"] = frozenset(
+        parsed_phases = frozenset(
             _require_str(p, where=f"{where}.routing.phase_eligibility") for p in phases
         )
+        unknown_phases = parsed_phases - KNOWN_PHASES
+        if unknown_phases:
+            raise ValueError(
+                f"forge.yaml '{where}.routing.phase_eligibility' only supports "
+                f"{sorted(KNOWN_PHASES)}; got {sorted(unknown_phases)}"
+            )
+        routing["phase_eligibility"] = parsed_phases
     if "cost_rank_basis" in routing_raw:
         routing["cost_rank_basis"] = _require_str(
             routing_raw["cost_rank_basis"], where=f"{where}.routing.cost_rank_basis"
@@ -458,7 +494,16 @@ def resolve_project(
     elif banded_cost_rank is not None:
         cost_rank = banded_cost_rank
         cost_rank_basis = declared_basis or price_cost_band_basis(str(provenance))
-        sources["cost_rank"] = sources["input_cost_per_mtok"]
+        # The band is derived from *both* figures, so it is the project's as soon
+        # as either one is — reading only the input side reported an output-only
+        # overlay's band as builtin, which is the opposite of what happened. Fall
+        # back to the input side's source when neither is declared, which is the
+        # inherited-figures case.
+        sources["cost_rank"] = (
+            SOURCE_PROJECT
+            if declares_price
+            else sources.get("input_cost_per_mtok", SOURCE_BUILTIN)
+        )
     elif builtin is not None:
         cost_rank = builtin.cost_rank
         cost_rank_basis = declared_basis or builtin.routing.cost_rank_basis

--- a/src/theforge/config/model_catalog.py
+++ b/src/theforge/config/model_catalog.py
@@ -43,10 +43,11 @@ Two resolution modes sit on top of that one syntax:
   records which of the two sources supplied it, which is what makes a partial
   project overlay auditable rather than a silent replacement.
 
-Import note: :mod:`theforge.config.models` imports this module *lazily* (from
-inside a function) because this module imports the registry dataclasses from it.
-Everything imported below is defined above the point where ``models.py`` builds
-``AGENT_REGISTRY``, so the deferred import resolves cleanly.
+Layering: the identity types this module builds on live in
+:mod:`theforge.config.model_identity`, a leaf both this module and
+:mod:`theforge.config.models` import. That is what lets ``models.py`` build
+``AGENT_REGISTRY`` by calling :func:`load_packaged_catalog` at import time
+without the two modules importing each other.
 """
 
 from __future__ import annotations
@@ -57,7 +58,7 @@ from typing import Any, Callable
 
 import yaml
 
-from .models import (
+from .model_identity import (
     _DEFAULT_PHASE_ELIGIBILITY,
     TRANSPORT_KINDS,
     AgentSpec,
@@ -176,8 +177,8 @@ def parse_transport_block(raw: Any, where: str) -> tuple[str, str | None]:
     """Read the bounded ``transport: {kind: cli|api, runner: …}`` object.
 
     ``runner`` only needs naming for ``(provider, kind)`` tuples that admit more
-    than one executor; :func:`theforge.config.models.transport_for` derives it
-    everywhere else and rejects a runner that contradicts the tuple.
+    than one executor; :func:`theforge.config.model_identity.transport_for`
+    derives it everywhere else and rejects a runner that contradicts the tuple.
     """
     if not isinstance(raw, dict):
         raise ValueError(f"forge.yaml '{where}.transport' must be a mapping with a 'kind' key")

--- a/src/theforge/config/model_catalog.py
+++ b/src/theforge/config/model_catalog.py
@@ -1,0 +1,553 @@
+"""One canonical schema for model definitions, and the parser that reads it.
+
+A model definition is not behaviour. It is a canonical identity
+(``provider`` + ``model`` + transport kind) paired with a routing policy,
+endpoint metadata and cost seeds. The only part that genuinely requires code is
+the *adapter* that reaches a provider, because a provider needs a runner module.
+
+So there is one schema and one parser for both sources of definitions:
+
+- the shipped default set, which lives in ``config/data/models.yaml`` and is
+  loaded by :func:`load_packaged_catalog`;
+- project-declared models in ``forge.yaml`` (``models.custom`` and inline
+  ``models.enabled`` mappings), which reach the same parser through the
+  compatibility adapters in :mod:`theforge.config.load`.
+
+Canonical shape::
+
+    provider: openai
+    model: gpt-5.5
+    transport: {kind: cli}          # optional `runner:` for ambiguous tuples
+    base_url: http://…              # endpoint metadata, optional
+    routing:
+      tier: strong
+      capability: 9
+      cost_rank: 2
+      dev_capable: true
+      phase_eligibility: [preflight, dev, plan, review]
+      cost_rank_basis: declared-policy
+    cost:
+      input_per_mtok: 1.25
+      output_per_mtok: 10.00
+      pricing_provenance: gpt-5.5
+
+Two resolution modes sit on top of that one syntax:
+
+- :func:`resolve_packaged` — no built-in entry to fall back on, so the routing
+  policy must be complete, and a cost band that cannot be attributed to an
+  attributable price must name its non-price basis or construction raises. This
+  is what the shipped catalog is held to.
+- :func:`resolve_project` — overlay semantics. Anything the declaration omits
+  falls back to the built-in entry with the same canonical identity (when there
+  is one), then to a value derived from ``tier``/transport. Each resolved field
+  records which of the two sources supplied it, which is what makes a partial
+  project overlay auditable rather than a silent replacement.
+
+Import note: :mod:`theforge.config.models` imports this module *lazily* (from
+inside a function) because this module imports the registry dataclasses from it.
+Everything imported below is defined above the point where ``models.py`` builds
+``AGENT_REGISTRY``, so the deferred import resolves cleanly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any, Callable
+
+import yaml
+
+from .models import (
+    _DEFAULT_PHASE_ELIGIBILITY,
+    TRANSPORT_KINDS,
+    AgentSpec,
+    RoutingPolicy,
+    TransportSpec,
+    canonical_model_id,
+    custom_model_capability,
+    custom_model_dev_capable,
+    transport_for,
+)
+from .pricing import (
+    COST_BAND_BASIS_OPERATOR_DECLARED,
+    COST_BAND_BASIS_UNPRICED_DEFAULT,
+    PRICING_PROVENANCE_OPERATOR_DECLARED,
+    UNPRICED_COST_RANK,
+    custom_model_cost_rank,
+    price_cost_band_basis,
+    resolve_cost_band_basis,
+)
+
+# Where a resolved field came from.
+SOURCE_BUILTIN = "builtin"
+SOURCE_PROJECT = "forge.yaml"
+
+DEFINITION_KEYS: frozenset[str] = frozenset(
+    {"provider", "model", "transport", "routing", "base_url", "cost"}
+)
+ROUTING_KEYS: frozenset[str] = frozenset(
+    {
+        "tier",
+        "capability",
+        "cost_rank",
+        "dev_capable",
+        "phase_eligibility",
+        "cost_rank_basis",
+    }
+)
+COST_KEYS: frozenset[str] = frozenset({"input_per_mtok", "output_per_mtok", "pricing_provenance"})
+
+# The resolved fields provenance is reported for. Identity (provider, model,
+# transport) is deliberately absent: it is what the two sources *agree* on when
+# they describe the same entry, so there is nothing to attribute.
+PROVENANCE_FIELDS: tuple[str, ...] = (
+    "tier",
+    "capability",
+    "cost_rank",
+    "cost_rank_basis",
+    "dev_capable",
+    "phase_eligibility",
+    "base_url",
+    "input_cost_per_mtok",
+    "output_cost_per_mtok",
+    "pricing_provenance",
+)
+
+_CATALOG_PACKAGE = "theforge.config"
+_CATALOG_RESOURCE = "data/models.yaml"
+
+
+@dataclass(frozen=True)
+class ParsedDefinition:
+    """A syntax-validated definition, before routing policy is resolved.
+
+    ``declared`` holds the *resolved* field names the raw mapping actually
+    stated (``tier``, ``input_cost_per_mtok``, …), which is what lets overlay
+    resolution tell "the project set this" from "this was inherited".
+    """
+
+    canonical_id: str
+    provider: str
+    model: str
+    transport: TransportSpec
+    routing: dict[str, Any]
+    cost: dict[str, Any]
+    base_url: str | None
+    declared: frozenset[str]
+
+
+@dataclass(frozen=True)
+class ResolvedModel:
+    """A definition resolved into a registry entry plus per-field provenance."""
+
+    canonical_id: str
+    spec: AgentSpec
+    field_sources: dict[str, str]
+
+
+# ── Syntax ────────────────────────────────────────────────────────────────
+
+
+def _require_str(value: Any, *, where: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"forge.yaml '{where}' must be a non-empty string")
+    return value
+
+
+def _require_int(value: Any, *, where: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"forge.yaml '{where}' must be an integer, got {value!r}")
+    return value
+
+
+def _require_bool(value: Any, *, where: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"forge.yaml '{where}' must be a boolean, got {value!r}")
+    return value
+
+
+def _require_price(value: Any, *, where: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or float(value) < 0:
+        raise ValueError(f"forge.yaml '{where}' must be a non-negative number, got {value!r}")
+    return float(value)
+
+
+def parse_transport_block(raw: Any, where: str) -> tuple[str, str | None]:
+    """Read the bounded ``transport: {kind: cli|api, runner: …}`` object.
+
+    ``runner`` only needs naming for ``(provider, kind)`` tuples that admit more
+    than one executor; :func:`theforge.config.models.transport_for` derives it
+    everywhere else and rejects a runner that contradicts the tuple.
+    """
+    if not isinstance(raw, dict):
+        raise ValueError(f"forge.yaml '{where}.transport' must be a mapping with a 'kind' key")
+    unknown = set(raw) - {"kind", "runner"}
+    if unknown:
+        raise ValueError(
+            f"forge.yaml '{where}.transport' only supports 'kind' and 'runner'; "
+            f"got {sorted(unknown)}"
+        )
+    kind = raw.get("kind")
+    if kind not in TRANSPORT_KINDS:
+        raise ValueError(
+            f"forge.yaml '{where}.transport.kind' must be one of {sorted(TRANSPORT_KINDS)}, "
+            f"got {kind!r}"
+        )
+    runner = raw.get("runner")
+    if runner is not None and (not isinstance(runner, str) or not runner):
+        raise ValueError(f"forge.yaml '{where}.transport.runner' must be a non-empty string")
+    return str(kind), runner
+
+
+def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
+    """Validate one canonical model definition's syntax.
+
+    Adapter validation happens here: the ``(provider, transport.kind)`` tuple is
+    resolved through :func:`transport_for`, so a provider with no runner module
+    fails at load time with a message naming the adapters that do exist.
+    """
+    if not isinstance(entry, dict):
+        raise ValueError(f"forge.yaml '{where}' must be a mapping")
+    unknown = set(entry) - DEFINITION_KEYS
+    if unknown:
+        raise ValueError(
+            f"forge.yaml '{where}' only supports {sorted(DEFINITION_KEYS)}; "
+            f"unknown key(s): {sorted(unknown)}"
+        )
+    for required in ("provider", "model", "transport"):
+        if required not in entry:
+            raise ValueError(f"forge.yaml '{where}' is missing required field {required!r}")
+
+    provider = _require_str(entry["provider"], where=f"{where}.provider")
+    model = _require_str(entry["model"], where=f"{where}.model")
+    kind, runner = parse_transport_block(entry["transport"], where)
+    transport = transport_for(provider, kind, runner=runner)
+
+    routing_raw = entry.get("routing") or {}
+    if not isinstance(routing_raw, dict):
+        raise ValueError(f"forge.yaml '{where}.routing' must be a mapping")
+    unknown_routing = set(routing_raw) - ROUTING_KEYS
+    if unknown_routing:
+        raise ValueError(
+            f"forge.yaml '{where}.routing' only supports {sorted(ROUTING_KEYS)}; "
+            f"unknown key(s): {sorted(unknown_routing)}"
+        )
+    cost_raw = entry.get("cost") or {}
+    if not isinstance(cost_raw, dict):
+        raise ValueError(f"forge.yaml '{where}.cost' must be a mapping")
+    unknown_cost = set(cost_raw) - COST_KEYS
+    if unknown_cost:
+        raise ValueError(
+            f"forge.yaml '{where}.cost' only supports {sorted(COST_KEYS)}; "
+            f"unknown key(s): {sorted(unknown_cost)}"
+        )
+
+    base_url = entry.get("base_url")
+    if base_url is not None:
+        base_url = _require_str(base_url, where=f"{where}.base_url")
+
+    routing: dict[str, Any] = {}
+    if "tier" in routing_raw:
+        routing["tier"] = _require_str(routing_raw["tier"], where=f"{where}.routing.tier")
+    if "capability" in routing_raw:
+        routing["capability"] = _require_int(
+            routing_raw["capability"], where=f"{where}.routing.capability"
+        )
+    if "cost_rank" in routing_raw:
+        routing["cost_rank"] = _require_int(
+            routing_raw["cost_rank"], where=f"{where}.routing.cost_rank"
+        )
+    if "dev_capable" in routing_raw:
+        routing["dev_capable"] = _require_bool(
+            routing_raw["dev_capable"], where=f"{where}.routing.dev_capable"
+        )
+    if "phase_eligibility" in routing_raw:
+        phases = routing_raw["phase_eligibility"]
+        if not isinstance(phases, (list, tuple, set, frozenset)) or not phases:
+            raise ValueError(
+                f"forge.yaml '{where}.routing.phase_eligibility' must be a non-empty list"
+            )
+        routing["phase_eligibility"] = frozenset(
+            _require_str(p, where=f"{where}.routing.phase_eligibility") for p in phases
+        )
+    if "cost_rank_basis" in routing_raw:
+        routing["cost_rank_basis"] = _require_str(
+            routing_raw["cost_rank_basis"], where=f"{where}.routing.cost_rank_basis"
+        )
+
+    cost: dict[str, Any] = {}
+    if "input_per_mtok" in cost_raw:
+        cost["input_cost_per_mtok"] = _require_price(
+            cost_raw["input_per_mtok"], where=f"{where}.cost.input_per_mtok"
+        )
+    if "output_per_mtok" in cost_raw:
+        cost["output_cost_per_mtok"] = _require_price(
+            cost_raw["output_per_mtok"], where=f"{where}.cost.output_per_mtok"
+        )
+    if "pricing_provenance" in cost_raw:
+        provenance = cost_raw["pricing_provenance"]
+        # An explicit null is meaningful: it says "these figures are not
+        # attributable to this identity", which is exactly what a vendor
+        # shorthand must be able to state.
+        if provenance is not None:
+            provenance = _require_str(provenance, where=f"{where}.cost.pricing_provenance")
+        cost["pricing_provenance"] = provenance
+
+    declared = frozenset(routing) | frozenset(cost) | ({"base_url"} if base_url else set())
+    return ParsedDefinition(
+        canonical_id=canonical_model_id(provider, model, transport.kind),
+        provider=provider,
+        model=model,
+        transport=transport,
+        routing=routing,
+        cost=cost,
+        base_url=base_url,
+        declared=declared,
+    )
+
+
+# ── Resolution ────────────────────────────────────────────────────────────
+
+
+def resolve_packaged(defn: ParsedDefinition, *, where: str) -> ResolvedModel:
+    """Resolve a definition that has no built-in entry behind it.
+
+    The routing policy must be complete — there is nothing to inherit from —
+    and the cost band is held to the attribution rule in
+    :func:`config.pricing.resolve_cost_band_basis`: a band that is not this
+    entry's own attributable price band has to name its non-price basis.
+    """
+    for required in ("tier", "capability", "cost_rank"):
+        if required not in defn.routing:
+            raise ValueError(
+                f"forge.yaml '{where}.routing' is missing required field {required!r}"
+            )
+    input_cost = defn.cost.get("input_cost_per_mtok")
+    output_cost = defn.cost.get("output_cost_per_mtok")
+    provenance = defn.cost.get("pricing_provenance")
+    basis = resolve_cost_band_basis(
+        defn.routing["cost_rank"],
+        input_cost_per_mtok=input_cost,
+        output_cost_per_mtok=output_cost,
+        pricing_provenance=provenance,
+        declared_basis=defn.routing.get("cost_rank_basis"),
+    )
+    spec = AgentSpec(
+        provider=defn.provider,
+        model=defn.model,
+        transport=defn.transport,
+        routing=RoutingPolicy(
+            tier=defn.routing["tier"],
+            capability=defn.routing["capability"],
+            cost_rank=defn.routing["cost_rank"],
+            dev_capable=defn.routing.get("dev_capable", True),
+            phase_eligibility=defn.routing.get("phase_eligibility", _DEFAULT_PHASE_ELIGIBILITY),
+            cost_rank_basis=basis,
+        ),
+        base_url=defn.base_url,
+        registry_source=SOURCE_BUILTIN,
+        input_cost_per_mtok=input_cost,
+        output_cost_per_mtok=output_cost,
+        pricing_provenance=provenance,
+    )
+    return ResolvedModel(
+        canonical_id=defn.canonical_id,
+        spec=spec,
+        field_sources={field: SOURCE_BUILTIN for field in PROVENANCE_FIELDS},
+    )
+
+
+def resolve_project(
+    defn: ParsedDefinition,
+    *,
+    where: str,
+    builtin: AgentSpec | None,
+) -> ResolvedModel:
+    """Resolve a project-declared definition, overlaying a built-in entry.
+
+    Precedence per field: what the declaration states, then the built-in entry
+    with the same canonical identity, then a value derived from ``tier`` and the
+    transport. Every resolved field records which of the two sources supplied it.
+    """
+    sources: dict[str, str] = {}
+
+    def _pick(
+        field: str,
+        declared: Any,
+        builtin_value: Any,
+        derived: Callable[[], Any] = lambda: None,
+    ) -> Any:
+        """Resolve one field and record where the value came from.
+
+        ``derived`` is a thunk: the fallback for a field the built-in registry
+        would have supplied must not be *computed* when a built-in entry exists
+        (deriving capability from tier rejects tiers an overlay may legitimately
+        use when it is only refining an existing entry).
+        """
+        if field in defn.declared:
+            sources[field] = SOURCE_PROJECT
+            return declared
+        if builtin is not None:
+            sources[field] = SOURCE_BUILTIN
+            return builtin_value
+        sources[field] = SOURCE_PROJECT
+        return derived()
+
+    tier = _pick("tier", defn.routing.get("tier"), builtin.tier if builtin is not None else None)
+    if not tier:
+        raise ValueError(
+            f"forge.yaml '{where}.routing.tier' is required for a model that is not "
+            "in the built-in registry"
+        )
+
+    input_cost = _pick(
+        "input_cost_per_mtok",
+        defn.cost.get("input_cost_per_mtok"),
+        builtin.input_cost_per_mtok if builtin is not None else None,
+    )
+    output_cost = _pick(
+        "output_cost_per_mtok",
+        defn.cost.get("output_cost_per_mtok"),
+        builtin.output_cost_per_mtok if builtin is not None else None,
+    )
+    # Declaring a `cost:` figure without saying what it is attributed to
+    # attributes it to this identity — the operator asserted it here. An
+    # explicit `pricing_provenance` (including an explicit null) wins over that
+    # inference. Figures merely *inherited* from a built-in entry keep that
+    # entry's attribution, which for a vendor-shorthand identity is None: the
+    # literal is carried for reference but must not band.
+    declares_price = bool({"input_cost_per_mtok", "output_cost_per_mtok"} & defn.declared)
+    if "pricing_provenance" in defn.declared:
+        sources["pricing_provenance"] = SOURCE_PROJECT
+        provenance = defn.cost["pricing_provenance"]
+    elif declares_price:
+        sources["pricing_provenance"] = SOURCE_PROJECT
+        provenance = PRICING_PROVENANCE_OPERATOR_DECLARED
+    else:
+        sources["pricing_provenance"] = SOURCE_BUILTIN if builtin is not None else SOURCE_PROJECT
+        provenance = builtin.pricing_provenance if builtin is not None else None
+
+    banded_cost_rank = (
+        custom_model_cost_rank(
+            float(input_cost or 0.0),
+            float(output_cost or 0.0),
+            pricing_provenance=provenance,
+        )
+        if input_cost is not None or output_cost is not None
+        else None
+    )
+    # The band travels with the reason it holds, in the same order of precedence:
+    # the operator's own declaration, then this entry's attributable price, then
+    # whatever the built-in entry already justified, then the unpriced default.
+    # Nothing here can reach the band of an unattributed literal — the second
+    # branch is gated on `banded_cost_rank`, which is None in that case.
+    declared_basis = defn.routing.get("cost_rank_basis")
+    if "cost_rank" in defn.declared:
+        cost_rank = defn.routing["cost_rank"]
+        # A stated band that *is* this entry's attributable price band is
+        # attributed to that price, exactly as the packaged path attributes it —
+        # the same definition must not read differently depending on which file
+        # it was written in. Any other stated band is the operator's own.
+        cost_rank_basis = declared_basis or (
+            price_cost_band_basis(str(provenance))
+            if banded_cost_rank == cost_rank
+            else COST_BAND_BASIS_OPERATOR_DECLARED
+        )
+        sources["cost_rank"] = SOURCE_PROJECT
+    elif banded_cost_rank is not None:
+        cost_rank = banded_cost_rank
+        cost_rank_basis = declared_basis or price_cost_band_basis(str(provenance))
+        sources["cost_rank"] = sources["input_cost_per_mtok"]
+    elif builtin is not None:
+        cost_rank = builtin.cost_rank
+        cost_rank_basis = declared_basis or builtin.routing.cost_rank_basis
+        sources["cost_rank"] = SOURCE_BUILTIN
+    else:
+        cost_rank = UNPRICED_COST_RANK
+        cost_rank_basis = declared_basis or COST_BAND_BASIS_UNPRICED_DEFAULT
+        sources["cost_rank"] = SOURCE_PROJECT
+    sources["cost_rank_basis"] = (
+        SOURCE_PROJECT if declared_basis is not None else sources["cost_rank"]
+    )
+
+    capability = _pick(
+        "capability",
+        defn.routing.get("capability"),
+        builtin.capability if builtin is not None else None,
+        lambda: custom_model_capability(tier),
+    )
+    dev_capable = _pick(
+        "dev_capable",
+        defn.routing.get("dev_capable"),
+        builtin.dev_capable if builtin is not None else None,
+        lambda: custom_model_dev_capable(defn.transport),
+    )
+    phase_eligibility = _pick(
+        "phase_eligibility",
+        defn.routing.get("phase_eligibility"),
+        builtin.phase_eligibility if builtin is not None else None,
+        lambda: _DEFAULT_PHASE_ELIGIBILITY,
+    )
+    base_url = _pick(
+        "base_url",
+        defn.base_url,
+        builtin.base_url if builtin is not None else None,
+    )
+
+    spec = AgentSpec(
+        provider=defn.provider,
+        model=defn.model,
+        transport=defn.transport,
+        routing=RoutingPolicy(
+            tier=tier,
+            capability=capability,
+            cost_rank=cost_rank,
+            dev_capable=dev_capable,
+            phase_eligibility=phase_eligibility,
+            cost_rank_basis=cost_rank_basis,
+        ),
+        base_url=base_url,
+        registry_source=SOURCE_PROJECT,
+        input_cost_per_mtok=input_cost,
+        output_cost_per_mtok=output_cost,
+        pricing_provenance=provenance,
+    )
+    return ResolvedModel(
+        canonical_id=defn.canonical_id,
+        spec=spec,
+        field_sources={field: sources.get(field, SOURCE_PROJECT) for field in PROVENANCE_FIELDS},
+    )
+
+
+# ── Packaged catalog ──────────────────────────────────────────────────────
+
+
+def _read_catalog_document() -> Any:
+    resource = resources.files(_CATALOG_PACKAGE).joinpath(_CATALOG_RESOURCE)
+    return yaml.safe_load(resource.read_text(encoding="utf-8"))
+
+
+def load_packaged_catalog() -> dict[str, AgentSpec]:
+    """Load the shipped default model set from ``config/data/models.yaml``.
+
+    Read through the same parser project declarations use, so both sources
+    produce identical structures and one schema governs them.
+    """
+    document = _read_catalog_document()
+    if not isinstance(document, dict) or not isinstance(document.get("models"), list):
+        raise ValueError(
+            "packaged model catalog (config/data/models.yaml) must be a mapping with a "
+            "'models' list"
+        )
+    registry: dict[str, AgentSpec] = {}
+    for index, entry in enumerate(document["models"]):
+        where = f"models[{index}]"
+        defn = parse_definition(entry, where=where)
+        resolved = resolve_packaged(defn, where=where)
+        if resolved.canonical_id in registry:
+            raise ValueError(
+                f"packaged model catalog declares {resolved.canonical_id!r} twice "
+                f"({where}); canonical identities must be unique"
+            )
+        registry[resolved.canonical_id] = resolved.spec
+    return registry

--- a/src/theforge/config/model_identity.py
+++ b/src/theforge/config/model_identity.py
@@ -1,0 +1,368 @@
+"""Canonical model identity: transport, routing policy, and the AgentSpec.
+
+The identity half of the model registry, kept in its own low-dependency module
+so both the registry (:mod:`theforge.config.models`) and the definition parser
+(:mod:`theforge.config.model_catalog`) can build on it without importing each
+other. A model is exactly ``(provider, model, transport.kind)``; everything that
+turns a raw operator spelling into that triple, and the routing policy attached
+to it, lives here.
+
+Transport is first class: ``cli``/``api`` is never encoded in a provider-like
+prefix (``openai-api/``, ``gemini-cli/``). Those spellings survive only as raw
+input aliases below and are normalized to canonical identities the moment they
+are read.
+
+Depends only on :mod:`theforge.config.pricing` (stdlib-only) and the standard
+library, so it stays importable from anywhere in the config package.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .pricing import AttributablePricing
+
+TRANSPORT_KINDS: frozenset[str] = frozenset({"cli", "api"})
+
+
+@dataclass(frozen=True)
+class TransportSpec:
+    """How to execute an agent.
+
+    kind: "cli" — invoke via a locally installed binary (Claude/Codex/Gemini CLI)
+          "api" — invoke via a provider SDK (Anthropic/OpenAI/Google/DeepSeek)
+    runner: the logical runner module key (e.g. "claude", "codex", "gemini",
+            "anthropic", "openai", "google", "deepseek"). For CLI transports this
+            identifies both the runner and the binary; for API transports this
+            identifies the adapter to dispatch to. It is *derived* from
+            ``(provider, kind)`` by :func:`transport_for` wherever that tuple has
+            exactly one valid executor; only genuinely ambiguous tuples require an
+            explicit runner.
+    executable: only meaningful for kind="cli" — the binary name on PATH.
+    """
+
+    kind: str  # "cli" | "api"
+    runner: str
+    executable: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in TRANSPORT_KINDS:
+            raise ValueError(f"TransportSpec.kind must be 'cli' or 'api', got {self.kind!r}")
+        if self.kind == "cli" and not self.executable:
+            raise ValueError("TransportSpec(kind='cli') requires an executable name")
+        if self.kind == "api" and self.executable is not None:
+            raise ValueError("TransportSpec(kind='api') must not set an executable")
+
+
+_DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = frozenset({"preflight", "dev", "plan", "review"})
+
+
+@dataclass(frozen=True)
+class RoutingPolicy:
+    """Routing/selection policy for a model — deliberately *not* its identity.
+
+    Two registry entries with the same ``(provider, model, transport.kind)`` are
+    the same model no matter how their routing policy differs. Keeping tier,
+    capability, cost band, dev capability and phase eligibility here (rather than
+    inline on :class:`AgentSpec`) is what makes that separation checkable.
+    """
+
+    tier: str  # "cheap" | "fast" | "strong" (semantic speed/latency band)
+    capability: int  # 1-10 relative capability score
+    cost_rank: int  # 1=cheap, 2=moderate, 3=expensive
+    dev_capable: bool = True  # whether this agent is allowed to own the dev role
+    phase_eligibility: frozenset[str] = _DEFAULT_PHASE_ELIGIBILITY
+    # What ``cost_rank`` is derived from: ``price:<provenance>`` when the band is
+    # the entry's own attributable price band, otherwise a COST_BAND_BASIS_*
+    # marker naming a non-price basis. The band is a routing input in its own
+    # right, so it may not be a bare number copied off an untraceable literal —
+    # see config/pricing.resolve_cost_band_basis.
+    cost_rank_basis: str | None = None
+
+
+# ── Runner derivation from (provider, transport.kind) ────────────────────
+#
+# The (provider, kind) tuple determines the executor wherever it is unambiguous.
+# Only tuples with more than one valid executor need an explicit runner — today
+# that is the gh-aw backend (ADR-0004), which reaches a remote agent through the
+# `gh` binary and therefore collides with the provider's own native CLI.
+_CLI_RUNNER_BY_PROVIDER: dict[str, tuple[str, str]] = {
+    # provider -> (runner, executable)
+    "anthropic": ("claude", "claude"),
+    "openai": ("codex", "codex"),
+    "google": ("gemini", "gemini"),
+}
+_API_RUNNER_BY_PROVIDER: dict[str, str] = {
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "google": "google",
+    "deepseek": "deepseek",
+}
+# Runners that must be named explicitly because (provider, kind) alone does not
+# select them: runner -> executable.
+_EXPLICIT_CLI_RUNNERS: dict[str, str] = {
+    "ghaw": "gh",  # gh-aw (GitHub Agentic Workflows) — dispatched via the `gh` binary
+}
+
+
+def transport_for(provider: str, kind: str, runner: str | None = None) -> TransportSpec:
+    """Build the canonical TransportSpec for a ``(provider, kind)`` identity.
+
+    The runner/executor is derived from ``(provider, kind)`` when that tuple has
+    exactly one valid executor. ``runner`` only needs to be supplied for tuples
+    that admit more than one (currently the gh-aw backend).
+    """
+    if kind not in TRANSPORT_KINDS:
+        raise ValueError(f"transport kind must be 'cli' or 'api', got {kind!r}")
+    if runner is not None and runner in _EXPLICIT_CLI_RUNNERS:
+        if kind != "cli":
+            raise ValueError(f"runner {runner!r} is a CLI runner but kind is {kind!r}")
+        return TransportSpec(kind="cli", runner=runner, executable=_EXPLICIT_CLI_RUNNERS[runner])
+    if kind == "cli":
+        derived = _CLI_RUNNER_BY_PROVIDER.get(provider)
+        if derived is None:
+            raise ValueError(
+                f"No CLI runner for provider {provider!r}. "
+                f"Providers with a CLI: {sorted(_CLI_RUNNER_BY_PROVIDER)}"
+            )
+        cli_runner, executable = derived
+        if runner is not None and runner != cli_runner:
+            raise ValueError(
+                f"runner {runner!r} is not valid for ({provider!r}, 'cli'); "
+                f"expected {cli_runner!r}"
+            )
+        return TransportSpec(kind="cli", runner=cli_runner, executable=executable)
+    api_runner = _API_RUNNER_BY_PROVIDER.get(provider)
+    if api_runner is None:
+        raise ValueError(
+            f"No API adapter for provider {provider!r}. "
+            f"Providers with an API adapter: {sorted(_API_RUNNER_BY_PROVIDER)}"
+        )
+    if runner is not None and runner != api_runner:
+        raise ValueError(
+            f"runner {runner!r} is not valid for ({provider!r}, 'api'); expected {api_runner!r}"
+        )
+    return TransportSpec(kind="api", runner=api_runner)
+
+
+@dataclass(frozen=True)
+class AgentSpec(AttributablePricing):
+    """First-class description of an agent: canonical identity + routing policy.
+
+    Identity is exactly ``(provider, model, transport.kind)`` — see
+    :func:`canonical_id_for_spec`. ``base_url`` is endpoint *metadata* on that
+    identity (this is how a local OpenAI-compatible model is expressed: an API
+    transport pointed at a localhost endpoint), and pricing is accounting
+    metadata. Neither participates in identity. Routing knobs live in
+    :attr:`routing`; the flat properties below are read-only conveniences for
+    callers that only need one of them.
+    """
+
+    provider: str  # "anthropic" | "openai" | "google" | "deepseek"
+    model: str  # model identifier (e.g. "sonnet", "gpt-5.4", "deepseek-reasoner")
+    transport: TransportSpec
+    routing: RoutingPolicy
+    base_url: str | None = None  # endpoint metadata (local/OpenAI-compatible servers)
+    tool_mode: str = "auto"  # "auto" = follow transport default; reserved for future use
+    registry_source: str = "builtin"  # "builtin" | "forge.yaml"
+    input_cost_per_mtok: float | None = None
+    output_cost_per_mtok: float | None = None
+    # What the prices above are attributed to (concrete billed identity or a
+    # PRICING_PROVENANCE_* marker). None = unattributed: routing treats the
+    # figures as unknown. See _AttributablePricing.
+    pricing_provenance: str | None = None
+
+    @property
+    def tier(self) -> str:
+        return self.routing.tier
+
+    @property
+    def capability(self) -> int:
+        return self.routing.capability
+
+    @property
+    def cost_rank(self) -> int:
+        return self.routing.cost_rank
+
+    @property
+    def dev_capable(self) -> bool:
+        return self.routing.dev_capable
+
+    @property
+    def phase_eligibility(self) -> frozenset[str]:
+        return self.routing.phase_eligibility
+
+
+# ── Canonical model identity ─────────────────────────────────────────
+#
+# The canonical model ID is the single key under which all profile data,
+# assignment history and audit records accumulate. Two registrations resolve
+# to the same canonical ID iff they refer to the same actual provider, model
+# and transport.kind. Format: ``<provider>/<model>/<transport.kind>``
+# (e.g. ``anthropic/sonnet/cli``, ``openai/gpt-5.4/api``).
+
+
+def canonical_model_id(provider: str, model: str, transport_kind: str) -> str:
+    """Build the canonical ID from its three constituent parts."""
+    return f"{provider}/{model}/{transport_kind}"
+
+
+def canonical_id_for_spec(spec: AgentSpec) -> str:
+    """Return the canonical ID for an :class:`AgentSpec`."""
+    return canonical_model_id(spec.provider, spec.model, spec.transport.kind)
+
+
+def is_canonical_model_id(value: str | None) -> bool:
+    """Return True if ``value`` already follows the canonical format."""
+    if not value or not isinstance(value, str):
+        return False
+    parts = value.split("/")
+    return len(parts) == 3 and bool(parts[0]) and bool(parts[1]) and parts[2] in ("cli", "api")
+
+
+# ── Routing defaults for a declaration that states no policy ─────────────
+#
+# A definition that names only a tier still has to land on a full routing
+# policy. These supply the two knobs that can be derived from what it did say,
+# and are used only when there is no built-in entry of the same identity to
+# inherit from — see config/model_catalog.resolve_project.
+
+
+def custom_model_capability(tier: str) -> int:
+    """Return the default capability score for a custom model tier."""
+    by_tier = {"cheap": 6, "fast": 7, "strong": 9}
+    if tier not in by_tier:
+        raise ValueError(f"models.custom tier must be one of {sorted(by_tier)}, got {tier!r}")
+    return by_tier[tier]
+
+
+def custom_model_dev_capable(transport: TransportSpec) -> bool:
+    """Return whether a custom model transport can own the dev role."""
+    return not (transport.kind == "cli" and transport.runner == "gemini")
+
+
+# ── Raw-input alias boundary ─────────────────────────────────────────────
+#
+# Everything below this comment exists only to translate *raw* operator input
+# into a canonical identity. Nothing downstream of config loading may consult it.
+
+# Provider-like tokens accepted in raw `models.custom` declarations. These are
+# aliases, not providers: each maps to a real provider family plus a transport
+# kind, and is normalized away immediately.
+_MODEL_OVERLAY_PROVIDER_MAP: dict[str, tuple[str, str]] = {
+    # alias token -> (provider family, transport kind)
+    "anthropic": ("anthropic", "cli"),
+    "claude": ("anthropic", "cli"),
+    "openai": ("openai", "cli"),
+    "openai-api": ("openai", "api"),
+    "deepseek": ("deepseek", "api"),
+    "google": ("google", "api"),
+    "gemini": ("google", "api"),
+    "gemini-cli": ("google", "cli"),
+}
+
+# Legacy CLI binary names accepted in raw profile/plan blocks, mapped to the
+# provider family whose CLI they are. Used only to migrate a raw ``cli:`` key
+# into a canonical transport at parse time.
+_LEGACY_CLI_TO_PROVIDER: dict[str, str] = {
+    "claude": "anthropic",
+    "codex": "openai",
+    "gemini": "google",
+    "ghaw": "anthropic",
+}
+
+
+def provider_for_cli_runner(runner: str | None) -> str | None:
+    """Map a CLI runner name (``claude``/``codex``/``gemini``) to its provider family."""
+    if not runner:
+        return None
+    return _LEGACY_CLI_TO_PROVIDER.get(runner)
+
+
+def provider_for_transport(transport: TransportSpec) -> str | None:
+    """Return the provider family a TransportSpec belongs to.
+
+    The inverse of :func:`transport_for`. Telemetry uses it to recover the
+    identity half (provider) from a CLI transport, where ``ModelProfile.provider``
+    is conventionally left unset.
+    """
+    if transport.kind == "api":
+        return next(
+            (p for p, runner in _API_RUNNER_BY_PROVIDER.items() if runner == transport.runner),
+            None,
+        )
+    for provider, (runner, _executable) in _CLI_RUNNER_BY_PROVIDER.items():
+        if runner == transport.runner:
+            return provider
+    return _LEGACY_CLI_TO_PROVIDER.get(transport.runner)
+
+
+def mirror_fields_for_transport(
+    transport: TransportSpec | None,
+    cli: str | None,
+    provider: str | None,
+) -> tuple[str | None, str | None]:
+    """Return the ``(cli, provider)`` pair that mirrors ``transport``.
+
+    Once a parse-boundary helper has resolved which transport an override lands
+    on, the legacy spelling has to be rewritten to match it — otherwise a stale
+    ``cli`` inherited from the profile being overridden survives into the
+    constructor and :func:`types._normalize_transport` re-derives the *old*
+    transport from it, silently discarding the switch.
+
+    Following the ``ModelProfile`` convention: a CLI transport mirrors as
+    ``(runner, None)`` and an API transport as ``(None, provider_family)``. When
+    the transport is unresolvable the raw pair is returned untouched so the
+    unresolved value still surfaces in error messages.
+    """
+    if transport is None:
+        return cli, provider
+    if transport.kind == "cli":
+        return transport.runner, None
+    return None, provider_for_transport(transport)
+
+
+def transport_from_raw_fields(
+    cli: str | None,
+    provider: str | None,
+) -> TransportSpec | None:
+    """Normalize a raw ``cli``/``provider`` pair into a canonical TransportSpec.
+
+    **Migration only.** ``cli`` and ``provider`` are raw-input spellings; runtime
+    dispatch reads :class:`TransportSpec` and never this pair. This helper exists
+    so the parsing boundary can turn old config (and legacy in-process
+    constructions) into a canonical transport once, at the edge.
+
+    ``cli`` wins when both are supplied — a declaration that names a CLI binary
+    is dispatched via that binary.
+    """
+    if cli and cli in _LEGACY_CLI_TO_PROVIDER:
+        runner = cli if cli in _EXPLICIT_CLI_RUNNERS else None
+        return transport_for(_LEGACY_CLI_TO_PROVIDER[cli], "cli", runner=runner)
+    if provider and provider in _API_RUNNER_BY_PROVIDER:
+        return transport_for(provider, "api")
+    return None
+
+
+def known_model_overlay_providers() -> tuple[str, ...]:
+    """Return accepted provider tokens for raw ``models.custom`` declarations."""
+    return tuple(sorted(_MODEL_OVERLAY_PROVIDER_MAP))
+
+
+def overlay_transport(
+    provider: str, transport_kind: str | None = None
+) -> tuple[str, TransportSpec]:
+    """Normalize a raw ``models.custom`` provider token into (provider, transport).
+
+    Raw-input boundary only. An explicit ``transport_kind`` (the canonical
+    spelling) wins; the provider-like alias tokens (``openai-api``,
+    ``gemini-cli``) are accepted purely for migration and carry an implied kind.
+    """
+    if provider not in _MODEL_OVERLAY_PROVIDER_MAP:
+        known = ", ".join(sorted(_MODEL_OVERLAY_PROVIDER_MAP))
+        raise ValueError(
+            f"Unknown provider {provider!r} in models.custom. Known providers/adapters: {known}"
+        )
+    family, implied_kind = _MODEL_OVERLAY_PROVIDER_MAP[provider]
+    kind = transport_kind or implied_kind
+    return family, transport_for(family, kind)

--- a/src/theforge/config/model_identity.py
+++ b/src/theforge/config/model_identity.py
@@ -56,6 +56,28 @@ class TransportSpec:
 
 _DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = frozenset({"preflight", "dev", "plan", "review"})
 
+# Domains of the routing fields, kept next to the policy they constrain so both
+# declaration surfaces check the same thing. Each is bounded by what actually
+# consumes it, not by taste:
+#
+# - ``MODEL_TIERS``: the tiers ``custom_model_capability`` below can score.
+# - ``CAPABILITY_RANGE``: the 1-10 scale ``RoutingPolicy.capability`` documents.
+# - ``COST_RANK_RANGE``: the bands role selection reads (1=cheap, 2=mid,
+#   3=strong) — see ``config/pricing.py``.
+# - ``KNOWN_PHASES``: the only phases ever queried, by ``derive_roles()`` in
+#   ``role_derivation.py``. It equals the default set today because every known
+#   phase is eligible by default; they are separate names because a future phase
+#   that is *not* default-eligible would make them diverge.
+#
+# An unrecognized phase is the sharpest of these: ``_phase_candidates`` falls
+# back to the whole list when filtering empties it, so ``[reviewer]`` for
+# ``[review]`` does not fail — it quietly drops the model from the pool it was
+# declared for, which is the failure mode that is impossible to see from config.
+MODEL_TIERS: frozenset[str] = frozenset({"cheap", "fast", "strong"})
+CAPABILITY_RANGE: tuple[int, int] = (1, 10)
+COST_RANK_RANGE: tuple[int, int] = (1, 3)
+KNOWN_PHASES: frozenset[str] = frozenset({"preflight", "dev", "plan", "review"})
+
 
 @dataclass(frozen=True)
 class RoutingPolicy:

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -1,12 +1,18 @@
-"""Model registry: AgentSpec / TransportSpec / ModelInfo and model-related helpers.
+"""Model registry: the shipped agent set, its legacy views, and lookup helpers.
 
 The registry is the single source of truth for what agents the system knows about.
 Each registry entry is expressed as an `AgentSpec` — a canonical identity
 (``provider`` + ``model`` + ``TransportSpec.kind``) paired with a separate
 :class:`RoutingPolicy` holding the routing/selection knobs (tier, capability,
-cost band, dev capability, phase eligibility). `ModelInfo` is retained as a
-legacy flat view derived from these specs so existing callers continue to work
-while the codebase migrates.
+cost band, dev capability, phase eligibility). Those identity types live in
+:mod:`theforge.config.model_identity` and are re-exported here, because this is
+the module the rest of the codebase has always imported them from.
+
+The entries themselves are *data*: :data:`AGENT_REGISTRY` is
+``config/data/models.yaml`` loaded through the shared canonical parser in
+:mod:`theforge.config.model_catalog`, the same one that reads project-declared
+models. `ModelInfo` is retained as a legacy flat view derived from these specs
+so existing callers continue to work while the codebase migrates.
 
 Transport is first class: ``cli``/``api`` is never encoded in a provider-like
 prefix (``openai-api/``, ``gemini-cli/``). Those spellings survive only as raw
@@ -28,6 +34,31 @@ from __future__ import annotations
 from dataclasses import dataclass, fields, replace
 from typing import Any, TypeVar, overload
 
+from .model_catalog import load_packaged_catalog, parse_definition, resolve_packaged
+from .model_identity import (
+    _DEFAULT_PHASE_ELIGIBILITY,
+    _LEGACY_CLI_TO_PROVIDER,
+)
+
+# Re-exported: the canonical identity types and the raw-input alias boundary
+# moved to config/model_identity.py so the definition parser can share them
+# without importing this module back. Every caller still imports them here.
+from .model_identity import TRANSPORT_KINDS as TRANSPORT_KINDS
+from .model_identity import AgentSpec as AgentSpec
+from .model_identity import RoutingPolicy as RoutingPolicy
+from .model_identity import TransportSpec as TransportSpec
+from .model_identity import canonical_id_for_spec as canonical_id_for_spec
+from .model_identity import canonical_model_id as canonical_model_id
+from .model_identity import custom_model_capability as custom_model_capability
+from .model_identity import custom_model_dev_capable as custom_model_dev_capable
+from .model_identity import is_canonical_model_id as is_canonical_model_id
+from .model_identity import known_model_overlay_providers as known_model_overlay_providers
+from .model_identity import mirror_fields_for_transport as mirror_fields_for_transport
+from .model_identity import overlay_transport as overlay_transport
+from .model_identity import provider_for_cli_runner as provider_for_cli_runner
+from .model_identity import provider_for_transport as provider_for_transport
+from .model_identity import transport_for as transport_for
+from .model_identity import transport_from_raw_fields as transport_from_raw_fields
 from .pricing import (
     AttributablePricing,
     price_tiebreak_signal_for,
@@ -50,290 +81,6 @@ from .types import (
 )
 
 _ProfileT = TypeVar("_ProfileT", ModelProfile, ModelRef, PlanConfig)
-
-TRANSPORT_KINDS: frozenset[str] = frozenset({"cli", "api"})
-
-
-@dataclass(frozen=True)
-class TransportSpec:
-    """How to execute an agent.
-
-    kind: "cli" — invoke via a locally installed binary (Claude/Codex/Gemini CLI)
-          "api" — invoke via a provider SDK (Anthropic/OpenAI/Google/DeepSeek)
-    runner: the logical runner module key (e.g. "claude", "codex", "gemini",
-            "anthropic", "openai", "google", "deepseek"). For CLI transports this
-            identifies both the runner and the binary; for API transports this
-            identifies the adapter to dispatch to. It is *derived* from
-            ``(provider, kind)`` by :func:`transport_for` wherever that tuple has
-            exactly one valid executor; only genuinely ambiguous tuples require an
-            explicit runner.
-    executable: only meaningful for kind="cli" — the binary name on PATH.
-    """
-
-    kind: str  # "cli" | "api"
-    runner: str
-    executable: str | None = None
-
-    def __post_init__(self) -> None:
-        if self.kind not in TRANSPORT_KINDS:
-            raise ValueError(f"TransportSpec.kind must be 'cli' or 'api', got {self.kind!r}")
-        if self.kind == "cli" and not self.executable:
-            raise ValueError("TransportSpec(kind='cli') requires an executable name")
-        if self.kind == "api" and self.executable is not None:
-            raise ValueError("TransportSpec(kind='api') must not set an executable")
-
-
-_DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = frozenset({"preflight", "dev", "plan", "review"})
-
-
-@dataclass(frozen=True)
-class RoutingPolicy:
-    """Routing/selection policy for a model — deliberately *not* its identity.
-
-    Two registry entries with the same ``(provider, model, transport.kind)`` are
-    the same model no matter how their routing policy differs. Keeping tier,
-    capability, cost band, dev capability and phase eligibility here (rather than
-    inline on :class:`AgentSpec`) is what makes that separation checkable.
-    """
-
-    tier: str  # "cheap" | "fast" | "strong" (semantic speed/latency band)
-    capability: int  # 1-10 relative capability score
-    cost_rank: int  # 1=cheap, 2=moderate, 3=expensive
-    dev_capable: bool = True  # whether this agent is allowed to own the dev role
-    phase_eligibility: frozenset[str] = _DEFAULT_PHASE_ELIGIBILITY
-    # What ``cost_rank`` is derived from: ``price:<provenance>`` when the band is
-    # the entry's own attributable price band, otherwise a COST_BAND_BASIS_*
-    # marker naming a non-price basis. The band is a routing input in its own
-    # right, so it may not be a bare number copied off an untraceable literal —
-    # see config/pricing.resolve_cost_band_basis.
-    cost_rank_basis: str | None = None
-
-
-# ── Runner derivation from (provider, transport.kind) ────────────────────
-#
-# The (provider, kind) tuple determines the executor wherever it is unambiguous.
-# Only tuples with more than one valid executor need an explicit runner — today
-# that is the gh-aw backend (ADR-0004), which reaches a remote agent through the
-# `gh` binary and therefore collides with the provider's own native CLI.
-_CLI_RUNNER_BY_PROVIDER: dict[str, tuple[str, str]] = {
-    # provider -> (runner, executable)
-    "anthropic": ("claude", "claude"),
-    "openai": ("codex", "codex"),
-    "google": ("gemini", "gemini"),
-}
-_API_RUNNER_BY_PROVIDER: dict[str, str] = {
-    "anthropic": "anthropic",
-    "openai": "openai",
-    "google": "google",
-    "deepseek": "deepseek",
-}
-# Runners that must be named explicitly because (provider, kind) alone does not
-# select them: runner -> executable.
-_EXPLICIT_CLI_RUNNERS: dict[str, str] = {
-    "ghaw": "gh",  # gh-aw (GitHub Agentic Workflows) — dispatched via the `gh` binary
-}
-
-
-def transport_for(provider: str, kind: str, runner: str | None = None) -> TransportSpec:
-    """Build the canonical TransportSpec for a ``(provider, kind)`` identity.
-
-    The runner/executor is derived from ``(provider, kind)`` when that tuple has
-    exactly one valid executor. ``runner`` only needs to be supplied for tuples
-    that admit more than one (currently the gh-aw backend).
-    """
-    if kind not in TRANSPORT_KINDS:
-        raise ValueError(f"transport kind must be 'cli' or 'api', got {kind!r}")
-    if runner is not None and runner in _EXPLICIT_CLI_RUNNERS:
-        if kind != "cli":
-            raise ValueError(f"runner {runner!r} is a CLI runner but kind is {kind!r}")
-        return TransportSpec(kind="cli", runner=runner, executable=_EXPLICIT_CLI_RUNNERS[runner])
-    if kind == "cli":
-        derived = _CLI_RUNNER_BY_PROVIDER.get(provider)
-        if derived is None:
-            raise ValueError(
-                f"No CLI runner for provider {provider!r}. "
-                f"Providers with a CLI: {sorted(_CLI_RUNNER_BY_PROVIDER)}"
-            )
-        cli_runner, executable = derived
-        if runner is not None and runner != cli_runner:
-            raise ValueError(
-                f"runner {runner!r} is not valid for ({provider!r}, 'cli'); "
-                f"expected {cli_runner!r}"
-            )
-        return TransportSpec(kind="cli", runner=cli_runner, executable=executable)
-    api_runner = _API_RUNNER_BY_PROVIDER.get(provider)
-    if api_runner is None:
-        raise ValueError(
-            f"No API adapter for provider {provider!r}. "
-            f"Providers with an API adapter: {sorted(_API_RUNNER_BY_PROVIDER)}"
-        )
-    if runner is not None and runner != api_runner:
-        raise ValueError(
-            f"runner {runner!r} is not valid for ({provider!r}, 'api'); expected {api_runner!r}"
-        )
-    return TransportSpec(kind="api", runner=api_runner)
-
-
-# Canonical transport objects — referenced by AGENT_REGISTRY entries.
-_TRANSPORT_CLAUDE_CLI = transport_for("anthropic", "cli")
-_TRANSPORT_CODEX_CLI = transport_for("openai", "cli")
-_TRANSPORT_GEMINI_CLI = transport_for("google", "cli")
-_TRANSPORT_GHAW_CLI = transport_for("anthropic", "cli", runner="ghaw")
-_TRANSPORT_ANTHROPIC_API = transport_for("anthropic", "api")
-_TRANSPORT_OPENAI_API = transport_for("openai", "api")
-_TRANSPORT_GOOGLE_API = transport_for("google", "api")
-_TRANSPORT_DEEPSEEK_API = transport_for("deepseek", "api")
-
-
-@dataclass(frozen=True)
-class AgentSpec(AttributablePricing):
-    """First-class description of an agent: canonical identity + routing policy.
-
-    Identity is exactly ``(provider, model, transport.kind)`` — see
-    :func:`canonical_id_for_spec`. ``base_url`` is endpoint *metadata* on that
-    identity (this is how a local OpenAI-compatible model is expressed: an API
-    transport pointed at a localhost endpoint), and pricing is accounting
-    metadata. Neither participates in identity. Routing knobs live in
-    :attr:`routing`; the flat properties below are read-only conveniences for
-    callers that only need one of them.
-    """
-
-    provider: str  # "anthropic" | "openai" | "google" | "deepseek"
-    model: str  # model identifier (e.g. "sonnet", "gpt-5.4", "deepseek-reasoner")
-    transport: TransportSpec
-    routing: RoutingPolicy
-    base_url: str | None = None  # endpoint metadata (local/OpenAI-compatible servers)
-    tool_mode: str = "auto"  # "auto" = follow transport default; reserved for future use
-    registry_source: str = "builtin"  # "builtin" | "forge.yaml"
-    input_cost_per_mtok: float | None = None
-    output_cost_per_mtok: float | None = None
-    # What the prices above are attributed to (concrete billed identity or a
-    # PRICING_PROVENANCE_* marker). None = unattributed: routing treats the
-    # figures as unknown. See _AttributablePricing.
-    pricing_provenance: str | None = None
-
-    @property
-    def tier(self) -> str:
-        return self.routing.tier
-
-    @property
-    def capability(self) -> int:
-        return self.routing.capability
-
-    @property
-    def cost_rank(self) -> int:
-        return self.routing.cost_rank
-
-    @property
-    def dev_capable(self) -> bool:
-        return self.routing.dev_capable
-
-    @property
-    def phase_eligibility(self) -> frozenset[str]:
-        return self.routing.phase_eligibility
-
-
-# ── Raw-input alias boundary ─────────────────────────────────────────────
-#
-# Everything below this comment exists only to translate *raw* operator input
-# into a canonical identity. Nothing downstream of config loading may consult it.
-
-# Provider-like tokens accepted in raw `models.custom` declarations. These are
-# aliases, not providers: each maps to a real provider family plus a transport
-# kind, and is normalized away immediately.
-_MODEL_OVERLAY_PROVIDER_MAP: dict[str, tuple[str, str]] = {
-    # alias token -> (provider family, transport kind)
-    "anthropic": ("anthropic", "cli"),
-    "claude": ("anthropic", "cli"),
-    "openai": ("openai", "cli"),
-    "openai-api": ("openai", "api"),
-    "deepseek": ("deepseek", "api"),
-    "google": ("google", "api"),
-    "gemini": ("google", "api"),
-    "gemini-cli": ("google", "cli"),
-}
-
-# Legacy CLI binary names accepted in raw profile/plan blocks, mapped to the
-# provider family whose CLI they are. Used only to migrate a raw ``cli:`` key
-# into a canonical transport at parse time.
-_LEGACY_CLI_TO_PROVIDER: dict[str, str] = {
-    "claude": "anthropic",
-    "codex": "openai",
-    "gemini": "google",
-    "ghaw": "anthropic",
-}
-
-
-def provider_for_cli_runner(runner: str | None) -> str | None:
-    """Map a CLI runner name (``claude``/``codex``/``gemini``) to its provider family."""
-    if not runner:
-        return None
-    return _LEGACY_CLI_TO_PROVIDER.get(runner)
-
-
-def provider_for_transport(transport: TransportSpec) -> str | None:
-    """Return the provider family a TransportSpec belongs to.
-
-    The inverse of :func:`transport_for`. Telemetry uses it to recover the
-    identity half (provider) from a CLI transport, where ``ModelProfile.provider``
-    is conventionally left unset.
-    """
-    if transport.kind == "api":
-        return next(
-            (p for p, runner in _API_RUNNER_BY_PROVIDER.items() if runner == transport.runner),
-            None,
-        )
-    for provider, (runner, _executable) in _CLI_RUNNER_BY_PROVIDER.items():
-        if runner == transport.runner:
-            return provider
-    return _LEGACY_CLI_TO_PROVIDER.get(transport.runner)
-
-
-def mirror_fields_for_transport(
-    transport: TransportSpec | None,
-    cli: str | None,
-    provider: str | None,
-) -> tuple[str | None, str | None]:
-    """Return the ``(cli, provider)`` pair that mirrors ``transport``.
-
-    Once a parse-boundary helper has resolved which transport an override lands
-    on, the legacy spelling has to be rewritten to match it — otherwise a stale
-    ``cli`` inherited from the profile being overridden survives into the
-    constructor and :func:`types._normalize_transport` re-derives the *old*
-    transport from it, silently discarding the switch.
-
-    Following the ``ModelProfile`` convention: a CLI transport mirrors as
-    ``(runner, None)`` and an API transport as ``(None, provider_family)``. When
-    the transport is unresolvable the raw pair is returned untouched so the
-    unresolved value still surfaces in error messages.
-    """
-    if transport is None:
-        return cli, provider
-    if transport.kind == "cli":
-        return transport.runner, None
-    return None, provider_for_transport(transport)
-
-
-def transport_from_raw_fields(
-    cli: str | None,
-    provider: str | None,
-) -> TransportSpec | None:
-    """Normalize a raw ``cli``/``provider`` pair into a canonical TransportSpec.
-
-    **Migration only.** ``cli`` and ``provider`` are raw-input spellings; runtime
-    dispatch reads :class:`TransportSpec` and never this pair. This helper exists
-    so the parsing boundary can turn old config (and legacy in-process
-    constructions) into a canonical transport once, at the edge.
-
-    ``cli`` wins when both are supplied — a declaration that names a CLI binary
-    is dispatched via that binary.
-    """
-    if cli and cli in _LEGACY_CLI_TO_PROVIDER:
-        runner = cli if cli in _EXPLICIT_CLI_RUNNERS else None
-        return transport_for(_LEGACY_CLI_TO_PROVIDER[cli], "cli", runner=runner)
-    if provider and provider in _API_RUNNER_BY_PROVIDER:
-        return transport_for(provider, "api")
-    return None
 
 
 @dataclass(frozen=True)
@@ -436,33 +183,6 @@ class AgentDef(AttributablePricing):
         )
 
 
-# ── Canonical model identity ─────────────────────────────────────────
-#
-# The canonical model ID is the single key under which all profile data,
-# assignment history and audit records accumulate. Two registrations resolve
-# to the same canonical ID iff they refer to the same actual provider, model
-# and transport.kind. Format: ``<provider>/<model>/<transport.kind>``
-# (e.g. ``anthropic/sonnet/cli``, ``openai/gpt-5.4/api``).
-
-
-def canonical_model_id(provider: str, model: str, transport_kind: str) -> str:
-    """Build the canonical ID from its three constituent parts."""
-    return f"{provider}/{model}/{transport_kind}"
-
-
-def canonical_id_for_spec(spec: AgentSpec) -> str:
-    """Return the canonical ID for an :class:`AgentSpec`."""
-    return canonical_model_id(spec.provider, spec.model, spec.transport.kind)
-
-
-def is_canonical_model_id(value: str | None) -> bool:
-    """Return True if ``value`` already follows the canonical format."""
-    if not value or not isinstance(value, str):
-        return False
-    parts = value.split("/")
-    return len(parts) == 3 and bool(parts[0]) and bool(parts[1]) and parts[2] in ("cli", "api")
-
-
 # ── Agent registry ────────────────────────────────────────────────────
 #
 # Keys are canonical model identities: ``<provider>/<model>/<transport.kind>``.
@@ -474,19 +194,6 @@ def is_canonical_model_id(value: str | None) -> bool:
 # Locality is endpoint metadata on an ordinary API transport; there is no
 # ``local`` provider and no ``local`` transport kind.
 LOCAL_OPENAI_COMPATIBLE_BASE_URL = "http://localhost:11434/v1"
-
-
-def custom_model_capability(tier: str) -> int:
-    """Return the default capability score for a custom model tier."""
-    by_tier = {"cheap": 6, "fast": 7, "strong": 9}
-    if tier not in by_tier:
-        raise ValueError(f"models.custom tier must be one of {sorted(by_tier)}, got {tier!r}")
-    return by_tier[tier]
-
-
-def custom_model_dev_capable(transport: TransportSpec) -> bool:
-    """Return whether a custom model transport can own the dev role."""
-    return not (transport.kind == "cli" and transport.runner == "gemini")
 
 
 def _entry(
@@ -525,8 +232,6 @@ def _entry(
     band — including every band on an entry whose price is unattributed — must
     name its non-price basis, or construction raises.
     """
-    from .model_catalog import parse_definition, resolve_packaged  # noqa: PLC0415
-
     transport_block: dict[str, Any] = {"kind": kind}
     if runner is not None:
         transport_block["runner"] = runner
@@ -561,26 +266,13 @@ def _entry(
     return resolved.canonical_id, resolved.spec
 
 
-def _load_packaged_registry() -> dict[str, AgentSpec]:
-    """Load the shipped default model set from packaged catalog data.
-
-    Imported lazily: :mod:`theforge.config.model_catalog` imports the registry
-    dataclasses from this module, and every name it needs is defined above this
-    call, so deferring the import to call time is what keeps the two modules
-    from forming an import cycle.
-    """
-    from .model_catalog import load_packaged_catalog  # noqa: PLC0415
-
-    return load_packaged_catalog()
-
-
 # The shipped default set is *data*, not code: it lives in
 # ``config/data/models.yaml`` and is read through the same canonical parser
 # project-declared models use. Adding or re-pinning a model that runs on an
 # already-supported adapter is an edit to that file — no code change, no
 # release. Adding a *provider* still requires code, because a provider needs a
 # runner module (see :func:`transport_for`).
-AGENT_REGISTRY: dict[str, AgentSpec] = _load_packaged_registry()
+AGENT_REGISTRY: dict[str, AgentSpec] = load_packaged_catalog()
 
 
 # Raw-input aliases for the pre-transport key spellings. These are accepted only
@@ -636,30 +328,6 @@ def normalize_model_key(model_key: str) -> str:
     if is_canonical_model_id(model_key):
         return model_key
     return _LEGACY_MODEL_KEY_ALIASES.get(model_key, model_key)
-
-
-def known_model_overlay_providers() -> tuple[str, ...]:
-    """Return accepted provider tokens for raw ``models.custom`` declarations."""
-    return tuple(sorted(_MODEL_OVERLAY_PROVIDER_MAP))
-
-
-def overlay_transport(
-    provider: str, transport_kind: str | None = None
-) -> tuple[str, TransportSpec]:
-    """Normalize a raw ``models.custom`` provider token into (provider, transport).
-
-    Raw-input boundary only. An explicit ``transport_kind`` (the canonical
-    spelling) wins; the provider-like alias tokens (``openai-api``,
-    ``gemini-cli``) are accepted purely for migration and carry an implied kind.
-    """
-    if provider not in _MODEL_OVERLAY_PROVIDER_MAP:
-        known = ", ".join(sorted(_MODEL_OVERLAY_PROVIDER_MAP))
-        raise ValueError(
-            f"Unknown provider {provider!r} in models.custom. Known providers/adapters: {known}"
-        )
-    family, implied_kind = _MODEL_OVERLAY_PROVIDER_MAP[provider]
-    kind = transport_kind or implied_kind
-    return family, transport_for(family, kind)
 
 
 def _spec_to_model_info(

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 from dataclasses import dataclass, fields, replace
 from typing import Any, TypeVar, overload
 
-from .model_catalog import load_packaged_catalog, parse_definition, resolve_packaged
+from .model_catalog import load_packaged_catalog
 from .model_identity import (
     _DEFAULT_PHASE_ELIGIBILITY,
     _LEGACY_CLI_TO_PROVIDER,
@@ -187,91 +187,15 @@ class AgentDef(AttributablePricing):
 #
 # Keys are canonical model identities: ``<provider>/<model>/<transport.kind>``.
 # CLI-vs-API is carried by the transport half of that key, never by a
-# provider-like prefix. Adding a model is a single entry here — no
-# role-derivation, profile, or runner-dispatch edits required.
-
-# Default endpoint for OpenAI-compatible models served locally (Ollama et al).
-# Locality is endpoint metadata on an ordinary API transport; there is no
-# ``local`` provider and no ``local`` transport kind.
-LOCAL_OPENAI_COMPATIBLE_BASE_URL = "http://localhost:11434/v1"
-
-
-def _entry(
-    provider: str,
-    model: str,
-    kind: str,
-    *,
-    tier: str,
-    capability: int,
-    cost_rank: int,
-    dev_capable: bool = True,
-    phases: frozenset[str] = _DEFAULT_PHASE_ELIGIBILITY,
-    runner: str | None = None,
-    base_url: str | None = None,
-    input_cost_per_mtok: float | None = None,
-    output_cost_per_mtok: float | None = None,
-    pricing_provenance: str | None = None,
-    cost_rank_basis: str | None = None,
-) -> tuple[str, AgentSpec]:
-    """Build a ``(canonical_id, AgentSpec)`` registry pair from keyword form.
-
-    A thin adapter over the canonical model-definition schema: the keywords are
-    assembled into a canonical definition mapping and resolved by the same
-    parser that reads the packaged catalog and project-declared models, so this
-    spelling cannot drift from the data one.
-
-    ``pricing_provenance`` names the concrete billed identity the price figures
-    were recorded for. Omitting it marks the figures unattributed, which is what
-    entries identified by a vendor shorthand must do: the shorthand resolves to
-    some other concrete version at invocation time, so nothing ties the stored
-    literal to what is actually billed.
-
-    ``cost_rank`` is a routing input too, so it is held to the same standard:
-    omit ``cost_rank_basis`` only when the band *is* this entry's attributable
-    price band (it is then attributed to that price automatically). Every other
-    band — including every band on an entry whose price is unattributed — must
-    name its non-price basis, or construction raises.
-    """
-    transport_block: dict[str, Any] = {"kind": kind}
-    if runner is not None:
-        transport_block["runner"] = runner
-    routing: dict[str, Any] = {
-        "tier": tier,
-        "capability": capability,
-        "cost_rank": cost_rank,
-        "dev_capable": dev_capable,
-        "phase_eligibility": sorted(phases),
-    }
-    if cost_rank_basis is not None:
-        routing["cost_rank_basis"] = cost_rank_basis
-    cost: dict[str, Any] = {}
-    if input_cost_per_mtok is not None:
-        cost["input_per_mtok"] = input_cost_per_mtok
-    if output_cost_per_mtok is not None:
-        cost["output_per_mtok"] = output_cost_per_mtok
-    if pricing_provenance is not None:
-        cost["pricing_provenance"] = pricing_provenance
-    definition: dict[str, Any] = {
-        "provider": provider,
-        "model": model,
-        "transport": transport_block,
-        "routing": routing,
-    }
-    if base_url is not None:
-        definition["base_url"] = base_url
-    if cost:
-        definition["cost"] = cost
-    where = f"{provider}/{model}/{kind}"
-    resolved = resolve_packaged(parse_definition(definition, where=where), where=where)
-    return resolved.canonical_id, resolved.spec
-
-
+# provider-like prefix.
+#
 # The shipped default set is *data*, not code: it lives in
 # ``config/data/models.yaml`` and is read through the same canonical parser
 # project-declared models use. Adding or re-pinning a model that runs on an
-# already-supported adapter is an edit to that file — no code change, no
-# release. Adding a *provider* still requires code, because a provider needs a
-# runner module (see :func:`transport_for`).
+# already-supported adapter is one entry in that file — no code change, no
+# release, and no role-derivation, profile, or runner-dispatch edits. Adding a
+# *provider* still requires code, because a provider needs a runner module (see
+# :func:`transport_for`).
 AGENT_REGISTRY: dict[str, AgentSpec] = load_packaged_catalog()
 
 

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -29,12 +29,8 @@ from dataclasses import dataclass, fields, replace
 from typing import Any, TypeVar, overload
 
 from .pricing import (
-    COST_BAND_BASIS_DECLARED_POLICY,
-    COST_BAND_BASIS_VENDOR_TIER,
-    PRICING_PROVENANCE_LOCAL_ENDPOINT,
     AttributablePricing,
     price_tiebreak_signal_for,
-    resolve_cost_band_basis,
 )
 
 # Re-exported: these moved to config/pricing.py, but callers (and the #1617
@@ -480,6 +476,19 @@ def is_canonical_model_id(value: str | None) -> bool:
 LOCAL_OPENAI_COMPATIBLE_BASE_URL = "http://localhost:11434/v1"
 
 
+def custom_model_capability(tier: str) -> int:
+    """Return the default capability score for a custom model tier."""
+    by_tier = {"cheap": 6, "fast": 7, "strong": 9}
+    if tier not in by_tier:
+        raise ValueError(f"models.custom tier must be one of {sorted(by_tier)}, got {tier!r}")
+    return by_tier[tier]
+
+
+def custom_model_dev_capable(transport: TransportSpec) -> bool:
+    """Return whether a custom model transport can own the dev role."""
+    return not (transport.kind == "cli" and transport.runner == "gemini")
+
+
 def _entry(
     provider: str,
     model: str,
@@ -497,7 +506,12 @@ def _entry(
     pricing_provenance: str | None = None,
     cost_rank_basis: str | None = None,
 ) -> tuple[str, AgentSpec]:
-    """Build a ``(canonical_id, AgentSpec)`` registry pair.
+    """Build a ``(canonical_id, AgentSpec)`` registry pair from keyword form.
+
+    A thin adapter over the canonical model-definition schema: the keywords are
+    assembled into a canonical definition mapping and resolved by the same
+    parser that reads the packaged catalog and project-declared models, so this
+    spelling cannot drift from the data one.
 
     ``pricing_provenance`` names the concrete billed identity the price figures
     were recorded for. Omitting it marks the figures unattributed, which is what
@@ -511,297 +525,62 @@ def _entry(
     band — including every band on an entry whose price is unattributed — must
     name its non-price basis, or construction raises.
     """
-    transport = transport_for(provider, kind, runner=runner)
-    basis = resolve_cost_band_basis(
-        cost_rank,
-        input_cost_per_mtok=input_cost_per_mtok,
-        output_cost_per_mtok=output_cost_per_mtok,
-        pricing_provenance=pricing_provenance,
-        declared_basis=cost_rank_basis,
-    )
-    spec = AgentSpec(
-        provider=provider,
-        model=model,
-        transport=transport,
-        routing=RoutingPolicy(
-            tier=tier,
-            capability=capability,
-            cost_rank=cost_rank,
-            dev_capable=dev_capable,
-            phase_eligibility=phases,
-            cost_rank_basis=basis,
-        ),
-        base_url=base_url,
-        input_cost_per_mtok=input_cost_per_mtok,
-        output_cost_per_mtok=output_cost_per_mtok,
-        pricing_provenance=pricing_provenance,
-    )
-    return canonical_id_for_spec(spec), spec
+    from .model_catalog import parse_definition, resolve_packaged  # noqa: PLC0415
+
+    transport_block: dict[str, Any] = {"kind": kind}
+    if runner is not None:
+        transport_block["runner"] = runner
+    routing: dict[str, Any] = {
+        "tier": tier,
+        "capability": capability,
+        "cost_rank": cost_rank,
+        "dev_capable": dev_capable,
+        "phase_eligibility": sorted(phases),
+    }
+    if cost_rank_basis is not None:
+        routing["cost_rank_basis"] = cost_rank_basis
+    cost: dict[str, Any] = {}
+    if input_cost_per_mtok is not None:
+        cost["input_per_mtok"] = input_cost_per_mtok
+    if output_cost_per_mtok is not None:
+        cost["output_per_mtok"] = output_cost_per_mtok
+    if pricing_provenance is not None:
+        cost["pricing_provenance"] = pricing_provenance
+    definition: dict[str, Any] = {
+        "provider": provider,
+        "model": model,
+        "transport": transport_block,
+        "routing": routing,
+    }
+    if base_url is not None:
+        definition["base_url"] = base_url
+    if cost:
+        definition["cost"] = cost
+    where = f"{provider}/{model}/{kind}"
+    resolved = resolve_packaged(parse_definition(definition, where=where), where=where)
+    return resolved.canonical_id, resolved.spec
 
 
-AGENT_REGISTRY: dict[str, AgentSpec] = dict(
-    [
-        # ── Anthropic ────────────────────────────────────────────────
-        #
-        # ``sonnet``/``opus`` are Claude-CLI shorthands, not billed identities:
-        # the CLI resolves each to whichever concrete version it currently ships
-        # (the vendor bills ``claude-sonnet-4-6`` / ``claude-opus-4-6``-style
-        # names — see runners/schema_utils.PRICING_TABLE). The entry identity can
-        # therefore move while the literal below does not, so these figures carry
-        # no pricing_provenance: they are indicative only and routing ignores
-        # them. Re-attributing them requires pinning the entry to the concrete
-        # version the price is true of.
-        #
-        # Their cost bands are not derived from those literals either — they
-        # restate the vendor's own tier naming, which is what the shorthand
-        # *means* and stays true when it resolves to a new version: ``opus`` is
-        # whatever Anthropic currently sells as its flagship (strong band),
-        # ``sonnet`` whatever it sells as the mid-priced workhorse (cheap band,
-        # as the fleet's baseline). Note the bands already disagree with the
-        # literals — 3.00/15.00 would band sonnet at 2 — so the figures could
-        # move to any value without moving either band.
-        _entry(
-            "anthropic",
-            "sonnet",
-            "cli",
-            tier="fast",
-            capability=7,
-            cost_rank=1,
-            input_cost_per_mtok=3.00,
-            output_cost_per_mtok=15.00,
-            cost_rank_basis=COST_BAND_BASIS_VENDOR_TIER,
-        ),
-        _entry(
-            "anthropic",
-            "opus",
-            "cli",
-            tier="strong",
-            capability=10,
-            cost_rank=3,
-            input_cost_per_mtok=15.00,
-            output_cost_per_mtok=75.00,
-            cost_rank_basis=COST_BAND_BASIS_VENDOR_TIER,
-        ),
-        # ── OpenAI (Codex CLI) ───────────────────────────────────────
-        #
-        # Unlike the Claude-CLI shorthands above, these model strings are the
-        # identity the vendor bills under — they are passed through verbatim and
-        # priced under the same name (runners/schema_utils.PRICING_TABLE keys
-        # them identically), so the figures are attributable to the entry.
-        _entry(
-            "openai",
-            "gpt-5.4",
-            "cli",
-            tier="strong",
-            capability=9,
-            cost_rank=2,
-            input_cost_per_mtok=1.25,
-            output_cost_per_mtok=10.00,
-            pricing_provenance="gpt-5.4",
-        ),
-        _entry(
-            "openai",
-            "gpt-5.4-mini",
-            "cli",
-            tier="cheap",
-            capability=7,
-            cost_rank=1,
-            input_cost_per_mtok=0.25,
-            output_cost_per_mtok=2.00,
-            pricing_provenance="gpt-5.4-mini",
-        ),
-        _entry(
-            "openai",
-            "gpt-5.4-pro",
-            "cli",
-            tier="strong",
-            capability=10,
-            cost_rank=3,
-            input_cost_per_mtok=15.00,
-            output_cost_per_mtok=120.00,
-            pricing_provenance="gpt-5.4-pro",
-        ),
-        # ── OpenAI (API) ─────────────────────────────────────────────
-        _entry(
-            "openai",
-            "gpt-5.4",
-            "api",
-            tier="strong",
-            capability=9,
-            cost_rank=2,
-            input_cost_per_mtok=1.25,
-            output_cost_per_mtok=10.00,
-            pricing_provenance="gpt-5.4",
-        ),
-        _entry(
-            "openai",
-            "gpt-5.4-mini",
-            "api",
-            tier="cheap",
-            capability=7,
-            cost_rank=1,
-            input_cost_per_mtok=0.25,
-            output_cost_per_mtok=2.00,
-            pricing_provenance="gpt-5.4-mini",
-        ),
-        _entry(
-            "openai",
-            "gpt-5.4-pro",
-            "api",
-            tier="strong",
-            capability=10,
-            cost_rank=3,
-            input_cost_per_mtok=15.00,
-            output_cost_per_mtok=120.00,
-            pricing_provenance="gpt-5.4-pro",
-            # Reasoning-heavy — intentionally excluded from the preflight role.
-            phases=frozenset({"dev", "plan", "review"}),
-        ),
-        # ── DeepSeek (API) ───────────────────────────────────────────
-        _entry(
-            "deepseek",
-            "deepseek-reasoner",
-            "api",
-            tier="strong",
-            capability=9,
-            cost_rank=2,
-            input_cost_per_mtok=0.55,
-            output_cost_per_mtok=2.19,
-            pricing_provenance="deepseek-reasoner",
-            # Banded a step above its per-MTok rate on purpose: a reasoning model
-            # spends far more output tokens per task, so the rate alone (band 1)
-            # understates what filling a role with it costs.
-            cost_rank_basis=COST_BAND_BASIS_DECLARED_POLICY,
-        ),
-        _entry(
-            "deepseek",
-            "deepseek-chat",
-            "api",
-            tier="fast",
-            capability=7,
-            cost_rank=1,
-            input_cost_per_mtok=0.27,
-            output_cost_per_mtok=1.10,
-            pricing_provenance="deepseek-chat",
-        ),
-        # ── Google (API) ─────────────────────────────────────────────
-        _entry(
-            "google",
-            "gemini-3-flash-preview",
-            "api",
-            tier="cheap",
-            capability=7,
-            cost_rank=1,
-        ),
-        _entry(
-            "google",
-            "gemini-3.1-pro-preview",
-            "api",
-            tier="strong",
-            capability=9,
-            cost_rank=2,
-            input_cost_per_mtok=2.00,
-            output_cost_per_mtok=12.00,
-            pricing_provenance="gemini-3.1-pro-preview",
-        ),
-        _entry(
-            "google",
-            "gemini-2.5-pro",
-            "api",
-            tier="strong",
-            capability=8,
-            cost_rank=2,
-            input_cost_per_mtok=1.25,
-            output_cost_per_mtok=10.00,
-            pricing_provenance="gemini-2.5-pro",
-        ),
-        # ── Google (Gemini CLI — explicit opt-in) ────────────────────
-        _entry(
-            "google",
-            "gemini-2.5-pro",
-            "cli",
-            tier="strong",
-            capability=8,
-            cost_rank=2,
-            dev_capable=False,
-            input_cost_per_mtok=1.25,
-            output_cost_per_mtok=10.00,
-            pricing_provenance="gemini-2.5-pro",
-        ),
-        _entry(
-            "google",
-            "gemini-3-flash-preview",
-            "cli",
-            tier="cheap",
-            capability=7,
-            cost_rank=1,
-            dev_capable=False,
-        ),
-        _entry(
-            "google",
-            "gemini-3.1-pro-preview",
-            "cli",
-            tier="strong",
-            capability=9,
-            cost_rank=2,
-            dev_capable=False,
-            input_cost_per_mtok=2.00,
-            output_cost_per_mtok=12.00,
-            pricing_provenance="gemini-3.1-pro-preview",
-        ),
-        # ── Local OpenAI-compatible models ───────────────────────────
-        # API transport + a localhost base_url. Not a provider prefix, not a
-        # transport kind — just an endpoint.
-        _entry(
-            "openai",
-            "codestral",
-            "api",
-            tier="fast",
-            capability=7,
-            cost_rank=1,
-            base_url=LOCAL_OPENAI_COMPATIBLE_BASE_URL,
-            input_cost_per_mtok=0.0,
-            output_cost_per_mtok=0.0,
-            pricing_provenance=PRICING_PROVENANCE_LOCAL_ENDPOINT,
-        ),
-        _entry(
-            "openai",
-            "deepseek-coder",
-            "api",
-            tier="fast",
-            capability=7,
-            cost_rank=1,
-            base_url=LOCAL_OPENAI_COMPATIBLE_BASE_URL,
-            input_cost_per_mtok=0.0,
-            output_cost_per_mtok=0.0,
-            pricing_provenance=PRICING_PROVENANCE_LOCAL_ENDPOINT,
-        ),
-        _entry(
-            "openai",
-            "llama3.1",
-            "api",
-            tier="fast",
-            capability=6,
-            cost_rank=1,
-            base_url=LOCAL_OPENAI_COMPATIBLE_BASE_URL,
-            input_cost_per_mtok=0.0,
-            output_cost_per_mtok=0.0,
-            pricing_provenance=PRICING_PROVENANCE_LOCAL_ENDPOINT,
-        ),
-        _entry(
-            "openai",
-            "qwen2.5-coder",
-            "api",
-            tier="fast",
-            capability=7,
-            cost_rank=1,
-            base_url=LOCAL_OPENAI_COMPATIBLE_BASE_URL,
-            input_cost_per_mtok=0.0,
-            output_cost_per_mtok=0.0,
-            pricing_provenance=PRICING_PROVENANCE_LOCAL_ENDPOINT,
-        ),
-    ]
-)
+def _load_packaged_registry() -> dict[str, AgentSpec]:
+    """Load the shipped default model set from packaged catalog data.
+
+    Imported lazily: :mod:`theforge.config.model_catalog` imports the registry
+    dataclasses from this module, and every name it needs is defined above this
+    call, so deferring the import to call time is what keeps the two modules
+    from forming an import cycle.
+    """
+    from .model_catalog import load_packaged_catalog  # noqa: PLC0415
+
+    return load_packaged_catalog()
+
+
+# The shipped default set is *data*, not code: it lives in
+# ``config/data/models.yaml`` and is read through the same canonical parser
+# project-declared models use. Adding or re-pinning a model that runs on an
+# already-supported adapter is an edit to that file — no code change, no
+# release. Adding a *provider* still requires code, because a provider needs a
+# runner module (see :func:`transport_for`).
+AGENT_REGISTRY: dict[str, AgentSpec] = _load_packaged_registry()
 
 
 # Raw-input aliases for the pre-transport key spellings. These are accepted only
@@ -881,19 +660,6 @@ def overlay_transport(
     family, implied_kind = _MODEL_OVERLAY_PROVIDER_MAP[provider]
     kind = transport_kind or implied_kind
     return family, transport_for(family, kind)
-
-
-def custom_model_capability(tier: str) -> int:
-    """Return the default capability score for a custom model tier."""
-    by_tier = {"cheap": 6, "fast": 7, "strong": 9}
-    if tier not in by_tier:
-        raise ValueError(f"models.custom tier must be one of {sorted(by_tier)}, got {tier!r}")
-    return by_tier[tier]
-
-
-def custom_model_dev_capable(transport: TransportSpec) -> bool:
-    """Return whether a custom model transport can own the dev role."""
-    return not (transport.kind == "cli" and transport.runner == "gemini")
 
 
 def _spec_to_model_info(

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -1239,6 +1239,13 @@ class ForgeConfig:
     # sets a populated dict (built-in + forge.yaml overlay).
     model_registry: dict[str, AgentSpec] | None = None
     model_registry_sources: dict[str, str] = field(default_factory=dict)
+    # Per-field provenance for the merged registry: {canonical_id: {field:
+    # "builtin" | "forge.yaml"}}. Entry-level ``model_registry_sources`` above
+    # says which file an entry came from; this says which file supplied each
+    # field of it, which is what makes a project declaration that only refines
+    # part of a shipped definition readable rather than opaque. Empty for a
+    # directly-constructed config that never went through load_config().
+    model_registry_field_sources: dict[str, dict[str, str]] = field(default_factory=dict)
     custom_models: tuple[str, ...] = ()
     diagnose: DiagnoseConfig = field(default_factory=DiagnoseConfig)
     # Identity of the configuration this object represents (#2056). Populated by

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 
 import argparse
 import ast
-import tomllib
+import zipfile
 from importlib import resources
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 import yaml
+from hatchling.builders.wheel import WheelBuilder
 
 from theforge.cli.check_config import cmd_check_config
 from theforge.config import load_config
@@ -113,35 +114,49 @@ class TestLayering:
 # ── The shipped set is data ───────────────────────────────────────────────
 
 # Routing policy of every entry the catalog shipped with, as ``(tier, capability,
-# cost_rank)``. These three fields decide which model gets which work, so a
-# change to one of them changes dispatch for every project on the release.
+# cost_rank, dev_capable, phase_eligibility)`` — the whole of RoutingPolicy that
+# decides *which* model gets work, so a change to any of it changes dispatch for
+# every project on the release.
+#
+# ``dev_capable`` and ``phase_eligibility`` are in here rather than left to the
+# first three because they gate rather than rank: dropping a phase removes a
+# model from that pool outright, and role derivation falls back to the unfiltered
+# list when a filter empties a pool, so the removal shows up as a quietly
+# different assignment rather than as an error.
+#
+# ``cost_rank_basis`` is deliberately excluded — it explains a band rather than
+# selecting anything, and pinning it here would duplicate the attribution tests
+# above.
 #
 # Asserted as a *subset*, which is what keeps the guard aligned with the point of
 # #2204 rather than fighting it: adding a model stays a pure data edit and needs
 # no test change, while re-tiering one of these fails until the expectation is
 # updated in the same commit. A silent re-tier is the failure #2217 was about,
 # and moving the set into YAML is what made it a one-line edit.
-_SHIPPED_ROUTING: dict[str, tuple[str, int, int]] = {
-    "anthropic/opus/cli": ("strong", 10, 3),
-    "anthropic/sonnet/cli": ("fast", 7, 1),
-    "deepseek/deepseek-chat/api": ("fast", 7, 1),
-    "deepseek/deepseek-reasoner/api": ("strong", 9, 2),
-    "google/gemini-2.5-pro/api": ("strong", 8, 2),
-    "google/gemini-2.5-pro/cli": ("strong", 8, 2),
-    "google/gemini-3-flash-preview/api": ("cheap", 7, 1),
-    "google/gemini-3-flash-preview/cli": ("cheap", 7, 1),
-    "google/gemini-3.1-pro-preview/api": ("strong", 9, 2),
-    "google/gemini-3.1-pro-preview/cli": ("strong", 9, 2),
-    "openai/codestral/api": ("fast", 7, 1),
-    "openai/deepseek-coder/api": ("fast", 7, 1),
-    "openai/gpt-5.4-mini/api": ("cheap", 7, 1),
-    "openai/gpt-5.4-mini/cli": ("cheap", 7, 1),
-    "openai/gpt-5.4-pro/api": ("strong", 10, 3),
-    "openai/gpt-5.4-pro/cli": ("strong", 10, 3),
-    "openai/gpt-5.4/api": ("strong", 9, 2),
-    "openai/gpt-5.4/cli": ("strong", 9, 2),
-    "openai/llama3.1/api": ("fast", 6, 1),
-    "openai/qwen2.5-coder/api": ("fast", 7, 1),
+_ALL_PHASES = ("dev", "plan", "preflight", "review")
+_SHIPPED_ROUTING: dict[str, tuple[str, int, int, bool, tuple[str, ...]]] = {
+    "anthropic/opus/cli": ("strong", 10, 3, True, _ALL_PHASES),
+    "anthropic/sonnet/cli": ("fast", 7, 1, True, _ALL_PHASES),
+    "deepseek/deepseek-chat/api": ("fast", 7, 1, True, _ALL_PHASES),
+    "deepseek/deepseek-reasoner/api": ("strong", 9, 2, True, _ALL_PHASES),
+    "google/gemini-2.5-pro/api": ("strong", 8, 2, True, _ALL_PHASES),
+    "google/gemini-2.5-pro/cli": ("strong", 8, 2, False, _ALL_PHASES),
+    "google/gemini-3-flash-preview/api": ("cheap", 7, 1, True, _ALL_PHASES),
+    "google/gemini-3-flash-preview/cli": ("cheap", 7, 1, False, _ALL_PHASES),
+    "google/gemini-3.1-pro-preview/api": ("strong", 9, 2, True, _ALL_PHASES),
+    "google/gemini-3.1-pro-preview/cli": ("strong", 9, 2, False, _ALL_PHASES),
+    "openai/codestral/api": ("fast", 7, 1, True, _ALL_PHASES),
+    "openai/deepseek-coder/api": ("fast", 7, 1, True, _ALL_PHASES),
+    "openai/gpt-5.4-mini/api": ("cheap", 7, 1, True, _ALL_PHASES),
+    "openai/gpt-5.4-mini/cli": ("cheap", 7, 1, True, _ALL_PHASES),
+    # No preflight: the pro tier is kept out of the phase that runs before
+    # complexity is known, so it cannot be drawn for cheap up-front work.
+    "openai/gpt-5.4-pro/api": ("strong", 10, 3, True, ("dev", "plan", "review")),
+    "openai/gpt-5.4-pro/cli": ("strong", 10, 3, True, _ALL_PHASES),
+    "openai/gpt-5.4/api": ("strong", 9, 2, True, _ALL_PHASES),
+    "openai/gpt-5.4/cli": ("strong", 9, 2, True, _ALL_PHASES),
+    "openai/llama3.1/api": ("fast", 6, 1, True, _ALL_PHASES),
+    "openai/qwen2.5-coder/api": ("fast", 7, 1, True, _ALL_PHASES),
 }
 
 
@@ -164,26 +179,30 @@ class TestPackagedCatalog:
         document = yaml.safe_load(resource.read_text(encoding="utf-8"))
         assert len(document["models"]) == len(AGENT_REGISTRY)
 
-    def test_the_wheel_is_declared_to_carry_the_catalog(self):
-        """The build config must keep package data in the distribution.
+    def test_the_built_wheel_carries_the_catalog(self, tmp_path):
+        """Build a real wheel and look inside it.
 
-        The catalog is read at import time, so if it does not travel in the
-        wheel then ``import theforge`` fails outright for an installed copy —
-        while CI, which imports from the source tree, stays green. Nothing else
-        in the suite can see that difference, so the build declaration itself is
-        what gets pinned: the wheel target names the package, and no exclusion
-        rule carves the data directory back out.
+        The catalog is read at import time, so if it stops travelling in the
+        wheel then ``import theforge`` fails outright for an installed copy while
+        CI, which imports from the source tree, stays green — the dogfood
+        substrate would find it at the next cut, not here.
+
+        Reading the build *declaration* instead is not equivalent, which is why
+        this builds. Hatch resolves inclusion through several interacting keys —
+        ``exclude`` takes precedence over inclusion, and ``only-include``
+        restricts traversal — so a rule that never mentions the data directory
+        can still drop it (``exclude = ["src/theforge/config/**"]``,
+        ``only-include = ["src/theforge/cli"]``). The artifact is the only thing
+        that answers the question the operator cares about.
         """
-        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-        build = tomllib.loads(pyproject.read_text(encoding="utf-8"))["tool"]["hatch"]["build"]
-        wheel = build["targets"]["wheel"]
-        assert "src/theforge" in wheel["packages"]
-        # An exclude/artifacts rule naming the data directory would silently
-        # drop it from a build that otherwise looks correctly configured.
-        for scope in (build, wheel):
-            for key in ("exclude", "artifacts", "only-include"):
-                for rule in scope.get(key, ()):
-                    assert "data" not in rule, f"build rule {key}={rule!r} may drop the catalog"
+        builder = WheelBuilder(str(Path(__file__).resolve().parents[1]))
+        artifact = next(iter(builder.build(directory=str(tmp_path), versions=["standard"])))
+        with zipfile.ZipFile(artifact) as wheel:
+            names = set(wheel.namelist())
+        assert "theforge/config/data/models.yaml" in names, (
+            "the shipped catalog is missing from the built wheel — an installed "
+            f"copy would fail at import. Wheel contains {len(names)} entries."
+        )
 
     def test_shipped_pricing_attribution_survives_the_data_round_trip(self):
         """The vendor shorthands stay unattributed with a declared band basis.
@@ -208,18 +227,60 @@ class TestPackagedCatalog:
         compares two loads of the same file and holds whatever that file says.
         This is the assertion that holds the file to something.
         """
-        drifted = {
-            model_id: (
-                (spec.routing.tier, spec.capability, spec.cost_rank),
-                expected,
+
+        def actual(spec) -> tuple:
+            return (
+                spec.routing.tier,
+                spec.capability,
+                spec.cost_rank,
+                spec.routing.dev_capable,
+                tuple(sorted(spec.routing.phase_eligibility)),
             )
+
+        drifted = {
+            model_id: (actual(spec), expected)
             for model_id, expected in _SHIPPED_ROUTING.items()
-            if (spec := AGENT_REGISTRY.get(model_id)) is not None
-            and (spec.routing.tier, spec.capability, spec.cost_rank) != expected
+            if (spec := AGENT_REGISTRY.get(model_id)) is not None and actual(spec) != expected
         }
         assert not drifted, f"shipped routing changed (got, expected): {drifted}"
         missing = sorted(_SHIPPED_ROUTING.keys() - AGENT_REGISTRY.keys())
         assert not missing, f"shipped entries disappeared from the catalog: {missing}"
+
+    @pytest.mark.parametrize(
+        "routing,expected",
+        [
+            ({"tier": "banana", "capability": 7, "cost_rank": 1}, "must be one of"),
+            ({"tier": "cheap", "capability": 999, "cost_rank": 1}, "between 1 and 10"),
+            ({"tier": "cheap", "capability": 7, "cost_rank": -8}, "between 1 and 3"),
+            (
+                {
+                    "tier": "cheap",
+                    "capability": 7,
+                    "cost_rank": 1,
+                    "phase_eligibility": ["launch"],
+                },
+                "only supports",
+            ),
+        ],
+    )
+    def test_routing_values_outside_their_domain_are_refused(self, routing, expected):
+        """Well-typed nonsense steers dispatch just as well as a real value.
+
+        Each of these parsed cleanly before: ``tier`` fell through to whatever
+        read it, an out-of-scale ``capability`` sorted the model to the top of
+        every candidate list, and an unrecognized phase is the quietest of the
+        four — ``_phase_candidates`` falls back to the unfiltered list when a
+        filter empties a pool, so a misspelled phase removes the model from the
+        pool it was declared for without failing anything.
+        """
+        definition = {
+            "provider": "openai",
+            "model": "m",
+            "transport": {"kind": "api"},
+            "routing": routing,
+        }
+        with pytest.raises(ValueError, match=expected):
+            parse_definition(definition, where="x")
 
     def test_a_new_shipped_entry_is_a_data_edit_not_a_code_edit(self):
         """Re-pinning a model on an already-supported adapter adds no code."""
@@ -683,6 +744,70 @@ class TestProjectDeclarationsAreAsExpressiveAsShipped:
 
 
 class TestFieldLevelProvenance:
+    @pytest.mark.parametrize("declared_side", ["input_per_mtok", "output_per_mtok"])
+    def test_a_price_overlay_owns_the_band_it_moved_whichever_side_it_stated(
+        self, tmp_path, declared_side
+    ):
+        """The band derives from both figures, so either one declared makes it ours.
+
+        Reading only the input side reported an output-only overlay's band as
+        ``builtin`` — the opposite of what happened, since the project's own
+        figure is what re-banded the entry. That is the one thing this provenance
+        map exists to answer, so it being backwards is worse than absent.
+        """
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        {
+                            "provider": "anthropic",
+                            "model": "sonnet",
+                            "transport": {"kind": "cli"},
+                            "cost": {declared_side: 99.0},
+                        }
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        sources = config.model_registry_field_sources["anthropic/sonnet/cli"]
+        assert sources[f"{declared_side.split('_')[0]}_cost_per_mtok"] == SOURCE_PROJECT
+        assert sources["cost_rank"] == SOURCE_PROJECT
+        assert sources["cost_rank_basis"] == SOURCE_PROJECT
+        # The band really did move off the shipped entry's, so the attribution is
+        # answering a live question rather than restating a no-op.
+        assert (config.model_registry or {})["anthropic/sonnet/cli"].cost_rank != AGENT_REGISTRY[
+            "anthropic/sonnet/cli"
+        ].cost_rank
+
+    def test_inherited_prices_leave_the_band_attributed_to_the_shipped_entry(self, tmp_path):
+        """A declaration that states no price at all has not moved the band."""
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        {
+                            "provider": "anthropic",
+                            "model": "sonnet",
+                            "transport": {"kind": "cli"},
+                            "routing": {"capability": 8},
+                        }
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        sources = config.model_registry_field_sources["anthropic/sonnet/cli"]
+        assert sources["capability"] == SOURCE_PROJECT
+        assert sources["cost_rank"] == SOURCE_BUILTIN
+        assert sources["input_cost_per_mtok"] == SOURCE_BUILTIN
+
     def test_a_partial_overlay_reports_which_source_supplied_each_field(self, tmp_path):
         path = _write(
             tmp_path,

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -17,6 +17,7 @@ claim load-bearing:
 from __future__ import annotations
 
 import argparse
+import ast
 from pathlib import Path
 from unittest.mock import patch
 
@@ -46,6 +47,64 @@ def _write(tmp_path: Path, body: dict) -> Path:
     path = tmp_path / "forge.yaml"
     path.write_text(yaml.dump(body), encoding="utf-8")
     return path
+
+
+# ── Module layering ───────────────────────────────────────────────────────
+
+
+class TestLayering:
+    """The parser and the registry it builds must not import each other.
+
+    ``models.py`` builds AGENT_REGISTRY by calling the parser at import time, so
+    a back-edge from ``model_catalog`` to ``models`` is a genuine import cycle
+    (and a hard convention violation), not merely untidy. Both sit on the
+    ``model_identity`` leaf instead.
+    """
+
+    def _imports(self, module_name: str) -> set[str]:
+        source = Path(__file__).resolve().parents[1] / f"src/theforge/config/{module_name}.py"
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        found: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                found.add(node.module)
+            elif isinstance(node, ast.Import):
+                found.update(alias.name for alias in node.names)
+        return found
+
+    def test_the_parser_does_not_import_the_registry(self):
+        # Every import, including function-level ones — a deferred import is
+        # still a cycle to the convention checker and to a reader.
+        assert "models" not in self._imports("model_catalog")
+
+    def test_the_identity_leaf_imports_neither(self):
+        identity_imports = self._imports("model_identity")
+        assert "models" not in identity_imports
+        assert "model_catalog" not in identity_imports
+
+    def test_the_registry_still_re_exports_the_identity_surface(self):
+        """Callers import these from config.models and must keep being able to."""
+        from theforge.config import model_identity, models
+
+        for name in (
+            "TRANSPORT_KINDS",
+            "TransportSpec",
+            "RoutingPolicy",
+            "AgentSpec",
+            "transport_for",
+            "canonical_model_id",
+            "canonical_id_for_spec",
+            "is_canonical_model_id",
+            "provider_for_cli_runner",
+            "provider_for_transport",
+            "mirror_fields_for_transport",
+            "transport_from_raw_fields",
+            "known_model_overlay_providers",
+            "overlay_transport",
+            "custom_model_capability",
+            "custom_model_dev_capable",
+        ):
+            assert getattr(models, name) is getattr(model_identity, name), name
 
 
 # ── The shipped set is data ───────────────────────────────────────────────

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -8,7 +8,8 @@ claim load-bearing:
 - the packaged defaults really do come from data, through the shared parser;
 - the shapes projects already write (``models.custom`` flat mappings, inline
   ``models.enabled`` mappings) still load unchanged;
-- a project declaration can express every field the shipped set can;
+- a project declaration can express every field the shipped set can, on either
+  surface — inline in ``models.enabled`` or reusable under ``models.custom``;
 - a provider with no adapter fails at load time, naming the adapters that exist;
 - where a project declaration overlays a shipped definition, the resolved entry
   reports which source supplied each field.
@@ -429,6 +430,134 @@ class TestProjectDeclarationsAreAsExpressiveAsShipped:
         assert spec.routing.cost_rank_basis == COST_BAND_BASIS_DECLARED_POLICY
         assert spec.pricing_provenance == "gemini-4-pro-2026-08"
         assert spec.base_url == "https://example.invalid/v1"
+
+    def test_models_custom_accepts_the_canonical_schema(self, tmp_path):
+        """A reusable declaration is as expressive as an inline one.
+
+        Before #2204 the only fully expressive surface was an inline
+        ``models.enabled`` mapping — a selection list, not a definition surface.
+        """
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": ["anthropic/sonnet/cli", "fast-reviewer"],
+                    "custom": {
+                        "fast-reviewer": {
+                            "provider": "google",
+                            "model": "gemini-4-flash",
+                            "transport": {"kind": "api"},
+                            "base_url": "https://example.invalid/v1",
+                            "routing": {
+                                "tier": "cheap",
+                                "capability": 8,
+                                "cost_rank": 1,
+                                "dev_capable": False,
+                                "phase_eligibility": ["review"],
+                                "cost_rank_basis": COST_BAND_BASIS_DECLARED_POLICY,
+                            },
+                            "cost": {
+                                "input_per_mtok": 0.30,
+                                "output_per_mtok": 2.50,
+                                "pricing_provenance": "gemini-4-flash-2026-08",
+                            },
+                        }
+                    },
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        spec = (config.model_registry or {})["google/gemini-4-flash/api"]
+        assert spec.capability == 8
+        assert spec.phase_eligibility == frozenset({"review"})
+        assert spec.dev_capable is False
+        assert spec.routing.cost_rank_basis == COST_BAND_BASIS_DECLARED_POLICY
+        assert spec.pricing_provenance == "gemini-4-flash-2026-08"
+        assert spec.base_url == "https://example.invalid/v1"
+        # And the operator-chosen key still selects it.
+        assert "google/gemini-4-flash/api" in config.models
+        assert "fast-reviewer" not in config.models
+
+    def test_a_canonical_models_custom_declaration_may_override_a_shipped_identity(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": ["anthropic/sonnet/cli", "pinned-opus"],
+                    "custom": {
+                        "pinned-opus": {
+                            "provider": "anthropic",
+                            "model": "opus",
+                            "transport": {"kind": "cli"},
+                            "override": True,
+                            "routing": {"tier": "strong", "capability": 9, "cost_rank": 3},
+                            "cost": {
+                                "input_per_mtok": 15.0,
+                                "output_per_mtok": 75.0,
+                                "pricing_provenance": "claude-opus-4-6",
+                            },
+                        }
+                    },
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        spec = (config.model_registry or {})["anthropic/opus/cli"]
+        assert spec.capability == 9  # the shipped entry says 10
+        assert spec.pricing_provenance == "claude-opus-4-6"
+        assert config.model_registry_sources["anthropic/opus/cli"] == "forge.yaml"
+
+    def test_an_unsupported_provider_in_a_canonical_custom_declaration_is_rejected(self, tmp_path):
+        """Adapter validation reaches the canonical models.custom path too."""
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": ["anthropic/sonnet/cli"],
+                    "custom": {
+                        "mistral": {
+                            "provider": "mistral",
+                            "model": "large",
+                            "transport": {"kind": "api"},
+                            "routing": {"tier": "strong"},
+                        }
+                    },
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        with pytest.raises(ValueError, match="No API adapter for provider 'mistral'"):
+            load_config(path)
+
+    def test_mixing_the_flat_and_canonical_shapes_is_rejected(self, tmp_path):
+        """Two spellings of tier in one declaration is ambiguous, not resolvable."""
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": ["anthropic/sonnet/cli", "muddle"],
+                    "custom": {
+                        "muddle": {
+                            "provider": "openai",
+                            "model": "gpt-5.5",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 1.5,
+                            "output_cost_per_mtok": 12.0,
+                            "routing": {"tier": "cheap", "capability": 3},
+                        }
+                    },
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        with pytest.raises(ValueError, match="mixes the flat declaration shape"):
+            load_config(path)
 
     def test_a_declaration_may_state_its_price_is_unattributable(self, tmp_path):
         """The vendor-shorthand case a project could not express before."""

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,511 @@
+"""One data-backed model catalog on a single schema (#2204).
+
+The shipped default set is data (``config/data/models.yaml``) read through the
+same canonical parser that reads project-declared models, so both sources
+produce identical structures. These tests pin the properties that make that
+claim load-bearing:
+
+- the packaged defaults really do come from data, through the shared parser;
+- the shapes projects already write (``models.custom`` flat mappings, inline
+  ``models.enabled`` mappings) still load unchanged;
+- a project declaration can express every field the shipped set can;
+- a provider with no adapter fails at load time, naming the adapters that exist;
+- where a project declaration overlays a shipped definition, the resolved entry
+  reports which source supplied each field.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from theforge.cli.check_config import cmd_check_config
+from theforge.config import load_config
+from theforge.config.model_catalog import (
+    PROVENANCE_FIELDS,
+    SOURCE_BUILTIN,
+    SOURCE_PROJECT,
+    load_packaged_catalog,
+    parse_definition,
+    resolve_packaged,
+    resolve_project,
+)
+from theforge.config.models import AGENT_REGISTRY, transport_for
+from theforge.config.pricing import (
+    COST_BAND_BASIS_DECLARED_POLICY,
+    COST_BAND_BASIS_VENDOR_TIER,
+    PRICING_PROVENANCE_OPERATOR_DECLARED,
+)
+
+
+def _write(tmp_path: Path, body: dict) -> Path:
+    path = tmp_path / "forge.yaml"
+    path.write_text(yaml.dump(body), encoding="utf-8")
+    return path
+
+
+# ── The shipped set is data ───────────────────────────────────────────────
+
+
+class TestPackagedCatalog:
+    def test_the_builtin_registry_is_what_the_catalog_data_says(self):
+        """AGENT_REGISTRY is not a literal — it is the packaged catalog loaded."""
+        assert load_packaged_catalog() == AGENT_REGISTRY
+        assert AGENT_REGISTRY  # and the data is actually there
+
+    def test_catalog_data_ships_inside_the_package(self):
+        catalog = Path(__file__).resolve().parents[1] / "src/theforge/config/data/models.yaml"
+        assert catalog.is_file()
+        document = yaml.safe_load(catalog.read_text(encoding="utf-8"))
+        assert len(document["models"]) == len(AGENT_REGISTRY)
+
+    def test_shipped_pricing_attribution_survives_the_data_round_trip(self):
+        """The vendor shorthands stay unattributed with a declared band basis.
+
+        Inferring operator attribution from the presence of a ``cost:`` block —
+        which is right for a project declaration — would re-band these off
+        literals nothing can vouch for, the exact defect #2217 fixed.
+        """
+        sonnet = AGENT_REGISTRY["anthropic/sonnet/cli"]
+        assert sonnet.pricing_provenance is None
+        assert sonnet.routing.cost_rank_basis == COST_BAND_BASIS_VENDOR_TIER
+        assert sonnet.cost_rank == 1
+        reasoner = AGENT_REGISTRY["deepseek/deepseek-reasoner/api"]
+        assert reasoner.routing.cost_rank_basis == COST_BAND_BASIS_DECLARED_POLICY
+        assert AGENT_REGISTRY["openai/gpt-5.4/cli"].pricing_provenance == "gpt-5.4"
+
+    def test_a_new_shipped_entry_is_a_data_edit_not_a_code_edit(self):
+        """Re-pinning a model on an already-supported adapter adds no code."""
+        definition = {
+            "provider": "anthropic",
+            "model": "claude-opus-4-6",
+            "transport": {"kind": "cli"},
+            "routing": {"tier": "strong", "capability": 10, "cost_rank": 3},
+            "cost": {
+                "input_per_mtok": 15.0,
+                "output_per_mtok": 75.0,
+                "pricing_provenance": "claude-opus-4-6",
+            },
+        }
+        resolved = resolve_packaged(parse_definition(definition, where="x"), where="x")
+        assert resolved.canonical_id == "anthropic/claude-opus-4-6/cli"
+        assert resolved.spec.transport == transport_for("anthropic", "cli")
+        assert resolved.spec.routing.cost_rank_basis == "price:claude-opus-4-6"
+
+    def test_a_shipped_band_with_no_traceable_source_is_refused(self):
+        """The packaged data is held to the same attribution rule code was."""
+        definition = {
+            "provider": "anthropic",
+            "model": "shorthand",
+            "transport": {"kind": "cli"},
+            "routing": {"tier": "strong", "capability": 10, "cost_rank": 3},
+            "cost": {"input_per_mtok": 15.0, "output_per_mtok": 75.0},
+        }
+        with pytest.raises(ValueError, match="cannot be attributed"):
+            resolve_packaged(parse_definition(definition, where="x"), where="x")
+
+    def test_one_schema_governs_both_sources(self):
+        """The same definition text resolves to the same routing either way."""
+        definition = {
+            "provider": "openai",
+            "model": "gpt-5.9",
+            "transport": {"kind": "api"},
+            "routing": {"tier": "strong", "capability": 9, "cost_rank": 2},
+            "cost": {
+                "input_per_mtok": 1.25,
+                "output_per_mtok": 10.0,
+                "pricing_provenance": "gpt-5.9",
+            },
+        }
+        packaged = resolve_packaged(parse_definition(definition, where="x"), where="x")
+        project = resolve_project(parse_definition(definition, where="x"), where="x", builtin=None)
+        assert packaged.canonical_id == project.canonical_id
+        assert packaged.spec.routing == project.spec.routing
+        assert packaged.spec.base_url == project.spec.base_url
+        assert packaged.spec.pricing_provenance == project.spec.pricing_provenance
+        # Only the entry-level source differs — that is what it is for.
+        assert (packaged.spec.registry_source, project.spec.registry_source) == (
+            SOURCE_BUILTIN,
+            SOURCE_PROJECT,
+        )
+
+
+# ── Adapter validation ────────────────────────────────────────────────────
+
+
+class TestAdapterValidation:
+    def test_a_provider_with_no_adapter_names_the_ones_that_exist(self):
+        definition = {
+            "provider": "mistral",
+            "model": "large",
+            "transport": {"kind": "api"},
+            "routing": {"tier": "strong"},
+        }
+        with pytest.raises(ValueError, match="No API adapter for provider 'mistral'"):
+            parse_definition(definition, where="models.enabled[0]")
+
+    def test_an_unsupported_provider_in_models_custom_names_the_adapters(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": ["anthropic/sonnet/cli"],
+                    "custom": {
+                        "mistral/large/api": {
+                            "provider": "mistral",
+                            "model": "large",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 2.0,
+                            "output_cost_per_mtok": 6.0,
+                        }
+                    },
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        with pytest.raises(ValueError, match="Known providers/adapters:"):
+            load_config(path)
+
+    def test_an_unsupported_provider_in_enabled_fails_at_load(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        {
+                            "provider": "mistral",
+                            "model": "large",
+                            "transport": {"kind": "api"},
+                            "routing": {"tier": "strong"},
+                        }
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        with pytest.raises(ValueError, match="No API adapter for provider 'mistral'"):
+            load_config(path)
+
+
+# ── Backward compatibility ────────────────────────────────────────────────
+
+
+class TestExistingShapesStillLoad:
+    def test_models_custom_flat_mapping_is_unchanged(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": ["anthropic/sonnet/cli", "openai/gpt-5.5/cli"],
+                    "custom": {
+                        "gpt-5.5": {
+                            "provider": "openai",
+                            "model": "gpt-5.5",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 1.5,
+                            "output_cost_per_mtok": 12.0,
+                        }
+                    },
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        spec = (config.model_registry or {})["openai/gpt-5.5/cli"]
+        assert spec.tier == "strong"
+        assert spec.capability == 9  # still derived from tier
+        assert spec.dev_capable is True
+        assert spec.cost_rank == 2  # banded from the operator-declared price
+        assert spec.pricing_provenance == PRICING_PROVENANCE_OPERATOR_DECLARED
+        assert config.model_registry_sources["openai/gpt-5.5/cli"] == "forge.yaml"
+
+    def test_models_enabled_can_still_select_a_custom_declaration_by_its_key(self, tmp_path):
+        """The operator-chosen declaration key stays a valid selector."""
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": ["anthropic/sonnet/cli", "gpt-5.5"],
+                    "custom": {
+                        "gpt-5.5": {
+                            "provider": "openai",
+                            "model": "gpt-5.5",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 1.5,
+                            "output_cost_per_mtok": 12.0,
+                        }
+                    },
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        assert "openai/gpt-5.5/cli" in config.models
+        assert "gpt-5.5" not in config.models
+
+    def test_models_custom_provider_alias_tokens_still_normalize(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": ["anthropic/sonnet/cli", "local"],
+                    "custom": {
+                        "local": {
+                            "provider": "openai-api",
+                            "model": "qwen3",
+                            "tier": "fast",
+                            "base_url": "http://localhost:11434/v1",
+                            "input_cost_per_mtok": 0.0,
+                            "output_cost_per_mtok": 0.0,
+                        }
+                    },
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        spec = (config.model_registry or {})["openai/qwen3/api"]
+        assert spec.transport == transport_for("openai", "api")
+        assert spec.base_url == "http://localhost:11434/v1"
+
+    def test_inline_enabled_mapping_is_unchanged(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        "anthropic/sonnet/cli",
+                        {
+                            "provider": "openai",
+                            "model": "gpt-5.9",
+                            "transport": {"kind": "api"},
+                            "routing": {"tier": "strong"},
+                            "cost": {"input_per_mtok": 30.0, "output_per_mtok": 60.0},
+                        },
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        spec = (config.model_registry or {})["openai/gpt-5.9/api"]
+        # A declared cost with no stated attribution is still attributed to the
+        # operator's own declaration, and still bands from it.
+        assert spec.pricing_provenance == PRICING_PROVENANCE_OPERATOR_DECLARED
+        assert spec.cost_rank == 3
+
+    def test_selecting_a_builtin_by_mapping_does_not_redeclare_it(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        {
+                            "provider": "anthropic",
+                            "model": "sonnet",
+                            "transport": {"kind": "cli"},
+                        },
+                        "anthropic/opus/cli",
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        assert config.model_registry_sources["anthropic/sonnet/cli"] == "builtin"
+
+
+# ── Expressiveness parity ─────────────────────────────────────────────────
+
+
+class TestProjectDeclarationsAreAsExpressiveAsShipped:
+    def test_a_project_definition_can_set_every_shipped_field(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        "anthropic/sonnet/cli",
+                        {
+                            "provider": "google",
+                            "model": "gemini-4-pro",
+                            "transport": {"kind": "api"},
+                            "base_url": "https://example.invalid/v1",
+                            "routing": {
+                                "tier": "strong",
+                                "capability": 10,
+                                "cost_rank": 3,
+                                "dev_capable": False,
+                                "phase_eligibility": ["dev", "plan", "review"],
+                                "cost_rank_basis": COST_BAND_BASIS_DECLARED_POLICY,
+                            },
+                            "cost": {
+                                "input_per_mtok": 2.0,
+                                "output_per_mtok": 12.0,
+                                "pricing_provenance": "gemini-4-pro-2026-08",
+                            },
+                        },
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        spec = (load_config(path).model_registry or {})["google/gemini-4-pro/api"]
+        assert spec.capability == 10  # not derivable from tier before this change
+        assert spec.phase_eligibility == frozenset({"dev", "plan", "review"})
+        assert spec.dev_capable is False
+        assert spec.cost_rank == 3
+        assert spec.routing.cost_rank_basis == COST_BAND_BASIS_DECLARED_POLICY
+        assert spec.pricing_provenance == "gemini-4-pro-2026-08"
+        assert spec.base_url == "https://example.invalid/v1"
+
+    def test_a_declaration_may_state_its_price_is_unattributable(self, tmp_path):
+        """The vendor-shorthand case a project could not express before."""
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        "anthropic/sonnet/cli",
+                        {
+                            "provider": "anthropic",
+                            "model": "haiku",
+                            "transport": {"kind": "cli"},
+                            "routing": {
+                                "tier": "cheap",
+                                "capability": 6,
+                                "cost_rank": 1,
+                                "cost_rank_basis": COST_BAND_BASIS_VENDOR_TIER,
+                            },
+                            "cost": {
+                                "input_per_mtok": 30.0,
+                                "output_per_mtok": 60.0,
+                                "pricing_provenance": None,
+                            },
+                        },
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        spec = (load_config(path).model_registry or {})["anthropic/haiku/cli"]
+        assert spec.pricing_provenance is None
+        # An unattributed literal must not band the entry.
+        assert spec.cost_rank == 1
+        assert spec.routing.cost_rank_basis == COST_BAND_BASIS_VENDOR_TIER
+
+
+# ── Field-level provenance ────────────────────────────────────────────────
+
+
+class TestFieldLevelProvenance:
+    def test_a_partial_overlay_reports_which_source_supplied_each_field(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        "anthropic/sonnet/cli",
+                        {
+                            "provider": "openai",
+                            "model": "gpt-5.4",
+                            "transport": {"kind": "cli"},
+                            "routing": {"capability": 10},
+                        },
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        config = load_config(path)
+        sources = config.model_registry_field_sources["openai/gpt-5.4/cli"]
+        assert sources["capability"] == SOURCE_PROJECT
+        assert sources["tier"] == SOURCE_BUILTIN
+        assert sources["input_cost_per_mtok"] == SOURCE_BUILTIN
+        assert sources["pricing_provenance"] == SOURCE_BUILTIN
+        assert sources["phase_eligibility"] == SOURCE_BUILTIN
+        assert set(sources) == set(PROVENANCE_FIELDS)
+        # The overlaid entry keeps the built-in values it did not restate.
+        spec = (config.model_registry or {})["openai/gpt-5.4/cli"]
+        assert spec.capability == 10
+        assert spec.tier == "strong"
+        assert spec.input_cost_per_mtok == 1.25
+
+    def test_check_config_names_the_fields_each_source_supplied(self, tmp_path, capsys):
+        """The provenance map has a consumer: the operator reading check-config."""
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        "anthropic/sonnet/cli",
+                        {
+                            "provider": "openai",
+                            "model": "gpt-5.4",
+                            "transport": {"kind": "cli"},
+                            "routing": {"capability": 10},
+                        },
+                    ]
+                },
+                "budget_usd": 30.0,
+                "workspace": {
+                    "create_command": "true",
+                    "path_pattern": str(tmp_path / "{slug}"),
+                    "branch_pattern": "x/{slug}",
+                },
+                "validation": {"gate_command": "true"},
+            },
+        )
+        args = argparse.Namespace(config=str(path))
+        with patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")):
+            cmd_check_config(args)
+        out = capsys.readouterr().out
+        assert "field provenance for openai/gpt-5.4/cli:" in out
+        assert "forge.yaml: capability" in out
+        assert "tier" in out.split("builtin:")[-1]
+
+    def test_a_shipped_entry_reports_every_field_as_builtin(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {"project": "p", "models": ["anthropic/sonnet/cli"], "budget_usd": 30.0},
+        )
+        sources = load_config(path).model_registry_field_sources["anthropic/sonnet/cli"]
+        assert set(sources.values()) == {SOURCE_BUILTIN}
+
+    def test_a_standalone_project_declaration_owns_every_field(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": ["anthropic/sonnet/cli", "gpt-5.5"],
+                    "custom": {
+                        "gpt-5.5": {
+                            "provider": "openai",
+                            "model": "gpt-5.5",
+                            "tier": "strong",
+                            "input_cost_per_mtok": 1.5,
+                            "output_cost_per_mtok": 12.0,
+                        }
+                    },
+                },
+                "budget_usd": 30.0,
+            },
+        )
+        sources = load_config(path).model_registry_field_sources["openai/gpt-5.5/cli"]
+        assert set(sources.values()) == {SOURCE_PROJECT}

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import argparse
 import ast
+import tomllib
+from importlib import resources
 from pathlib import Path
 from unittest.mock import patch
 
@@ -110,6 +112,38 @@ class TestLayering:
 
 # ── The shipped set is data ───────────────────────────────────────────────
 
+# Routing policy of every entry the catalog shipped with, as ``(tier, capability,
+# cost_rank)``. These three fields decide which model gets which work, so a
+# change to one of them changes dispatch for every project on the release.
+#
+# Asserted as a *subset*, which is what keeps the guard aligned with the point of
+# #2204 rather than fighting it: adding a model stays a pure data edit and needs
+# no test change, while re-tiering one of these fails until the expectation is
+# updated in the same commit. A silent re-tier is the failure #2217 was about,
+# and moving the set into YAML is what made it a one-line edit.
+_SHIPPED_ROUTING: dict[str, tuple[str, int, int]] = {
+    "anthropic/opus/cli": ("strong", 10, 3),
+    "anthropic/sonnet/cli": ("fast", 7, 1),
+    "deepseek/deepseek-chat/api": ("fast", 7, 1),
+    "deepseek/deepseek-reasoner/api": ("strong", 9, 2),
+    "google/gemini-2.5-pro/api": ("strong", 8, 2),
+    "google/gemini-2.5-pro/cli": ("strong", 8, 2),
+    "google/gemini-3-flash-preview/api": ("cheap", 7, 1),
+    "google/gemini-3-flash-preview/cli": ("cheap", 7, 1),
+    "google/gemini-3.1-pro-preview/api": ("strong", 9, 2),
+    "google/gemini-3.1-pro-preview/cli": ("strong", 9, 2),
+    "openai/codestral/api": ("fast", 7, 1),
+    "openai/deepseek-coder/api": ("fast", 7, 1),
+    "openai/gpt-5.4-mini/api": ("cheap", 7, 1),
+    "openai/gpt-5.4-mini/cli": ("cheap", 7, 1),
+    "openai/gpt-5.4-pro/api": ("strong", 10, 3),
+    "openai/gpt-5.4-pro/cli": ("strong", 10, 3),
+    "openai/gpt-5.4/api": ("strong", 9, 2),
+    "openai/gpt-5.4/cli": ("strong", 9, 2),
+    "openai/llama3.1/api": ("fast", 6, 1),
+    "openai/qwen2.5-coder/api": ("fast", 7, 1),
+}
+
 
 class TestPackagedCatalog:
     def test_the_builtin_registry_is_what_the_catalog_data_says(self):
@@ -118,10 +152,38 @@ class TestPackagedCatalog:
         assert AGENT_REGISTRY  # and the data is actually there
 
     def test_catalog_data_ships_inside_the_package(self):
-        catalog = Path(__file__).resolve().parents[1] / "src/theforge/config/data/models.yaml"
-        assert catalog.is_file()
-        document = yaml.safe_load(catalog.read_text(encoding="utf-8"))
+        """Reach the catalog the way production does, not by source-tree path.
+
+        ``importlib.resources`` is what :func:`load_packaged_catalog` uses, so
+        resolving it here is what proves the file is addressable *as package
+        data*. A source-tree ``Path(__file__).parents[1]`` lookup passes even
+        after a move that makes the resource unreachable once installed.
+        """
+        resource = resources.files("theforge.config").joinpath("data/models.yaml")
+        assert resource.is_file()
+        document = yaml.safe_load(resource.read_text(encoding="utf-8"))
         assert len(document["models"]) == len(AGENT_REGISTRY)
+
+    def test_the_wheel_is_declared_to_carry_the_catalog(self):
+        """The build config must keep package data in the distribution.
+
+        The catalog is read at import time, so if it does not travel in the
+        wheel then ``import theforge`` fails outright for an installed copy —
+        while CI, which imports from the source tree, stays green. Nothing else
+        in the suite can see that difference, so the build declaration itself is
+        what gets pinned: the wheel target names the package, and no exclusion
+        rule carves the data directory back out.
+        """
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        build = tomllib.loads(pyproject.read_text(encoding="utf-8"))["tool"]["hatch"]["build"]
+        wheel = build["targets"]["wheel"]
+        assert "src/theforge" in wheel["packages"]
+        # An exclude/artifacts rule naming the data directory would silently
+        # drop it from a build that otherwise looks correctly configured.
+        for scope in (build, wheel):
+            for key in ("exclude", "artifacts", "only-include"):
+                for rule in scope.get(key, ()):
+                    assert "data" not in rule, f"build rule {key}={rule!r} may drop the catalog"
 
     def test_shipped_pricing_attribution_survives_the_data_round_trip(self):
         """The vendor shorthands stay unattributed with a declared band basis.
@@ -137,6 +199,27 @@ class TestPackagedCatalog:
         reasoner = AGENT_REGISTRY["deepseek/deepseek-reasoner/api"]
         assert reasoner.routing.cost_rank_basis == COST_BAND_BASIS_DECLARED_POLICY
         assert AGENT_REGISTRY["openai/gpt-5.4/cli"].pricing_provenance == "gpt-5.4"
+
+    def test_every_shipped_entry_keeps_the_routing_it_shipped_with(self):
+        """Transcribing the set into YAML must not have moved any dispatch.
+
+        ``test_the_builtin_registry_is_what_the_catalog_data_says`` cannot see a
+        drift here — ``AGENT_REGISTRY`` *is* ``load_packaged_catalog()``, so it
+        compares two loads of the same file and holds whatever that file says.
+        This is the assertion that holds the file to something.
+        """
+        drifted = {
+            model_id: (
+                (spec.routing.tier, spec.capability, spec.cost_rank),
+                expected,
+            )
+            for model_id, expected in _SHIPPED_ROUTING.items()
+            if (spec := AGENT_REGISTRY.get(model_id)) is not None
+            and (spec.routing.tier, spec.capability, spec.cost_rank) != expected
+        }
+        assert not drifted, f"shipped routing changed (got, expected): {drifted}"
+        missing = sorted(_SHIPPED_ROUTING.keys() - AGENT_REGISTRY.keys())
+        assert not missing, f"shipped entries disappeared from the catalog: {missing}"
 
     def test_a_new_shipped_entry_is_a_data_edit_not_a_code_edit(self):
         """Re-pinning a model on an already-supported adapter adds no code."""

--- a/tests/test_pricing_provenance.py
+++ b/tests/test_pricing_provenance.py
@@ -18,12 +18,12 @@ import pytest
 import yaml
 
 from theforge.config import load_config
+from theforge.config.model_catalog import parse_definition, resolve_packaged
 from theforge.config.models import (
     AGENT_REGISTRY,
     MODEL_REGISTRY,
     AgentSpec,
     RoutingPolicy,
-    _entry,
     _spec_to_model_info,
     transport_for,
 )
@@ -350,19 +350,25 @@ def test_the_defects_exact_entry_shape_no_longer_builds():
     """The shape the bug was reported in: a vendor-shorthand entry carrying an
     unattributable 15.00/75.00 and banded 3 — the band those figures produce, with
     nothing recording whether that was a derivation or a coincidence. Building it
-    now raises; the entry only exists once it says why band 3 holds without them."""
-    args = ("anthropic", "opus", "cli")
-    kwargs = dict(
-        tier="strong",
-        capability=10,
-        cost_rank=3,
-        input_cost_per_mtok=15.00,
-        output_cost_per_mtok=75.00,
-    )
-    with pytest.raises(ValueError, match="cannot be attributed"):
-        _entry(*args, **kwargs)
+    now raises; the entry only exists once it says why band 3 holds without them.
 
-    _key, spec = _entry(*args, **kwargs, cost_rank_basis=COST_BAND_BASIS_VENDOR_TIER)
+    Written as catalog data, because that is what a shipped entry is since #2204:
+    the guard has to hold at the parser the packaged catalog goes through."""
+
+    def _shipped(**routing_extra):
+        definition = {
+            "provider": "anthropic",
+            "model": "opus",
+            "transport": {"kind": "cli"},
+            "routing": {"tier": "strong", "capability": 10, "cost_rank": 3, **routing_extra},
+            "cost": {"input_per_mtok": 15.00, "output_per_mtok": 75.00},
+        }
+        return resolve_packaged(parse_definition(definition, where="x"), where="x")
+
+    with pytest.raises(ValueError, match="cannot be attributed"):
+        _shipped()
+
+    spec = _shipped(cost_rank_basis=COST_BAND_BASIS_VENDOR_TIER).spec
     assert spec.cost_rank == 3
     assert spec.routing.cost_rank_basis == COST_BAND_BASIS_VENDOR_TIER
     # And that band still owes nothing to the figures beside it.


### PR DESCRIPTION
Closes #2204.

**Merge state: NOT ready — awaiting review of the current SHA.**

- Gate: PASS (3 runs, last `✓ VALIDATE PASS` at 09:26:45)
- Review: `REQUEST_CHANGES` (cycle 1) — 1 P1, 3 P2
- The P1 (`models.custom` canonical schema rejected, `config/load.py:275`) was fixed in `de50fe9`
- **Review cycle 2 never ran** — the story exhausted its allocation (`needs $17.55, $12.96 left`), which is what triggered the escalation

So the blocking finding was addressed and the gate is green, but no reviewer has seen the fix. Operator decision recorded as `land_core_defer_edges` (#1664 taxonomy) — that names the operation and preserves the worktree; it does not merge.

Deferred edge, filed separately: no `load_config` regression test proving canonical `models.custom` is accepted and selectable by key.

Verified: `forge.yaml` untouched, per the acceptance criterion barring this change from rewriting the project's own configuration.