### PR TITLE
A story is seated with an allocation that cannot fund the review cycles it is permitted, so verification is defunded by arithmetic

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -50,6 +50,7 @@ from theforge.task import (
 )
 
 from . import live_state as _live_state
+from . import story_budget as _story_budget
 from .agent_failure import is_infrastructure_abort
 from .cancellation import StoryCancelled
 from .log_tee import (  # noqa: E402
@@ -415,11 +416,87 @@ def _coordinator_loop(
                 dev_cost_estimate_usd=_static_dev_cost_estimate,
                 audit=_audit,
             )
+        # ── Seat permissions the allocation can actually fund (#2238) ─────────
+        # The allocation and the permitted review cycles are derived
+        # independently from the same complexity signal, so nothing stops a
+        # story being granted more review cycles than its allocation can pay
+        # for. Reconcile them here — the last point before dev spends, where
+        # reducing scope is still free — rather than discovering the shortfall
+        # at review dispatch, where the only options left are escalate or
+        # accept unverified work.
+        #
+        # The per-cycle cost is the full configured pool sum: an upper bound
+        # (demotion only ever removes reviewers) and the same number the
+        # dispatch-time funding check plans against.
+        _reviewer_names = [profile.name for profile in config.review_pool]
+        _reconciliation = _story_budget.reconcile_review_cycles(
+            state.story_allocation,
+            dev_cost_estimate_usd=_limits.dev_cost_estimate_usd,
+            review_cycle_cost_usd=sum(float(p.budget_usd) for p in config.review_pool),
+            requested_review_max=_limits.review_max,
+            spent_so_far_usd=state.total_cost_measured,
+        )
+        _audit = dict(_limits.audit)
+        _audit["review_cycle_reconciliation"] = _reconciliation
+        if _reconciliation["action"] in (
+            _story_budget.RECONCILE_REDUCED,
+            _story_budget.RECONCILE_UNFUNDABLE,
+        ):
+            _audit["rationale"] = (
+                f"{_audit.get('rationale', '')} "
+                f"{_story_budget.format_reconciliation(_reconciliation)}"
+            ).strip()
+        _limits = type(_limits)(
+            dev_max=_limits.dev_max,
+            review_max=_reconciliation["reconciled_review_max"],
+            dev_timeout_seconds=_limits.dev_timeout_seconds,
+            dev_cost_estimate_usd=_limits.dev_cost_estimate_usd,
+            audit=_audit,
+        )
+
         state.adaptive_dev_max = _limits.dev_max
         state.adaptive_review_max = _limits.review_max
         state.adaptive_dev_timeout_seconds = _limits.dev_timeout_seconds
         state.adaptive_dev_cost_estimate_usd = _limits.dev_cost_estimate_usd
         state.adaptive_limits_audit = _limits.audit
+
+        if _reconciliation["action"] == _story_budget.RECONCILE_UNFUNDABLE:
+            # Not one review cycle fits. Spending on work that cannot then be
+            # checked is the failure this reconciliation exists to prevent, so
+            # the run stops here — before DEV — and says why.
+            _shortfall = _story_budget.seating_shortfall(
+                state.story_allocation,
+                _reconciliation,
+                participants=_reviewer_names,
+            )
+            if _shortfall is not None:
+                state.allocation_exhausted = _shortfall
+                state.error = _story_budget.format_shortfall(_shortfall, story=task.slug)
+                state.error_type = "allocation_exhausted"
+                state.phase = Phase.ESCALATE
+                _log(f"  ⚠ {state.error}")
+                if logger:
+                    logger._safe_emit(
+                        "allocation_exhausted",
+                        phase="SEATING",
+                        **{
+                            k: _reconciliation.get(k)
+                            for k in (
+                                "allocation_usd",
+                                "dev_cost_estimate_usd",
+                                "review_cycle_cost_usd",
+                                "requested_review_max",
+                                "shortfall_usd",
+                            )
+                        },
+                    )
+                return CoordinatorResult(
+                    success=False,
+                    phase=Phase.ESCALATE,
+                    state=state,
+                    message=state.error,
+                )
+
         _log_verbose(
             "  adaptive limits: "
             f"dev_max={_limits.dev_max} review_max={_limits.review_max} "

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -305,6 +305,182 @@ def phase_funding_shortfall(
     }
 
 
+# ── Seating-time reconciliation of permissions against the allocation (#2238) ──
+# Actions a reconciliation can report. The first four are no-ops: the inputs do
+# not admit an honest answer, so the requested permission stands and the record
+# says why nothing was decided.
+RECONCILE_NO_ALLOCATION = "no_allocation"
+RECONCILE_NO_BAND_HISTORY = "no_band_history"
+RECONCILE_NO_DEV_ESTIMATE = "no_dev_estimate"
+RECONCILE_NO_REVIEW_COST = "no_review_cost"
+RECONCILE_COST_UNKNOWN = "cost_unknown"
+RECONCILE_AFFORDABLE = "within_allocation"
+RECONCILE_REDUCED = "review_max_reduced"
+RECONCILE_UNFUNDABLE = "review_unfundable"
+
+
+def reconcile_review_cycles(
+    allocation: dict | None,
+    *,
+    dev_cost_estimate_usd: float | None,
+    review_cycle_cost_usd: float | None,
+    requested_review_max: int,
+    spent_so_far_usd: float | None = 0.0,
+) -> dict:
+    """Reconcile permitted review cycles against what the allocation can fund.
+
+    Pure arithmetic over numbers that are all known at seating time: the
+    allocation, the spend already incurred (preflight/plan/plan-review), the
+    adaptive dev cost estimate, and the per-cycle cost of the review panel the
+    run plans to seat. Returns the audit record of the decision; the caller
+    applies it.
+
+    ``reconciled_review_max`` is the number of review cycles the allocation can
+    actually fund. It equals ``requested_review_max`` whenever the inputs do not
+    support a decision — an absent allocation, a configured-fallback allocation,
+    an absent dev estimate, a zero per-cycle review cost, or cost-unknown spend
+    are recorded as explicit no-ops rather than guessed at. ``action`` is
+    ``review_unfundable`` when not even one cycle fits, which is the case the
+    caller must refuse before dev spends.
+
+    Only a band-derived allocation governs here. The configured fallback is by
+    construction one pass through every role (see ``_configured_story_budget``),
+    so it funds exactly one review cycle for arithmetic reasons that say nothing
+    about this story — reconciling against it would clamp verification to a
+    single cycle on every story in a project with no band history. That is a
+    guess dressed as evidence, and the pre-existing dispatch-time guard already
+    covers the fallback case honestly, against measured spend.
+    """
+    record: dict = {
+        "requested_review_max": int(requested_review_max),
+        "reconciled_review_max": int(requested_review_max),
+        "affordable_review_cycles": None,
+        "allocation_usd": None,
+        "spent_so_far_usd": None
+        if spent_so_far_usd is None
+        else round(float(spent_so_far_usd), 4),
+        "dev_cost_estimate_usd": None,
+        "review_cycle_cost_usd": None,
+        "action": RECONCILE_AFFORDABLE,
+    }
+    try:
+        allocation_usd = float((allocation or {}).get("allocation_usd"))
+    except (TypeError, ValueError, AttributeError):
+        record["action"] = RECONCILE_NO_ALLOCATION
+        return record
+    record["allocation_usd"] = round(allocation_usd, 2)
+    record["basis"] = (allocation or {}).get("basis")
+
+    if record["basis"] != BASIS_SUBSTRATE_BAND:
+        record["action"] = RECONCILE_NO_BAND_HISTORY
+        return record
+
+    if spent_so_far_usd is None:
+        # An unmeasured total is a lower bound. Reducing a permission on a
+        # number the run does not actually have would be a guess.
+        record["action"] = RECONCILE_COST_UNKNOWN
+        return record
+
+    try:
+        dev_estimate = float(dev_cost_estimate_usd)
+    except (TypeError, ValueError):
+        dev_estimate = 0.0
+    if dev_estimate <= 0.0:
+        record["action"] = RECONCILE_NO_DEV_ESTIMATE
+        return record
+    record["dev_cost_estimate_usd"] = round(dev_estimate, 4)
+
+    try:
+        cycle_cost = float(review_cycle_cost_usd)
+    except (TypeError, ValueError):
+        cycle_cost = 0.0
+    if cycle_cost <= 0.0:
+        record["action"] = RECONCILE_NO_REVIEW_COST
+        return record
+    record["review_cycle_cost_usd"] = round(cycle_cost, 4)
+
+    if requested_review_max <= 0:
+        record["action"] = RECONCILE_AFFORDABLE
+        return record
+
+    remaining = allocation_usd - float(spent_so_far_usd) - dev_estimate
+    record["remaining_after_dev_usd"] = round(remaining, 4)
+    affordable = 0 if remaining < cycle_cost else int(remaining // cycle_cost)
+    record["affordable_review_cycles"] = affordable
+    if affordable == 0:
+        record["reconciled_review_max"] = int(requested_review_max)
+        record["action"] = RECONCILE_UNFUNDABLE
+        record["shortfall_usd"] = round(cycle_cost - remaining, 4)
+        return record
+    if affordable >= requested_review_max:
+        record["action"] = RECONCILE_AFFORDABLE
+        return record
+    record["reconciled_review_max"] = affordable
+    record["action"] = RECONCILE_REDUCED
+    record["shortfall_usd"] = round(
+        (requested_review_max - affordable) * cycle_cost - (remaining - affordable * cycle_cost),
+        4,
+    )
+    return record
+
+
+def format_reconciliation(record: dict) -> str:
+    """One-line operator-facing summary of a seating reconciliation."""
+    action = record.get("action")
+    if action == RECONCILE_REDUCED:
+        return (
+            f"review_max reduced {record['requested_review_max']} → "
+            f"{record['reconciled_review_max']}: the "
+            f"${float(record['allocation_usd']):.2f} allocation funds "
+            f"{record['affordable_review_cycles']} review cycle(s) at "
+            f"${float(record['review_cycle_cost_usd']):.2f} each after a "
+            f"${float(record['dev_cost_estimate_usd']):.2f} dev estimate."
+        )
+    if action == RECONCILE_UNFUNDABLE:
+        return (
+            f"the ${float(record['allocation_usd']):.2f} allocation cannot fund one "
+            f"${float(record['review_cycle_cost_usd']):.2f} review cycle after a "
+            f"${float(record['dev_cost_estimate_usd']):.2f} dev estimate "
+            f"(short ${float(record['shortfall_usd']):.2f})."
+        )
+    if action == RECONCILE_AFFORDABLE:
+        return f"allocation funds the permitted {record['requested_review_max']} review cycle(s)."
+    return f"review-cycle reconciliation not decided ({action})."
+
+
+def seating_shortfall(
+    allocation: dict | None,
+    record: dict,
+    *,
+    participants: list[str],
+) -> dict | None:
+    """Build the allocation-exhausted payload for an unfundable seating.
+
+    Reuses the shape :func:`phase_funding_shortfall` produces so every existing
+    consumer (sprint audit, status reader, run record) reads it unchanged. The
+    "observed" figure is the projected spend at the point review would be
+    reached — the already-incurred spend plus the dev estimate — and the record
+    says so via ``projected`` so it is never mistaken for measured cost.
+    """
+    if record.get("action") != RECONCILE_UNFUNDABLE:
+        return None
+    projected = float(record.get("spent_so_far_usd") or 0.0) + float(
+        record.get("dev_cost_estimate_usd") or 0.0
+    )
+    shortfall = phase_funding_shortfall(
+        allocation,
+        projected,
+        phase="review",
+        participants=list(participants),
+        planned_usd=float(record["review_cycle_cost_usd"]),
+    )
+    if shortfall is None:  # pragma: no cover - unfundable implies a shortfall
+        return None
+    shortfall["projected"] = True
+    shortfall["seating_reconciliation"] = dict(record)
+    return shortfall
+
+
 def format_shortfall(shortfall: dict, *, story: str | None = None) -> str:
     """Render the operator-facing allocation-exhausted message."""
     story_label = f"story {story}" if story else "story"
@@ -316,6 +492,13 @@ def format_shortfall(shortfall: dict, *, story: str | None = None) -> str:
             f"max ${float(shortfall['max_usd']):.2f} over "
             f"{shortfall.get('sample_count')} run(s)"
         )
+    observed_label = "projected" if shortfall.get("projected") else "observed"
+    seating = ""
+    if shortfall.get("projected"):
+        seating = (
+            " Decided at seating, before dev spent: the permitted review cycles "
+            "cost more than the allocation leaves after the dev estimate."
+        )
     return (
         f"Story allocation exhausted: {story_label} cannot fund its planned "
         f"{shortfall['phase']} participants "
@@ -323,8 +506,8 @@ def format_shortfall(shortfall: dict, *, story: str | None = None) -> str:
         f"${shortfall['planned_usd']:.2f}, ${shortfall['remaining_usd']:.2f} left of the "
         f"${shortfall['allocation_usd']:.2f} allocation "
         f"(complexity score {shortfall.get('complexity_score')}, basis "
-        f"{shortfall.get('basis')}, expected {expected}); observed "
-        f"${shortfall['observed_usd']:.2f}. Sprint headroom is reported "
+        f"{shortfall.get('basis')}, expected {expected}); {observed_label} "
+        f"${shortfall['observed_usd']:.2f}.{seating} Sprint headroom is reported "
         f"alongside this story in the sprint summary."
     )
 

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -305,3 +305,149 @@ class TestPhaseFundingShortfall:
             )
             is None
         )
+
+
+class TestReviewCycleReconciliation:
+    """Permitted review cycles are reconciled against the allocation (#2238)."""
+
+    def _allocation(self, usd: float = 48.02) -> dict:
+        return {
+            "allocation_usd": usd,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 8,
+            "median_usd": 7.53,
+            "p90_usd": 19.74,
+            "max_usd": 38.42,
+            "sample_count": 12,
+        }
+
+    def test_issue_2204_arithmetic_reduces_five_permitted_cycles_to_one(self) -> None:
+        """The seating numbers from run 88a7e2cc81eb admit one review cycle."""
+        record = sb.reconcile_review_cycles(
+            self._allocation(),
+            dev_cost_estimate_usd=25.0428,
+            review_cycle_cost_usd=17.55,
+            requested_review_max=5,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_REDUCED
+        assert record["affordable_review_cycles"] == 1
+        assert record["reconciled_review_max"] == 1
+        assert record["allocation_usd"] == 48.02
+        assert record["dev_cost_estimate_usd"] == 25.0428
+        assert record["review_cycle_cost_usd"] == 17.55
+        assert record["requested_review_max"] == 5
+        assert record["remaining_after_dev_usd"] == round(48.02 - 25.0428, 4)
+        assert record["shortfall_usd"] > 0
+
+        message = sb.format_reconciliation(record)
+        assert "5 → 1" in message
+        assert "$48.02" in message
+
+    def test_spend_already_incurred_counts_against_the_remainder(self) -> None:
+        """Preflight/plan spend is real money and is not affordable twice."""
+        record = sb.reconcile_review_cycles(
+            self._allocation(),
+            dev_cost_estimate_usd=25.0428,
+            review_cycle_cost_usd=17.55,
+            requested_review_max=5,
+            spent_so_far_usd=6.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_UNFUNDABLE
+        assert record["affordable_review_cycles"] == 0
+        assert record["spent_so_far_usd"] == 6.0
+        assert record["shortfall_usd"] == round(17.55 - (48.02 - 6.0 - 25.0428), 4)
+
+    def test_an_allocation_that_funds_the_permission_is_left_alone(self) -> None:
+        record = sb.reconcile_review_cycles(
+            self._allocation(usd=120.0),
+            dev_cost_estimate_usd=25.0,
+            review_cycle_cost_usd=17.55,
+            requested_review_max=5,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_AFFORDABLE
+        assert record["reconciled_review_max"] == 5
+        assert record["affordable_review_cycles"] == 5
+
+    def test_missing_inputs_are_explicit_no_ops_not_guesses(self) -> None:
+        base = dict(
+            dev_cost_estimate_usd=25.0,
+            review_cycle_cost_usd=17.55,
+            requested_review_max=5,
+            spent_so_far_usd=0.0,
+        )
+        assert sb.reconcile_review_cycles(None, **base)["action"] == sb.RECONCILE_NO_ALLOCATION
+        assert (
+            sb.reconcile_review_cycles(
+                self._allocation(), **{**base, "dev_cost_estimate_usd": 0.0}
+            )["action"]
+            == sb.RECONCILE_NO_DEV_ESTIMATE
+        )
+        assert (
+            sb.reconcile_review_cycles(
+                self._allocation(), **{**base, "review_cycle_cost_usd": 0.0}
+            )["action"]
+            == sb.RECONCILE_NO_REVIEW_COST
+        )
+        # The configured fallback is one pass through every role by
+        # construction, so it funds exactly one review cycle for reasons that
+        # say nothing about this story. Reconciling against it would clamp
+        # verification to one cycle on every band without history.
+        fallback = sb.reconcile_review_cycles(
+            {**self._allocation(), "basis": sb.BASIS_CONFIGURED_FALLBACK}, **base
+        )
+        assert fallback["action"] == sb.RECONCILE_NO_BAND_HISTORY
+        assert fallback["reconciled_review_max"] == 5
+        # Cost-unknown spend is a lower bound; refusing on it would be a guess.
+        unknown = sb.reconcile_review_cycles(
+            self._allocation(usd=1.0), **{**base, "spent_so_far_usd": None}
+        )
+        assert unknown["action"] == sb.RECONCILE_COST_UNKNOWN
+        assert unknown["reconciled_review_max"] == 5
+        for record in (
+            sb.reconcile_review_cycles(None, **base),
+            fallback,
+            unknown,
+        ):
+            assert record["reconciled_review_max"] == record["requested_review_max"]
+
+    def test_unfundable_seating_reports_the_existing_shortfall_shape(self) -> None:
+        allocation = self._allocation(usd=30.0)
+        record = sb.reconcile_review_cycles(
+            allocation,
+            dev_cost_estimate_usd=25.0,
+            review_cycle_cost_usd=17.55,
+            requested_review_max=5,
+            spent_so_far_usd=0.0,
+        )
+        shortfall = sb.seating_shortfall(allocation, record, participants=["a", "b", "c"])
+
+        assert shortfall is not None
+        # Same keys every existing consumer already reads.
+        assert shortfall["phase"] == "review"
+        assert shortfall["participants"] == ["a", "b", "c"]
+        assert shortfall["planned_usd"] == 17.55
+        assert shortfall["allocation_usd"] == 30.0
+        assert shortfall["observed_usd"] == 25.0
+        assert shortfall["projected"] is True
+        assert shortfall["seating_reconciliation"]["action"] == sb.RECONCILE_UNFUNDABLE
+
+        message = sb.format_shortfall(shortfall, story="issue-2204")
+        assert "issue-2204" in message
+        assert "projected" in message
+        assert "Decided at seating" in message
+
+    def test_no_shortfall_payload_when_the_seating_was_fundable(self) -> None:
+        allocation = self._allocation(usd=120.0)
+        record = sb.reconcile_review_cycles(
+            allocation,
+            dev_cost_estimate_usd=25.0,
+            review_cycle_cost_usd=17.55,
+            requested_review_max=5,
+            spent_so_far_usd=0.0,
+        )
+        assert sb.seating_shortfall(allocation, record, participants=["a"]) is None

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -472,3 +472,222 @@ class TestResumeCarriesTheAllocation:
         assert state.story_allocation["allocation_usd"] == first["allocation_usd"]
         assert state.story_allocation["fallback_configured_usd"] == 50.0
         assert _runtime_total(twice) == pytest.approx(_runtime_total(once), abs=0.05)
+
+
+class TestSeatingReconcilesPermissionsWithTheAllocation:
+    """A story is never seated with review cycles it cannot pay for (#2238)."""
+
+    def _adaptive_config(
+        self,
+        tmp_path: Path,
+        *,
+        dev_budget_usd: float,
+        reviewer_budget_usd: float,
+        reviewers: int = 3,
+    ):
+        from coord_test_helpers import _make_config, _make_review_profile
+
+        from theforge.config.types import AssignmentConfig, RetryPolicy
+
+        config = _make_config(tmp_path)
+        return dataclasses.replace(
+            config,
+            dev_profile=dataclasses.replace(config.dev_profile, budget_usd=dev_budget_usd),
+            review_pool=[
+                _make_review_profile(name, budget_usd=reviewer_budget_usd)
+                for name in ("a", "b", "c")[:reviewers]
+            ],
+            synthesis_profile=None,
+            retry=RetryPolicy(
+                max_dev_iterations=3,
+                max_review_cycles=5,
+                max_dev_iterations_cap=6,
+                max_review_cycles_cap=5,
+                adaptive_iterations=True,
+            ),
+            assignment=AssignmentConfig(enabled=True, adaptive_enabled=True),
+        )
+
+    def _seated_state(self, tmp_path: Path, allocation_usd: float):
+        state = CoordinatorState()
+        state.preflight_complexity = "large"
+        state.preflight_complexity_score = 9
+        state.workspace_path = tmp_path
+        state.branch_name = "feat/test"
+        state.story_allocation = {
+            "allocation_usd": allocation_usd,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 9,
+            "median_usd": 7.53,
+            "p90_usd": 19.74,
+            "max_usd": round(allocation_usd / 1.25, 2),
+            "sample_count": 12,
+        }
+        return state
+
+    def test_review_max_is_reduced_to_what_the_allocation_funds_before_dev(
+        self, tmp_path: Path
+    ) -> None:
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        # The seating numbers from run 88a7e2cc81eb: $48.02 allocation, a
+        # $25.0428 dev estimate, a $17.55-per-cycle panel.
+        config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path, 48.02)
+
+        class _StopAtDev(Exception):
+            pass
+
+        seen: dict = {}
+
+        def _fake_dev(*_args, **_kwargs):
+            seen["review_max_at_dev"] = state.adaptive_review_max
+            raise _StopAtDev()
+
+        with patch("theforge.coordinator.engine._run_dev_phase", _fake_dev):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert record["action"] == sb.RECONCILE_REDUCED
+        assert record["requested_review_max"] > 1
+        assert record["reconciled_review_max"] == 1
+        assert record["review_cycle_cost_usd"] == 17.55
+        assert record["allocation_usd"] == 48.02
+        # The reduction is in force before dev spends a cent, not afterwards.
+        assert seen["review_max_at_dev"] == 1
+        assert state.adaptive_review_max == 1
+        assert "review_max reduced" in state.adaptive_limits_audit["rationale"]
+
+    def test_an_allocation_that_cannot_fund_one_cycle_escalates_before_dev(
+        self, tmp_path: Path
+    ) -> None:
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path, 30.0)
+
+        with patch("theforge.coordinator.engine._run_dev_phase") as mock_dev:
+            result = _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        # No dev spend on work that could never have been reviewed.
+        assert mock_dev.called is False
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert state.phase == Phase.ESCALATE
+        assert state.error_type == "allocation_exhausted"
+        assert state.allocation_exhausted is not None
+        assert state.allocation_exhausted["participants"] == ["a", "b", "c"]
+        assert state.allocation_exhausted["planned_usd"] == 17.55
+        assert "test-task" in state.error
+        assert "Decided at seating" in state.error
+        assert (
+            state.adaptive_limits_audit["review_cycle_reconciliation"]["action"]
+            == sb.RECONCILE_UNFUNDABLE
+        )
+
+    def test_a_sufficient_allocation_leaves_the_permitted_cycles_intact(
+        self, tmp_path: Path
+    ) -> None:
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path, 500.0)
+
+        class _StopAtDev(Exception):
+            pass
+
+        with patch("theforge.coordinator.engine._run_dev_phase", side_effect=_StopAtDev()):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert record["action"] == sb.RECONCILE_AFFORDABLE
+        assert state.adaptive_review_max == record["requested_review_max"]
+        assert state.allocation_exhausted is None
+
+    def test_a_story_without_an_allocation_is_left_untouched(self, tmp_path: Path) -> None:
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path, 1.0)
+        state.story_allocation = None
+
+        class _StopAtDev(Exception):
+            pass
+
+        with patch("theforge.coordinator.engine._run_dev_phase", side_effect=_StopAtDev()):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert record["action"] == sb.RECONCILE_NO_ALLOCATION
+        assert state.adaptive_review_max == record["requested_review_max"]
+
+    def test_a_configured_fallback_allocation_does_not_clamp_review_cycles(
+        self, tmp_path: Path
+    ) -> None:
+        """No band history means no evidence — the dispatch guard still covers it."""
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path, 48.02)
+        state.story_allocation = {
+            **state.story_allocation,
+            "basis": sb.BASIS_CONFIGURED_FALLBACK,
+        }
+
+        class _StopAtDev(Exception):
+            pass
+
+        with patch("theforge.coordinator.engine._run_dev_phase", side_effect=_StopAtDev()):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert record["action"] == sb.RECONCILE_NO_BAND_HISTORY
+        assert state.adaptive_review_max == record["requested_review_max"]
+        assert state.allocation_exhausted is None
+
+    def test_the_reconciliation_reaches_the_run_audit(self, tmp_path: Path) -> None:
+        """The operator can see which of the two governors moved, and why."""
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.audit import generate_audit_log
+        from theforge.coordinator.engine import _coordinator_loop
+        from theforge.coordinator.state import CoordinatorResult
+
+        config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path, 48.02)
+
+        class _StopAtDev(Exception):
+            pass
+
+        with patch("theforge.coordinator.engine._run_dev_phase", side_effect=_StopAtDev()):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        audit = generate_audit_log(
+            config,
+            task,
+            CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message="x"),
+        )
+        block = audit["iterations"]["adaptive_limits"]["review_cycle_reconciliation"]
+        assert block["action"] == sb.RECONCILE_REDUCED
+        assert block["reconciled_review_max"] == 1


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change reconciles review-cycle permissions against substrate-derived story allocations before dispatch and has focused regression coverage for the observed issue-2204 arithmetic. | [google-gemini-3.5-flash-api] The implementation successfully reconciles permitted review cycles with the story allocation at seating time, preventing defunding of verification by arithmetic. | [anthropic-haiku-cli] A story's allocation and permitted review cycles are now reconciled at seating time, before dev spends, rather than discovered at review dispatch. The implementation is correct: it runs at the right phase boundary, applies only where evidence supports it (substrate band allocations), and makes three deterministic decisions (affordable, reduced, unfundable) with full audit visibility. Acceptance criteria verified against actual code behavior and integration tests.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $6.07
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A story is seated with an allocation that cannot fund the review cycles it is permitted, so verification is defunded by arithmetic (GitHub Issue #2238)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2238