### PR TITLE
fix(cli): give forge review a story source for issue-backed work

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -86,15 +86,23 @@ Run only the review phase on an existing worktree.
 
 ```bash
 forge review <story-file> [flags]
+forge review --issue <N> [flags]
 ```
 
 **Use this when:** You implemented or fixed something in a worktree and want to
 run review without re-running PLAN/DEV.
 
+Name the **story**, not the worktree. A story sourced from a GitHub issue is
+never written to disk, so `--issue N` is the only way to review one — it reads
+the issue exactly as the sprint path does, and the slug it derives (`issue-N`)
+is what points at the existing worktree. Pass a story file *or* `--issue`, not
+both.
+
 **Flags:**
 
 | Flag | Description |
 |------|-------------|
+| `--issue <N>` | Review a GitHub-issue-backed story (instead of a story file) |
 | `--worktree <path>` | Explicit worktree path |
 | `--auto-merge` | Merge after APPROVE |
 | `--verbose`, `-v` | Show reviewer activity |

--- a/src/theforge/cli/review.py
+++ b/src/theforge/cli/review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 from theforge.cli.shared import _build_task, _find_config, _write_audit
@@ -11,21 +12,46 @@ from theforge.coordinator.engine import run_from_review
 from theforge.coordinator.util import set_log_level as coordinator_set_log_level
 from theforge.runners import LogLevel
 from theforge.runners import set_log_level as runner_set_log_level
+from theforge.sprint.sources import GitHubIssueSource, IssueClosedError
 
 
 def cmd_review(args: object) -> int:
     """Run only the review pool on an existing worktree."""
-    story_path = Path(args.story).resolve()
-    if not story_path.exists():
-        print(f"Story file not found: {story_path}", file=sys.stderr)
+    issue = getattr(args, "issue", None)
+    story_arg = getattr(args, "story", None)
+    if (issue is None) == (story_arg is None):
+        print(
+            "forge review needs exactly one story source: a story file path, "
+            "or --issue N for a GitHub-issue-backed story.",
+            file=sys.stderr,
+        )
         return 1
+
+    story_path: Path | None = None
+    if story_arg is not None:
+        story_path = Path(story_arg).resolve()
+        if not story_path.exists():
+            print(f"Story file not found: {story_path}", file=sys.stderr)
+            return 1
+        # A worktree is the thing being reviewed, not the story describing it —
+        # a directory here is almost always someone reaching for --worktree or
+        # --issue, so name both rather than letting read_text() raise IsADirectoryError.
+        if story_path.is_dir():
+            print(
+                f"{story_path} is a directory, not a story file.\n"
+                "  To review a GitHub-issue-backed story:  forge review --issue N\n"
+                "  To point at a worktree explicitly:      forge review <story> "
+                "--worktree <path>",
+                file=sys.stderr,
+            )
+            return 1
 
     # Find config
     config_path: Path | None = None
     if args.config:
         config_path = Path(args.config).resolve()
     else:
-        config_path = _find_config(story_path.parent)
+        config_path = _find_config(story_path.parent if story_path is not None else Path.cwd())
 
     if config_path is None or not config_path.exists():
         print(
@@ -40,7 +66,22 @@ def cmd_review(args: object) -> int:
         runner_set_log_level(LogLevel.VERBOSE)
 
     config = load_config(config_path)
-    task = _build_task(story_path, slug=args.slug)
+    if story_path is not None:
+        task = _build_task(story_path, slug=args.slug)
+    else:
+        # Same fetch the sprint path uses, so a re-review reads the issue exactly
+        # as the run that produced the worktree did — including the slug, which is
+        # what derives the default worktree path.
+        try:
+            task = GitHubIssueSource().fetch(str(issue), config.project_root)
+        except IssueClosedError as exc:
+            print(f"✗ {exc}", file=sys.stderr)
+            return 1
+        except (RuntimeError, ValueError) as exc:
+            print(f"✗ could not read issue #{issue}: {exc}", file=sys.stderr)
+            return 1
+        if args.slug:
+            task = replace(task, slug=args.slug)
 
     # Resolve workspace path
     if args.worktree:
@@ -91,7 +132,16 @@ def register_parser(subparsers: object) -> None:
     review_parser = subparsers.add_parser(
         "review", help="Run only the review pool on an existing worktree"
     )
-    review_parser.add_argument("story", help="Path to the story file")
+    review_parser.add_argument(
+        "story",
+        nargs="?",
+        help="Path to the story file (omit when using --issue)",
+    )
+    review_parser.add_argument(
+        "--issue",
+        type=int,
+        help="Review a GitHub-issue-backed story by number, as the sprint path builds it",
+    )
     review_parser.add_argument("--slug", help="Workspace slug (default: story filename stem)")
     review_parser.add_argument("--config", help="Path to forge.yaml (default: auto-detect)")
     review_parser.add_argument(

--- a/tests/test_cli_review_entrypoint.py
+++ b/tests/test_cli_review_entrypoint.py
@@ -1,0 +1,139 @@
+"""`forge review` story-source resolution.
+
+Review-only mode existed for file-backed stories, but a story sourced from a
+GitHub issue is never written to disk — ``GitHubIssueSource`` builds a
+``TaskStory`` with ``story_path=None`` and the body in ``story_text``. That left
+no invocation at all for re-reviewing an issue-backed worktree, and reaching for
+the worktree path instead (the obvious guess, since it is the thing being
+reviewed) crashed inside ``read_text()`` with ``IsADirectoryError``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.cli.review import cmd_review
+from theforge.sprint.sources import IssueClosedError
+from theforge.task import TaskStory
+
+
+def _args(**overrides) -> argparse.Namespace:
+    base = dict(
+        story=None,
+        issue=None,
+        slug=None,
+        config=None,
+        worktree=None,
+        auto_merge=False,
+        verbose=False,
+        no_notify=True,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _fake_result(success: bool = True) -> MagicMock:
+    result = MagicMock()
+    result.success = success
+    result.message = "APPROVE"
+    result.state.total_cost = 1.25
+    return result
+
+
+class TestStorySourceSelection:
+    def test_no_story_source_is_refused(self, capsys):
+        assert cmd_review(_args()) == 1
+        assert "exactly one story source" in capsys.readouterr().err
+
+    def test_both_story_sources_is_refused(self, capsys):
+        """Two sources cannot be silently reconciled — they may disagree."""
+        assert cmd_review(_args(story="story.md", issue=2204)) == 1
+        assert "exactly one story source" in capsys.readouterr().err
+
+    def test_a_directory_names_the_flags_that_would_have_worked(self, tmp_path, capsys):
+        """The worktree is what an operator reaches for, so say what to use instead."""
+        worktree = tmp_path / "issue-2204"
+        worktree.mkdir()
+        assert cmd_review(_args(story=str(worktree))) == 1
+        err = capsys.readouterr().err
+        assert "is a directory, not a story file" in err
+        assert "--issue" in err
+        assert "--worktree" in err
+
+    def test_a_missing_story_file_still_reports_plainly(self, tmp_path, capsys):
+        assert cmd_review(_args(story=str(tmp_path / "nope.md"))) == 1
+        assert "Story file not found" in capsys.readouterr().err
+
+
+class TestIssueBackedReview:
+    """--issue builds the task through the same source the sprint path uses."""
+
+    def _patches(self, tmp_path, task, fetch_error=None):
+        config = MagicMock()
+        config.project_root = tmp_path
+        config.workspace.path_pattern = ".forge/worktrees/{slug}"
+        config.review_pool = [MagicMock(model="m", name="r")]
+        source = MagicMock()
+        if fetch_error is not None:
+            source.fetch.side_effect = fetch_error
+        else:
+            source.fetch.return_value = task
+        return config, source
+
+    def test_issue_number_resolves_the_story_and_derives_the_worktree(self, tmp_path):
+        task = TaskStory(name="T", story_path=None, slug="issue-2204", github_issue=2204)
+        config, source = self._patches(tmp_path, task)
+        with (
+            patch("theforge.cli.review._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.review.load_config", return_value=config),
+            patch("theforge.cli.review.GitHubIssueSource", return_value=source),
+            patch("theforge.cli.review.run_from_review", return_value=_fake_result()) as run,
+            patch("theforge.cli.review._write_audit", return_value=tmp_path / "a.yaml"),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            assert cmd_review(_args(issue=2204)) == 0
+        source.fetch.assert_called_once_with("2204", tmp_path)
+        passed_task, workspace = run.call_args.args[1], run.call_args.args[2]
+        assert passed_task.github_issue == 2204
+        # The slug the issue source derives is what points at the existing worktree.
+        assert workspace == tmp_path / ".forge/worktrees/issue-2204"
+
+    def test_an_explicit_slug_overrides_the_derived_one(self, tmp_path):
+        task = TaskStory(name="T", story_path=None, slug="issue-2204", github_issue=2204)
+        config, source = self._patches(tmp_path, task)
+        with (
+            patch("theforge.cli.review._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.review.load_config", return_value=config),
+            patch("theforge.cli.review.GitHubIssueSource", return_value=source),
+            patch("theforge.cli.review.run_from_review", return_value=_fake_result()) as run,
+            patch("theforge.cli.review._write_audit", return_value=tmp_path / "a.yaml"),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            assert cmd_review(_args(issue=2204, slug="custom")) == 0
+        assert run.call_args.args[1].slug == "custom"
+        assert run.call_args.args[2] == tmp_path / ".forge/worktrees/custom"
+
+    def test_a_closed_issue_is_reported_not_raised(self, tmp_path, capsys):
+        closed = IssueClosedError("#2204 closed")
+        config, source = self._patches(tmp_path, None, fetch_error=closed)
+        with (
+            patch("theforge.cli.review._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.review.load_config", return_value=config),
+            patch("theforge.cli.review.GitHubIssueSource", return_value=source),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            assert cmd_review(_args(issue=2204)) == 1
+        assert "#2204 closed" in capsys.readouterr().err
+
+    def test_an_unreadable_issue_is_reported_not_raised(self, tmp_path, capsys):
+        config, source = self._patches(tmp_path, None, fetch_error=RuntimeError("gh: not found"))
+        with (
+            patch("theforge.cli.review._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.review.load_config", return_value=config),
+            patch("theforge.cli.review.GitHubIssueSource", return_value=source),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            assert cmd_review(_args(issue=2204)) == 1
+        assert "could not read issue #2204" in capsys.readouterr().err


### PR DESCRIPTION
## Why

`forge review` takes a story **file** path and nothing else. A story sourced from a GitHub issue is never written to disk — `GitHubIssueSource` builds a `TaskStory` with `story_path=None` and the body in `story_text`. So for an issue-backed worktree there was **no invocation at all**: the story file the command demands does not exist, and `--worktree` only overrides the location, not the source.

Reaching for the worktree path instead is the obvious guess, since the worktree is the thing being reviewed. That crashed with an unhandled `IsADirectoryError` out of `read_text()`, four frames deep in story parsing — which reads as a forge bug rather than as wrong input.

Found while reviewing #2204 by hand, because `forge review` could not be pointed at its worktree.

## What

- `--issue N` resolves the story through the same `GitHubIssueSource.fetch()` the sprint path uses, so a re-review reads the issue exactly as the run that produced the worktree did — including the slug, which derives the default worktree path (`issue-N`).
- `story` is now optional; exactly one source is required. Supplying both is refused rather than reconciled, since a file and an issue can disagree about the same story.
- A closed or unreadable issue reports and exits 1 instead of raising.
- A directory passed as `story` names both flags that would have worked. A missing file keeps its existing message.

```bash
forge review --issue 2204 --worktree .forge/worktrees/issue-2204 --verbose
```

## Verification

- New `tests/test_cli_review_entrypoint.py`: 8 tests. Mutation-checked — **7 of 8 fail against the unfixed `review.py`**, all 8 pass with it. The one that passes on base guards the pre-existing missing-file message.
- Full suite: 7293 passed, 32 skipped. `ruff check` clean.
- `docs/guides/cli-reference.md` updated for the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)