### PR TITLE
A collision gate releases when the blocking story escalates, so a dependent story builds on preserved work that has not landed

### DIFF
--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1729,6 +1729,12 @@ CLAIM_PENDING_LANDING = "landing pending"
 #: the files it planned to rewrite stay claimed until the sprint ends (#2234).
 CLAIM_PRESERVED = "preserved for operator decision"
 
+#: How often a queued PR whose claim is holding a sibling's plan gate is probed
+#: while the scheduling loop is otherwise busy. Matches _poll_queued_pr's own
+#: inter-poll sleep: the gate should open on the merge, not on its own timeout,
+#: without turning the 2s gate-service tick into a `gh pr view` per second.
+_QUEUED_CLAIM_PROBE_SECONDS = 30.0
+
 
 def _release_plan_gates(
     plan_done: dict[str, str],
@@ -5161,6 +5167,7 @@ def run_sprint(
     collision_claims: dict[str, str] = {}  # slug -> claim reason (CLAIM_* above)
     claim_results: dict[str, CoordinatorResult] = {}  # slug -> last known result
     gate_stood_down: dict[str, str] = {}  # slug -> reason it never entered DEV
+    _queued_probe_at: dict[str, float] = {}  # slug -> monotonic time of last PR probe
 
     def _end_collision_claim(slug: str, why: str) -> None:
         """Drop a story's claim on its planned files, and the state behind it."""
@@ -5205,24 +5212,6 @@ def run_sprint(
             _c_result = claim_results.get(_c_slug)
             if _c_result is not None:
                 _reconcile_collision_claim(_c_slug, _c_result)
-
-    def _service_plan_gates() -> None:
-        """Release openable plan gates and stand down the unopenable ones."""
-        for _sd_slug in _release_plan_gates(
-            plan_done, file_footprints, plan_gates, active, phase_lock, collision_claims
-        ):
-            _sd_gate = plan_gates.pop(_sd_slug, None)
-            gate_stood_down[_sd_slug] = (
-                "collision gate stood down: the files it planned to change are held "
-                "by preserved work that has not landed"
-            )
-            # stop_event BEFORE the gate, same ordering as the deadline teardown:
-            # the worker must observe the shutdown flag when the gate wakes it.
-            _sd_evt = stop_events.get(_sd_slug)
-            if _sd_evt is not None:
-                _sd_evt.set()
-            if _sd_gate is not None:
-                _sd_gate.set()
 
     def _apply_batch_landing_to_member(
         member_slug: str,
@@ -5294,6 +5283,118 @@ def run_sprint(
             _apply_batch_landing_to_member(
                 member_slug, member_task, member_result, landing_status, leader_slug, group_id
             )
+
+    def _resolve_queued_pr(slug: str, *, blocking: bool, context: str) -> str:
+        """Poll one queued PR and apply its landing verdict everywhere it is owed.
+
+        The single site for queued-PR resolution during the work loop. Every
+        caller owes the same bookkeeping — DAG, canonical outcome, durable
+        landing evidence, audit, batch-leader propagation and, since #2234, the
+        collision claim — and the copies drifted: the dependent-dispatch gate
+        recorded neither the landing nor the claim release, so a merged parent
+        left a gated sibling parked on a claim nothing would ever clear.
+
+        With *blocking* false the PR is probed exactly once and anything short
+        of a confirmed merge returns ``"pending"``, leaving it queued for the
+        blocking poll that owns the failure verdict. Returns ``"merged"``,
+        ``"failed"`` or ``"pending"``.
+        """
+        task, result, pr_url = queued_prs[slug]
+        _queued_probe_at[slug] = time.monotonic()
+        poll_result = _poll_queued_pr(
+            pr_url,
+            config.project_root,
+            config.workspace.merge_wait_timeout_seconds if blocking else 0,
+            base_branch=config.workspace.base_branch,
+        )
+        if not blocking and poll_result["status"] != "merged":
+            # A single probe cannot tell "still in the queue" from "decided
+            # against us" without re-running the wait budget, and only a merge
+            # is safe to conclude from it. Everything else stays queued.
+            return "pending"
+
+        # Out of queued_prs before the claim is reconciled: membership there is
+        # itself a reason to keep a collision claim alive.
+        del queued_prs[slug]
+
+        if poll_result["status"] == "merged":
+            merged_slugs.add(slug)
+            dag.mark_complete(slug)
+            result.landing_status = "landed"
+            # The immutability marker: this DONE is confirmed-landed and must
+            # not be clobbered by a later re-dispatch or wrap-up pass.
+            _set_outcome(slug, StoryOutcome.DONE, landed=True)
+            _persist_story_landing(slug, result)
+            _write_story_audit(config, task, result, sprint_id=_sprint_id)
+            _resolve_batch_leader_landing(slug, "landed")
+            _end_collision_claim(slug, "queued PR merged")
+            _log(f"INFO {slug}: queued PR merged ({context}); unblocking dependents")
+            return "merged"
+
+        from ..coordinator.completion import (  # noqa: PLC0415
+            mark_merge_failed as _mark_mf,
+        )
+
+        _err = _queued_pr_failure_message(
+            poll_result, pr_url, config.workspace.merge_wait_timeout_seconds
+        )
+        _mark_mf(result.state, result, _err, result.state.branch_name)
+        _set_outcome(slug, StoryOutcome.MERGE_FAILED, phase=result.phase.name)
+        _persist_story_landing(slug, result)
+        # Defensive/idempotent: the parent is normally already in the DAG's
+        # _finished set (added when its PR was queued, via the
+        # pending_integration classify branch), so its collision (soft) edge is
+        # already released; this guarantees it on any path that skipped that
+        # classification. _finished (not _completed) is what still blocks a hard
+        # depends_on dependent. Actual redispatch of a released dependent onto
+        # the current base comes from the dag.ready() re-check at the top of the
+        # deadlock-cleanup branch.
+        dag.mark_skipped(slug)
+        _write_story_audit(config, task, result, sprint_id=_sprint_id)
+        _resolve_batch_leader_landing(slug, "failed")
+        _end_collision_claim(slug, f"queued PR {poll_result['status']}")
+        _log(f"✗ {slug}: queued PR {poll_result['status']} ({context})")
+        return "failed"
+
+    def _service_plan_gates() -> None:
+        """Release openable plan gates and stand down the unopenable ones."""
+        # A CLAIM_PENDING_LANDING claim is resolvable *in this run*, but only
+        # the queued-PR paths resolve it, and those run when the loop has no
+        # active workers. A worker parked at its plan gate keeps the loop busy
+        # forever, so the gate would wait on a PR that may have merged minutes
+        # ago and then open on its own 7200s timeout instead (#2234). Probe
+        # cheaply — one `gh pr view`, no queue wait — so the gate opens on the
+        # merge. The blocking polls keep sole ownership of the failure verdict.
+        if plan_gates and queued_prs:
+            _probe_now: float | None = None
+            for _q_slug in list(queued_prs):
+                if collision_claims.get(_q_slug) != CLAIM_PENDING_LANDING:
+                    continue
+                # Read the clock only once a probe is actually in question: this
+                # runs on the 2s gate-service tick, and the common case has no
+                # queued PR holding a claim at all.
+                if _probe_now is None:
+                    _probe_now = time.monotonic()
+                _last = _queued_probe_at.get(_q_slug)
+                if _last is not None and _probe_now - _last < _QUEUED_CLAIM_PROBE_SECONDS:
+                    continue
+                _resolve_queued_pr(_q_slug, blocking=False, context="holding a collision gate")
+
+        for _sd_slug in _release_plan_gates(
+            plan_done, file_footprints, plan_gates, active, phase_lock, collision_claims
+        ):
+            _sd_gate = plan_gates.pop(_sd_slug, None)
+            gate_stood_down[_sd_slug] = (
+                "collision gate stood down: the files it planned to change are held "
+                "by preserved work that has not landed"
+            )
+            # stop_event BEFORE the gate, same ordering as the deadline teardown:
+            # the worker must observe the shutdown flag when the gate wakes it.
+            _sd_evt = stop_events.get(_sd_slug)
+            if _sd_evt is not None:
+                _sd_evt.set()
+            if _sd_gate is not None:
+                _sd_gate.set()
 
     def _attempt_integration(
         slug: str,
@@ -5449,56 +5550,12 @@ def run_sprint(
                 if blocked_by_queued:
                     dependency_failed = False
                     for dep in blocked_by_queued:
-                        dep_task, dep_result, dep_pr_url = queued_prs[dep]
-                        poll_result = _poll_queued_pr(
-                            dep_pr_url,
-                            config.project_root,
-                            config.workspace.merge_wait_timeout_seconds,
-                            base_branch=config.workspace.base_branch,
-                        )
-                        if poll_result["status"] == "merged":
-                            merged_slugs.add(dep)
-                            dag.mark_complete(dep)
-                            del queued_prs[dep]
-                            _write_story_audit(config, dep_task, dep_result, sprint_id=_sprint_id)
-                            _resolve_batch_leader_landing(dep, "landed")
-                        else:
-                            from ..coordinator.completion import (  # noqa: PLC0415
-                                mark_merge_failed as _mark_mf,
+                        if (
+                            _resolve_queued_pr(
+                                dep, blocking=True, context="before dependent dispatch"
                             )
-
-                            _err = _queued_pr_failure_message(
-                                poll_result,
-                                dep_pr_url,
-                                config.workspace.merge_wait_timeout_seconds,
-                            )
-                            _mark_mf(
-                                dep_result.state,
-                                dep_result,
-                                _err,
-                                dep_result.state.branch_name,
-                            )
-                            _set_outcome(
-                                dep, StoryOutcome.MERGE_FAILED, phase=dep_result.phase.name
-                            )
-                            del queued_prs[dep]
-                            # Defensive/idempotent: the parent is normally already
-                            # in the DAG's _finished set (added when its PR was
-                            # queued, via the pending_integration classify branch),
-                            # so its collision (soft) edge is already released. This
-                            # call guarantees _finished membership on any path that
-                            # queued without that classification. _finished (not
-                            # _completed) is what keeps a genuine depends_on (hard)
-                            # dependent blocked. The redispatch of the released
-                            # dependent onto the current base is driven by the
-                            # dag.ready() re-check before the deadlock-cleanup sweep.
-                            dag.mark_skipped(dep)
-                            _write_story_audit(config, dep_task, dep_result, sprint_id=_sprint_id)
-                            _resolve_batch_leader_landing(dep, "failed")
-                            _log(
-                                f"✗ {dep}: queued PR {poll_result['status']} "
-                                "before dependent dispatch"
-                            )
+                            == "failed"
+                        ):
                             dependency_failed = True
                     if dependency_failed:
                         continue
@@ -5804,56 +5861,11 @@ def run_sprint(
             # once the PR lands — do not declare deadlock while PRs are pending.
             if not active and queued_prs:
                 for _qp_slug in list(queued_prs):
-                    _qp_task, _qp_result, _qp_pr_url = queued_prs[_qp_slug]
-                    _qp_poll = _poll_queued_pr(
-                        _qp_pr_url,
-                        config.project_root,
-                        config.workspace.merge_wait_timeout_seconds,
-                        base_branch=config.workspace.base_branch,
-                    )
-                    if _qp_poll["status"] == "merged":
-                        merged_slugs.add(_qp_slug)
-                        dag.mark_complete(_qp_slug)
-                        _qp_result.landing_status = "landed"
-                        # Record the confirmed-landed DONE with the immutability
-                        # marker. This is the code path most directly implicated
-                        # in the redispatch-after-restart bug: a queued PR merges
-                        # while another story occupies the only worker slot. The
-                        # marker guarantees this DONE cannot later be clobbered.
-                        _set_outcome(_qp_slug, StoryOutcome.DONE, landed=True)
-                        _persist_story_landing(_qp_slug, _qp_result)
-                        del queued_prs[_qp_slug]
-                        _write_story_audit(config, _qp_task, _qp_result, sprint_id=_sprint_id)
-                        _resolve_batch_leader_landing(_qp_slug, "landed")
-                        _log(f"INFO {_qp_slug}: queued PR merged; unblocking dependents")
-                    else:
-                        from ..coordinator.completion import (  # noqa: PLC0415
-                            mark_merge_failed as _mark_mf,
-                        )
-
-                        _err = _queued_pr_failure_message(
-                            _qp_poll, _qp_pr_url, config.workspace.merge_wait_timeout_seconds
-                        )
-                        _mark_mf(_qp_result.state, _qp_result, _err, _qp_result.state.branch_name)
-                        _set_outcome(
-                            _qp_slug, StoryOutcome.MERGE_FAILED, phase=_qp_result.phase.name
-                        )
-                        _persist_story_landing(_qp_slug, _qp_result)
-                        del queued_prs[_qp_slug]
-                        # Defensive/idempotent: the parent is normally already in
-                        # _finished (added when its PR was queued), so its collision
-                        # (soft) edge is already released; this guarantees it on any
-                        # path that skipped that classification. _finished (not
-                        # _completed) is what still blocks a hard depends_on
-                        # dependent. Actual redispatch of a released dependent onto
-                        # the current base comes from the dag.ready() re-check at the
-                        # top of the deadlock-cleanup branch, reached after the
-                        # `continue` below.
-                        dag.mark_skipped(_qp_slug)
-                        _write_story_audit(config, _qp_task, _qp_result, sprint_id=_sprint_id)
-                        _resolve_batch_leader_landing(_qp_slug, "failed")
-                        _log(f"✗ {_qp_slug}: queued PR {_qp_poll['status']} (no active workers)")
-                    _reconcile_collision_claim(_qp_slug, _qp_result)
+                    # The redispatch-after-restart bug lives on this path: a
+                    # queued PR merges while another story occupies the only
+                    # worker slot. _resolve_queued_pr writes the confirmed-landed
+                    # DONE with its immutability marker so it cannot be clobbered.
+                    _resolve_queued_pr(_qp_slug, blocking=True, context="no active workers")
                 continue
 
             _log(f"[debug] calling wait() with {len(active)} active futures")
@@ -6382,7 +6394,10 @@ def run_sprint(
             _persist_story_landing(slug, result)
             _write_story_audit(config, task, result, sprint_id=_sprint_id)
             del queued_prs[slug]
-            _reconcile_collision_claim(slug, result)
+            # The landing verdict is in: end the claim outright rather than
+            # re-deriving it from the result, whose phase mark_merge_failed can
+            # legitimately leave as ESCALATE (inherited-dev-residue).
+            _end_collision_claim(slug, f"queued PR {poll_result['status']} at wrap-up")
 
     finished_at = datetime.datetime.now(datetime.timezone.utc)
     set_worker_slug("")

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -5175,6 +5175,10 @@ def run_sprint(
             _log(f"Collision claim released for {slug} ({why})")
         claim_results.pop(slug, None)
         file_footprints.pop(slug, None)
+        # Nothing throttles a claim that no longer exists, and a slug that were
+        # ever re-queued must be probed immediately rather than inheriting a
+        # timestamp from its previous landing attempt.
+        _queued_probe_at.pop(slug, None)
         # plan_done is what re-derives the footprint; leaving it behind would
         # resurrect the claim on the next _release_plan_gates pass.
         with phase_lock:
@@ -5316,6 +5320,10 @@ def run_sprint(
         # Out of queued_prs before the claim is reconciled: membership there is
         # itself a reason to keep a collision claim alive.
         del queued_prs[slug]
+        # The throttle only exists to pace probes of a *queued* PR. This one is
+        # decided; _end_collision_claim drops the entry on the paths that keep a
+        # claim, and this covers a resolution with no claim behind it.
+        _queued_probe_at.pop(slug, None)
 
         if poll_result["status"] == "merged":
             merged_slugs.add(slug)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1719,18 +1719,60 @@ def parse_manifest_slugs(config: "ForgeConfig", manifest_path: Path) -> list[str
         return []
 
 
+#: A collision claim is held while its story is running past the plan gate.
+CLAIM_IN_DEV = "in dev"
+#: Held while the story's work is queued/pending a landing decision that this
+#: run will still resolve — the gate can legitimately open once it resolves.
+CLAIM_PENDING_LANDING = "landing pending"
+#: Held because the story stopped without a landing verdict but its work was
+#: preserved for an operator decision. Nothing in this run can resolve it, so
+#: the files it planned to rewrite stay claimed until the sprint ends (#2234).
+CLAIM_PRESERVED = "preserved for operator decision"
+
+
 def _release_plan_gates(
     plan_done: dict[str, str],
     file_footprints: dict[str, set[str]],
     plan_gates: dict[str, threading.Event],
     active: dict[str, object],
     phase_lock: threading.Lock,
-) -> None:
+    collision_claims: "dict[str, str] | None" = None,
+) -> list[str]:
     """Check newly-planned stories and release their gates if no file overlap.
 
     Called from the scheduling loop — both the poll interval and after a future
     completes — to avoid deadlock when gated workers block in _run_fresh.
+
+    *collision_claims* maps slug -> claim reason for stories that are past their
+    plan gate. A claim, not worker liveness, is what holds a file: a story that
+    escalates with its worktree preserved is no longer ``active`` but its work
+    is still expected to land, so releasing the gate on that transition would
+    hand the waiting story a base the pending decision is about to rewrite
+    (#2234).
+
+    Returns the slugs whose gate can never open in this run — every file they
+    are blocked on is claimed by preserved, undecided work — for the caller to
+    stand down. Those slugs are left in *plan_gates* for the caller to remove.
     """
+    claims = collision_claims if collision_claims is not None else {}
+
+    def _blockers(slug: str, footprint: set[str]) -> dict[str, set[str]]:
+        """Map blocker slug -> overlapping files for stories holding *footprint*.
+
+        A story holds its files while it is running past its own gate (``active``)
+        *or* while it still holds a collision claim.
+        """
+        held: dict[str, set[str]] = {}
+        for other_slug, other_files in file_footprints.items():
+            if other_slug == slug or other_slug in plan_gates:
+                continue
+            if other_slug not in active and other_slug not in claims:
+                continue
+            shared = footprint & other_files
+            if shared:
+                held[other_slug] = shared
+        return held
+
     with phase_lock:
         pd_snapshot = dict(plan_done)
 
@@ -1740,38 +1782,49 @@ def _release_plan_gates(
             footprint = _extract_plan_footprint(ws_path)
             file_footprints[pd_slug] = footprint
 
-            # Check overlap with stories already past their gate (in DEV)
-            active_dev_files: set[str] = set()
-            for other_slug, other_files in file_footprints.items():
-                if other_slug != pd_slug and other_slug in active and other_slug not in plan_gates:
-                    active_dev_files |= other_files
-
-            overlap = footprint & active_dev_files
-            if overlap:
+            # Check overlap with stories already past their gate (in DEV) or
+            # still claiming their files after leaving the active set.
+            blockers = _blockers(pd_slug, footprint)
+            if blockers:
+                overlap = set().union(*blockers.values())
                 _log(
                     f"WARNING: {pd_slug} overlaps with active stories on: "
                     f"{', '.join(sorted(overlap))}"
                 )
             else:
-                if pd_slug in plan_gates:
-                    plan_gates[pd_slug].set()
-                    del plan_gates[pd_slug]
+                gate = plan_gates.pop(pd_slug, None)
+                if gate is not None:
+                    gate.set()
+                claims[pd_slug] = CLAIM_IN_DEV
 
     # Re-check deferred gates (conflicting story may have finished)
+    stood_down: list[str] = []
     for deferred_slug, gate in list(plan_gates.items()):
-        if deferred_slug in file_footprints:
-            active_dev_files = set()
-            for other_slug, other_files in file_footprints.items():
-                if (
-                    other_slug != deferred_slug
-                    and other_slug in active
-                    and other_slug not in plan_gates
-                ):
-                    active_dev_files |= other_files
-            overlap = file_footprints[deferred_slug] & active_dev_files
-            if not overlap:
-                gate.set()
-                del plan_gates[deferred_slug]
+        if deferred_slug not in file_footprints:
+            continue
+        blockers = _blockers(deferred_slug, file_footprints[deferred_slug])
+        if not blockers:
+            gate.set()
+            del plan_gates[deferred_slug]
+            claims[deferred_slug] = CLAIM_IN_DEV
+            continue
+        # Every blocker is preserved, undecided work that no longer has a
+        # worker or a landing path in this run: the gate cannot open here.
+        # Waiting forever and releasing onto a doomed base are both wrong —
+        # stand the story down instead so the operator's decision on the
+        # preserved work comes first.
+        if all(
+            blocker not in active and claims.get(blocker) == CLAIM_PRESERVED
+            for blocker in blockers
+        ):
+            overlap = sorted(set().union(*blockers.values()))
+            _log(
+                f"STAND DOWN {deferred_slug}: blocked only by preserved, undecided "
+                f"work from {', '.join(sorted(blockers))} on {', '.join(overlap)} — "
+                "the collision gate cannot open in this run"
+            )
+            stood_down.append(deferred_slug)
+    return stood_down
 
 
 def _validate_story_paths(config: ForgeConfig, manifest_path: Path) -> list[Path]:
@@ -1952,6 +2005,14 @@ def _run_fresh(
 
     # Wait for scheduler to release the gate (with safety timeout)
     plan_gate.wait(timeout=7200)
+
+    # The scheduler also opens the gate to *stop* a worker — on a stand-down
+    # (blocked only by preserved work that cannot land in this run), an auth
+    # abort, or a deadline. It sets stop_event first, so an open gate plus a set
+    # stop_event means "come back out", not "proceed into DEV" (#2234).
+    if stop_event is not None and stop_event.is_set():
+        _log(f"{task.slug}: plan gate opened for shutdown — not entering DEV")
+        return plan_result
 
     # Phase 2: continue from DEV
     return run_from_dev(
@@ -5092,6 +5153,77 @@ def run_sprint(
     plan_done: dict[str, str] = {}  # slug -> workspace_path (set by phase callback)
     use_plan_gates = max_parallel > 1  # only for parallel mode
 
+    # Collision claims (#2234). A story past its plan gate *claims* the files it
+    # planned to touch, and the claim outlives the worker: a story that escalates
+    # with its work preserved is no longer active, but the decision pending on it
+    # is precisely whether that work lands. Releasing the claim on the status
+    # transition hands a gated sibling a base that is about to change.
+    collision_claims: dict[str, str] = {}  # slug -> claim reason (CLAIM_* above)
+    claim_results: dict[str, CoordinatorResult] = {}  # slug -> last known result
+    gate_stood_down: dict[str, str] = {}  # slug -> reason it never entered DEV
+
+    def _end_collision_claim(slug: str, why: str) -> None:
+        """Drop a story's claim on its planned files, and the state behind it."""
+        if collision_claims.pop(slug, None) is not None:
+            _log(f"Collision claim released for {slug} ({why})")
+        claim_results.pop(slug, None)
+        file_footprints.pop(slug, None)
+        # plan_done is what re-derives the footprint; leaving it behind would
+        # resurrect the claim on the next _release_plan_gates pass.
+        with phase_lock:
+            plan_done.pop(slug, None)
+
+    def _reconcile_collision_claim(slug: str, result: CoordinatorResult) -> None:
+        """Re-evaluate whether *slug* can still land the files it claimed."""
+        if slug not in collision_claims:
+            return
+        claim_results[slug] = result
+        if (
+            slug in queued_prs
+            or slug in pending_integration
+            or result.landing_status == "pending_integration"
+        ):
+            reason = CLAIM_PENDING_LANDING
+        elif result.phase == Phase.ESCALATE and not getattr(
+            result, "infrastructure_failure", False
+        ):
+            # Escalation preserves the worktree and its commits for an operator
+            # decision. The work has not been abandoned — holding is the cheap
+            # side of the asymmetry (waiting vs. a conflict found after spend).
+            reason = CLAIM_PRESERVED
+        else:
+            _end_collision_claim(slug, f"landing_status={result.landing_status or 'none'}")
+            return
+        if collision_claims.get(slug) != reason:
+            collision_claims[slug] = reason
+            _files = ", ".join(sorted(file_footprints.get(slug, set()))) or "its planned files"
+            _log(f"Holding collision claim for {slug} on {_files}: {reason}")
+
+    def _refresh_collision_claims() -> None:
+        """Re-evaluate every live claim against the latest known result."""
+        for _c_slug in list(collision_claims):
+            _c_result = claim_results.get(_c_slug)
+            if _c_result is not None:
+                _reconcile_collision_claim(_c_slug, _c_result)
+
+    def _service_plan_gates() -> None:
+        """Release openable plan gates and stand down the unopenable ones."""
+        for _sd_slug in _release_plan_gates(
+            plan_done, file_footprints, plan_gates, active, phase_lock, collision_claims
+        ):
+            _sd_gate = plan_gates.pop(_sd_slug, None)
+            gate_stood_down[_sd_slug] = (
+                "collision gate stood down: the files it planned to change are held "
+                "by preserved work that has not landed"
+            )
+            # stop_event BEFORE the gate, same ordering as the deadline teardown:
+            # the worker must observe the shutdown flag when the gate wakes it.
+            _sd_evt = stop_events.get(_sd_slug)
+            if _sd_evt is not None:
+                _sd_evt.set()
+            if _sd_gate is not None:
+                _sd_gate.set()
+
     def _apply_batch_landing_to_member(
         member_slug: str,
         task: TaskStory,
@@ -5721,6 +5853,7 @@ def run_sprint(
                         _write_story_audit(config, _qp_task, _qp_result, sprint_id=_sprint_id)
                         _resolve_batch_leader_landing(_qp_slug, "failed")
                         _log(f"✗ {_qp_slug}: queued PR {_qp_poll['status']} (no active workers)")
+                    _reconcile_collision_claim(_qp_slug, _qp_result)
                 continue
 
             _log(f"[debug] calling wait() with {len(active)} active futures")
@@ -5755,7 +5888,7 @@ def run_sprint(
                 story_wait_started.update(active)
                 if not done_futs and use_plan_gates:
                     # Service plan gates while polling
-                    _release_plan_gates(plan_done, file_footprints, plan_gates, active, phase_lock)
+                    _service_plan_gates()
                 _now = time.monotonic()
                 expired_slugs = [
                     slug
@@ -5775,6 +5908,10 @@ def run_sprint(
                     fut = active.pop(slug)
                     story_deadlines.pop(slug, None)
                     story_wait_started.discard(slug)
+                    # A worker killed at its deadline is not preserved work
+                    # awaiting a decision — nothing can land it, so its files
+                    # are free.
+                    _end_collision_claim(slug, "worker timed out")
                     # Set the cancellation event BEFORE cancel() so any in-flight
                     # work stops at the next phase boundary or subprocess read.
                     # Future.cancel() is a no-op for an already-running thread.
@@ -5881,6 +6018,7 @@ def run_sprint(
                     story_deadlines.pop(slug, None)
                     story_wait_started.discard(slug)
                     stop_events.pop(slug, None)
+                    _end_collision_claim(slug, "worker raised")
                     spec_str = slug_to_spec[slug]
                     failed_at = datetime.datetime.now(datetime.timezone.utc)
                     snapshot = _snapshot_last_known(slug, _state_writer)
@@ -6021,9 +6159,33 @@ def run_sprint(
                     auth_cancelled_slugs.discard(slug)
                     _cancel_reason = f"cancelled mid-flight: {auth_circuit_reason}"
                     _mark_story_auth_cancelled(result, auth_circuit, reason=_cancel_reason)
+                    _end_collision_claim(slug, "cancelled by the auth circuit breaker")
                     _log(f"SKIPPED {slug} ({_cancel_reason})")
                     _record_current_story_entry(slug, "SKIPPED", error=_cancel_reason)
                     _set_outcome(slug, StoryOutcome.SKIPPED, reason=_cancel_reason)
+                    if _state_writer is not None:
+                        _state_writer.update(slug, status="skipped")
+                    dag.mark_skipped(slug)
+                    _write_story_audit(config, task, result, sprint_id=_sprint_id)
+                    _print_worker_status(active, worker_phases, dag, total)
+                    continue
+
+                # Stood down at its collision gate (#2234): the scheduler opened
+                # the gate to release the worker, not to admit it to DEV. The
+                # story reached PLAN and stopped, so it is skipped — not failed:
+                # nothing judged it, and its planned work is still valid once the
+                # preserved work it collided with is decided.
+                if slug in gate_stood_down:
+                    _stand_down_reason = gate_stood_down.pop(slug)
+                    _end_collision_claim(slug, "stood down before entering DEV")
+                    _log(f"SKIPPED {slug} ({_stand_down_reason})")
+                    _record_current_story_entry(slug, "SKIPPED", error=_stand_down_reason)
+                    _set_outcome(
+                        slug,
+                        StoryOutcome.SKIPPED,
+                        reason=_stand_down_reason,
+                        phase=result.phase.name,
+                    )
                     if _state_writer is not None:
                         _state_writer.update(slug, status="skipped")
                     dag.mark_skipped(slug)
@@ -6136,6 +6298,14 @@ def run_sprint(
                 else:
                     _write_story_audit(config, task, result, sprint_id=_sprint_id)
 
+                # The landing verdict — not the worker exiting — is what ends a
+                # collision claim (#2234). Re-check every live claim, not just
+                # this story's: the integration drain above can turn a sibling's
+                # pending_integration into landed or merge-failed.
+                if use_plan_gates:
+                    _reconcile_collision_claim(slug, result)
+                    _refresh_collision_claims()
+
                 # Batch groups land as one branch (#727) — the leader's. Register
                 # each member so a leader landing that resolves later (queued PR,
                 # wrap-up) can still correct it, and apply the leader's verdict
@@ -6181,7 +6351,7 @@ def run_sprint(
 
             # ── Overlap detection: check plan gates ────────────────────
             if use_plan_gates:
-                _release_plan_gates(plan_done, file_footprints, plan_gates, active, phase_lock)
+                _service_plan_gates()
 
     if queued_prs:
         for slug, (task, result, pr_url) in list(queued_prs.items()):
@@ -6212,6 +6382,7 @@ def run_sprint(
             _persist_story_landing(slug, result)
             _write_story_audit(config, task, result, sprint_id=_sprint_id)
             del queued_prs[slug]
+            _reconcile_collision_claim(slug, result)
 
     finished_at = datetime.datetime.now(datetime.timezone.utc)
     set_worker_slug("")

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -2955,6 +2955,181 @@ class TestCollisionGatePreservedWork:
         assert "Holding collision claim for story-a" in err
 
 
+class TestCollisionGateQueuedParent:
+    """#2234: a claim held for a queued PR must end when that PR lands.
+
+    A ``CLAIM_PENDING_LANDING`` claim is resolvable *in this run*, but only the
+    queued-PR polling paths resolve it — and the no-active-workers loop cannot
+    run while a worker sits parked at its plan gate. Both remaining resolution
+    paths (the gate-service probe and the dependent-dispatch pre-check) must
+    therefore release the claim, or the gated sibling waits out its own timeout
+    on work that landed minutes ago.
+    """
+
+    @staticmethod
+    def _plan_result(tmp_path: Path, slug: str):
+        plan_result = _make_coordinator_result(success=True, cost=1.0, phase=Phase.PLAN_REVIEW)
+        plan_result.state.workspace_path = tmp_path / slug
+        return plan_result
+
+    @staticmethod
+    def _queued_land(*args, **kwargs):  # noqa: ANN002, ANN003
+        return (
+            {"merge_queued": True, "pr_url": "https://github.com/x/y/pull/1"},
+            "pending_integration",
+        )
+
+    def test_gate_service_probe_releases_claim_when_queued_pr_lands(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """story-b is parked at its gate, so the loop never goes idle.
+
+        Nothing else polls story-a's queued PR while story-b keeps a worker
+        alive; the gate-service probe is what turns the merge into a released
+        claim. Before the fix story-b waited out its 7200s gate timeout.
+        """
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        _make_spec_file(tmp_path, "Story B", "story-b")
+        manifest_path = _make_manifest_parallel(
+            tmp_path, ["story-a.md", "story-b.md"], budget=10.0, max_parallel=2
+        )
+        config = _make_config(tmp_path)
+
+        a_in_dev = threading.Event()
+        b_footprint_seen = threading.Event()
+        dev_calls: list[str] = []
+        poll_timeouts: list[int] = []
+
+        def _fake_run_task(cfg, task, **kwargs):  # noqa: ANN001
+            if task.slug == "story-b":
+                assert a_in_dev.wait(timeout=30)
+            return self._plan_result(tmp_path, task.slug)
+
+        def _fake_run_from_dev(cfg, task, workspace_path, **kwargs):  # noqa: ANN001
+            dev_calls.append(task.slug)
+            if task.slug == "story-a":
+                a_in_dev.set()
+                # Park story-b at its gate before story-a queues its PR, so the
+                # claim is created while a worker still holds the loop open.
+                assert b_footprint_seen.wait(timeout=30)
+                return _make_coordinator_result(
+                    success=True, cost=1.0, landing_status="pending_integration"
+                )
+            return _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+        def _fake_footprint(workspace_path):  # noqa: ANN001
+            if workspace_path is not None and Path(workspace_path).name == "story-b":
+                b_footprint_seen.set()
+            return {"src/shared.py"}
+
+        def _fake_poll(pr_url, project_root, timeout_seconds, **kwargs):  # noqa: ANN001
+            poll_timeouts.append(timeout_seconds)
+            return {"status": "merged"}
+
+        with (
+            patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.run_task", side_effect=_fake_run_task),
+            patch("theforge.sprint.runner.run_from_dev", side_effect=_fake_run_from_dev),
+            patch("theforge.sprint.runner._extract_plan_footprint", side_effect=_fake_footprint),
+            patch("theforge.coordinator.completion.land_story", side_effect=self._queued_land),
+            patch("theforge.sprint.runner._poll_queued_pr", side_effect=_fake_poll),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        err = capsys.readouterr().err
+        # The gate opened on the merge, not on a timeout, and not by dropping
+        # the claim when story-a stopped being active.
+        assert dev_calls == ["story-a", "story-b"]
+        assert "queued PR merged (holding a collision gate)" in err
+        assert "Collision claim released for story-a" in err
+        # The probe is single-shot: it must not spend the merge-wait budget on
+        # the 2s gate-service tick.
+        assert poll_timeouts[0] == 0
+        assert sprint.specs_succeeded == 2
+        assert sprint.specs_skipped == 0
+
+    def test_dependent_dispatch_precheck_releases_claim_when_queued_pr_lands(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """The cited path: story-c's dispatch pre-check resolves story-a's PR.
+
+        story-b is parked at its gate on story-a's claim. story-c is released
+        by the collision edge and hits the queued-PR pre-check, which polls the
+        PR as merged. That branch previously recorded neither the landing nor
+        the claim release, leaving story-b parked on a claim nothing else in the
+        run would ever clear.
+        """
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        _make_spec_file(tmp_path, "Story B", "story-b")
+        _make_spec_file(tmp_path, "Story C", "story-c")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md", "story-b.md", "story-c.md"],
+            budget=20.0,
+            max_parallel=2,
+        )
+        config = _make_config(tmp_path)
+
+        a_in_dev = threading.Event()
+        b_footprint_seen = threading.Event()
+        dev_calls: list[str] = []
+
+        def _fake_run_task(cfg, task, **kwargs):  # noqa: ANN001
+            if task.slug == "story-b":
+                assert a_in_dev.wait(timeout=30)
+            return self._plan_result(tmp_path, task.slug)
+
+        def _fake_run_from_dev(cfg, task, workspace_path, **kwargs):  # noqa: ANN001
+            dev_calls.append(task.slug)
+            if task.slug == "story-a":
+                a_in_dev.set()
+                assert b_footprint_seen.wait(timeout=30)
+                return _make_coordinator_result(
+                    success=True, cost=1.0, landing_status="pending_integration"
+                )
+            return _make_coordinator_result(success=True, cost=1.0, landing_status="landed")
+
+        def _fake_footprint(workspace_path):  # noqa: ANN001
+            name = Path(workspace_path).name if workspace_path is not None else ""
+            if name == "story-c":
+                # Disjoint: story-c is gated by the DAG edge, not by a collision.
+                return {"src/other.py"}
+            if name == "story-b":
+                b_footprint_seen.set()
+            return {"src/shared.py"}
+
+        def _fake_poll(pr_url, project_root, timeout_seconds, **kwargs):  # noqa: ANN001
+            # Keep the single-shot gate-service probe (timeout 0) undecided so
+            # resolution lands on the blocking dependent-dispatch pre-check,
+            # which is the path under test.
+            if timeout_seconds == 0:
+                return {"status": "timeout"}
+            return {"status": "merged"}
+
+        with (
+            patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch(
+                "theforge.sprint.runner.compute_synthetic_edges",
+                return_value={"story-c": ["story-a"]},
+            ),
+            patch("theforge.sprint.runner.run_task", side_effect=_fake_run_task),
+            patch("theforge.sprint.runner.run_from_dev", side_effect=_fake_run_from_dev),
+            patch("theforge.sprint.runner._extract_plan_footprint", side_effect=_fake_footprint),
+            patch("theforge.coordinator.completion.land_story", side_effect=self._queued_land),
+            patch("theforge.sprint.runner._poll_queued_pr", side_effect=_fake_poll),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        err = capsys.readouterr().err
+        assert "queued PR merged (before dependent dispatch)" in err
+        assert "Collision claim released for story-a" in err
+        # story-b got off the gate and ran; nothing was skipped or stood down.
+        assert "story-b" in dev_calls
+        assert "STAND DOWN" not in err
+        assert sprint.specs_succeeded == 3
+        assert sprint.specs_skipped == 0
+
+
 class TestSprintLandsLocallyResolution:
     """run_sprint answers the local-landing question sprint-wide, once."""
 

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -3130,6 +3130,80 @@ class TestCollisionGateQueuedParent:
         assert sprint.specs_skipped == 0
 
 
+class TestCollisionClaimWrapUpDrain:
+    """#2234: the wrap-up drain must resolve a claim left on a still-queued PR.
+
+    A story whose PR is queued is marked terminal immediately, so a sprint can
+    finish its work loop with that PR outstanding and reach the wrap-up drain
+    without any in-loop path having polled it. That drain is the last place a
+    collision claim can be released, and it runs after every gate is gone — so
+    it is also the path least likely to be exercised by the other tests.
+    """
+
+    def _run(self, tmp_path: Path, *, pr_status: str):
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        # One story, but max_parallel=2 so plan gates (and therefore collision
+        # claims) are active. Queuing its PR makes it terminal, so the work loop
+        # ends with the PR still in flight and drops straight into wrap-up.
+        manifest_path = _make_manifest_parallel(
+            tmp_path, ["story-a.md"], budget=10.0, max_parallel=2
+        )
+        config = _make_config(tmp_path)
+
+        def _fake_run_task(cfg, task, **kwargs):  # noqa: ANN001
+            plan_result = _make_coordinator_result(success=True, cost=1.0, phase=Phase.PLAN_REVIEW)
+            plan_result.state.workspace_path = tmp_path / task.slug
+            return plan_result
+
+        def _fake_run_from_dev(cfg, task, workspace_path, **kwargs):  # noqa: ANN001
+            return _make_coordinator_result(
+                success=True, cost=1.0, landing_status="pending_integration"
+            )
+
+        def _fake_land_story(*args, **kwargs):  # noqa: ANN002, ANN003
+            return (
+                {"merge_queued": True, "pr_url": "https://github.com/x/y/pull/1"},
+                "pending_integration",
+            )
+
+        with (
+            patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.run_task", side_effect=_fake_run_task),
+            patch("theforge.sprint.runner.run_from_dev", side_effect=_fake_run_from_dev),
+            patch(
+                "theforge.sprint.runner._extract_plan_footprint",
+                return_value={"src/shared.py"},
+            ),
+            patch("theforge.coordinator.completion.land_story", side_effect=_fake_land_story),
+            patch(
+                "theforge.sprint.runner._poll_queued_pr",
+                return_value={"status": pr_status},
+            ) as mock_poll,
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        return sprint, mock_poll
+
+    def test_wrap_up_drain_releases_claim_on_merged_pr(self, tmp_path: Path, capsys) -> None:
+        sprint, mock_poll = self._run(tmp_path, pr_status="merged")
+        err = capsys.readouterr().err
+
+        # The drain ran (nothing in the loop polled this PR) and the claim went
+        # with the landing verdict.
+        assert mock_poll.call_count == 1
+        assert "Collision claim released for story-a (queued PR merged at wrap-up)" in err
+        assert sprint.specs_succeeded == 1
+
+    def test_wrap_up_drain_releases_claim_on_failed_pr(self, tmp_path: Path, capsys) -> None:
+        sprint, mock_poll = self._run(tmp_path, pr_status="closed")
+        err = capsys.readouterr().err
+
+        assert mock_poll.call_count == 1
+        assert "queued PR closed during sprint wrap-up" in err
+        assert "Collision claim released for story-a (queued PR closed at wrap-up)" in err
+        assert sprint.specs_succeeded == 0
+
+
 class TestSprintLandsLocallyResolution:
     """run_sprint answers the local-landing question sprint-wide, once."""
 

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -2869,6 +2869,92 @@ class TestRunFreshPlanGatedForwarding:
         assert mock_run_from_dev.call_args.kwargs["base_lands_locally"] is True
 
 
+class TestCollisionGatePreservedWork:
+    """#2234: a collision claim ends when the work ends, not when the story does.
+
+    story-a and story-b plan the same file. story-a passes the gate first and
+    then escalates — which *preserves* its worktree and commits for an operator
+    decision. Before the fix, leaving the ``active`` set dropped story-a's
+    footprint, the gate opened, and story-b built twelve files' worth of work on
+    a base the pending decision was about to rewrite.
+    """
+
+    def _run(self, tmp_path: Path):
+        _make_spec_file(tmp_path, "Story A", "story-a")
+        _make_spec_file(tmp_path, "Story B", "story-b")
+        manifest_path = _make_manifest_parallel(
+            tmp_path,
+            ["story-a.md", "story-b.md"],
+            budget=10.0,
+            max_parallel=2,
+        )
+        config = _make_config(tmp_path)
+
+        a_in_dev = threading.Event()
+        b_footprint_seen = threading.Event()
+        dev_calls: list[str] = []
+
+        def _fake_run_task(cfg, task, **kwargs):  # noqa: ANN001
+            # Deterministic ordering: story-b only reaches PLAN_DONE after
+            # story-a is past its gate, so story-a is the claim holder.
+            if task.slug == "story-b":
+                assert a_in_dev.wait(timeout=30)
+            plan_result = _make_coordinator_result(success=True, cost=1.0, phase=Phase.PLAN_REVIEW)
+            plan_result.state.workspace_path = tmp_path / task.slug
+            return plan_result
+
+        def _fake_run_from_dev(cfg, task, workspace_path, **kwargs):  # noqa: ANN001
+            dev_calls.append(task.slug)
+            a_in_dev.set()
+            # Hold story-a in DEV until story-b is parked at the gate, so the
+            # escalation lands on a scheduler that is already holding a gate.
+            assert b_footprint_seen.wait(timeout=30)
+            return _make_coordinator_result(success=False, cost=1.0, phase=Phase.ESCALATE)
+
+        def _fake_footprint(workspace_path):  # noqa: ANN001
+            if workspace_path is not None and Path(workspace_path).name == "story-b":
+                b_footprint_seen.set()
+            return {"src/shared.py"}
+
+        with (
+            patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+            patch("theforge.sprint.runner.run_task", side_effect=_fake_run_task),
+            patch("theforge.sprint.runner.run_from_dev", side_effect=_fake_run_from_dev),
+            patch("theforge.sprint.runner._extract_plan_footprint", side_effect=_fake_footprint),
+        ):
+            sprint = run_sprint(config, manifest_path)
+
+        return sprint, dev_calls
+
+    def test_gated_story_never_enters_dev_behind_preserved_escalation(
+        self, tmp_path: Path
+    ) -> None:
+        sprint, dev_calls = self._run(tmp_path)
+
+        # The whole point: story-b must not build on a base that excludes the
+        # preserved rewrite it was gated on.
+        assert dev_calls == ["story-a"]
+        assert "story-b" not in dev_calls
+
+    def test_stood_down_story_is_skipped_not_failed(self, tmp_path: Path) -> None:
+        sprint, _ = self._run(tmp_path)
+
+        # story-a escalated (failed); story-b is deferred work, not a verdict.
+        assert sprint.specs_failed == 1
+        assert sprint.specs_skipped == 1
+        assert sprint.specs_succeeded == 0
+
+    def test_stand_down_reason_is_recorded(self, tmp_path: Path, capsys) -> None:
+        self._run(tmp_path)
+        err = capsys.readouterr().err
+
+        assert "STAND DOWN story-b" in err
+        assert "preserved, undecided work from story-a" in err
+        assert "src/shared.py" in err
+        # The claim retention decision is visible too, not just its consequence.
+        assert "Holding collision claim for story-a" in err
+
+
 class TestSprintLandsLocallyResolution:
     """run_sprint answers the local-landing question sprint-wide, once."""
 

--- a/tests/test_story_sources.py
+++ b/tests/test_story_sources.py
@@ -1199,6 +1199,118 @@ class TestReleaseplanGates:
         assert gate_b.is_set()
         assert "story-b" not in plan_gates
 
+    def test_deferred_gate_stays_closed_while_blocker_holds_a_claim(self) -> None:
+        """#2234: a blocker that left ``active`` still holds its files while claimed.
+
+        story-a escalated with its worktree preserved — no longer active, but the
+        pending decision is precisely whether its rewrite of src/shared.py lands.
+        """
+        from theforge.sprint.runner import CLAIM_PRESERVED, _release_plan_gates
+
+        plan_done: dict[str, str] = {}
+        file_footprints = {
+            "story-a": {"src/shared.py"},
+            "story-b": {"src/shared.py"},
+        }
+        gate_b = threading.Event()
+        plan_gates = {"story-b": gate_b}
+        # story-a is no longer active, but its claim survives.
+        active: dict[str, object] = {"story-b": MagicMock()}
+        collision_claims = {"story-a": CLAIM_PRESERVED}
+        phase_lock = threading.Lock()
+
+        stood_down = _release_plan_gates(
+            plan_done, file_footprints, plan_gates, active, phase_lock, collision_claims
+        )
+
+        assert not gate_b.is_set()
+        # Nothing in this run can resolve the preserved claim, so story-b is
+        # stood down rather than released onto a base that is about to change.
+        assert stood_down == ["story-b"]
+        assert "story-b" in plan_gates
+
+    def test_deferred_gate_waits_while_blocker_claim_is_still_resolvable(self) -> None:
+        """A claim held for a pending landing is not a stand-down: it can resolve."""
+        from theforge.sprint.runner import CLAIM_PENDING_LANDING, _release_plan_gates
+
+        plan_done: dict[str, str] = {}
+        file_footprints = {
+            "story-a": {"src/shared.py"},
+            "story-b": {"src/shared.py"},
+        }
+        gate_b = threading.Event()
+        plan_gates = {"story-b": gate_b}
+        active: dict[str, object] = {"story-b": MagicMock()}
+        collision_claims = {"story-a": CLAIM_PENDING_LANDING}
+        phase_lock = threading.Lock()
+
+        stood_down = _release_plan_gates(
+            plan_done, file_footprints, plan_gates, active, phase_lock, collision_claims
+        )
+
+        assert not gate_b.is_set()
+        assert stood_down == []
+        assert "story-b" in plan_gates
+
+    def test_deferred_gate_releases_once_claim_is_dropped(self) -> None:
+        """The claim, not the status transition, is what holds the gate."""
+        from theforge.sprint.runner import CLAIM_PRESERVED, _release_plan_gates
+
+        plan_done: dict[str, str] = {}
+        file_footprints = {
+            "story-a": {"src/shared.py"},
+            "story-b": {"src/shared.py"},
+        }
+        gate_b = threading.Event()
+        plan_gates = {"story-b": gate_b}
+        active: dict[str, object] = {"story-b": MagicMock()}
+        collision_claims = {"story-a": CLAIM_PRESERVED}
+        phase_lock = threading.Lock()
+
+        _release_plan_gates(
+            plan_done, file_footprints, plan_gates, active, phase_lock, collision_claims
+        )
+        assert not gate_b.is_set()
+
+        # The claim ends (work landed or was abandoned) — the scheduler clears
+        # the footprint alongside it, exactly as _end_collision_claim does.
+        del collision_claims["story-a"]
+        del file_footprints["story-a"]
+
+        stood_down = _release_plan_gates(
+            plan_done, file_footprints, plan_gates, active, phase_lock, collision_claims
+        )
+
+        assert gate_b.is_set()
+        assert stood_down == []
+        assert "story-b" not in plan_gates
+        # Passing the gate registers story-b's own claim on its files.
+        assert "story-b" in collision_claims
+
+    def test_new_plan_defers_behind_a_preserved_claim(self) -> None:
+        """A story reaching PLAN_DONE after the blocker escalated is still held."""
+        from theforge.sprint.runner import CLAIM_PRESERVED, _release_plan_gates
+
+        plan_done = {"story-b": "/tmp/ws-b"}
+        file_footprints: dict[str, set[str]] = {"story-a": {"src/shared.py"}}
+        gate_b = threading.Event()
+        plan_gates = {"story-b": gate_b}
+        active: dict[str, object] = {"story-b": MagicMock()}
+        collision_claims = {"story-a": CLAIM_PRESERVED}
+        phase_lock = threading.Lock()
+
+        with patch(
+            "theforge.sprint.runner._extract_plan_footprint",
+            return_value={"src/shared.py"},
+        ):
+            _release_plan_gates(
+                plan_done, file_footprints, plan_gates, active, phase_lock, collision_claims
+            )
+
+        assert not gate_b.is_set()
+        assert "story-b" in plan_gates
+        assert "story-b" not in collision_claims
+
     def test_poll_loop_no_false_timeout_after_last_gate_released(self):
         """Releasing the last plan gate must not cause a false timeout.
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior P1 paths are verified resolved, the targeted collision-gate tests pass locally, and I found no blocking regressions in the reviewed change set. | [google-gemini-3.5-flash-api] The implementation is safe to merge, fully satisfying all acceptance criteria with excellent test coverage and resolving the prior P1 findings. | [anthropic-haiku-cli] Cycle 1 P1 fixed via _resolve_queued_pr extraction. Cycle 2 P1 (NameError) was a false positive—poll_result is in scope due to truncated diff showing wrap-up polling code. Cycle 2 P2 (_queued_probe_at memory) fixed by cleanup in _end_collision_claim and _resolve_queued_pr. New test coverage (TestCollisionClaimWrapUpDrain) validates the wrap-up path exercises all poll_result reads.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $23.23
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

A collision gate releases when the blocking story escalates, so a dependent story builds on preserved work that has not landed (GitHub Issue #2234)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2234