### PR TITLE
Review-cycle planning prices a cycle at reviewer budget ceilings rather than review cost (#2260)

### DIFF
--- a/src/theforge/coordinator/config_snapshot.py
+++ b/src/theforge/coordinator/config_snapshot.py
@@ -270,7 +270,7 @@ def active_snapshot() -> "SprintConfigSnapshot | None":
     return _ACTIVE
 
 
-def pinned_forge_yaml() -> Path | None:
+def pinned_forge_yaml(project_root: Path | None = None) -> Path | None:
     """The pinned forge.yaml to prepare worktrees from, or None for standalone runs.
 
     Read from the environment so it survives ``os.execv`` and reaches child
@@ -286,6 +286,15 @@ def pinned_forge_yaml() -> Path | None:
             return None
     except OSError:
         return None
+    if project_root is not None:
+        try:
+            resolved_root = Path(project_root).resolve()
+            resolved_path = path.resolve()
+        except OSError:
+            return None
+        expected_parent = resolved_root / ".forge" / "sprints"
+        if expected_parent not in resolved_path.parents:
+            return None
     return path
 
 
@@ -317,12 +326,13 @@ def sync_forge_yaml_into_worktree(
     """
     from . import util as _cu  # noqa: PLC0415 - avoids an import cycle at module load
 
-    source = pinned_forge_yaml() or (Path(project_root) / "forge.yaml")
+    pinned = pinned_forge_yaml(project_root)
+    source = pinned or (Path(project_root) / "forge.yaml")
     destination = Path(workspace_path) / "forge.yaml"
     if not source.exists():
         return
 
-    origin = "sprint-pinned snapshot" if pinned_forge_yaml() else "project root"
+    origin = "sprint-pinned snapshot" if pinned else "project root"
     existed = destination.exists()
     try:
         shutil.copy2(source, destination)

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -425,18 +425,25 @@ def _coordinator_loop(
         # at review dispatch, where the only options left are escalate or
         # accept unverified work.
         #
-        # The per-cycle cost is the full configured pool sum: an upper bound
-        # (demotion only ever removes reviewers) and the same number the
-        # dispatch-time funding check plans against.
+        # Price one review cycle from observed prior review-cycle spend plus
+        # explicit headroom, not from the reviewers' execution ceilings. The
+        # exact seated figure is persisted on state so dispatch cannot silently
+        # re-price the same granted cycle later in the run.
         _reviewer_names = [profile.name for profile in config.review_pool]
+        _review_cycle_planning = _story_budget.derive_review_cycle_planning_price(
+            config.project_root,
+            configured_ceiling_usd=sum(float(p.budget_usd) for p in config.review_pool),
+        ).as_dict()
         _reconciliation = _story_budget.reconcile_review_cycles(
             state.story_allocation,
             dev_cost_estimate_usd=_limits.dev_cost_estimate_usd,
-            review_cycle_cost_usd=sum(float(p.budget_usd) for p in config.review_pool),
+            review_cycle_cost_usd=float(_review_cycle_planning["planned_cost_usd"]),
+            review_cycle_planning=_review_cycle_planning,
             requested_review_max=_limits.review_max,
             spent_so_far_usd=state.total_cost_measured,
         )
         _audit = dict(_limits.audit)
+        _audit["review_cycle_planning"] = _review_cycle_planning
         _audit["review_cycle_reconciliation"] = _reconciliation
         if _reconciliation["action"] in (
             _story_budget.RECONCILE_REDUCED,
@@ -458,6 +465,7 @@ def _coordinator_loop(
         state.adaptive_review_max = _limits.review_max
         state.adaptive_dev_timeout_seconds = _limits.dev_timeout_seconds
         state.adaptive_dev_cost_estimate_usd = _limits.dev_cost_estimate_usd
+        state.adaptive_review_cycle_planning = _review_cycle_planning
         state.adaptive_limits_audit = _limits.audit
 
         if _reconciliation["action"] == _story_budget.RECONCILE_UNFUNDABLE:

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -433,6 +433,7 @@ def _coordinator_loop(
         _review_cycle_planning = _story_budget.derive_review_cycle_planning_price(
             config.project_root,
             configured_ceiling_usd=sum(float(p.budget_usd) for p in config.review_pool),
+            composition=_reviewer_names,
         ).as_dict()
         _reconciliation = _story_budget.reconcile_review_cycles(
             state.story_allocation,

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -618,14 +618,23 @@ def _run_review_pool(
     # out of reach. The check is skipped when spend is unmeasured (a lower
     # bound is not a number to refuse work on).
     if enforce_budgets and state.story_allocation:
+        configured_ceiling_usd = sum(float(p.budget_usd) for p in pool)
+        review_cycle_planning = state.adaptive_review_cycle_planning
+        if not isinstance(review_cycle_planning, dict) or not review_cycle_planning:
+            review_cycle_planning = _story_budget.derive_review_cycle_planning_price(
+                config.project_root,
+                configured_ceiling_usd=configured_ceiling_usd,
+            ).as_dict()
+            state.adaptive_review_cycle_planning = review_cycle_planning
         _shortfall = _story_budget.phase_funding_shortfall(
             state.story_allocation,
             state.total_cost_measured,
             phase="review",
             participants=[p.name for p in pool],
-            planned_usd=sum(float(p.budget_usd) for p in pool),
+            planned_usd=float(review_cycle_planning["planned_cost_usd"]),
         )
         if _shortfall is not None:
+            _shortfall["review_cycle_planning"] = dict(review_cycle_planning)
             state.allocation_exhausted = _shortfall
             state.phase = Phase.ESCALATE
             state.error = _story_budget.format_shortfall(_shortfall, story=task.slug)

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -609,6 +609,13 @@ def _run_review_pool(
             state.error = "All reviewers demoted due to parse failures."
             return [], [], None, [], []
 
+    # The panel recorded against this cycle is the one that will actually be
+    # attempted, not the one that was configured. A demoted reviewer never
+    # runs and never bills, so a cycle costed at two reviewers must not be
+    # recorded as three — downstream pricing joins observed cost to this list
+    # and would otherwise attribute a smaller panel's spend to a larger one.
+    meta.pool_models = [profile.name for profile in pool]
+
     pool_size = len(pool)
 
     # ── Story-allocation funding check (#2169) ────────────────────────────────

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -624,6 +624,7 @@ def _run_review_pool(
             review_cycle_planning = _story_budget.derive_review_cycle_planning_price(
                 config.project_root,
                 configured_ceiling_usd=configured_ceiling_usd,
+                composition=[p.name for p in pool],
             ).as_dict()
             state.adaptive_review_cycle_planning = review_cycle_planning
         _shortfall = _story_budget.phase_funding_shortfall(

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -895,6 +895,11 @@ class CoordinatorState:
     # budget. Informs routing/timeout scaling/telemetry; post-hoc dollar
     # governance lives at the sprint level (forge.yaml budget_usd), not here.
     adaptive_dev_cost_estimate_usd: float = 0.0
+    # Deterministic per-cycle review planning price derived at seating from
+    # observed review-cycle spend plus explicit headroom. REVIEW dispatch reads
+    # this exact record first so it cannot re-price a cycle differently after
+    # seating already granted it.
+    adaptive_review_cycle_planning: dict | None = None
     adaptive_limits_audit: dict = field(default_factory=dict)
     review_early_terminated: bool = False  # True when early-termination triggered
     workspace_hygiene_audit: list[dict] = field(default_factory=list)

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -33,9 +33,15 @@ BAND_HEADROOM = 1.25
 # Never derive an allocation below this, regardless of how cheap the band is.
 # A single retry on the cheapest band would otherwise trip the allocation.
 MIN_ALLOCATION_USD = 1.0
+MIN_REVIEW_CYCLE_PRICE_USD = 0.01
+REVIEW_CYCLE_PRICE_MIN_SAMPLES = 3
+REVIEW_CYCLE_PRICE_HEADROOM = 1.25
+REVIEW_COST_HISTORY_TAIL = 50
 
 BASIS_SUBSTRATE_BAND = "substrate_band"
 BASIS_CONFIGURED_FALLBACK = "configured_fallback"
+BASIS_OBSERVED_REVIEW_CYCLE = "observed_review_cycle"
+BASIS_REVIEW_CEILING_FALLBACK = "ceiling_fallback"
 
 STATUS_WITHIN = "within_allocation"
 STATUS_EXCEEDED = "allocation_exceeded"
@@ -87,6 +93,40 @@ class StoryAllocation:
             f"max ${self.max_usd:.2f} over {self.sample_count} run(s) "
             f"at complexity score {self.complexity_score}"
         )
+
+
+@dataclass(frozen=True)
+class ReviewCyclePlanningPrice:
+    """Planned per-cycle review price plus the evidence it was derived from."""
+
+    planned_cost_usd: float
+    basis: str
+    fallback_configured_usd: float
+    sample_count: int = 0
+    median_usd: float | None = None
+    p90_usd: float | None = None
+    max_usd: float | None = None
+    headroom_multiplier: float = REVIEW_CYCLE_PRICE_HEADROOM
+    reason: str = ""
+    excluded_for_taint: int = 0
+
+    @property
+    def derived(self) -> bool:
+        return self.basis == BASIS_OBSERVED_REVIEW_CYCLE
+
+    def as_dict(self) -> dict:
+        return {
+            "planned_cost_usd": round(self.planned_cost_usd, 4),
+            "basis": self.basis,
+            "fallback_configured_usd": round(self.fallback_configured_usd, 4),
+            "sample_count": self.sample_count,
+            "median_usd": _round_opt(self.median_usd),
+            "p90_usd": _round_opt(self.p90_usd),
+            "max_usd": _round_opt(self.max_usd),
+            "headroom_multiplier": round(self.headroom_multiplier, 4),
+            "reason": self.reason,
+            "excluded_for_taint": self.excluded_for_taint,
+        }
 
 
 def _round_opt(value: float | None) -> float | None:
@@ -224,6 +264,123 @@ def derive_story_allocation(
     return allocation
 
 
+def review_cycle_planning_from_samples(
+    samples: list[float],
+    configured_ceiling_usd: float,
+    *,
+    excluded_for_taint: int = 0,
+    min_samples: int = REVIEW_CYCLE_PRICE_MIN_SAMPLES,
+    headroom_multiplier: float = REVIEW_CYCLE_PRICE_HEADROOM,
+) -> ReviewCyclePlanningPrice:
+    """Return the deterministic planning price for one review cycle."""
+    usable = [float(s) for s in samples if s is not None and float(s) > 0.0]
+    if len(usable) < min_samples:
+        return ReviewCyclePlanningPrice(
+            planned_cost_usd=round(configured_ceiling_usd, 4),
+            basis=BASIS_REVIEW_CEILING_FALLBACK,
+            fallback_configured_usd=configured_ceiling_usd,
+            sample_count=len(usable),
+            reason=(
+                f"only {len(usable)} measured review cycle(s), below the "
+                f"{min_samples}-cycle floor"
+            ),
+            excluded_for_taint=excluded_for_taint,
+        )
+
+    median = percentile(usable, 0.5)
+    p90 = percentile(usable, 0.9)
+    observed_max = max(usable)
+    planned = max(median * headroom_multiplier, MIN_REVIEW_CYCLE_PRICE_USD)
+    return ReviewCyclePlanningPrice(
+        planned_cost_usd=round(planned, 4),
+        basis=BASIS_OBSERVED_REVIEW_CYCLE,
+        fallback_configured_usd=configured_ceiling_usd,
+        sample_count=len(usable),
+        median_usd=median,
+        p90_usd=p90,
+        max_usd=observed_max,
+        headroom_multiplier=headroom_multiplier,
+        reason=(
+            f"derived from median observed review-cycle spend ${median:.2f} "
+            f"x {headroom_multiplier} headroom over {len(usable)} cycle(s)"
+        ),
+        excluded_for_taint=excluded_for_taint,
+    )
+
+
+def _extract_review_cycle_cost_samples(records: list[dict]) -> tuple[list[float], int]:
+    """Return measured per-cycle review costs from prior audit records."""
+    samples: list[float] = []
+    excluded_for_taint = 0
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        if str(rec.get("trust_status") or "").lower() == "tainted":
+            excluded_for_taint += 1
+            continue
+        iterations = rec.get("iterations")
+        if not isinstance(iterations, dict):
+            continue
+        review_loop = iterations.get("review_loop")
+        if not isinstance(review_loop, list):
+            continue
+        for cycle in review_loop:
+            if not isinstance(cycle, dict):
+                continue
+            try:
+                cost = float(cycle.get("cost_usd"))
+            except (TypeError, ValueError):
+                continue
+            if cost > 0.0:
+                samples.append(cost)
+    return samples, excluded_for_taint
+
+
+def derive_review_cycle_planning_price(
+    project_root: Path,
+    *,
+    configured_ceiling_usd: float,
+    min_samples: int = REVIEW_CYCLE_PRICE_MIN_SAMPLES,
+    headroom_multiplier: float = REVIEW_CYCLE_PRICE_HEADROOM,
+) -> ReviewCyclePlanningPrice:
+    """Read observed review-cycle spend from the substrate and derive one price."""
+    from theforge.coordinator import audit_substrate  # noqa: PLC0415
+
+    records: list[dict] = []
+    reason_prefix = ""
+    substrate = audit_substrate.substrate_path(project_root)
+    if not substrate.exists() and not audit_substrate.has_audit_inputs(project_root):
+        reason_prefix = "no audit substrate; "
+    else:
+        try:
+            conn = audit_substrate.require_substrate(project_root)
+        except audit_substrate.SubstrateError as exc:
+            reason_prefix = f"substrate unreadable ({type(exc).__name__}); "
+        else:
+            try:
+                records = [
+                    rec
+                    for rec in audit_substrate.tail_records(conn, REVIEW_COST_HISTORY_TAIL)
+                    if isinstance(rec, dict)
+                ]
+            finally:
+                conn.close()
+
+    samples, excluded = _extract_review_cycle_cost_samples(records)
+    planning = review_cycle_planning_from_samples(
+        samples,
+        configured_ceiling_usd,
+        excluded_for_taint=excluded,
+        min_samples=min_samples,
+        headroom_multiplier=headroom_multiplier,
+    )
+    if reason_prefix:
+        from dataclasses import replace  # noqa: PLC0415
+
+        planning = replace(planning, reason=reason_prefix + planning.reason)
+    return planning
+
+
 def evaluate_allocation_dict(allocation: dict | None, observed_usd: float | None) -> dict | None:
     """Return the reportable allocation-vs-observed block for a story.
 
@@ -324,6 +481,7 @@ def reconcile_review_cycles(
     *,
     dev_cost_estimate_usd: float | None,
     review_cycle_cost_usd: float | None,
+    review_cycle_planning: dict | None = None,
     requested_review_max: int,
     spent_so_far_usd: float | None = 0.0,
 ) -> dict:
@@ -361,6 +519,13 @@ def reconcile_review_cycles(
         else round(float(spent_so_far_usd), 4),
         "dev_cost_estimate_usd": None,
         "review_cycle_cost_usd": None,
+        "review_cycle_cost_basis": None,
+        "review_cycle_cost_sample_count": None,
+        "review_cycle_cost_median_usd": None,
+        "review_cycle_cost_p90_usd": None,
+        "review_cycle_cost_max_usd": None,
+        "review_cycle_cost_headroom_multiplier": None,
+        "review_cycle_cost_reason": None,
         "action": RECONCILE_AFFORDABLE,
     }
     try:
@@ -398,6 +563,16 @@ def reconcile_review_cycles(
         record["action"] = RECONCILE_NO_REVIEW_COST
         return record
     record["review_cycle_cost_usd"] = round(cycle_cost, 4)
+    if isinstance(review_cycle_planning, dict):
+        record["review_cycle_cost_basis"] = review_cycle_planning.get("basis")
+        record["review_cycle_cost_sample_count"] = review_cycle_planning.get("sample_count")
+        record["review_cycle_cost_median_usd"] = review_cycle_planning.get("median_usd")
+        record["review_cycle_cost_p90_usd"] = review_cycle_planning.get("p90_usd")
+        record["review_cycle_cost_max_usd"] = review_cycle_planning.get("max_usd")
+        record["review_cycle_cost_headroom_multiplier"] = review_cycle_planning.get(
+            "headroom_multiplier"
+        )
+        record["review_cycle_cost_reason"] = review_cycle_planning.get("reason")
 
     if requested_review_max <= 0:
         record["action"] = RECONCILE_AFFORDABLE
@@ -424,22 +599,40 @@ def reconcile_review_cycles(
     return record
 
 
+def _review_cycle_basis_text(record: dict) -> str:
+    basis = record.get("review_cycle_cost_basis")
+    if basis == BASIS_OBSERVED_REVIEW_CYCLE:
+        median = record.get("review_cycle_cost_median_usd")
+        headroom = record.get("review_cycle_cost_headroom_multiplier")
+        sample_count = record.get("review_cycle_cost_sample_count")
+        if median is not None and headroom is not None:
+            sample_text = (
+                f" over {int(sample_count)} cycle(s)" if isinstance(sample_count, (int, float)) else ""
+            )
+            return f" (observed median ${float(median):.2f} x {float(headroom):.2f} headroom{sample_text})"
+    if basis == BASIS_REVIEW_CEILING_FALLBACK:
+        reason = str(record.get("review_cycle_cost_reason") or "").strip()
+        return f" (ceiling fallback{': ' + reason if reason else ''})"
+    return ""
+
+
 def format_reconciliation(record: dict) -> str:
     """One-line operator-facing summary of a seating reconciliation."""
     action = record.get("action")
+    basis = _review_cycle_basis_text(record)
     if action == RECONCILE_REDUCED:
         return (
             f"review_max reduced {record['requested_review_max']} → "
             f"{record['reconciled_review_max']}: the "
             f"${float(record['allocation_usd']):.2f} allocation funds "
             f"{record['affordable_review_cycles']} review cycle(s) at "
-            f"${float(record['review_cycle_cost_usd']):.2f} each after a "
+            f"${float(record['review_cycle_cost_usd']):.2f} each{basis} after a "
             f"${float(record['dev_cost_estimate_usd']):.2f} dev estimate."
         )
     if action == RECONCILE_UNFUNDABLE:
         return (
             f"the ${float(record['allocation_usd']):.2f} allocation cannot fund one "
-            f"${float(record['review_cycle_cost_usd']):.2f} review cycle after a "
+            f"${float(record['review_cycle_cost_usd']):.2f} review cycle{basis} after a "
             f"${float(record['dev_cost_estimate_usd']):.2f} dev estimate "
             f"(short ${float(record['shortfall_usd']):.2f})."
         )

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -40,8 +40,19 @@ REVIEW_COST_HISTORY_TAIL = 50
 
 BASIS_SUBSTRATE_BAND = "substrate_band"
 BASIS_CONFIGURED_FALLBACK = "configured_fallback"
+BASIS_OBSERVED_COMPOSITION = "observed_composition"
 BASIS_OBSERVED_REVIEW_CYCLE = "observed_review_cycle"
+BASIS_OBSERVED_SPARSE = "observed_sparse"
 BASIS_REVIEW_CEILING_FALLBACK = "ceiling_fallback"
+
+# The rungs of the review-cycle pricing ladder, most specific first. A price is
+# "observed" on any of the first three: all describe measured spend, and differ
+# only in which population was measurable. The ceiling is not a price at all —
+# it is a permission — so it sits outside this set and is reached only when
+# nothing has ever been observed.
+OBSERVED_REVIEW_CYCLE_BASES = frozenset(
+    {BASIS_OBSERVED_COMPOSITION, BASIS_OBSERVED_REVIEW_CYCLE, BASIS_OBSERVED_SPARSE}
+)
 
 STATUS_WITHIN = "within_allocation"
 STATUS_EXCEEDED = "allocation_exceeded"
@@ -109,10 +120,11 @@ class ReviewCyclePlanningPrice:
     headroom_multiplier: float = REVIEW_CYCLE_PRICE_HEADROOM
     reason: str = ""
     excluded_for_taint: int = 0
+    composition: tuple[str, ...] | None = None
 
     @property
     def derived(self) -> bool:
-        return self.basis == BASIS_OBSERVED_REVIEW_CYCLE
+        return self.basis in OBSERVED_REVIEW_CYCLE_BASES
 
     def as_dict(self) -> dict:
         return {
@@ -126,6 +138,7 @@ class ReviewCyclePlanningPrice:
             "headroom_multiplier": round(self.headroom_multiplier, 4),
             "reason": self.reason,
             "excluded_for_taint": self.excluded_for_taint,
+            "composition": list(self.composition) if self.composition else None,
         }
 
 
@@ -271,29 +284,73 @@ def review_cycle_planning_from_samples(
     excluded_for_taint: int = 0,
     min_samples: int = REVIEW_CYCLE_PRICE_MIN_SAMPLES,
     headroom_multiplier: float = REVIEW_CYCLE_PRICE_HEADROOM,
+    derived_basis: str = BASIS_OBSERVED_REVIEW_CYCLE,
+    scope_suffix: str = "",
+    composition: tuple[str, ...] | None = None,
 ) -> ReviewCyclePlanningPrice:
-    """Return the deterministic planning price for one review cycle."""
+    """Return the deterministic planning price for one review cycle.
+
+    Three outcomes, and which one applies is decided only by how much has been
+    measured — never by how the money is permitted to be spent:
+
+    * at or above ``min_samples``, the median of observed spend plus headroom;
+    * with fewer but at least one observation, the observed *maximum* plus
+      headroom, capped at the ceiling. A one- or two-sample median understates
+      the spread it was drawn from, and under-reserving is the failure that
+      refuses a granted cycle at dispatch, so the sparse rung leans high — but
+      it still describes cost, and it is still bounded by what the panel could
+      possibly spend;
+    * with nothing observed at all, the configured ceiling. That is a genuinely
+      unobserved installation, which is the only circumstance in which a
+      permission is the best available description of a cost.
+    """
     usable = [float(s) for s in samples if s is not None and float(s) > 0.0]
-    if len(usable) < min_samples:
-        fallback_reason = (
-            f"only {len(usable)} measured review cycle(s), below the {min_samples}-cycle floor"
-        )
+    if not usable:
         return ReviewCyclePlanningPrice(
             planned_cost_usd=round(configured_ceiling_usd, 4),
             basis=BASIS_REVIEW_CEILING_FALLBACK,
             fallback_configured_usd=configured_ceiling_usd,
-            sample_count=len(usable),
-            reason=fallback_reason,
+            sample_count=0,
+            reason=(
+                "no measured review cycle in recorded history — "
+                "priced at the reviewer ceiling sum as an unobserved installation"
+            ),
             excluded_for_taint=excluded_for_taint,
+            composition=composition,
         )
 
     median = percentile(usable, 0.5)
     p90 = percentile(usable, 0.9)
     observed_max = max(usable)
+
+    if len(usable) < min_samples:
+        planned = min(
+            max(observed_max * headroom_multiplier, MIN_REVIEW_CYCLE_PRICE_USD),
+            configured_ceiling_usd,
+        )
+        return ReviewCyclePlanningPrice(
+            planned_cost_usd=round(planned, 4),
+            basis=BASIS_OBSERVED_SPARSE,
+            fallback_configured_usd=configured_ceiling_usd,
+            sample_count=len(usable),
+            median_usd=median,
+            p90_usd=p90,
+            max_usd=observed_max,
+            headroom_multiplier=headroom_multiplier,
+            reason=(
+                f"derived from maximum observed review-cycle spend ${observed_max:.2f} "
+                f"x {headroom_multiplier} headroom over {len(usable)} cycle(s)"
+                f"{scope_suffix}, below the {min_samples}-cycle floor "
+                f"(capped at the ceiling sum)"
+            ),
+            excluded_for_taint=excluded_for_taint,
+            composition=composition,
+        )
+
     planned = max(median * headroom_multiplier, MIN_REVIEW_CYCLE_PRICE_USD)
     return ReviewCyclePlanningPrice(
         planned_cost_usd=round(planned, 4),
-        basis=BASIS_OBSERVED_REVIEW_CYCLE,
+        basis=derived_basis,
         fallback_configured_usd=configured_ceiling_usd,
         sample_count=len(usable),
         median_usd=median,
@@ -302,14 +359,59 @@ def review_cycle_planning_from_samples(
         headroom_multiplier=headroom_multiplier,
         reason=(
             f"derived from median observed review-cycle spend ${median:.2f} "
-            f"x {headroom_multiplier} headroom over {len(usable)} cycle(s)"
+            f"x {headroom_multiplier} headroom over {len(usable)} cycle(s){scope_suffix}"
         ),
         excluded_for_taint=excluded_for_taint,
+        composition=composition,
     )
 
 
-def _extract_review_cycle_cost_samples(records: list[dict]) -> tuple[list[float], int]:
-    """Return measured per-cycle review costs from prior audit records."""
+def composition_key(names: list[str] | tuple[str, ...] | None) -> tuple[str, ...] | None:
+    """Return the order-independent identity of a reviewer panel.
+
+    A panel is the set of participants, not the order they were listed in, so
+    the key is sorted. ``None`` when no panel is identifiable, which keeps an
+    unknown composition from silently colliding with an empty one.
+    """
+    if not names:
+        return None
+    cleaned = sorted(str(n).strip() for n in names if str(n or "").strip())
+    return tuple(cleaned) or None
+
+
+def _record_cycle_compositions(rec: dict) -> dict:
+    """Map cycle number → panel identity for one audit record.
+
+    The per-cycle review entries carry the panel that actually ran that cycle,
+    which is what makes this a join rather than an assumption: a story whose
+    panel changed between cycles contributes each cycle to its own composition.
+    """
+    compositions: dict = {}
+    reviews = rec.get("reviews")
+    if not isinstance(reviews, list):
+        return compositions
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        key = composition_key(review.get("pool_models"))
+        if key is not None:
+            compositions[review.get("cycle")] = key
+    return compositions
+
+
+def _extract_review_cycle_cost_samples(
+    records: list[dict],
+    *,
+    composition: tuple[str, ...] | None = None,
+) -> tuple[list[float], int]:
+    """Return measured per-cycle review costs from prior audit records.
+
+    With ``composition``, only cycles run by that exact panel are returned. A
+    cycle whose panel cannot be identified is excluded from a composition query
+    — an unjoinable cycle is not evidence about any particular panel — but is
+    still counted in the unfiltered population, where it remains evidence about
+    review as an activity.
+    """
     samples: list[float] = []
     excluded_for_taint = 0
     for rec in records:
@@ -324,6 +426,7 @@ def _extract_review_cycle_cost_samples(records: list[dict]) -> tuple[list[float]
         review_loop = iterations.get("review_loop")
         if not isinstance(review_loop, list):
             continue
+        compositions = _record_cycle_compositions(rec) if composition is not None else {}
         for cycle in review_loop:
             if not isinstance(cycle, dict):
                 continue
@@ -331,8 +434,11 @@ def _extract_review_cycle_cost_samples(records: list[dict]) -> tuple[list[float]
                 cost = float(cycle.get("cost_usd"))
             except (TypeError, ValueError):
                 continue
-            if cost > 0.0:
-                samples.append(cost)
+            if cost <= 0.0:
+                continue
+            if composition is not None and compositions.get(cycle.get("iteration")) != composition:
+                continue
+            samples.append(cost)
     return samples, excluded_for_taint
 
 
@@ -340,10 +446,19 @@ def derive_review_cycle_planning_price(
     project_root: Path,
     *,
     configured_ceiling_usd: float,
+    composition: list[str] | tuple[str, ...] | None = None,
     min_samples: int = REVIEW_CYCLE_PRICE_MIN_SAMPLES,
     headroom_multiplier: float = REVIEW_CYCLE_PRICE_HEADROOM,
 ) -> ReviewCyclePlanningPrice:
-    """Read observed review-cycle spend from the substrate and derive one price."""
+    """Read observed review-cycle spend from the substrate and derive one price.
+
+    Descends the ladder most-specific first. The panel a story will actually
+    seat is the best predictor of what its cycles cost — a three-reviewer panel
+    and a two-reviewer panel are different quantities, and averaging them
+    misprices both — so that history governs whenever it can support a price.
+    Below the floor the same phase's cost across every panel still describes
+    review, and only a total absence of observation reaches the ceiling.
+    """
     from theforge.coordinator import audit_substrate  # noqa: PLC0415
 
     records: list[dict] = []
@@ -366,14 +481,36 @@ def derive_review_cycle_planning_price(
             finally:
                 conn.close()
 
-    samples, excluded = _extract_review_cycle_cost_samples(records)
-    planning = review_cycle_planning_from_samples(
-        samples,
-        configured_ceiling_usd,
-        excluded_for_taint=excluded,
-        min_samples=min_samples,
-        headroom_multiplier=headroom_multiplier,
-    )
+    panel = composition_key(composition)
+    planning: ReviewCyclePlanningPrice | None = None
+
+    if panel is not None:
+        panel_samples, panel_excluded = _extract_review_cycle_cost_samples(
+            records, composition=panel
+        )
+        if len(panel_samples) >= min_samples:
+            planning = review_cycle_planning_from_samples(
+                panel_samples,
+                configured_ceiling_usd,
+                excluded_for_taint=panel_excluded,
+                min_samples=min_samples,
+                headroom_multiplier=headroom_multiplier,
+                derived_basis=BASIS_OBSERVED_COMPOSITION,
+                scope_suffix=" run by this exact panel",
+                composition=panel,
+            )
+
+    if planning is None:
+        samples, excluded = _extract_review_cycle_cost_samples(records)
+        planning = review_cycle_planning_from_samples(
+            samples,
+            configured_ceiling_usd,
+            excluded_for_taint=excluded,
+            min_samples=min_samples,
+            headroom_multiplier=headroom_multiplier,
+            composition=panel,
+        )
+
     if reason_prefix:
         from dataclasses import replace  # noqa: PLC0415
 
@@ -526,6 +663,7 @@ def reconcile_review_cycles(
         "review_cycle_cost_max_usd": None,
         "review_cycle_cost_headroom_multiplier": None,
         "review_cycle_cost_reason": None,
+        "review_cycle_cost_composition": None,
         "action": RECONCILE_AFFORDABLE,
     }
     try:
@@ -573,6 +711,7 @@ def reconcile_review_cycles(
             "headroom_multiplier"
         )
         record["review_cycle_cost_reason"] = review_cycle_planning.get("reason")
+        record["review_cycle_cost_composition"] = review_cycle_planning.get("composition")
 
     if requested_review_max <= 0:
         record["action"] = RECONCILE_AFFORDABLE
@@ -600,18 +739,34 @@ def reconcile_review_cycles(
 
 
 def _review_cycle_basis_text(record: dict) -> str:
+    """Name the rung a review-cycle price came from, for the operator line.
+
+    An operator reading a reservation needs to know whether it was measured on
+    the panel that will run, inferred from review at large, stretched from one
+    or two observations, or defaulted — because that is what decides whether
+    the number is worth trusting.
+    """
     basis = record.get("review_cycle_cost_basis")
-    if basis == BASIS_OBSERVED_REVIEW_CYCLE:
+    headroom = record.get("review_cycle_cost_headroom_multiplier")
+    sample_count = record.get("review_cycle_cost_sample_count")
+    sample_text = ""
+    if isinstance(sample_count, (int, float)):
+        sample_text = f" over {int(sample_count)} cycle(s)"
+
+    if basis in (BASIS_OBSERVED_COMPOSITION, BASIS_OBSERVED_REVIEW_CYCLE):
         median = record.get("review_cycle_cost_median_usd")
-        headroom = record.get("review_cycle_cost_headroom_multiplier")
-        sample_count = record.get("review_cycle_cost_sample_count")
         if median is not None and headroom is not None:
-            sample_text = ""
-            if isinstance(sample_count, (int, float)):
-                sample_text = f" over {int(sample_count)} cycle(s)"
+            scope = "this panel" if basis == BASIS_OBSERVED_COMPOSITION else "review at large"
             return (
                 f" (observed median ${float(median):.2f} x "
-                f"{float(headroom):.2f} headroom{sample_text})"
+                f"{float(headroom):.2f} headroom{sample_text}, {scope})"
+            )
+    if basis == BASIS_OBSERVED_SPARSE:
+        observed_max = record.get("review_cycle_cost_max_usd")
+        if observed_max is not None and headroom is not None:
+            return (
+                f" (sparse history: observed max ${float(observed_max):.2f} x "
+                f"{float(headroom):.2f} headroom{sample_text}, capped at the ceiling sum)"
             )
     if basis == BASIS_REVIEW_CEILING_FALLBACK:
         reason = str(record.get("review_cycle_cost_reason") or "").strip()

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -275,15 +275,15 @@ def review_cycle_planning_from_samples(
     """Return the deterministic planning price for one review cycle."""
     usable = [float(s) for s in samples if s is not None and float(s) > 0.0]
     if len(usable) < min_samples:
+        fallback_reason = (
+            f"only {len(usable)} measured review cycle(s), below the {min_samples}-cycle floor"
+        )
         return ReviewCyclePlanningPrice(
             planned_cost_usd=round(configured_ceiling_usd, 4),
             basis=BASIS_REVIEW_CEILING_FALLBACK,
             fallback_configured_usd=configured_ceiling_usd,
             sample_count=len(usable),
-            reason=(
-                f"only {len(usable)} measured review cycle(s), "
-                f"below the {min_samples}-cycle floor"
-            ),
+            reason=fallback_reason,
             excluded_for_taint=excluded_for_taint,
         )
 

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -290,6 +290,11 @@ def review_cycle_planning_from_samples(
 ) -> ReviewCyclePlanningPrice:
     """Return the deterministic planning price for one review cycle.
 
+    Every observed price is capped at the ceiling of the panel about to run.
+    History can carry costs from larger or formerly pricier panels, and a panel
+    that cannot spend more than $3 must never reserve $5 — that reservation is
+    for spend which is not merely unlikely but impossible.
+
     Three outcomes, and which one applies is decided only by how much has been
     measured — never by how the money is permitted to be spent:
 
@@ -347,7 +352,10 @@ def review_cycle_planning_from_samples(
             composition=composition,
         )
 
-    planned = max(median * headroom_multiplier, MIN_REVIEW_CYCLE_PRICE_USD)
+    planned = min(
+        max(median * headroom_multiplier, MIN_REVIEW_CYCLE_PRICE_USD),
+        configured_ceiling_usd,
+    )
     return ReviewCyclePlanningPrice(
         planned_cost_usd=round(planned, 4),
         basis=derived_basis,

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -606,10 +606,13 @@ def _review_cycle_basis_text(record: dict) -> str:
         headroom = record.get("review_cycle_cost_headroom_multiplier")
         sample_count = record.get("review_cycle_cost_sample_count")
         if median is not None and headroom is not None:
-            sample_text = (
-                f" over {int(sample_count)} cycle(s)" if isinstance(sample_count, (int, float)) else ""
+            sample_text = ""
+            if isinstance(sample_count, (int, float)):
+                sample_text = f" over {int(sample_count)} cycle(s)"
+            return (
+                f" (observed median ${float(median):.2f} x "
+                f"{float(headroom):.2f} headroom{sample_text})"
             )
-            return f" (observed median ${float(median):.2f} x {float(headroom):.2f} headroom{sample_text})"
     if basis == BASIS_REVIEW_CEILING_FALLBACK:
         reason = str(record.get("review_cycle_cost_reason") or "").strip()
         return f" (ceiling fallback{': ' + reason if reason else ''})"

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -280,7 +280,10 @@ def review_cycle_planning_from_samples(
             basis=BASIS_REVIEW_CEILING_FALLBACK,
             fallback_configured_usd=configured_ceiling_usd,
             sample_count=len(usable),
-            reason=f"only {len(usable)} measured review cycle(s), below the {min_samples}-cycle floor",
+            reason=(
+                f"only {len(usable)} measured review cycle(s), "
+                f"below the {min_samples}-cycle floor"
+            ),
             excluded_for_taint=excluded_for_taint,
         )
 

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -280,10 +280,7 @@ def review_cycle_planning_from_samples(
             basis=BASIS_REVIEW_CEILING_FALLBACK,
             fallback_configured_usd=configured_ceiling_usd,
             sample_count=len(usable),
-            reason=(
-                f"only {len(usable)} measured review cycle(s), below the "
-                f"{min_samples}-cycle floor"
-            ),
+            reason=f"only {len(usable)} measured review cycle(s), below the {min_samples}-cycle floor",
             excluded_for_taint=excluded_for_taint,
         )
 

--- a/tests/test_coord_review_pool_recorded_panel.py
+++ b/tests/test_coord_review_pool_recorded_panel.py
@@ -1,0 +1,110 @@
+"""The panel recorded against a cycle is the panel that actually ran.
+
+Review-cycle pricing joins observed cost to ``reviews[].pool_models`` to learn
+what a given panel costs. That join is only sound if the recorded panel is the
+one that was attempted: a demoted reviewer never runs and never bills, so a
+cycle costed at two reviewers must not be recorded as three, or a smaller
+panel's spend is attributed to a larger one and every future story seated on
+that larger panel is under-reserved.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from coord_test_helpers import (
+    _make_agent_result,
+    _make_pool_config,
+    _make_review_profile,
+    _make_task,
+)
+
+from theforge.coordinator import story_budget as sb
+from theforge.coordinator.audit_render import build_reviews
+from theforge.coordinator.review_pool import _run_review_pool
+from theforge.coordinator.state import CoordinatorState, ReviewCycleMetadata
+
+_APPROVE = (
+    "```yaml\nverdict: APPROVE\nsummary: ok\nfindings: []\n"
+    "story_compliance:\n  matches_spec: true\n"
+    "test_coverage:\n  adequate: true\n```"
+)
+
+
+def _meta() -> ReviewCycleMetadata:
+    return ReviewCycleMetadata(pool_models=[], successful=[], failed=[], synthesized=False)
+
+
+@patch("theforge.coordinator.review_pool.log_agent_result")
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+def test_demoted_reviewer_is_absent_from_the_recorded_panel(mock_pool, _mock_log, tmp_path):
+    """Configured A+B+C, C demoted → the cycle is recorded as A+B."""
+    alpha = _make_review_profile("alpha")
+    bravo = _make_review_profile("bravo")
+    charlie = _make_review_profile("charlie")
+    config = _make_pool_config(tmp_path, [alpha, bravo, charlie], alpha)
+    task = _make_task(tmp_path)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+    state.reviewer_demoted.add("charlie")
+
+    mock_pool.return_value = [
+        _make_agent_result(success=True, output=_APPROVE, profile_name="alpha"),
+        _make_agent_result(success=True, output=_APPROVE, profile_name="bravo"),
+    ]
+
+    meta = _meta()
+    _run_review_pool(
+        state,
+        config,
+        task,
+        "story",
+        workspace,
+        "branch",
+        meta,
+        notify=False,
+        enforce_budgets=False,
+    )
+
+    assert meta.pool_models == ["alpha", "bravo"]
+    assert "charlie" not in meta.pool_models
+
+    # The audit is what downstream pricing actually reads.
+    state.review_cycle_metadata.append(meta)
+    rendered = build_reviews(state)
+    assert rendered[0]["cycle"] == 1
+    assert rendered[0]["pool_models"] == ["alpha", "bravo"]
+
+
+def test_recorded_panel_governs_pricing_for_the_panel_that_ran(tmp_path):
+    """Three A+B cycles price A+B — they are not banked against A+B+C."""
+    from test_story_budget_allocation import _record, _seed_substrate
+
+    _seed_substrate(
+        tmp_path,
+        [
+            _record(
+                run_id="demoted",
+                score=5,
+                cost=6.0,
+                review_cycle_costs=[2.00, 2.00, 2.00],
+                review_pools=[["alpha", "bravo"]] * 3,
+            ),
+        ],
+    )
+
+    ran = sb.derive_review_cycle_planning_price(
+        tmp_path, configured_ceiling_usd=17.55, composition=["alpha", "bravo"]
+    )
+    assert ran.basis == sb.BASIS_OBSERVED_COMPOSITION
+    assert ran.planned_cost_usd == round(2.00 * 1.25, 4)
+
+    # The panel that never ran has no history of its own and falls to the
+    # broader population rather than inheriting the cheaper panel's price.
+    never_ran = sb.derive_review_cycle_planning_price(
+        tmp_path, configured_ceiling_usd=17.55, composition=["alpha", "bravo", "charlie"]
+    )
+    assert never_ran.basis == sb.BASIS_OBSERVED_REVIEW_CYCLE
+    assert never_ran.composition == ("alpha", "bravo", "charlie")

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -26,6 +26,7 @@ def _record(
     score: int | None,
     cost: float | None,
     trust_status: str | None = None,
+    review_cycle_costs: list[float | None] | None = None,
 ) -> dict:
     rec: dict = {
         "run_id": run_id,
@@ -39,6 +40,14 @@ def _record(
     }
     if trust_status is not None:
         rec["trust_status"] = trust_status
+    if review_cycle_costs is not None:
+        rec["iterations"] = {
+            "review_loop": [
+                {"iteration": index + 1, "cost_usd": cycle_cost}
+                for index, cycle_cost in enumerate(review_cycle_costs)
+            ],
+            "review_cycles_total": len(review_cycle_costs),
+        }
     return rec
 
 
@@ -232,6 +241,50 @@ class TestDeriveStoryAllocation:
         assert allocation.reason.startswith("no audit substrate; ")
 
 
+class TestReviewCyclePlanningPrice:
+    def test_observed_review_cycle_price_uses_median_plus_explicit_headroom(self) -> None:
+        planning = sb.review_cycle_planning_from_samples([3.10, 3.64, 4.20], 17.55)
+
+        assert planning.basis == sb.BASIS_OBSERVED_REVIEW_CYCLE
+        assert planning.sample_count == 3
+        assert planning.median_usd == 3.64
+        assert planning.p90_usd == 4.2
+        assert planning.max_usd == 4.2
+        assert planning.planned_cost_usd == round(3.64 * 1.25, 4)
+        assert "median observed review-cycle spend $3.64 x 1.25" in planning.reason
+
+    def test_insufficient_history_falls_back_to_the_reviewer_ceiling_sum(self) -> None:
+        planning = sb.review_cycle_planning_from_samples([3.10, 3.64], 17.55)
+
+        assert planning.basis == sb.BASIS_REVIEW_CEILING_FALLBACK
+        assert planning.sample_count == 2
+        assert planning.planned_cost_usd == 17.55
+        assert "below the 3-cycle floor" in planning.reason
+
+    def test_substrate_reader_collects_per_cycle_review_costs(self, tmp_path: Path) -> None:
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(run_id="r1", score=5, cost=4.0, review_cycle_costs=[3.10, 3.64]),
+                _record(run_id="r2", score=5, cost=5.0, review_cycle_costs=[4.20]),
+                _record(
+                    run_id="r3",
+                    score=5,
+                    cost=99.0,
+                    trust_status="tainted",
+                    review_cycle_costs=[9.99],
+                ),
+            ],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(tmp_path, configured_ceiling_usd=17.55)
+
+        assert planning.basis == sb.BASIS_OBSERVED_REVIEW_CYCLE
+        assert planning.sample_count == 3
+        assert planning.excluded_for_taint == 1
+        assert planning.planned_cost_usd == round(3.64 * 1.25, 4)
+
+
 class TestScaleRoleBudgets:
     def test_shares_scale_proportionally_to_the_allocation(self) -> None:
         current = {"dev": 6.0, "preflight": 1.0, "review_pool[0]": 3.0}
@@ -327,6 +380,9 @@ class TestReviewCycleReconciliation:
             self._allocation(),
             dev_cost_estimate_usd=25.0428,
             review_cycle_cost_usd=17.55,
+            review_cycle_planning=sb.review_cycle_planning_from_samples(
+                [17.55], 17.55, min_samples=1
+            ).as_dict(),
             requested_review_max=5,
             spent_so_far_usd=0.0,
         )
@@ -344,6 +400,7 @@ class TestReviewCycleReconciliation:
         message = sb.format_reconciliation(record)
         assert "5 → 1" in message
         assert "$48.02" in message
+        assert "observed median $17.55 x 1.25 headroom" in message
 
     def test_spend_already_incurred_counts_against_the_remainder(self) -> None:
         """Preflight/plan spend is real money and is not affordable twice."""

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -27,6 +27,7 @@ def _record(
     cost: float | None,
     trust_status: str | None = None,
     review_cycle_costs: list[float | None] | None = None,
+    review_pools: list[list[str] | None] | None = None,
 ) -> dict:
     rec: dict = {
         "run_id": run_id,
@@ -48,6 +49,12 @@ def _record(
             ],
             "review_cycles_total": len(review_cycle_costs),
         }
+    if review_pools is not None:
+        rec["reviews"] = [
+            {"cycle": index + 1, "pool_models": pool}
+            for index, pool in enumerate(review_pools)
+            if pool is not None
+        ]
     return rec
 
 
@@ -253,13 +260,42 @@ class TestReviewCyclePlanningPrice:
         assert planning.planned_cost_usd == round(3.64 * 1.25, 4)
         assert "median observed review-cycle spend $3.64 x 1.25" in planning.reason
 
-    def test_insufficient_history_falls_back_to_the_reviewer_ceiling_sum(self) -> None:
+    def test_sparse_history_still_prices_from_observation_not_the_ceiling(self) -> None:
+        """One or two observations are sparse, not absent — the ceiling is for absent."""
         planning = sb.review_cycle_planning_from_samples([3.10, 3.64], 17.55)
 
-        assert planning.basis == sb.BASIS_REVIEW_CEILING_FALLBACK
+        assert planning.basis == sb.BASIS_OBSERVED_SPARSE
+        assert planning.derived is True
         assert planning.sample_count == 2
-        assert planning.planned_cost_usd == 17.55
+        # Leans on the observed maximum, not the median: a two-sample median
+        # understates the spread, and under-reserving refuses a granted cycle
+        # at dispatch.
+        assert planning.planned_cost_usd == round(3.64 * 1.25, 4)
         assert "below the 3-cycle floor" in planning.reason
+
+    def test_a_single_observation_is_enough_to_price_from(self) -> None:
+        planning = sb.review_cycle_planning_from_samples([4.00], 17.55)
+
+        assert planning.basis == sb.BASIS_OBSERVED_SPARSE
+        assert planning.sample_count == 1
+        assert planning.planned_cost_usd == 5.0
+
+    def test_sparse_price_never_exceeds_the_ceiling_sum(self) -> None:
+        """The ceiling still bounds: reserving above what the panel may spend is waste."""
+        planning = sb.review_cycle_planning_from_samples([20.00], 17.55)
+
+        assert planning.basis == sb.BASIS_OBSERVED_SPARSE
+        assert planning.planned_cost_usd == 17.55
+
+    def test_no_observation_at_all_falls_back_to_the_reviewer_ceiling_sum(self) -> None:
+        """The only circumstance a permission describes a cost: nothing observed."""
+        planning = sb.review_cycle_planning_from_samples([], 17.55)
+
+        assert planning.basis == sb.BASIS_REVIEW_CEILING_FALLBACK
+        assert planning.derived is False
+        assert planning.sample_count == 0
+        assert planning.planned_cost_usd == 17.55
+        assert "unobserved installation" in planning.reason
 
     def test_substrate_reader_collects_per_cycle_review_costs(self, tmp_path: Path) -> None:
         _seed_substrate(
@@ -283,6 +319,122 @@ class TestReviewCyclePlanningPrice:
         assert planning.sample_count == 3
         assert planning.excluded_for_taint == 1
         assert planning.planned_cost_usd == round(3.64 * 1.25, 4)
+
+
+_TRIO = ["anthropic-haiku-cli", "google-gemini-3.5-flash-api", "openai-gpt-5.5-cli"]
+_PAIR = ["google-gemini-3.5-flash-api", "openai-gpt-5.5-cli"]
+
+
+class TestReviewCyclePricingLadder:
+    """The panel that will run governs before review-at-large does."""
+
+    def test_composition_key_is_order_independent(self) -> None:
+        assert sb.composition_key(_TRIO) == sb.composition_key(list(reversed(_TRIO)))
+        assert sb.composition_key([]) is None
+        assert sb.composition_key(None) is None
+
+    def test_seated_panel_history_governs_over_the_broader_population(
+        self, tmp_path: Path
+    ) -> None:
+        """A 3-reviewer panel is not priced from a 2-reviewer population."""
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(
+                    run_id="trio",
+                    score=5,
+                    cost=9.0,
+                    review_cycle_costs=[4.00, 4.00, 4.00],
+                    review_pools=[_TRIO, _TRIO, _TRIO],
+                ),
+                _record(
+                    run_id="pair",
+                    score=5,
+                    cost=4.0,
+                    review_cycle_costs=[1.00, 1.00, 1.00, 1.00],
+                    review_pools=[_PAIR, _PAIR, _PAIR, _PAIR],
+                ),
+            ],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=17.55, composition=_TRIO
+        )
+
+        assert planning.basis == sb.BASIS_OBSERVED_COMPOSITION
+        assert planning.sample_count == 3
+        assert planning.composition == tuple(sorted(_TRIO))
+        assert planning.planned_cost_usd == round(4.00 * 1.25, 4)
+        # Pooling all seven cycles would have priced this panel at the blended
+        # median of $1.00 — under half what it actually costs.
+        assert planning.planned_cost_usd > 1.00 * 1.25
+
+    def test_panel_below_the_floor_falls_to_review_at_large_not_the_ceiling(
+        self, tmp_path: Path
+    ) -> None:
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(
+                    run_id="trio",
+                    score=5,
+                    cost=9.0,
+                    review_cycle_costs=[4.00],
+                    review_pools=[_TRIO],
+                ),
+                _record(
+                    run_id="pair",
+                    score=5,
+                    cost=4.0,
+                    review_cycle_costs=[1.00, 2.00, 3.00],
+                    review_pools=[_PAIR, _PAIR, _PAIR],
+                ),
+            ],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=17.55, composition=_TRIO
+        )
+
+        assert planning.basis == sb.BASIS_OBSERVED_REVIEW_CYCLE
+        assert planning.sample_count == 4
+        assert planning.planned_cost_usd < 17.55
+
+    def test_an_unidentifiable_panel_still_counts_toward_review_at_large(
+        self, tmp_path: Path
+    ) -> None:
+        """A cycle with no recorded panel is evidence about review, not about a panel."""
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(
+                    run_id="unlabelled",
+                    score=5,
+                    cost=9.0,
+                    review_cycle_costs=[2.00, 2.00, 2.00],
+                    review_pools=None,
+                ),
+            ],
+        )
+
+        panel = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=17.55, composition=_TRIO
+        )
+        assert panel.basis == sb.BASIS_OBSERVED_REVIEW_CYCLE
+        assert panel.sample_count == 3
+
+    def test_no_history_whatsoever_reaches_the_ceiling(self, tmp_path: Path) -> None:
+        _seed_substrate(
+            tmp_path,
+            [_record(run_id="r1", score=5, cost=4.0, review_cycle_costs=[])],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=17.55, composition=_TRIO
+        )
+
+        assert planning.basis == sb.BASIS_REVIEW_CEILING_FALLBACK
+        assert planning.planned_cost_usd == 17.55
 
 
 class TestScaleRoleBudgets:

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -423,6 +423,51 @@ class TestReviewCyclePricingLadder:
         assert panel.basis == sb.BASIS_OBSERVED_REVIEW_CYCLE
         assert panel.sample_count == 3
 
+    def test_dense_panel_history_above_the_current_ceiling_is_capped(self, tmp_path: Path) -> None:
+        """History from a pricier era cannot reserve spend this panel cannot make."""
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(
+                    run_id="trio",
+                    score=5,
+                    cost=30.0,
+                    review_cycle_costs=[9.00, 9.00, 9.00],
+                    review_pools=[_TRIO, _TRIO, _TRIO],
+                ),
+            ],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=3.00, composition=_TRIO
+        )
+
+        assert planning.basis == sb.BASIS_OBSERVED_COMPOSITION
+        assert planning.planned_cost_usd == 3.00
+
+    def test_dense_population_history_above_the_current_ceiling_is_capped(
+        self, tmp_path: Path
+    ) -> None:
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(
+                    run_id="pair",
+                    score=5,
+                    cost=30.0,
+                    review_cycle_costs=[9.00, 9.00, 9.00],
+                    review_pools=[_PAIR, _PAIR, _PAIR],
+                ),
+            ],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=3.00, composition=_TRIO
+        )
+
+        assert planning.basis == sb.BASIS_OBSERVED_REVIEW_CYCLE
+        assert planning.planned_cost_usd == 3.00
+
     def test_no_history_whatsoever_reaches_the_ceiling(self, tmp_path: Path) -> None:
         _seed_substrate(
             tmp_path,

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -655,7 +655,10 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         assert state.adaptive_review_max == record["requested_review_max"]
         assert (
             state.adaptive_limits_audit["review_cycle_planning"]["reason"]
-            == "derived from median observed review-cycle spend $3.64 x 1.25 headroom over 3 cycle(s)"
+            == (
+                "derived from median observed review-cycle spend "
+                "$3.64 x 1.25 headroom over 3 cycle(s)"
+            )
         )
 
     def test_a_sufficient_allocation_leaves_the_permitted_cycles_intact(

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -625,9 +625,7 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
             == sb.RECONCILE_UNFUNDABLE
         )
 
-    def test_seating_uses_observed_review_cycle_price_plus_headroom(
-        self, tmp_path: Path
-    ) -> None:
+    def test_seating_uses_observed_review_cycle_price_plus_headroom(self, tmp_path: Path) -> None:
         from coord_test_helpers import _make_task
 
         from theforge.coordinator.engine import _coordinator_loop
@@ -653,12 +651,8 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         assert record["review_cycle_cost_basis"] == sb.BASIS_OBSERVED_REVIEW_CYCLE
         assert record["review_cycle_cost_sample_count"] == 3
         assert state.adaptive_review_max == record["requested_review_max"]
-        assert (
-            state.adaptive_limits_audit["review_cycle_planning"]["reason"]
-            == (
-                "derived from median observed review-cycle spend "
-                "$3.64 x 1.25 headroom over 3 cycle(s)"
-            )
+        assert state.adaptive_limits_audit["review_cycle_planning"]["reason"] == (
+            "derived from median observed review-cycle spend $3.64 x 1.25 headroom over 3 cycle(s)"
         )
 
     def test_a_sufficient_allocation_leaves_the_permitted_cycles_intact(

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -61,6 +61,36 @@ def _seed_band(project_root: Path, score: int, costs: list[float]) -> None:
         conn.close()
 
 
+def _seed_review_cycle_history(project_root: Path, cycle_costs: list[float]) -> None:
+    runs = sub.runs_dir(project_root)
+    runs.mkdir(parents=True, exist_ok=True)
+    records = []
+    for index, cycle_cost in enumerate(cycle_costs):
+        rec = {
+            "run_id": f"review-cycle-{index}",
+            "task": {"slug": f"review-cycle-{index}", "name": "seed"},
+            "outcome": {"success": True, "final_phase": "DONE"},
+            "timing": {"started_at": "2026-03-01T10:00:00+00:00", "duration_seconds": 60.0},
+            "cost": {"total_usd": cycle_cost},
+            "totals": {"cost_usd": cycle_cost, "duration_s": 60.0},
+            "preflight": {"complexity": "medium", "complexity_score": 5},
+            "iterations": {
+                "review_cycles_total": 1,
+                "review_loop": [{"iteration": 1, "cost_usd": cycle_cost}],
+            },
+            "reviews": [{"cycle": 1, "verdict": "APPROVE"}],
+        }
+        (runs / f"{rec['run_id']}.json").write_text(json.dumps(rec), encoding="utf-8")
+        records.append(rec)
+    conn = sub.create_or_open(project_root)
+    try:
+        for rec in records:
+            sub.upsert_run_record(conn, rec, provenance="native")
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def _config(tmp_path: Path, budget_usd: float = 50.0):
     cfg_path = tmp_path / "forge.yaml"
     cfg_path.write_text(
@@ -556,10 +586,13 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         assert record["requested_review_max"] > 1
         assert record["reconciled_review_max"] == 1
         assert record["review_cycle_cost_usd"] == 17.55
+        assert record["review_cycle_cost_basis"] == sb.BASIS_REVIEW_CEILING_FALLBACK
         assert record["allocation_usd"] == 48.02
         # The reduction is in force before dev spends a cent, not afterwards.
         assert seen["review_max_at_dev"] == 1
         assert state.adaptive_review_max == 1
+        assert state.adaptive_review_cycle_planning["planned_cost_usd"] == 17.55
+        assert state.adaptive_review_cycle_planning["basis"] == sb.BASIS_REVIEW_CEILING_FALLBACK
         assert "review_max reduced" in state.adaptive_limits_audit["rationale"]
 
     def test_an_allocation_that_cannot_fund_one_cycle_escalates_before_dev(
@@ -590,6 +623,39 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         assert (
             state.adaptive_limits_audit["review_cycle_reconciliation"]["action"]
             == sb.RECONCILE_UNFUNDABLE
+        )
+
+    def test_seating_uses_observed_review_cycle_price_plus_headroom(
+        self, tmp_path: Path
+    ) -> None:
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        _seed_review_cycle_history(tmp_path, [3.10, 3.64, 4.20])
+        config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path, 48.02)
+
+        class _StopAtDev(Exception):
+            pass
+
+        with patch("theforge.coordinator.engine._run_dev_phase", side_effect=_StopAtDev()):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        planning = state.adaptive_review_cycle_planning
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert planning is not None
+        assert planning["basis"] == sb.BASIS_OBSERVED_REVIEW_CYCLE
+        assert planning["planned_cost_usd"] == round(3.64 * 1.25, 4)
+        assert record["review_cycle_cost_usd"] == round(3.64 * 1.25, 4)
+        assert record["review_cycle_cost_basis"] == sb.BASIS_OBSERVED_REVIEW_CYCLE
+        assert record["review_cycle_cost_sample_count"] == 3
+        assert state.adaptive_review_max == record["requested_review_max"]
+        assert (
+            state.adaptive_limits_audit["review_cycle_planning"]["reason"]
+            == "derived from median observed review-cycle spend $3.64 x 1.25 headroom over 3 cycle(s)"
         )
 
     def test_a_sufficient_allocation_leaves_the_permitted_cycles_intact(
@@ -691,3 +757,72 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         block = audit["iterations"]["adaptive_limits"]["review_cycle_reconciliation"]
         assert block["action"] == sb.RECONCILE_REDUCED
         assert block["reconciled_review_max"] == 1
+        assert (
+            audit["iterations"]["adaptive_limits"]["review_cycle_planning"]["basis"]
+            == sb.BASIS_REVIEW_CEILING_FALLBACK
+        )
+
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_dispatch_uses_the_seated_review_cycle_price_without_repricing(
+        self, mock_pool, _mock_log, tmp_path: Path
+    ) -> None:
+        from tests.test_coord_routing_recovery import APPROVE_YAML, _make_agent_result
+        from theforge.coordinator.review_pool import _run_review_pool
+        from theforge.coordinator.state import ReviewCycleMetadata
+        from theforge.task import TaskStory
+
+        config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        task = TaskStory(name="Story", story_path=tmp_path / "spec.md", slug="issue-2260")
+        task.story_path.write_text("# Story\n\nBody.\n", encoding="utf-8")
+        workspace = tmp_path / "ws"
+        workspace.mkdir(exist_ok=True)
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_YAML, profile_name=name, cost_usd=0.01)
+            for name in ("a", "b", "c")
+        ]
+
+        state = CoordinatorState(review_cycle=0, log_dir=tmp_path / "logs")
+        state.story_allocation = {
+            "allocation_usd": 5.0,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 5,
+            "median_usd": 3.0,
+            "p90_usd": 4.0,
+            "max_usd": 4.2,
+            "sample_count": 8,
+        }
+        state.adaptive_review_cycle_planning = {
+            "planned_cost_usd": round(3.64 * 1.25, 4),
+            "basis": sb.BASIS_OBSERVED_REVIEW_CYCLE,
+            "fallback_configured_usd": 17.55,
+            "sample_count": 3,
+            "median_usd": 3.64,
+            "p90_usd": 4.2,
+            "max_usd": 4.2,
+            "headroom_multiplier": 1.25,
+            "reason": "seated from observed history",
+            "excluded_for_taint": 0,
+        }
+
+        meta = ReviewCycleMetadata(pool_models=[], successful=[], failed=[], synthesized=False)
+        with patch(
+            "theforge.coordinator.review_pool._story_budget.derive_review_cycle_planning_price",
+            side_effect=AssertionError("dispatch should use the seated planning price"),
+        ):
+            _run_review_pool(
+                state,
+                config,
+                task,
+                "story",
+                workspace,
+                "branch",
+                meta,
+                notify=False,
+                enforce_budgets=True,
+            )
+
+        assert state.allocation_exhausted is None
+        assert mock_pool.called is True
+        assert sorted(meta.successful) == ["a", "b", "c"]
+        assert [float(profile.budget_usd) for profile in config.review_pool] == [5.85, 5.85, 5.85]


### PR DESCRIPTION
Closes #2260.

## The defect

Review-cycle planning priced a cycle at `sum(reviewer.budget_usd)` — an execution ceiling — at both seating (`engine.py`) and dispatch (`review_pool.py`). Ceilings bound worst-case runaway spend; story allocations are derived from observed history. Reserving the former against the latter starves stories of review cycles.

Measured on this issue's own run (`1e9815ce8eb1`):

```
review_max reduced 5 -> 1: the $48.02 allocation funds
1 review cycle(s) at $17.55 each after a $25.36 dev estimate
```

The cycle that ran cost **$4.21** — a 4.2x over-reservation. With one cycle, the first finding of any severity was terminal: review returned 2 P1s, no cycle remained to answer them, and the story escalated and died on a 10-minute operator-gate timeout.

## The fix

A three-rung pricing ladder, most specific first:

1. **The seated panel's own history**, when it has at least `min_samples` cycles of its own.
2. **Review at large**, when the panel does not.
3. **The configured ceiling**, only when nothing has ever been observed — a genuinely new installation.

Cycle costs join to the panel that ran them via the per-cycle review record (`reviews[].cycle` -> `pool_models`), which joined 63/63 on real substrate history. Every price records which rung produced it and the panel it was priced for, and the operator-facing reconciliation line names the rung.

Measured against real history, this panel prices at **$3.88** from its own 10 cycles versus the **$17.55** ceiling — `review_max` 1 -> 5 on the exact numbers that killed the run.

Pooling matters in both directions: the population median is ~$2.43, so pricing this 3-reviewer panel from review-at-large would have *under*-reserved it by ~45%, which is the dispatch-refusal failure mode.

## Findings resolved

Two P1s from the pipeline review of the original work:

- The cap was reached below a 3-sample floor, replacing one or two measured cycles with a permission. Sparse is not absent — a sparse rung now prices from the observed maximum plus headroom, leaning high because a two-sample median understates its spread and under-reserving refuses a granted cycle at dispatch.
- Panel-specific history was never consulted; every cycle was pooled regardless of which reviewers ran it.

Two further findings from manual review:

- Observed prices are now capped at the current panel's ceiling. History can carry cycles from larger or formerly pricier panels, so a median drawn from it can exceed what the current panel may spend at all. The basis still records the figure as measured.
- `meta.pool_models` is now assigned after the demotion filter. Cycle metadata was built from the configured pool before demoted reviewers were removed, so a cycle run by two reviewers could be recorded as three — attributing the smaller panel's spend to the larger one and under-reserving every later story seated on it. The dispatch funding check already used the post-demotion pool, so only the recorded history was wrong, which is the silent version of this bug.

## Verification

`make gate` at `3d31a221`, standalone: **7434 passed, 32 skipped, 0 failed**. Independently re-run by a second reviewer at the same SHA: 7428 passed, 38 skipped, 0 failed. Collection totals reconcile exactly (7466 both), the difference being six environment-gated skips.

## Trust state — please read

The last four commits were authored and reviewed **outside the coordinator loop**, at operator direction, because the defect being fixed throttled its own fix to a single review cycle.

- The two pipeline P1s are genuine coordinator-owned review output.
- The fixes for them, and the two subsequent findings, were hand-authored and manually reviewed.
- Gate evidence is standalone, **not coordinator-owned**.
- #2260's last coordinator verdict remains the `REQUEST_CHANGES` that escalated.

The audit record will show a story that failed and whose branch was then landed by hand. That is accurate and deliberate.