### PR TITLE
A story dropped at a re-exec generation boundary is recorded as never having run, discarding the work and spend of the prior generation

### DIFF
--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -169,16 +170,23 @@ def _write_native_story_record(project_root: Path, audit_data: dict) -> None:
         from ..coordinator import audit_substrate
         from ..coordinator.redact import redact
 
+        # ``parent_run_id`` is preserved from the audit when it carries one: a
+        # record written for a story whose work happened in an earlier generation
+        # names that generation as its parent, and flattening it to null severs
+        # the only link back to the run that did the work (#2214).
+        parent_run_id = audit_data.get("parent_run_id")
+        if not isinstance(parent_run_id, str) or not parent_run_id:
+            parent_run_id = None
         record = {
             "schema_version": audit_substrate.CURRENT_RECORD_SCHEMA_VERSION,
             "run_id": run_id,
-            "parent_run_id": None,
+            "parent_run_id": parent_run_id,
             "forge_version": audit_data.get("forge_version"),
         }
         record.update(audit_data)
         record["schema_version"] = audit_substrate.CURRENT_RECORD_SCHEMA_VERSION
         record["run_id"] = run_id
-        record["parent_run_id"] = None
+        record["parent_run_id"] = parent_run_id
         record["forge_version"] = audit_data.get("forge_version")
 
         env_file = audit_substrate.secrets_env_path(project_root)
@@ -1298,6 +1306,7 @@ def _write_story_audit(
     sprint_id: str | None = None,
     telemetry_snapshot: dict | None = None,
     overwrite_story_audit: bool = True,
+    prior_generation: "PriorGeneration | None" = None,
 ) -> None:
     """Write per-story audit.yaml to the durable log directory and preserve ESCALATE worktrees.
 
@@ -1306,6 +1315,12 @@ def _write_story_audit(
     generation that actually ran it, and a synthetic drop record must never
     overwrite a real run's evidence. The drop record is written beside it
     instead.
+
+    ``prior_generation`` is that earlier generation's flushed audit, when this
+    record is being written for a story whose work happened before the
+    boundary. Its accounting is folded into the record rather than replaced by
+    the synthetic post-boundary state (#2214) — see
+    :func:`carry_prior_generation_work`.
 
     Best-effort: silently ignores missing workspace or log dir.
     """
@@ -1317,6 +1332,9 @@ def _write_story_audit(
     except Exception as exc:
         _log(f"Warning: failed to generate story audit log for {task.slug}: {exc}")
         return
+
+    if prior_generation:
+        carry_prior_generation_work(audit_data, prior_generation)
 
     if telemetry_snapshot:
         last_phase = telemetry_snapshot.get("last_phase")
@@ -1525,3 +1543,252 @@ def finalize_interrupted_story_audit(
     except OSError:
         return None
     return path
+
+
+# ── Cross-generation accounting (#2214) ───────────────────────────────
+#
+# A sprint that re-execs begins a new generation of the same run. A story the
+# launch guard drops in the new generation may already have run in the old one —
+# dev, review, a committed implementation, real spend. The drop record is
+# synthesized from a state that never entered the state machine, so written as
+# it stands it says INIT, $0.00, unsuccessful: indistinguishable from a story
+# that never began, and every record derived from it inherits that silently.
+#
+# The generation that ran flushed its own evidence to the story's audit.yaml as
+# it went (#2013). That evidence is what the drop record carries forward, so the
+# record accounts for the work its run performed instead of being replaced by
+# the state of the generation that dropped it.
+
+#: Audit sections that describe work a run performed, rather than the
+#: circumstances of its exit. These are the ones an abnormal-exit record must
+#: take from the generation that did the work.
+PRIOR_GENERATION_WORK_KEYS = (
+    "iterations",
+    "cost",
+    "preflight",
+    "context_manifests",
+    "dev_handoffs",
+    "dev_prompt_injections",
+    "reviews",
+    "reviewer_attempts",
+    "human_review",
+    "plan_review",
+    "plan_validation",
+    "story_validation",
+    "convention_violations",
+    "validate_blocks",
+    "finding_registry",
+    "non_blocking_p1s",
+    "routing_decision",
+    "trust_checks",
+    "trust_status",
+    "phase_recovery",
+    "phases",
+    "totals",
+    "workspace",
+)
+
+
+def _is_informative(value: object) -> bool:
+    """True when ``value`` says something a record would otherwise be missing.
+
+    A synthetic exit record is not empty — it carries zeroed counters, null
+    phases and empty lists. Only values that assert something are carried, so a
+    prior generation's silence on a section never overwrites the current
+    record's own.
+    """
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, dict):
+        return any(_is_informative(v) for v in value.values())
+    if isinstance(value, (list, tuple, set, str)):
+        return len(value) > 0
+    return True
+
+
+def records_performed_work(audit: dict) -> bool:
+    """True when an audit records a run that actually did something.
+
+    Deliberately explicit rather than derived from :func:`_is_informative`: a
+    run that never started still carries configured limits (``usage_summary``'s
+    ``max``), so "this section is non-empty" is not the same claim as "this run
+    performed work". The test is dev/review/gate activity, measured spend, or a
+    phase that produced an outcome.
+    """
+    if not isinstance(audit, dict):
+        return False
+
+    iterations = audit.get("iterations")
+    if isinstance(iterations, dict):
+        for key in (
+            "dev_attempts_total",
+            "dev_iterations",
+            "review_cycles_total",
+            "review_cycles",
+            "gate_runs",
+        ):
+            count = iterations.get(key)
+            if isinstance(count, int) and not isinstance(count, bool) and count > 0:
+                return True
+        for key in ("dev_loop", "review_loop", "gate_decisions"):
+            if iterations.get(key):
+                return True
+
+    cost = audit.get("cost")
+    if isinstance(cost, dict):
+        total = cost.get("total_usd")
+        if isinstance(total, (int, float)) and not isinstance(total, bool) and total > 0:
+            return True
+        if cost.get("agents"):
+            return True
+
+    for key in ("reviews", "dev_handoffs", "preflight", "plan_review", "reviewer_attempts"):
+        if audit.get(key):
+            return True
+
+    phases = audit.get("phases")
+    if isinstance(phases, dict) and any(_is_informative(v) for v in phases.values()):
+        return True
+
+    return False
+
+
+def prior_generation_summary(audit: dict) -> dict:
+    """What an earlier generation's audit says it reached and spent.
+
+    ``cost_measured`` distinguishes a recovered amount from an unmeasured one:
+    a ``None`` ``cost_usd`` with ``cost_measured`` false means the prior
+    generation's spend is unknown, which must never be read as zero (#1992).
+    """
+    cost = audit.get("cost") if isinstance(audit.get("cost"), dict) else {}
+    raw_cost = cost.get("total_usd")
+    measured = isinstance(raw_cost, (int, float)) and not isinstance(raw_cost, bool)
+    outcome = audit.get("outcome") if isinstance(audit.get("outcome"), dict) else {}
+    timing = audit.get("timing") if isinstance(audit.get("timing"), dict) else {}
+    run_id = audit.get("run_id")
+    return {
+        "run_id": run_id if isinstance(run_id, str) and run_id else None,
+        "final_phase": outcome.get("final_phase"),
+        "cost_usd": round(float(raw_cost), 4) if measured else None,
+        "cost_measured": measured,
+        "in_flight": bool(audit.get(AUDIT_IN_FLIGHT_KEY)),
+        "started_at": timing.get("started_at"),
+    }
+
+
+@dataclass(frozen=True)
+class PriorGeneration:
+    """An earlier generation's flushed story audit, and how to account for it.
+
+    ``independently_recorded`` says the prior generation already wrote its own
+    per-run record. Its work is then visible on its own, so this record links to
+    it and reports the phase it reached but does not restate its spend —
+    counting the same dollars in two records would overstate the run.
+    """
+
+    audit: dict
+    independently_recorded: bool = False
+
+    @property
+    def summary(self) -> dict:
+        return {
+            **prior_generation_summary(self.audit),
+            "independently_recorded": self.independently_recorded,
+        }
+
+    @property
+    def recoverable_cost_usd(self) -> float | None:
+        """The prior generation's spend when this record is the one to carry it."""
+        if self.independently_recorded:
+            return None
+        summary = prior_generation_summary(self.audit)
+        return summary["cost_usd"] if summary["cost_measured"] else None
+
+
+def carry_prior_generation_work(audit_data: dict, prior: PriorGeneration) -> list[str]:
+    """Fold an earlier generation's recorded work into this record; return the keys carried.
+
+    The record keeps its own identity and its own account of how it ended — the
+    drop is what happened to *this* generation — but reports the phase the work
+    reached and the budget it consumed, because those are properties of the run,
+    not of the generation that observed its end. ``prior_generation`` names where
+    the accounting came from so a reader is never left to infer it, and
+    ``parent_run_id`` links the record back to the run that produced the work.
+    """
+    source = prior.audit
+    summary = prior.summary
+    skip = {"cost"} if prior.independently_recorded else set()
+
+    carried: list[str] = []
+    for key in PRIOR_GENERATION_WORK_KEYS:
+        if key in skip or key not in source:
+            continue
+        value = source[key]
+        if not _is_informative(value):
+            continue
+        audit_data[key] = value
+        carried.append(key)
+
+    outcome = audit_data.get("outcome")
+    if isinstance(outcome, dict):
+        # The phase this record reports is the furthest phase the run reached.
+        # Reporting the post-boundary INIT is the specific falsehood being fixed:
+        # it renders a story that ran dev and review as one that never started.
+        if summary["final_phase"]:
+            outcome["dropped_at_phase"] = outcome.get("final_phase")
+            outcome["final_phase"] = summary["final_phase"]
+        if summary["cost_measured"] and not prior.independently_recorded:
+            outcome["cost_usd"] = summary["cost_usd"]
+    if summary["run_id"]:
+        audit_data["parent_run_id"] = summary["run_id"]
+    audit_data["prior_generation"] = {**summary, "carried_keys": carried}
+    return carried
+
+
+def load_prior_generation_story_audit(
+    project_root: Path,
+    sprint_name: str | None,
+    slug: str,
+    *,
+    exclude_run_id: str | None = None,
+) -> PriorGeneration | None:
+    """The audit an earlier generation flushed for ``slug``, when it holds work to carry.
+
+    Returns ``None`` when there is no readable audit, when the audit belongs to
+    *this* generation (``exclude_run_id``), or when it records no performed work
+    — there is nothing to carry from a generation that did nothing.
+
+    Best-effort: an unreadable or malformed audit yields ``None``.
+    """
+    if not sprint_name:
+        return None
+    path = _story_audit_path(project_root, sprint_name, slug)
+    try:
+        with open(path, encoding="utf-8") as f:
+            audit = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(audit, dict):
+        return None
+
+    run_id = audit.get("run_id")
+    if exclude_run_id is not None and run_id == exclude_run_id:
+        return None
+    if not records_performed_work(audit):
+        return None
+
+    independently_recorded = False
+    if isinstance(run_id, str) and run_id:
+        try:
+            from ..coordinator import audit_substrate  # noqa: PLC0415
+
+            independently_recorded = (
+                audit_substrate.runs_dir(project_root) / f"{run_id}.json"
+            ).exists()
+        except Exception:  # noqa: BLE001 - identity lookup must not block the record
+            independently_recorded = False
+    return PriorGeneration(audit=audit, independently_recorded=independently_recorded)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -72,6 +72,7 @@ from .audit import (
     _write_sprint_audit,
     _write_sprint_summary,
     _write_story_audit,
+    load_prior_generation_story_audit,
     persist_accumulated_story_state,
     write_live_story_audit,
 )
@@ -4527,6 +4528,10 @@ def run_sprint(
     # kept for human review, and counts as skipped (not failed) in aggregates.
     _dropped_slugs: dict[str, str] = dict(dropped_slugs or {})
     _dropped_work: dict[str, WorktreeWork] = {}
+    # slug -> what the generation that ran the story before this one recorded.
+    # Populated when its drop record is written, and read back for the story's
+    # sprint row so both surfaces report the same accounting (#2214).
+    _prior_generation_work: dict[str, dict] = {}
     # slug -> description of the work the drop abandoned. Membership is the
     # single test for "this drop was not free and not evidence-free".
     _dropped_with_work: dict[str, str] = {}
@@ -4640,6 +4645,53 @@ def run_sprint(
             return entry.cost_usd
         return 0.0
 
+    def _attribute_prior_generation_cost(slug: str) -> float | None:
+        """Spend recovered from the generation that ran ``slug`` before this one.
+
+        The prior generation's audit is the only surviving account of a story
+        that was still in flight when the boundary was crossed: it never wrote an
+        accumulated row, so its spend is in neither ``prior_cost`` nor this
+        generation's ledger, and the story's row would report 0.0 for work that
+        cost real money (#2214). Rolling it into ``accumulated_cost`` as the row
+        is written keeps the sprint total and the sum of the rows equal, and the
+        bump happens once per story however many times this is asked.
+
+        Returns ``None`` when nothing was recovered — never 0.0, which would
+        assert that the prior generation spent nothing.
+        """
+        nonlocal accumulated_cost
+
+        carried = _prior_generation_work.get(slug)
+        if not carried:
+            return None
+        cost = carried.get("recoverable_cost_usd")
+        if cost is None:
+            return None
+        if not carried.get("cost_attributed"):
+            # No lock: the drop loop runs before any worker is dispatched, so
+            # this generation has no other writer to the ledger yet.
+            carried["cost_attributed"] = True
+            accumulated_cost += cost
+            _log(f"RECOVERED {slug}: ${cost:.4f} of prior-generation spend rolled into the total")
+        return cost
+
+    def _dropped_row_cost(slug: str) -> float | None:
+        """The cost every surface reports for a dropped story's row.
+
+        Ordered by what is actually known: spend recovered from the generation
+        that ran the story, then unmeasured for a drop that abandoned work whose
+        cost nothing recorded, then 0.0 only for a story that really did nothing.
+
+        Only *attributed* spend is reported. A recovered amount that the drop
+        branch decided not to use (because the sprint already held a measured
+        cost for the story) is not in this generation's ledger, and putting it on
+        the row would make the rows sum to more than the sprint total.
+        """
+        carried = _prior_generation_work.get(slug)
+        if carried and carried.get("cost_attributed"):
+            return carried.get("recoverable_cost_usd")
+        return None if slug in _dropped_with_work else 0.0
+
     def _record_dropped_story_audit(slug: str, cause_text: str) -> dict:
         """Write the per-run audit record for a story dropped before dispatch.
 
@@ -4649,6 +4701,13 @@ def run_sprint(
         here is deliberately the same shape as the worker-exception and
         worker-timeout ones: same synthetic result, same ``error``, same
         ``abnormal_termination`` block, differing only in ``kind``.
+
+        A drop at a re-exec boundary is not necessarily a story that never ran:
+        the generation before the boundary may have run dev, run review and
+        committed an implementation. The record it flushed as it went is carried
+        into this one, so the drop reports the phase that work reached and the
+        budget it consumed instead of the INIT/$0.00 of a story that never
+        started (#2214).
 
         Returns the cause record so the caller can retain it in sprint state as
         well. Best-effort: a story is never left un-dropped because its evidence
@@ -4680,6 +4739,23 @@ def run_sprint(
                 source="sprint.runner:launch-guard-drop",
             )
             drop_result.state.abnormal_termination = cause
+            prior = load_prior_generation_story_audit(
+                config.project_root,
+                resolved.name,
+                slug,
+                exclude_run_id=drop_result.state.run_id,
+            )
+            if prior is not None:
+                _prior_generation_work[slug] = {
+                    **prior.summary,
+                    "recoverable_cost_usd": prior.recoverable_cost_usd,
+                }
+                _log(
+                    f"CARRIED {slug}: drop record carries the prior generation's work "
+                    f"(run {prior.summary['run_id']}, phase "
+                    f"{prior.summary['final_phase']}, cost "
+                    f"{prior.summary['cost_usd']})"
+                )
             _write_story_audit(
                 config,
                 task_ctx[0],
@@ -4689,6 +4765,7 @@ def run_sprint(
                 # that actually ran it. Its audit.yaml is that run's evidence and
                 # must survive the drop record, not be replaced by it.
                 overwrite_story_audit=False,
+                prior_generation=prior,
             )
             return cause
         except Exception as exc:  # noqa: BLE001 - evidence writing must not fail the sprint
@@ -4755,6 +4832,13 @@ def run_sprint(
             dag.mark_skipped(slug)
             _stranded_cause = _record_dropped_story_audit(slug, reason)
             _stranded_cost = _measured_recorded_cost(slug)
+            if _stranded_cost == 0.0:
+                # No record of spend anywhere the sprint keeps one — but the
+                # generation that stranded this worktree may have flushed its own
+                # audit before it was interrupted (#2214).
+                _recovered_stranded = _attribute_prior_generation_cost(slug)
+                if _recovered_stranded is not None:
+                    _stranded_cost = _recovered_stranded
             if _stranded_cost is None:
                 unmeasured_spend.append(f"stranded-unmeasured:{slug}")
             _set_outcome(
@@ -4767,21 +4851,29 @@ def run_sprint(
             # Same reasoning as the reconciled branch: the prior generation's
             # measured spend is this sprint's spend, whatever outcome the story
             # ended at. It must not be replaced by the 0.0 default (#2189).
+            _stranded_extras: dict[str, object] = {"drop_reason": reason}
+            _stranded_prior = _prior_generation_work.get(slug)
+            if _stranded_prior:
+                _stranded_extras["prior_generation_run_id"] = _stranded_prior.get("run_id")
+                _stranded_extras["prior_generation_final_phase"] = _stranded_prior.get(
+                    "final_phase"
+                )
             _record_current_story_entry(
                 slug,
                 "DROPPED",
                 error=reason,
                 error_type="dropped",
                 cost_usd=_stranded_cost,
-                extras={"drop_reason": reason},
+                extras=_stranded_extras,
                 failure_cause=_stranded_cause or None,
             )
         else:
             # A dropped story is normally a story that never ran — but if its
             # worktree holds commits, it did run, and recording that as a $0.00
             # no-evidence drop erases exactly the run an operator needs evidence
-            # for. Cost cannot be recovered here (the spend was the previous
-            # process image's), so it is recorded as unmeasured, not as zero.
+            # for. The spend was the previous process image's, so it is recovered
+            # from the audit that generation flushed when there is one (#2214),
+            # and recorded as unmeasured — never as zero — when there is not.
             work = _inspect_dropped_work(slug)
             work_detail = describe_worktree_work(work)
             if work_detail:
@@ -4794,13 +4886,23 @@ def run_sprint(
             # reason plus whatever work the drop abandoned — because that record,
             # not the sprint summary line, is what outlives the next resume.
             _drop_cause = _record_dropped_story_audit(slug, _detail_msg)
+            # The generation that ran this story recorded what it reached and
+            # what it spent; the sprint row reports the same, so the summary
+            # cannot claim a story with committed work cost nothing and reached
+            # nothing (#2214).
+            _carried = _prior_generation_work.get(slug)
+            if _carried:
+                _extras["prior_generation_run_id"] = _carried.get("run_id")
+                _extras["prior_generation_final_phase"] = _carried.get("final_phase")
+            _carried_cost = _attribute_prior_generation_cost(slug)
             if work_detail:
-                unmeasured_spend.append(f"dropped-with-work:{slug}")
+                if _carried_cost is None:
+                    unmeasured_spend.append(f"dropped-with-work:{slug}")
                 _set_outcome(
                     slug,
                     StoryOutcome.DROPPED,
                     reason=_detail_msg,
-                    cost_usd=None,
+                    cost_usd=_carried_cost,
                     detail={"final_outcome": "DROPPED", **_extras},
                     failure_cause=_drop_cause or None,
                 )
@@ -4809,19 +4911,27 @@ def run_sprint(
                     "DROPPED",
                     error=_detail_msg,
                     error_type="dropped",
-                    cost_usd=None,
+                    cost_usd=_carried_cost,
                     extras=_extras,
                     failure_cause=_drop_cause or None,
                 )
             else:
+                # No worktree work to describe, but a prior generation may still
+                # have spent budget on this story; 0.0 only when nothing did.
+                _row_cost = _carried_cost if _carried_cost is not None else 0.0
                 _set_outcome(
-                    slug, StoryOutcome.DROPPED, reason=reason, failure_cause=_drop_cause or None
+                    slug,
+                    StoryOutcome.DROPPED,
+                    reason=reason,
+                    cost_usd=_row_cost,
+                    failure_cause=_drop_cause or None,
                 )
                 _record_current_story_entry(
                     slug,
                     "DROPPED",
                     error=reason,
                     error_type="dropped",
+                    cost_usd=_row_cost,
                     extras=_extras,
                     failure_cause=_drop_cause or None,
                 )
@@ -5002,9 +5112,10 @@ def run_sprint(
                     "path": _display_key,
                     "status": _status,
                     "phase": "PREFLIGHT" if _status == "waiting" else None,
-                    # A dropped story that abandoned work has a real, unrecovered
-                    # cost: record it unmeasured rather than fabricating $0.00.
-                    "cost_usd": None if _slug in _dropped_with_work else 0.0,
+                    # A dropped story that abandoned work has a real cost: the
+                    # prior generation's when its audit survived (#2214),
+                    # unmeasured when it did not — never a fabricated $0.00.
+                    "cost_usd": _dropped_row_cost(_slug),
                     "bundle_candidate": _slug in _bundle_candidate_slugs,
                     "batch_group": batch_group_by_slug.get(_slug),
                     "blocked_by": _blocked_by,

--- a/tests/test_sprint_generation_accounting.py
+++ b/tests/test_sprint_generation_accounting.py
@@ -1,0 +1,425 @@
+"""Seam tests for issue #2214: work must survive a re-exec generation boundary.
+
+A sprint that re-execs begins a new generation of the same run. A story the
+launch guard drops in the new generation may already have run dev, run review
+and committed an implementation in the old one. The drop record is synthesized
+from a state that never entered the state machine, so written as it stands it
+says INIT, $0.00, unsuccessful — indistinguishable from a story that never
+began, and every record derived from it inherits that silently.
+
+These tests pin the accounting the drop leaves behind: the record reports the
+phase the work reached and the budget it consumed, the sprint row and the sprint
+total agree with it, and a generation that genuinely did nothing still records
+nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from tests.test_sprint_abnormal_evidence import _story_audits
+from tests.test_sprint_launch_liveness import (
+    _make_config,
+    _make_coordinator_result,
+    _make_manifest,
+    _make_spec_file,
+    _triage_full,
+)
+from theforge.coordinator import audit_substrate
+from theforge.sprint import run_sprint
+from theforge.sprint.audit import (
+    PriorGeneration,
+    carry_prior_generation_work,
+    load_prior_generation_story_audit,
+    records_performed_work,
+)
+from theforge.sprint.dropped_work import WorktreeWork
+from theforge.sprint.launch_guard import REASON_ACTIVE_WORKTREE, REASON_STRANDED_WORKTREE
+
+SPRINT_NAME = "Test Sprint"
+DROPPED_SLUG = "issue-2048"
+PRIOR_RUN_ID = "priorgen0001"
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _prior_generation_audit(
+    *,
+    run_id: str = PRIOR_RUN_ID,
+    cost: float | None = 4.25,
+    final_phase: str = "REVIEW",
+    in_flight: bool = True,
+) -> dict:
+    """An audit shaped like one a generation flushed mid-flight (#2013)."""
+    return {
+        "run_id": run_id,
+        "forge_version": "0.13.0",
+        "in_flight": in_flight,
+        "task": {"slug": DROPPED_SLUG, "name": "Issue 2048"},
+        "outcome": {"success": False, "final_phase": final_phase, "message": "in flight"},
+        "timing": {"started_at": "2026-08-05T03:00:00+00:00"},
+        "workspace": {"path": f"/tmp/{DROPPED_SLUG}", "branch": f"feat/{DROPPED_SLUG}"},
+        "iterations": {
+            "dev_attempts_total": 2,
+            "dev_iterations": 2,
+            "review_cycles_total": 1,
+            "gate_runs": 3,
+            "gate_decisions": ["PASS"],
+            "dev_loop": [{"iteration": 1}, {"iteration": 2}],
+        },
+        "cost": {
+            "total_usd": cost,
+            "dev_usd": 3.0,
+            "review_usd": 1.25,
+            "agents": [{"role": "dev", "model": "strong"}],
+        },
+        "reviews": [{"reviewer": "r1", "verdict": "APPROVE"}],
+        "phases": {
+            "preflight": {"cost_usd": 0.1, "outcome": "proceed"},
+            "dev": {"cost_usd": 3.0, "outcome": "success"},
+            "review": {"cost_usd": 1.25, "outcome": "approve"},
+        },
+        "totals": {"cost_usd": cost},
+    }
+
+
+def _write_prior_audit(tmp_path: Path, audit: dict, slug: str = DROPPED_SLUG) -> Path:
+    log_dir = tmp_path / ".forge" / "logs" / SPRINT_NAME / slug
+    log_dir.mkdir(parents=True, exist_ok=True)
+    path = log_dir / "audit.yaml"
+    path.write_text(yaml.dump(audit), encoding="utf-8")
+    return path
+
+
+def _run_sprint_with_drop(
+    tmp_path: Path,
+    *,
+    reason: str = REASON_ACTIVE_WORKTREE,
+    worktree_work: WorktreeWork | None = None,
+):
+    _make_spec_file(tmp_path, "Issue 2048", DROPPED_SLUG)
+    _make_spec_file(tmp_path, "Issue 2060", "issue-2060")
+    manifest_path = _make_manifest(tmp_path, [f"{DROPPED_SLUG}.md", "issue-2060.md"])
+    config = _make_config(tmp_path)
+
+    work_patch = (
+        patch("theforge.sprint.runner.inspect_worktree_work", return_value=worktree_work)
+        if worktree_work is not None
+        else patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full)
+    )
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=_make_coordinator_result()),
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+        work_patch,
+    ):
+        mock_gate.return_value = {"passed": True, "message": "ok"}
+        return run_sprint(
+            config,
+            manifest_path,
+            run_id="run-2214",
+            dropped_slugs={DROPPED_SLUG: reason},
+        )
+
+
+def _sprint_story_row(tmp_path: Path, slug: str = DROPPED_SLUG) -> dict:
+    state_file = next((tmp_path / ".forge" / "sprints").glob("*/state.yaml"))
+    stories = yaml.safe_load(state_file.read_text())["stories"]
+    return {s["slug"]: s for s in stories}[slug]
+
+
+# ── the drop record accounts for the work that ran ───────────────────
+
+
+def test_drop_record_reports_the_phase_the_work_reached(tmp_path: Path) -> None:
+    """A story that ran dev and review is not recorded as never having started."""
+    _write_prior_audit(tmp_path, _prior_generation_audit())
+
+    _run_sprint_with_drop(tmp_path)
+
+    record = _story_audits(tmp_path)[DROPPED_SLUG]
+    assert record["outcome"]["final_phase"] == "REVIEW", (
+        "the drop record still reports INIT for a story that ran dev and review"
+    )
+    # The drop is still visible as what happened to *this* generation.
+    assert record["outcome"]["dropped_at_phase"] == "INIT"
+    assert record["abnormal_termination"]["kind"] == "launch_guard_drop"
+
+
+def test_drop_record_carries_the_cost_the_work_consumed(tmp_path: Path) -> None:
+    """Spend that produced committed output is never recorded as zero."""
+    _write_prior_audit(tmp_path, _prior_generation_audit(cost=4.25))
+
+    _run_sprint_with_drop(tmp_path)
+
+    record = _story_audits(tmp_path)[DROPPED_SLUG]
+    assert record["cost"]["total_usd"] == 4.25
+    assert record["outcome"]["cost_usd"] == 4.25
+    assert record["iterations"]["dev_attempts_total"] == 2
+    assert record["reviews"], "the reviews the prior generation ran are absent"
+    assert record["phases"]["dev"]["outcome"] == "success"
+
+
+def test_drop_record_names_the_generation_the_work_came_from(tmp_path: Path) -> None:
+    """Carried accounting is attributed, never presented as this generation's own."""
+    _write_prior_audit(tmp_path, _prior_generation_audit())
+
+    _run_sprint_with_drop(tmp_path)
+
+    record = _story_audits(tmp_path)[DROPPED_SLUG]
+    prior = record["prior_generation"]
+    assert prior["run_id"] == PRIOR_RUN_ID
+    assert prior["final_phase"] == "REVIEW"
+    assert prior["cost_usd"] == 4.25
+    assert prior["in_flight"] is True
+    assert "cost" in prior["carried_keys"]
+    # The record is linked to the run that produced the work, not orphaned from it.
+    assert record["parent_run_id"] == PRIOR_RUN_ID
+    assert record["run_id"] != PRIOR_RUN_ID
+
+
+def test_indexed_record_is_no_longer_a_zero_cost_init_no_op(tmp_path: Path) -> None:
+    """The substrate columns a reader queries carry the work, not the drop's INIT."""
+    _write_prior_audit(tmp_path, _prior_generation_audit())
+
+    _run_sprint_with_drop(tmp_path)
+
+    conn = audit_substrate.require_substrate(tmp_path)
+    try:
+        row = conn.execute(
+            "SELECT final_phase, total_cost_usd FROM audit_records WHERE slug = ?",
+            (DROPPED_SLUG,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row["final_phase"] == "REVIEW"
+    assert row["total_cost_usd"] == 4.25
+
+
+# ── the sprint's own surfaces agree with the record ──────────────────
+
+
+def test_sprint_row_reports_the_recovered_cost(tmp_path: Path) -> None:
+    """The summary row cannot say $0.00 while the record says $4.25."""
+    _write_prior_audit(tmp_path, _prior_generation_audit())
+
+    _run_sprint_with_drop(tmp_path)
+
+    row = _sprint_story_row(tmp_path)
+    assert row["outcome"] == "DROPPED"
+    assert row["cost_usd"] == 4.25
+    assert row["prior_generation_run_id"] == PRIOR_RUN_ID
+    assert row["prior_generation_final_phase"] == "REVIEW"
+
+
+def test_recovered_spend_reaches_the_sprint_total(tmp_path: Path) -> None:
+    """Recovered spend is this sprint's spend; the total must include it."""
+    _write_prior_audit(tmp_path, _prior_generation_audit())
+
+    result = _run_sprint_with_drop(tmp_path)
+
+    assert result.total_cost_usd >= 4.25, (
+        "prior-generation spend was attributed to the story but not to the sprint"
+    )
+    assert result.cost_complete
+
+
+def test_dropped_worktree_with_commits_reports_recovered_cost_not_unknown(
+    tmp_path: Path,
+) -> None:
+    """A drop that abandons committed work reports what that work cost."""
+    _write_prior_audit(tmp_path, _prior_generation_audit())
+    work = WorktreeWork(
+        slug=DROPPED_SLUG,
+        path=str(tmp_path / DROPPED_SLUG),
+        branch=f"feat/{DROPPED_SLUG}",
+        exists=True,
+        commits_ahead=1,
+        dirty=False,
+    )
+
+    result = _run_sprint_with_drop(tmp_path, worktree_work=work)
+
+    row = _sprint_story_row(tmp_path)
+    assert row["cost_usd"] == 4.25
+    assert not [s for s in result.unmeasured_spend_sources if DROPPED_SLUG in s], (
+        "a cost recovered from the prior generation was still reported as unmeasured"
+    )
+
+
+def test_unmeasured_prior_spend_stays_unknown_never_zero(tmp_path: Path) -> None:
+    """A prior generation whose spend was never measured is not recorded as free."""
+    _write_prior_audit(tmp_path, _prior_generation_audit(cost=None))
+    work = WorktreeWork(
+        slug=DROPPED_SLUG,
+        path=str(tmp_path / DROPPED_SLUG),
+        branch=f"feat/{DROPPED_SLUG}",
+        exists=True,
+        commits_ahead=1,
+        dirty=False,
+    )
+
+    result = _run_sprint_with_drop(tmp_path, worktree_work=work)
+
+    row = _sprint_story_row(tmp_path)
+    assert row["cost_usd"] is None
+    assert any(DROPPED_SLUG in s for s in result.unmeasured_spend_sources)
+    assert not result.cost_complete, "an unmeasured story certified a sprint total"
+
+
+def test_stranded_drop_also_carries_the_prior_generation(tmp_path: Path) -> None:
+    """The stranded-worktree drop is the same boundary and gets the same treatment."""
+    _write_prior_audit(tmp_path, _prior_generation_audit())
+
+    _run_sprint_with_drop(tmp_path, reason=REASON_STRANDED_WORKTREE)
+
+    record = _story_audits(tmp_path)[DROPPED_SLUG]
+    assert record["outcome"]["final_phase"] == "REVIEW"
+    assert _sprint_story_row(tmp_path)["cost_usd"] == 4.25
+
+
+# ── a generation that did nothing still records nothing ──────────────
+
+
+def test_a_prior_generation_that_did_no_work_carries_nothing(tmp_path: Path) -> None:
+    """The fix must not manufacture history for a story that really never ran."""
+    _write_prior_audit(
+        tmp_path,
+        {
+            "run_id": "emptygen0001",
+            "in_flight": True,
+            "outcome": {"success": False, "final_phase": "INIT"},
+            "iterations": {
+                "dev_attempts_total": 0,
+                "review_cycles_total": 0,
+                "gate_runs": 0,
+                "usage_summary": {"dev": {"used": 0, "max": 3}},
+            },
+            "cost": {"total_usd": 0.0, "agents": []},
+        },
+    )
+
+    _run_sprint_with_drop(tmp_path)
+
+    record = _story_audits(tmp_path)[DROPPED_SLUG]
+    assert "prior_generation" not in record
+    assert record["outcome"]["final_phase"] == "INIT"
+    assert _sprint_story_row(tmp_path)["cost_usd"] == 0.0
+
+
+def test_no_prior_audit_leaves_the_drop_record_unchanged(tmp_path: Path) -> None:
+    """With nothing flushed by an earlier generation there is nothing to carry."""
+    _run_sprint_with_drop(tmp_path)
+
+    record = _story_audits(tmp_path)[DROPPED_SLUG]
+    assert "prior_generation" not in record
+    assert record["outcome"]["final_phase"] == "INIT"
+
+
+def test_independently_recorded_prior_spend_is_not_counted_twice(tmp_path: Path) -> None:
+    """A prior generation with its own run record is linked, not restated.
+
+    Its cost already stands as a record of its own; copying it into a second
+    record would report the same dollars twice.
+    """
+    _write_prior_audit(tmp_path, _prior_generation_audit(in_flight=False))
+    runs_dir = audit_substrate.runs_dir(tmp_path)
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / f"{PRIOR_RUN_ID}.json").write_text(
+        '{"run_id": "%s", "cost": {"total_usd": 4.25}}' % PRIOR_RUN_ID, encoding="utf-8"
+    )
+
+    result = _run_sprint_with_drop(tmp_path)
+
+    record = _story_audits(tmp_path)[DROPPED_SLUG]
+    assert record["prior_generation"]["independently_recorded"] is True
+    assert record["parent_run_id"] == PRIOR_RUN_ID
+    # The phase it reached is still reported — that is not a double count.
+    assert record["outcome"]["final_phase"] == "REVIEW"
+    assert record["cost"]["total_usd"] in (0.0, None)
+    assert _sprint_story_row(tmp_path)["cost_usd"] == 0.0
+    assert result.total_cost_usd < 4.25
+
+
+# ── unit level: what counts as work, and what gets carried ───────────
+
+
+def test_records_performed_work_ignores_configured_limits() -> None:
+    """Zeroed counters beside a configured max are not evidence of work."""
+    assert not records_performed_work(
+        {"iterations": {"dev_attempts_total": 0, "usage_summary": {"dev": {"used": 0, "max": 3}}}}
+    )
+    assert records_performed_work({"iterations": {"dev_attempts_total": 1}})
+    assert records_performed_work({"cost": {"total_usd": 0.5}})
+    assert records_performed_work({"phases": {"dev": {"outcome": "success"}}})
+    assert not records_performed_work({"phases": {"dev": None, "review": None}})
+    assert not records_performed_work({})
+
+
+def test_carry_leaves_this_generations_own_account_of_the_exit_intact() -> None:
+    """The record still says how *this* generation ended, and why."""
+    audit_data = {
+        "run_id": "dropgen0001",
+        "outcome": {
+            "success": False,
+            "final_phase": "INIT",
+            "message": "Launch guard dropped issue-2048",
+            "error_type": "LaunchGuardDrop",
+        },
+        "error": "Dropped before dispatch",
+        "cost": {"total_usd": 0.0},
+    }
+    carried = carry_prior_generation_work(
+        audit_data, PriorGeneration(audit=_prior_generation_audit())
+    )
+
+    assert "cost" in carried
+    assert audit_data["run_id"] == "dropgen0001"
+    assert audit_data["outcome"]["error_type"] == "LaunchGuardDrop"
+    assert "Launch guard dropped" in audit_data["outcome"]["message"]
+    assert audit_data["error"] == "Dropped before dispatch"
+    assert audit_data["outcome"]["final_phase"] == "REVIEW"
+
+
+def test_carry_never_overwrites_with_a_prior_generations_silence() -> None:
+    """A section the prior generation left empty does not erase this record's."""
+    audit_data = {
+        "outcome": {"final_phase": "INIT"},
+        "reviews": [{"reviewer": "current"}],
+        "cost": {"total_usd": 0.0},
+    }
+    prior = _prior_generation_audit()
+    prior["reviews"] = []
+
+    carry_prior_generation_work(audit_data, PriorGeneration(audit=prior))
+
+    assert audit_data["reviews"] == [{"reviewer": "current"}]
+
+
+def test_loader_ignores_an_audit_from_this_generation(tmp_path: Path) -> None:
+    """This generation's own flushed audit is not a prior generation's."""
+    _write_prior_audit(tmp_path, _prior_generation_audit())
+
+    assert (
+        load_prior_generation_story_audit(
+            tmp_path, SPRINT_NAME, DROPPED_SLUG, exclude_run_id=PRIOR_RUN_ID
+        )
+        is None
+    )
+    assert load_prior_generation_story_audit(tmp_path, SPRINT_NAME, DROPPED_SLUG) is not None
+
+
+def test_loader_survives_an_unreadable_audit(tmp_path: Path) -> None:
+    """Evidence recovery is best-effort and never raises into the drop path."""
+    log_dir = tmp_path / ".forge" / "logs" / SPRINT_NAME / DROPPED_SLUG
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "audit.yaml").write_text("::: not : yaml :::\n  - [", encoding="utf-8")
+
+    assert load_prior_generation_story_audit(tmp_path, SPRINT_NAME, DROPPED_SLUG) is None
+    assert load_prior_generation_story_audit(tmp_path, None, DROPPED_SLUG) is None


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The drop path now carries prior-generation phase and cost accounting into the abnormal drop record, indexed row, sprint row, and sprint total, with targeted seam coverage passing. | [google-gemini-3.5-flash-api] The implementation successfully carries prior generation work and spend into launch-guard drop records and sprint totals, fully resolving the accounting discrepancy.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $10.36
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A story dropped at a re-exec generation boundary is recorded as never having run, discarding the work and spend of the prior generation (GitHub Issue #2214)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2214