### PR TITLE
The same model is indexed under multiple identity spellings, so per-model evidence splits across them

### DIFF
--- a/docs/adr/0002-audit-substrate-and-queryable-run-history.md
+++ b/docs/adr/0002-audit-substrate-and-queryable-run-history.md
@@ -154,6 +154,12 @@ The substrate evolves over the project's lifetime. The contract that keeps that 
 - New per-run records are written at `schema_version=2` (`CURRENT_RECORD_SCHEMA_VERSION` in `audit_substrate.py`). Pre-slice records without a `schema_version` field are read as version 1.
 - `audit_substrate._migrate_record(record, from_version=...)` is the reader-side seam. It is a no-op today (no breaking field changes have shipped) but every reader (`iter_records`, `tail_records`, `iter_escalation_records`, `has_review_approve_in_substrate`) now consults the indexed `record_schema_version` and routes the parsed record through it. Future breaking changes register translations there.
 
+**Landed in #2225 (one identity namespace for `dev_model`):**
+
+- `dev_model` had indexed whatever spelling the runner recorded (`anthropic/sonnet/cli`, `sonnet`, `claude-sonnet-4-6`), so `GROUP BY dev_model` — a clause-3 query dimension — returned several partial populations for one model. Identities are now canonicalized at the shared `coordinator.agent_identity` projection, using the `transport_used` the renderer records to disambiguate bare model names the catalog offers over both transports.
+- A spelling that still cannot be resolved is kept verbatim, which is the truthful record, but `audit_records.dev_model_resolution` now says whether the stored value is `canonical` or `unresolved`, so a consumer can tell an unrecognized identity from a normalized one instead of treating both as equally authoritative.
+- `SUBSTRATE_SCHEMA_VERSION` is 6. Opening a version-5 substrate re-derives the `dev_model*` columns from each row's `raw_json`, so the normalization reaches already-indexed history rather than only new writes.
+
 **Writer-side guard (tracked in #1528):**
 
 - A CI check refuses a `schema_version` bump on the writer side without a matching migration-helper entry. This is the writer-side counterpart to #1522's reader-side dispatch; the two issues are sized to land independently.

--- a/src/theforge/coordinator/agent_identity.py
+++ b/src/theforge/coordinator/agent_identity.py
@@ -32,20 +32,36 @@ SOURCE_DIRECT = "direct"
 SOURCE_RECOVERED = "recovered"
 """Identity was reconstructed after the fact (config block / legacy keys)."""
 
+RESOLUTION_CANONICAL = "canonical"
+"""Identity is in the canonical ``provider/model/transport`` namespace."""
 
-def _canonicalize(raw: str) -> str:
-    """Return the canonical ``provider/model/transport`` id for ``raw``.
+RESOLUTION_UNRESOLVED = "unresolved"
+"""Identity is the runner's verbatim spelling — no canonical id resolved."""
+
+
+def _canonicalize(raw: str, entry: object = None) -> tuple[str, str]:
+    """Return ``(identity, resolution)`` for the raw identity ``raw``.
 
     Falls back to ``raw`` unchanged when the key cannot be resolved
     unambiguously — an unresolvable identity is still a truthful record of
     what ran, and guessing at it would be worse than reporting it verbatim.
+    The returned resolution status is what keeps that fallback *visible*: a
+    consumer grouping by identity can tell one namespace from a mixture
+    (#2225), which a bare value in the same field cannot express.
+
+    ``entry`` is the ``cost.agents`` entry the identity was read from, passed
+    through as a hint source: its ``transport_used`` disambiguates bare model
+    names the registry offers over both CLI and API.
     """
     try:
         from theforge.model_profiles import canonical_id_for_legacy_key  # noqa: PLC0415
 
-        return canonical_id_for_legacy_key(raw) or raw
+        resolved = canonical_id_for_legacy_key(raw, entry if isinstance(entry, dict) else None)
     except Exception:  # noqa: BLE001 - identity projection must never break indexing
-        return raw
+        return (raw, RESOLUTION_UNRESOLVED)
+    if resolved:
+        return (resolved, RESOLUTION_CANONICAL)
+    return (raw, RESOLUTION_UNRESOLVED)
 
 
 def is_dev_entry(entry: object) -> bool:
@@ -59,8 +75,8 @@ def is_dev_entry(entry: object) -> bool:
     return entry.get("role") == "dev" or entry.get("phase") == "dev"
 
 
-def entry_model_identity(entry: object) -> tuple[str, str] | None:
-    """Return ``(identity, source)`` for one ``cost.agents`` entry, or None.
+def entry_model_identity_detail(entry: object) -> tuple[str, str, str] | None:
+    """Return ``(identity, source, resolution)`` for one entry, or None.
 
     Resolution order:
       1. ``model_used`` — the model the runner reports having invoked
@@ -71,54 +87,86 @@ def entry_model_identity(entry: object) -> tuple[str, str] | None:
       3. Legacy ``provider``/``model``/``cli`` or ``name`` keys, kept only as
          compatibility for records written before the current renderer
          (:data:`SOURCE_RECOVERED`).
+
+    The third element says whether the identity was normalized onto the
+    canonical namespace (:data:`RESOLUTION_CANONICAL`) or is the runner's
+    spelling reported verbatim (:data:`RESOLUTION_UNRESOLVED`).
     """
     if not isinstance(entry, dict):
         return None
 
     model_used = str(entry.get("model_used") or "").strip()
     if model_used:
-        return (_canonicalize(model_used), SOURCE_DIRECT)
+        # The entry is a hint source only for the identity the runner actually
+        # invoked: ``transport_used`` describes *that* invocation.
+        identity, resolution = _canonicalize(model_used, entry)
+        return (identity, SOURCE_DIRECT, resolution)
 
     model_config = entry.get("model_config")
     if isinstance(model_config, list):
         for candidate in model_config:
             configured = str(candidate or "").strip()
             if configured:
-                return (_canonicalize(configured), SOURCE_RECOVERED)
+                # No transport hint here: which preference-list entry served is
+                # not recorded, so the invocation's transport does not
+                # necessarily describe the preferred one.
+                identity, resolution = _canonicalize(configured)
+                return (identity, SOURCE_RECOVERED, resolution)
 
     provider = str(entry.get("provider") or "").strip()
     model = str(entry.get("model") or "").strip()
     cli = str(entry.get("cli") or "").strip()
     if provider and model:
-        return (f"{provider}/{model}/{'cli' if cli else 'api'}", SOURCE_RECOVERED)
+        # Already assembled in canonical shape by construction.
+        return (
+            f"{provider}/{model}/{'cli' if cli else 'api'}",
+            SOURCE_RECOVERED,
+            RESOLUTION_CANONICAL,
+        )
     name = str(entry.get("name") or "").strip()
     if name:
-        return (name, SOURCE_RECOVERED)
+        identity, resolution = _canonicalize(name)
+        return (identity, SOURCE_RECOVERED, resolution)
     return None
 
 
-def dev_model_identity(record: object) -> tuple[str | None, str | None]:
-    """Return ``(identity, source)`` for the dev agent of an audit record.
+def entry_model_identity(entry: object) -> tuple[str, str] | None:
+    """Return ``(identity, source)`` for one ``cost.agents`` entry, or None.
+
+    Thin compatibility view over :func:`entry_model_identity_detail` for
+    callers that do not care whether the identity was canonicalized.
+    """
+    detail = entry_model_identity_detail(entry)
+    if detail is None:
+        return None
+    return (detail[0], detail[1])
+
+
+def dev_model_identity_detail(
+    record: object,
+) -> tuple[str | None, str | None, str | None]:
+    """Return ``(identity, source, resolution)`` for a record's dev agent.
 
     A directly recorded identity wins over a reconstructed one regardless of
     entry order, so a run whose later dev attempt recorded ``model_used`` is
-    not reported as recovered. Returns ``(None, None)`` when no dev-role entry
-    carries a trustworthy invocation identity.
+    not reported as recovered. Returns ``(None, None, None)`` when no dev-role
+    entry carries a trustworthy invocation identity.
     """
+    empty: tuple[str | None, str | None, str | None] = (None, None, None)
     if not isinstance(record, dict):
-        return (None, None)
+        return empty
     cost_block = record.get("cost")
     if not isinstance(cost_block, dict):
-        return (None, None)
+        return empty
     agents = cost_block.get("agents")
     if not isinstance(agents, list):
-        return (None, None)
+        return empty
 
-    recovered: tuple[str, str] | None = None
+    recovered: tuple[str, str, str] | None = None
     for entry in agents:
         if not is_dev_entry(entry):
             continue
-        resolved = entry_model_identity(entry)
+        resolved = entry_model_identity_detail(entry)
         if resolved is None:
             continue
         if resolved[1] == SOURCE_DIRECT:
@@ -127,4 +175,15 @@ def dev_model_identity(record: object) -> tuple[str | None, str | None]:
             recovered = resolved
     if recovered is not None:
         return recovered
-    return (None, None)
+    return empty
+
+
+def dev_model_identity(record: object) -> tuple[str | None, str | None]:
+    """Return ``(identity, source)`` for the dev agent of an audit record.
+
+    Compatibility view over :func:`dev_model_identity_detail`; consumers that
+    persist or expose the identity should prefer the detailed projection so an
+    unresolved spelling stays distinguishable from a canonical one (#2225).
+    """
+    identity, source, _resolution = dev_model_identity_detail(record)
+    return (identity, source)

--- a/src/theforge/coordinator/audit_render.py
+++ b/src/theforge/coordinator/audit_render.py
@@ -57,6 +57,11 @@ def _agent_entry(r: object, role: str, profile_fallback: str, dur: float | None)
     if r.model_config:
         # Preference list configured for this profile — present whenever list has >1 entry
         entry["model_config"] = list(r.model_config)
+    if r.transport_used:
+        # The transport that actually served. Recorded because it is the hint
+        # that makes a bare ``model_used`` (e.g. ``gpt-5.4``, offered over both
+        # CLI and API) resolvable to one canonical identity (#2225).
+        entry["transport_used"] = r.transport_used
     return entry
 
 

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-from .agent_identity import dev_model_identity
+from .agent_identity import dev_model_identity_detail
 
 # Substrate (SQLite) schema version. Bumped to 5 by #2201, which added
 # ``audit_records.dev_model_source`` and repaired the dev-model projection:
@@ -37,7 +37,14 @@ from .agent_identity import dev_model_identity
 # row, so opening an older one re-derives both columns from the stored
 # ``raw_json`` (see :func:`_reindex_dev_model_identity`) instead of leaving the
 # repaired projection unapplied to already-indexed history.
-SUBSTRATE_SCHEMA_VERSION = 5
+#
+# Bumped to 6 by #2225: ``dev_model`` had been indexing whatever spelling the
+# runner recorded, so one model split across several values. Canonicalization
+# now resolves more spellings, and ``audit_records.dev_model_resolution``
+# records whether a stored value is canonical or a verbatim fallback. Both
+# changes have to reach already-indexed history, so a version-5 substrate is
+# re-derived on open.
+SUBSTRATE_SCHEMA_VERSION = 6
 # Current per-record schema version. Records pre-dating the indexed-dimensions
 # slice (#1522) are treated as version 1. The reader-side migration helper
 # (`_migrate_record`) is the seam future breaking changes hang off — a version
@@ -162,6 +169,7 @@ CREATE TABLE IF NOT EXISTS audit_records (
     issue_id INTEGER,
     dev_model TEXT,
     dev_model_source TEXT,
+    dev_model_resolution TEXT,
     verdict TEXT,
     raw_json TEXT NOT NULL
 );
@@ -278,6 +286,7 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
         "ALTER TABLE audit_records ADD COLUMN issue_id INTEGER",
         "ALTER TABLE audit_records ADD COLUMN dev_model TEXT",
         "ALTER TABLE audit_records ADD COLUMN dev_model_source TEXT",
+        "ALTER TABLE audit_records ADD COLUMN dev_model_resolution TEXT",
         "ALTER TABLE audit_records ADD COLUMN verdict TEXT",
         "ALTER TABLE readiness_events ADD COLUMN staleness_verdict TEXT",
         "ALTER TABLE readiness_events ADD COLUMN diagnosis_baseline_sha TEXT",
@@ -338,7 +347,7 @@ def _stored_schema_version(conn: sqlite3.Connection) -> int | None:
 
 
 def _reindex_dev_model_identity(conn: sqlite3.Connection) -> int:
-    """Re-derive ``dev_model``/``dev_model_source`` from each row's raw_json.
+    """Re-derive the ``dev_model*`` columns from each row's raw_json.
 
     The canonical per-run JSON is not needed — ``raw_json`` is the record, so
     rows imported from legacy history are repaired alongside native ones. Rows
@@ -363,12 +372,13 @@ def _reindex_dev_model_identity(conn: sqlite3.Connection) -> int:
             continue
         if not isinstance(record, dict):
             continue
-        identity, source = dev_model_identity(record)
+        identity, source, resolution = dev_model_identity_detail(record)
         if not identity:
             continue
         conn.execute(
-            "UPDATE audit_records SET dev_model = ?, dev_model_source = ? WHERE run_id = ?",
-            (identity, source, run_id),
+            "UPDATE audit_records SET dev_model = ?, dev_model_source = ?, "
+            "dev_model_resolution = ? WHERE run_id = ?",
+            (identity, source, resolution, run_id),
         )
         updated += 1
     return updated
@@ -698,7 +708,7 @@ def _flat_fields(record: dict) -> dict:
     else:
         issue_id = None
 
-    dev_model, dev_model_source = dev_model_identity(record)
+    dev_model, dev_model_source, dev_model_resolution = dev_model_identity_detail(record)
 
     return {
         "slug": task.get("slug"),
@@ -715,6 +725,7 @@ def _flat_fields(record: dict) -> dict:
         "issue_id": issue_id,
         "dev_model": dev_model,
         "dev_model_source": dev_model_source,
+        "dev_model_resolution": dev_model_resolution,
         "verdict": _derive_record_verdict(record),
     }
 
@@ -1354,6 +1365,7 @@ def upsert_run_record(
         flat["issue_id"],
         flat["dev_model"],
         flat["dev_model_source"],
+        flat["dev_model_resolution"],
         flat["verdict"],
         raw_json,
     )
@@ -1362,8 +1374,8 @@ def upsert_run_record(
         "(run_id, slug, started_at, finished_at, total_cost_usd, final_phase, "
         "outcome_success, branch, landing_status, provenance, source_path, "
         "source_mtime, complexity_score, record_schema_version, milestone, "
-        "issue_id, dev_model, dev_model_source, verdict, raw_json) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+        "issue_id, dev_model, dev_model_source, dev_model_resolution, verdict, raw_json) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
         "ON CONFLICT(run_id) DO UPDATE SET "
         "slug=excluded.slug, started_at=excluded.started_at, "
         "finished_at=excluded.finished_at, total_cost_usd=excluded.total_cost_usd, "
@@ -1375,7 +1387,8 @@ def upsert_run_record(
         "record_schema_version=excluded.record_schema_version, "
         "milestone=excluded.milestone, issue_id=excluded.issue_id, "
         "dev_model=excluded.dev_model, "
-        "dev_model_source=excluded.dev_model_source, verdict=excluded.verdict, "
+        "dev_model_source=excluded.dev_model_source, "
+        "dev_model_resolution=excluded.dev_model_resolution, verdict=excluded.verdict, "
         "raw_json=excluded.raw_json",
         params,
     )
@@ -1927,6 +1940,7 @@ def derive_assignment_history(
         dev_raw = assignments.get("dev")
         dev = dev_raw if isinstance(dev_raw, dict) else {}
         dev_model = dev.get("canonical_id") or dev.get("model")
+        dev_model_resolution: str | None = None
         # Fallback: when the audit record lacks the preflight.complexity_routing
         # block (older audits, or audits seeded by tests that bypass routing),
         # derive the canonical dev model from cost.agents — the model that
@@ -1934,7 +1948,7 @@ def derive_assignment_history(
         # the routing block would have provided. Shares the one reading of the
         # agent-entry identity contract (#2201).
         if not (isinstance(dev_model, str) and dev_model):
-            dev_model = dev_model_identity(record)[0]
+            dev_model, _source, dev_model_resolution = dev_model_identity_detail(record)
         if not isinstance(dev_model, str) or not dev_model:
             continue
         timing = record.get("timing") or {}
@@ -1950,6 +1964,9 @@ def derive_assignment_history(
                 "reason": reason or "",
                 "timestamp": str(timestamp),
                 "complexity_score": _coerce_complexity_score(pre.get("complexity_score")),
+                # Only set on the cost.agents fallback: a routing-block model is
+                # canonical by construction and carries no resolution status.
+                "dev_model_resolution": dev_model_resolution,
             }
         )
     return out
@@ -2035,7 +2052,8 @@ def _derive_escalation(record: dict) -> dict | None:
 
     # Canonical dev model identity, derived from the cost.agents block when
     # present, through the one shared reading of that contract (#2201).
-    dev_model = dev_model_identity(record)[0] or ""
+    dev_model, _dev_model_source, dev_model_resolution = dev_model_identity_detail(record)
+    dev_model = dev_model or ""
 
     raw_score = preflight.get("complexity_score") if isinstance(preflight, dict) else None
     if isinstance(raw_score, bool):
@@ -2063,6 +2081,10 @@ def _derive_escalation(record: dict) -> dict | None:
         "reason": reason,
         "timestamp": timestamp,
         "complexity_score": complexity_score,
+        # Whether ``dev_model`` is a canonical identity or the runner's verbatim
+        # spelling — a consumer aggregating per model needs to be able to tell
+        # an unrecognized identity from a normalized one (#2225).
+        "dev_model_resolution": dev_model_resolution,
     }
 
 

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -2186,7 +2186,22 @@ def canonical_id_for_legacy_key(model_key: str, entry: dict | None = None) -> st
          (e.g. ``sonnet-cli`` → unique anthropic/sonnet CLI spec).
       5. Bare-name unique-spec lookup with constructable transport
          (e.g. ``deepseek-deepseek-reasoner`` → unique deepseek/deepseek-reasoner
-         API spec).
+         API spec), narrowed by a transport hint recorded on ``entry`` when the
+         bare name alone is ambiguous (``gpt-5.4`` + ``transport_used: cli`` →
+         ``openai/gpt-5.4/cli``).
+      6. Anthropic CLI concrete-version family match (``claude-sonnet-4-6`` →
+         ``anthropic/sonnet/cli``). This one is a *prefix heuristic*, not a
+         registry-derived rule: it holds only because the Anthropic registry
+         slots are the shorthands ``sonnet``/``opus`` while the runner reports
+         dated concrete versions. It is gated on the shorthand slot actually
+         existing in the registry, and applies only to Anthropic CLI, so a
+         future ``claude-<family>-*`` model with no matching shorthand stays
+         unresolved rather than being folded into the wrong slot.
+
+    ``entry`` is the optional record the key was read from — either a profiles
+    storage entry (``_identity`` metadata) or an audit ``cost.agents`` entry
+    (``transport_used``). It is only ever used as a *hint*; a key that stays
+    ambiguous with the hint applied is still reported unresolved.
 
     Returns ``None`` when the key cannot be resolved unambiguously — those keys
     are reported as ambiguous by the migration tool and left under their legacy
@@ -2196,6 +2211,7 @@ def canonical_id_for_legacy_key(model_key: str, entry: dict | None = None) -> st
     if not key:
         return None
 
+    entry_transport: str | None = None
     if isinstance(entry, dict):
         metadata = entry.get("_identity")
         if isinstance(metadata, dict):
@@ -2206,6 +2222,11 @@ def canonical_id_for_legacy_key(model_key: str, entry: dict | None = None) -> st
                 transport = "cli"
             if provider and model and transport in ("cli", "api"):
                 return f"{provider}/{model}/{transport}"
+        for hint_key in ("transport_used", "transport"):
+            hint = str(entry.get(hint_key) or "").strip().lower()
+            if hint in ("cli", "api"):
+                entry_transport = hint
+                break
 
     # Already canonical?
     parts = key.split("/")
@@ -2225,9 +2246,17 @@ def canonical_id_for_legacy_key(model_key: str, entry: dict | None = None) -> st
         transport_hint = "api"
         base = key[: -len("-api")]
 
-    spec = _unique_registry_spec(base, transport_hint)
+    # A suffix on the key is a stronger statement than a hint recorded
+    # alongside it, so the suffix wins when both are present.
+    effective_hint = transport_hint or entry_transport
+
+    spec = _unique_registry_spec(base, effective_hint)
     if spec is not None:
         return f"{spec.provider}/{spec.model}/{spec.transport.kind}"
+
+    family = _anthropic_cli_family_id(key, effective_hint)
+    if family is not None:
+        return family
 
     if transport_hint is None:
         # Try `<provider>-<model>` style: split at the first dash where the
@@ -2252,6 +2281,42 @@ def canonical_id_for_legacy_key(model_key: str, entry: dict | None = None) -> st
                         return f"{spec_obj.provider}/{spec_obj.model}/{spec_obj.transport.kind}"
 
     return None
+
+
+def _anthropic_cli_family_id(model_key: str, transport: str | None) -> str | None:
+    """Map a concrete Anthropic CLI model version onto its registry shorthand.
+
+    The Anthropic registry slots are family shorthands (``anthropic/sonnet/cli``,
+    ``anthropic/opus/cli``) while the Claude CLI reports dated concrete versions
+    (``claude-sonnet-4-6``). Without this the same model indexes under two
+    spellings (#2225).
+
+    Deliberately narrow, because this is the one prefix heuristic in the
+    resolver rather than a registry-derived rule:
+
+    * only ``claude-<family>-<version…>`` keys,
+    * only when ``anthropic/<family>/cli`` exists in the registry, and
+    * only when nothing hints at a non-CLI transport.
+
+    A future ``claude-<family>-*`` model with no matching shorthand slot
+    resolves to ``None`` and is reported unresolved, which is the behaviour a
+    catalog change should surface rather than silently mis-bucket.
+    """
+    if transport not in (None, "cli"):
+        return None
+    prefix = "claude-"
+    if not model_key.startswith(prefix):
+        return None
+    rest = model_key[len(prefix) :]
+    family, sep, version = rest.partition("-")
+    if not family or not sep or not version:
+        return None
+    try:
+        from theforge.config.models import AGENT_REGISTRY  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    canonical = f"anthropic/{family}/cli"
+    return canonical if canonical in AGENT_REGISTRY else None
 
 
 def _unique_registry_spec(model_name: str, transport: str | None) -> Any | None:

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -943,6 +943,27 @@ def _run_single_api_model(
         return runner_fn(prompt, profile, secrets)
 
 
+def _stamp_api_transport(result: AgentResult) -> AgentResult:
+    """Record that this result came over the API transport.
+
+    The transport is a *hint the identity projection needs*: a bare model name
+    the catalog offers over both CLI and API (``gpt-5.4``) cannot be resolved to
+    one canonical id without it, so an API result that omits it indexes under
+    the bare spelling and splits from ``openai/gpt-5.4/api`` (#2225). Stamping
+    it here rather than only at the callers means every API invocation carries
+    it regardless of which entry point ran — including single-model profiles,
+    which never pass through the preference-list annotation below.
+
+    Only fills an empty value: a caller that already knows the transport (the
+    CLI→API fallback in ``cli.py``, which also records *why* it switched) has
+    the more specific reading. Non-dataclass results — the mocks that
+    ``run_api_agent``'s callers return in tests — are passed through untouched.
+    """
+    if not isinstance(result, AgentResult) or result.transport_used:
+        return result
+    return dataclasses.replace(result, transport_used="api")
+
+
 def run_api_agent(
     *,
     prompt: str,
@@ -1017,8 +1038,10 @@ def run_api_agent(
             # configured. Skip replace() for single-model profiles to avoid breaking
             # callers that return non-dataclass objects (e.g., mocks in tests).
             if model_config:
-                return dataclasses.replace(result, model_config=model_config, model_used=model)
-            return result
+                return _stamp_api_transport(
+                    dataclasses.replace(result, model_config=model_config, model_used=model)
+                )
+            return _stamp_api_transport(result)
 
         last_result = result
 
@@ -1043,5 +1066,7 @@ def run_api_agent(
         )
         _log_verbose(f"  ... {label} done | {status} | cost={cost_str}")
     if model_config:
-        return dataclasses.replace(last_result, model_config=model_config, model_used=model)
-    return last_result
+        return _stamp_api_transport(
+            dataclasses.replace(last_result, model_config=model_config, model_used=model)
+        )
+    return _stamp_api_transport(last_result)

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -454,6 +454,28 @@ def _profile_cli_runner(profile: ModelProfile) -> str | None:
     return None
 
 
+def _fill_invocation_identity(result: AgentResult, profile: ModelProfile) -> AgentResult:
+    """Back-fill the identity fields a runner did not report for itself.
+
+    ``model_used`` alone is not an identity: a bare model name the catalog
+    offers over both transports (``gpt-5.4``) cannot be canonicalized without
+    knowing which one ran, and indexes under its own spelling instead (#2225).
+    So the transport is filled from the profile alongside the model whenever a
+    runner left it empty.
+
+    Both fields are only ever filled, never overwritten — a runner that
+    switched transport mid-invocation (the CLI→API fallback) has already
+    recorded the transport that actually served.
+    """
+    if result.model_used is not None and result.transport_used:
+        return result
+    return replace(
+        result,
+        model_used=result.model_used if result.model_used is not None else profile.model,
+        transport_used=result.transport_used or _profile_transport_kind(profile),
+    )
+
+
 def run_agent(
     *,
     prompt: str,
@@ -521,9 +543,7 @@ def run_agent(
             secrets=secrets,
             plain_text=plain_text,
         )
-        if result.model_used is None:
-            result = replace(result, model_used=profile.model)
-        return result
+        return _fill_invocation_identity(result, profile)
 
     if cli == "codex":
         from .runner_codex import _run_codex  # noqa: PLC0415
@@ -548,9 +568,7 @@ def run_agent(
             secrets=secrets,
             plain_text=plain_text,
         )
-        if result.model_used is None:
-            result = replace(result, model_used=profile.model)
-        return result
+        return _fill_invocation_identity(result, profile)
 
     if cli == "gemini":
         from .runner_gemini import _run_gemini  # noqa: PLC0415
@@ -575,9 +593,7 @@ def run_agent(
             secrets=secrets,
             plain_text=plain_text,
         )
-        if result.model_used is None:
-            result = replace(result, model_used=profile.model)
-        return result
+        return _fill_invocation_identity(result, profile)
 
     if cli == "ghaw":
         from .runner_ghaw import _run_ghaw  # noqa: PLC0415
@@ -594,9 +610,7 @@ def run_agent(
             is_pool=is_pool,
             secrets=secrets,
         )
-        if result.model_used is None:
-            result = replace(result, model_used=profile.model)
-        return result
+        return _fill_invocation_identity(result, profile)
 
     # No CLI runner resolved. When the profile has no transport at all its raw
     # ``cli`` never normalized to one — name that unresolved value so the

--- a/tests/test_agent_identity.py
+++ b/tests/test_agent_identity.py
@@ -60,3 +60,72 @@ def test_dev_entry_matches_role_or_legacy_phase_key() -> None:
 def test_malformed_records_project_to_nothing() -> None:
     for record in (None, {}, {"cost": "nope"}, {"cost": {"agents": "nope"}}, {"cost": {}}):
         assert ai.dev_model_identity(record) == (None, None)
+        assert ai.dev_model_identity_detail(record) == (None, None, None)
+
+
+# ── Resolution status (#2225) ──────────────────────────────────────────
+
+
+def test_canonicalized_identity_reports_canonical_resolution() -> None:
+    assert ai.entry_model_identity_detail({"role": "dev", "model_used": "sonnet"}) == (
+        "anthropic/sonnet/cli",
+        ai.SOURCE_DIRECT,
+        ai.RESOLUTION_CANONICAL,
+    )
+
+
+def test_verbatim_identity_reports_unresolved_resolution() -> None:
+    """Verbatim is correct; indistinguishable-from-canonical is the defect."""
+    assert ai.entry_model_identity_detail({"role": "dev", "model_used": "some-new-model"}) == (
+        "some-new-model",
+        ai.SOURCE_DIRECT,
+        ai.RESOLUTION_UNRESOLVED,
+    )
+
+
+def test_concrete_anthropic_version_folds_onto_the_registry_shorthand() -> None:
+    """The three live spellings of one model project to one identity."""
+    identities = {
+        ai.entry_model_identity_detail({"role": "dev", "model_used": spelling})[0]
+        for spelling in ("anthropic/sonnet/cli", "sonnet", "claude-sonnet-4-6")
+    }
+    assert identities == {"anthropic/sonnet/cli"}
+
+
+def test_transport_used_disambiguates_a_bare_model_name() -> None:
+    for transport in ("cli", "api"):
+        assert ai.entry_model_identity_detail(
+            {"role": "dev", "model_used": "gpt-5.4", "transport_used": transport}
+        ) == (f"openai/gpt-5.4/{transport}", ai.SOURCE_DIRECT, ai.RESOLUTION_CANONICAL)
+
+
+def test_bare_model_name_without_a_hint_stays_unresolved() -> None:
+    assert ai.entry_model_identity_detail({"role": "dev", "model_used": "gpt-5.4"}) == (
+        "gpt-5.4",
+        ai.SOURCE_DIRECT,
+        ai.RESOLUTION_UNRESOLVED,
+    )
+
+
+def test_transport_hint_does_not_leak_into_the_recovered_config_reading() -> None:
+    """Which preference-list entry served is unrecorded, so the hint does not apply."""
+    assert ai.entry_model_identity_detail(
+        {"role": "dev", "model_config": ["gpt-5.4"], "transport_used": "cli"}
+    ) == ("gpt-5.4", ai.SOURCE_RECOVERED, ai.RESOLUTION_UNRESOLVED)
+
+
+def test_dev_model_identity_detail_prefers_the_direct_entry() -> None:
+    record = {
+        "cost": {
+            "agents": [
+                {"role": "dev", "model_config": ["opus"]},
+                {"role": "dev", "model_used": "claude-sonnet-4-6"},
+            ]
+        }
+    }
+    assert ai.dev_model_identity_detail(record) == (
+        "anthropic/sonnet/cli",
+        ai.SOURCE_DIRECT,
+        ai.RESOLUTION_CANONICAL,
+    )
+    assert ai.dev_model_identity(record) == ("anthropic/sonnet/cli", ai.SOURCE_DIRECT)

--- a/tests/test_audit_substrate.py
+++ b/tests/test_audit_substrate.py
@@ -1157,20 +1157,101 @@ class TestRendererIndexerModelIdentitySeam:
             "direct",
         )
 
-    def test_unresolvable_model_used_is_recorded_verbatim_not_dropped(
+    def _index_detail(self, tmp_path: Path, record: dict) -> tuple:
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, record, provenance="native")
+            conn.commit()
+            return tuple(
+                conn.execute(
+                    "SELECT dev_model, dev_model_source, dev_model_resolution "
+                    "FROM audit_records WHERE run_id = ?",
+                    (record["run_id"],),
+                ).fetchone()
+            )
+        finally:
+            conn.close()
+
+    def test_unresolvable_model_used_is_recorded_verbatim_and_marked_unresolved(
         self, tmp_path: Path
     ) -> None:
-        """An identity the profile registry cannot canonicalize is still what ran."""
+        """An identity the registry cannot canonicalize is still what ran (#2225).
+
+        Keeping it verbatim is correct; presenting it in the same form as a
+        canonical id is what made the fragmentation undetectable, so the row
+        also records that it was never normalized.
+        """
         from theforge.coordinator import audit_render
 
         entry = audit_render._agent_entry(
-            self._agent_result(model_used="claude-opus-4-1-20250805"), "dev", "dev", 12.0
+            self._agent_result(model_used="brand-new-model-9"), "dev", "dev", 12.0
         )
 
-        assert self._index(tmp_path, self._record_with_agent_entry(entry)) == (
-            "claude-opus-4-1-20250805",
+        assert self._index_detail(tmp_path, self._record_with_agent_entry(entry)) == (
+            "brand-new-model-9",
             "direct",
+            "unresolved",
         )
+
+    def test_canonicalized_identity_is_marked_canonical(self, tmp_path: Path) -> None:
+        from theforge.coordinator import audit_render
+
+        entry = audit_render._agent_entry(
+            self._agent_result(model_used="claude-sonnet-4-6"), "dev", "dev", 12.0
+        )
+
+        assert self._index_detail(tmp_path, self._record_with_agent_entry(entry)) == (
+            "anthropic/sonnet/cli",
+            "direct",
+            "canonical",
+        )
+
+    def test_transport_used_disambiguates_a_bare_model_name(self, tmp_path: Path) -> None:
+        """``gpt-5.4`` exists over both transports; the recorded one resolves it."""
+        from theforge.coordinator import audit_render
+
+        entry = audit_render._agent_entry(
+            self._agent_result(model_used="gpt-5.4", transport_used="api"), "dev", "dev", 12.0
+        )
+        assert entry["transport_used"] == "api", "renderer dropped the disambiguating hint"
+
+        assert self._index_detail(tmp_path, self._record_with_agent_entry(entry)) == (
+            "openai/gpt-5.4/api",
+            "direct",
+            "canonical",
+        )
+
+    def test_bare_name_without_a_transport_hint_stays_unresolved(self, tmp_path: Path) -> None:
+        """No hint and two registry transports → guessing would be worse than verbatim."""
+        from theforge.coordinator import audit_render
+
+        entry = audit_render._agent_entry(
+            self._agent_result(model_used="gpt-5.4"), "dev", "dev", 12.0
+        )
+
+        assert self._index_detail(tmp_path, self._record_with_agent_entry(entry)) == (
+            "gpt-5.4",
+            "direct",
+            "unresolved",
+        )
+
+    def test_one_model_spelled_three_ways_indexes_under_one_identity(self, tmp_path: Path) -> None:
+        """The #2225 regression: canonical id, shorthand and concrete version agree."""
+        conn = sub.create_or_open(tmp_path)
+        try:
+            for i, spelling in enumerate(("anthropic/sonnet/cli", "sonnet", "claude-sonnet-4-6")):
+                rec = _make_record(run_id=f"frag-{i}")
+                rec["cost"]["agents"] = [{"role": "dev", "model_used": spelling}]
+                sub.upsert_run_record(conn, rec, provenance="native")
+            conn.commit()
+            rows = conn.execute(
+                "SELECT dev_model, COUNT(*) FROM audit_records "
+                "WHERE run_id LIKE 'frag-%' GROUP BY dev_model"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert [tuple(r) for r in rows] == [("anthropic/sonnet/cli", 3)]
 
     def test_model_config_only_entry_indexes_as_recovered_identity(self, tmp_path: Path) -> None:
         """No recorded model_used → reconstruct from invocation config, marked recovered."""
@@ -1286,3 +1367,33 @@ class TestRendererIndexerModelIdentitySeam:
 
         assert row == ("anthropic/sonnet/cli", "direct")
         assert version == str(sub.SUBSTRATE_SCHEMA_VERSION)
+
+    def test_reindex_recanonicalizes_a_schema_5_substrate(self, tmp_path: Path) -> None:
+        """A version-5 row holds the runner's spelling; opening it normalizes (#2225)."""
+        rec = _make_record(run_id="v5-1")
+        rec["cost"]["agents"] = [{"role": "dev", "model_used": "claude-sonnet-4-6"}]
+        conn = sub.create_or_open(tmp_path)
+        try:
+            sub.upsert_run_record(conn, rec, provenance="native")
+            conn.execute(
+                "UPDATE audit_records SET dev_model = 'claude-sonnet-4-6', "
+                "dev_model_source = 'direct', dev_model_resolution = NULL "
+                "WHERE run_id = 'v5-1'"
+            )
+            conn.execute("UPDATE meta SET value = '5' WHERE key = 'schema_version'")
+            conn.commit()
+        finally:
+            conn.close()
+
+        conn = sub.create_or_open(tmp_path)
+        try:
+            row = tuple(
+                conn.execute(
+                    "SELECT dev_model, dev_model_source, dev_model_resolution "
+                    "FROM audit_records WHERE run_id='v5-1'"
+                ).fetchone()
+            )
+        finally:
+            conn.close()
+
+        assert row == ("anthropic/sonnet/cli", "direct", "canonical")

--- a/tests/test_audit_substrate.py
+++ b/tests/test_audit_substrate.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from theforge.config import ModelProfile
 from theforge.coordinator import audit_substrate as sub
 
 
@@ -1202,6 +1204,60 @@ class TestRendererIndexerModelIdentitySeam:
 
         assert self._index_detail(tmp_path, self._record_with_agent_entry(entry)) == (
             "anthropic/sonnet/cli",
+            "direct",
+            "canonical",
+        )
+
+    def test_production_shaped_api_result_indexes_as_the_api_identity(
+        self, tmp_path: Path
+    ) -> None:
+        """The whole runner → renderer → indexer path for a single-model API profile.
+
+        This is the shape that fragmented in production: an API result carries
+        no ``model_used`` at all, so the renderer back-fills it from per-model
+        billing and gets the bare ``gpt-5.4``. The runner's recorded transport
+        is the only thing that keeps it from indexing under its own spelling
+        (#2225), so the runner is driven for real here rather than the entry
+        being hand-shaped.
+        """
+        from theforge.agent_types import ModelUsage
+        from theforge.coordinator import audit_render
+        from theforge.runners.api import run_api_agent
+
+        api_profile = ModelProfile(
+            name="dev",
+            provider="openai",
+            cli=None,
+            model="gpt-5.4",
+            budget_usd=1.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+        )
+        billed_only = self._agent_result(
+            model_usage=(
+                ModelUsage(
+                    model="gpt-5.4",
+                    input_tokens=10,
+                    output_tokens=5,
+                    cache_read_tokens=0,
+                    cache_creation_tokens=0,
+                    cost_usd=1.0,
+                ),
+            )
+        )
+        with patch.dict(
+            "theforge.runners.api.PROVIDER_RUNNERS",
+            {"openai": lambda prompt, prof, secrets: billed_only},
+        ):
+            result = run_api_agent(
+                prompt="go", profile=api_profile, working_dir=tmp_path, quiet=True
+            )
+
+        entry = audit_render._agent_entry(result, "dev", "dev", 12.0)
+        assert entry["model_used"] == "gpt-5.4", "renderer no longer back-fills from billing"
+
+        assert self._index_detail(tmp_path, self._record_with_agent_entry(entry)) == (
+            "openai/gpt-5.4/api",
             "direct",
             "canonical",
         )

--- a/tests/test_model_preference.py
+++ b/tests/test_model_preference.py
@@ -10,6 +10,7 @@ Covers:
 
 from __future__ import annotations
 
+import dataclasses
 from unittest.mock import patch
 
 import pytest
@@ -419,6 +420,67 @@ class TestRunApiAgentPreferenceList:
             )
 
         assert result.model_config == ()
+
+    def test_single_model_success_records_the_api_transport(self, tmp_path):
+        """#2225: a bare model name needs the transport to canonicalize.
+
+        A single-model API profile never passes through the preference-list
+        annotation, so without a stamp here its ``gpt-5.4`` stays ambiguous
+        (the catalog offers that model over CLI and API alike) and indexes
+        separately from ``openai/gpt-5.4/api``.
+        """
+        profile = _make_api_profile(model="gpt-5.4")
+        expected = _success_result("gpt-5.4")
+
+        with patch.dict(
+            "theforge.runners.api.PROVIDER_RUNNERS", {"openai": lambda p, pr, s: expected}
+        ):
+            result = run_api_agent(
+                prompt="test", profile=profile, working_dir=tmp_path, quiet=True
+            )
+
+        assert result.transport_used == "api"
+
+    def test_preference_list_success_records_the_api_transport(self, tmp_path):
+        profile = _make_api_profile(model="gpt-5.4", fallback_models=("gpt-5.4-mini",))
+
+        with patch.dict(
+            "theforge.runners.api.PROVIDER_RUNNERS",
+            {"openai": lambda prompt, prof, secrets: _success_result(prof.model)},
+        ):
+            result = run_api_agent(
+                prompt="test", profile=profile, working_dir=tmp_path, quiet=True
+            )
+
+        assert (result.model_used, result.transport_used) == ("gpt-5.4", "api")
+
+    def test_failure_result_also_records_the_api_transport(self, tmp_path):
+        profile = _make_api_profile(model="gpt-5.4")
+        failed = _runtime_fail_result()
+
+        with patch.dict(
+            "theforge.runners.api.PROVIDER_RUNNERS", {"openai": lambda p, pr, s: failed}
+        ):
+            result = run_api_agent(
+                prompt="test", profile=profile, working_dir=tmp_path, quiet=True
+            )
+
+        assert not result.success
+        assert result.transport_used == "api"
+
+    def test_transport_already_recorded_is_not_overwritten(self, tmp_path):
+        """A caller that knows more — the CLI→API fallback — keeps its reading."""
+        profile = _make_api_profile(model="gpt-5.4")
+        expected = dataclasses.replace(_success_result("gpt-5.4"), transport_used="cli")
+
+        with patch.dict(
+            "theforge.runners.api.PROVIDER_RUNNERS", {"openai": lambda p, pr, s: expected}
+        ):
+            result = run_api_agent(
+                prompt="test", profile=profile, working_dir=tmp_path, quiet=True
+            )
+
+        assert result.transport_used == "cli"
 
     def test_three_model_list_second_succeeds(self, tmp_path):
         """Middle model succeeds after first quota-fails; third is never tried."""

--- a/tests/test_profiles_migration.py
+++ b/tests/test_profiles_migration.py
@@ -138,6 +138,51 @@ def test_identity_metadata_takes_precedence():
     assert canonical_id_for_legacy_key("legacy-name", entry) == "anthropic/sonnet/cli"
 
 
+def test_concrete_anthropic_cli_version_resolves_to_the_family_shorthand():
+    # #2225: the CLI reports dated concrete versions; the registry slot is the
+    # family shorthand, so both must land on one identity.
+    assert canonical_id_for_legacy_key("claude-sonnet-4-6") == "anthropic/sonnet/cli"
+    assert canonical_id_for_legacy_key("claude-opus-4-6") == "anthropic/opus/cli"
+
+
+def test_family_match_is_gated_on_the_registry_slot_existing():
+    # No ``anthropic/haiku/cli`` slot in the catalog → unresolved, not guessed.
+    assert canonical_id_for_legacy_key("claude-haiku-4-5") is None
+    # An API hint contradicts the CLI-only heuristic.
+    assert canonical_id_for_legacy_key("claude-sonnet-4-6", {"transport_used": "api"}) is None
+
+
+def test_transport_hint_resolves_an_otherwise_ambiguous_bare_name():
+    # ``gpt-5.4`` is registered over both CLI and API.
+    assert canonical_id_for_legacy_key("gpt-5.4") is None
+    assert (
+        canonical_id_for_legacy_key("gpt-5.4", {"transport_used": "cli"}) == "openai/gpt-5.4/cli"
+    )
+    assert canonical_id_for_legacy_key("gpt-5.4", {"transport": "api"}) == "openai/gpt-5.4/api"
+
+
+def test_key_suffix_outranks_a_contradicting_transport_hint():
+    assert canonical_id_for_legacy_key("gpt-5.4-cli", {"transport_used": "api"}) == (
+        "openai/gpt-5.4/cli"
+    )
+
+
+def test_newly_resolving_key_merges_rather_than_displaces_its_collision():
+    """#2225 makes ``claude-sonnet-4-6`` resolve onto an id another key already owns."""
+    data = {
+        "models": {
+            "claude-sonnet-4-6": {"dev": {"runs": 3, "_successes": 1}},
+            "sonnet-cli": {"dev": {"runs": 7, "_successes": 2}},
+        }
+    }
+    migrated, _report = migrate_profiles_data(data)
+    assert list(migrated["models"]) == ["anthropic/sonnet/cli"]
+    assert migrated["models"]["anthropic/sonnet/cli"]["dev"]["runs"] == 10
+    # Still idempotent with the wider resolver.
+    again, _ = migrate_profiles_data(migrated)
+    assert again["models"]["anthropic/sonnet/cli"]["dev"]["runs"] == 10
+
+
 # ── migrate_profiles_data ──────────────────────────────────────────────
 
 

--- a/tests/test_runner_ghaw.py
+++ b/tests/test_runner_ghaw.py
@@ -164,6 +164,10 @@ class TestGhawGuards:
             )
         assert mock_run.call_count == 1
         assert result.model_used == "copilot"
+        # The model back-fill without a transport is only half an identity: a
+        # bare model name cannot be canonicalized without knowing which
+        # transport served it (#2225). gh-aw dispatches a CLI engine.
+        assert result.transport_used == "cli"
 
 
 def _make_result():


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Cycle 1 API transport split is fixed, targeted coverage passed, and I found no P1 regressions. | [google-gemini-3.5-flash-api] The model identity canonicalization and transport-hinting are fully resolved and robustly tested. | [anthropic-haiku-cli] Prior P1 fixed; runner-side transport stamping closes the gap for bare model names like gpt-5.4 that the coordinator cannot resolve without a hint.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $17.87
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

The same model is indexed under multiple identity spellings, so per-model evidence splits across them (GitHub Issue #2225)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2225