### PR TITLE
Request construction is unsafe for models the code predates: optional sampling controls are added per call site and gated on name patterns

### DIFF
--- a/src/theforge/runners/adapters/anthropic.py
+++ b/src/theforge/runners/adapters/anthropic.py
@@ -12,6 +12,7 @@ from theforge.runners.schema_utils import (
     ProviderAdapter,
     ToolCallRequest,
     _estimate_cost,
+    sampling_control_kwargs,
 )
 
 if TYPE_CHECKING:
@@ -37,7 +38,6 @@ def _run_anthropic(
         response = client.messages.create(
             model=profile.model,
             max_tokens=4096,
-            temperature=0,
             messages=[{"role": "user", "content": prompt}],
             tools=[
                 {
@@ -47,6 +47,7 @@ def _run_anthropic(
                 }
             ],
             tool_choice={"type": "tool", "name": "review_output"},
+            **sampling_control_kwargs(),
         )
 
         output_text = ""
@@ -155,8 +156,8 @@ def _make_anthropic_adapter(
         kwargs: dict[str, Any] = {
             "model": profile.model,
             "max_tokens": 8192,
-            "temperature": 0,
             "messages": anth_messages,
+            **sampling_control_kwargs(),
         }
         if tools:
             kwargs["tools"] = tools

--- a/src/theforge/runners/adapters/google.py
+++ b/src/theforge/runners/adapters/google.py
@@ -16,6 +16,7 @@ from theforge.runners.schema_utils import (
     _estimate_cost,
     _sanitize_schema_for_google,
     forced_output_contract,
+    sampling_control_kwargs,
 )
 
 if TYPE_CHECKING:
@@ -78,8 +79,12 @@ def _make_google_generate_config(
     profile: "ModelProfile",
     **kwargs: Any,
 ) -> Any:
-    """Build GenerateContentConfig with optional ThinkingConfig."""
-    config_kwargs = dict(kwargs)
+    """Build GenerateContentConfig with optional ThinkingConfig.
+
+    Every Google request builds its config here, so optional sampling controls
+    are decided once — see :func:`sampling_control_kwargs`.
+    """
+    config_kwargs: dict[str, Any] = {**sampling_control_kwargs(), **kwargs}
     if profile.thinking_budget is not None:
         config_kwargs["thinking_config"] = genai_types.ThinkingConfig(
             thinking_budget=profile.thinking_budget
@@ -168,7 +173,7 @@ def _run_google(
 
     try:
         if plain_text:
-            config = _make_google_generate_config(genai_types, profile, temperature=0)
+            config = _make_google_generate_config(genai_types, profile)
         else:
             schema = _sanitize_schema_for_google(review_json_schema())
             config = _make_google_generate_config(
@@ -176,7 +181,6 @@ def _run_google(
                 profile,
                 response_mime_type="application/json",
                 response_schema=schema,
-                temperature=0,
             )
 
         response = client.models.generate_content(
@@ -380,7 +384,6 @@ def _make_google_adapter(
         config = _make_google_generate_config(
             genai_types,
             profile,
-            temperature=0,
             response_mime_type="application/json",
             response_schema=_finalize_schema,
         )
@@ -419,7 +422,6 @@ def _make_google_adapter(
         config = _make_google_generate_config(
             genai_types,
             profile,
-            temperature=0,
             tools=google_tools,
         )
         response = client.models.generate_content(

--- a/src/theforge/runners/adapters/openai.py
+++ b/src/theforge/runners/adapters/openai.py
@@ -12,7 +12,7 @@ from theforge.runners.schema_utils import (
     ProviderAdapter,
     ToolCallRequest,
     _estimate_cost,
-    _is_reasoning_model,
+    sampling_control_kwargs,
     uses_openai_responses_api,
 )
 
@@ -105,9 +105,8 @@ def _run_openai_chat(
             "model": profile.model,
             "messages": [{"role": "user", "content": prompt}],
             "response_format": response_format,
+            **sampling_control_kwargs(),
         }
-        if not _is_reasoning_model(profile.model):
-            create_kwargs["temperature"] = 0
         response = client.chat.completions.create(**create_kwargs)
         output_text = response.choices[0].message.content or ""
         usage = response.usage
@@ -242,9 +241,8 @@ def _make_openai_chat_adapter(
         kwargs: dict[str, Any] = {
             "model": profile.model,
             "messages": oai_messages,
+            **sampling_control_kwargs(),
         }
-        if not _is_reasoning_model(profile.model):
-            kwargs["temperature"] = 0
         if tools:
             kwargs["tools"] = tools
         if response_format is not None:

--- a/src/theforge/runners/finalizers.py
+++ b/src/theforge/runners/finalizers.py
@@ -11,9 +11,9 @@ from theforge.runners.schema_utils import (
     Finalizer,
     LoopTurn,
     _build_submit_tools_anthropic,
-    _is_reasoning_model,
     _sanitize_schema_for_google,
     forced_output_contract,
+    sampling_control_kwargs,
 )
 
 if TYPE_CHECKING:
@@ -50,9 +50,8 @@ def _make_openai_chat_finalizer(
                 "type": "json_schema",
                 "json_schema": {"name": schema_name, "schema": schema, "strict": True},
             },
+            **sampling_control_kwargs(),
         }
-        if not _is_reasoning_model(profile.model):
-            kwargs["temperature"] = 0
 
         response = client.chat.completions.create(**kwargs)
         output_text = response.choices[0].message.content or ""
@@ -108,9 +107,8 @@ def _make_deepseek_finalizer(
             "model": profile.model,
             "messages": oai_messages,
             "response_format": {"type": "json_object"},
+            **sampling_control_kwargs(),
         }
-        if not _is_reasoning_model(profile.model):
-            kwargs["temperature"] = 0
 
         response = client.chat.completions.create(**kwargs)
         output_text = response.choices[0].message.content or ""
@@ -217,9 +215,9 @@ def _make_anthropic_finalizer(
         response = client.messages.create(
             model=profile.model,
             max_tokens=8192,
-            temperature=0,
             messages=anth_messages,
             tools=[submit_tool],
+            **sampling_control_kwargs(),
             tool_choice={"type": "tool", "name": contract.submit_tool},
         )
 
@@ -278,7 +276,6 @@ def _make_google_finalizer(
         config = _make_google_generate_config(
             genai_types,
             profile,
-            temperature=0,
             response_mime_type="application/json",
             response_schema=finalize_schema,
         )

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -108,16 +107,21 @@ def uses_openai_responses_api(model: str) -> bool:
     return model in _RESPONSES_ONLY_MODELS
 
 
-# OpenAI reasoning models that do not support temperature=0.
-# These models only accept temperature=1 (the default).
-_REASONING_MODEL_RE = re.compile(r"^o\d")
+def sampling_control_kwargs() -> dict[str, Any]:
+    """Optional sampling controls to merge into any provider request.
 
+    Empty by design, and deliberately provider- and model-agnostic: no runner
+    behaviour depends on a fixed ``temperature``, and providers increasingly
+    reject the value outright for current models. Deciding this per call site —
+    or from the shape of a model's name — encodes the set of models known when
+    the code was written and misclassifies everything released afterwards, so
+    every request builder in this subsystem routes through here instead.
 
-def _is_reasoning_model(model: str) -> bool:
-    """Return True for reasoning models that do not support temperature=0."""
-    return bool(_REASONING_MODEL_RE.match(model)) or model.startswith(
-        ("deepseek-r1", "deepseek-reasoner")
-    )
+    Re-introducing a control requires two things, neither of which is a model
+    name: a runner behaviour that demonstrably depends on it, and evidence the
+    selected provider accepts it for the selected model.
+    """
+    return {}
 
 
 # Submit tool names — loop-internal, not in TOOL_REGISTRY

--- a/tests/test_runner_api_providers.py
+++ b/tests/test_runner_api_providers.py
@@ -18,7 +18,6 @@ from theforge.runners.api import (
 from theforge.runners.schema_utils import (
     LoopTurn,
     ToolCallRequest,
-    _is_reasoning_model,
 )
 from theforge.runners.tool_runtime import TOOL_REGISTRY
 
@@ -469,18 +468,6 @@ class TestDeepSeekProvider:
             base_url=base_url,
         )
 
-    # ── _is_reasoning_model ──────────────────────────────────────────
-
-    def test_is_reasoning_model_deepseek_r1(self):
-        assert _is_reasoning_model("deepseek-r1") is True
-
-    def test_is_reasoning_model_deepseek_r1_prefix_variants(self):
-        assert _is_reasoning_model("deepseek-r1-zero") is True
-        assert _is_reasoning_model("deepseek-r1-distill-qwen-7b") is True
-
-    def test_is_reasoning_model_deepseek_v3_is_false(self):
-        assert _is_reasoning_model("deepseek-v3") is False
-
     # ── _deepseek_client base_url ─────────────────────────────────────
 
     def _patch_openai(self):
@@ -556,8 +543,8 @@ class TestDeepSeekProvider:
         mock_client.chat.completions.create.assert_called_once()
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs["model"] == "deepseek-v3"
-        # deepseek-v3 is not a reasoning model — temperature should be set
-        assert call_kwargs.get("temperature") == 0
+        # Optional sampling controls are never sent — see sampling_control_kwargs
+        assert "temperature" not in call_kwargs
 
     def test_run_deepseek_r1_skips_temperature(self, tmp_path):
         profile = self._make_deepseek_profile(model="deepseek-r1")

--- a/tests/test_runner_sampling_controls.py
+++ b/tests/test_runner_sampling_controls.py
@@ -1,0 +1,358 @@
+"""Request construction must be safe for models the code predates.
+
+Optional sampling controls (``temperature``) used to be decided at each request
+construction site, either unguarded or from the shape of the model's *name*. A
+name is not a capability, so any model released after the guard was written was
+misclassified and every request to it failed with HTTP 400. These tests pin the
+single shared decision — :func:`sampling_control_kwargs` — and assert that no
+request builder in the runners subsystem reintroduces the parameter, including
+for model names that did not exist when this test was written.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from theforge.config import ModelProfile
+from theforge.runners.schema_utils import sampling_control_kwargs
+
+# Names deliberately chosen to span "known at authoring time" and "not yet
+# released": the policy must be identical for all of them.
+FUTURE_AND_CURRENT_MODELS = ["gpt-4o", "o3-mini", "gpt-5.6-sol", "gpt-5.6-terra"]
+
+REVIEW_JSON = json.dumps(
+    {
+        "verdict": "APPROVE",
+        "summary": "ok",
+        "findings": [],
+        "story_compliance": {"matches_spec": True, "mismatches": []},
+        "test_coverage": {"adequate": True, "gaps": []},
+    }
+)
+
+
+def _profile(
+    provider: str = "openai",
+    model: str = "gpt-5.6-sol",
+    phase: str | None = "review",
+    thinking_budget: int | None = None,
+) -> ModelProfile:
+    return ModelProfile(
+        name="test-reviewer",
+        provider=provider,
+        cli=None,
+        model=model,
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=(),
+        phase=phase,
+        thinking_budget=thinking_budget,
+    )
+
+
+def _openai_chat_client() -> MagicMock:
+    client = MagicMock()
+    response = MagicMock()
+    response.choices[0].message.content = REVIEW_JSON
+    response.choices[0].message.tool_calls = None
+    response.usage.prompt_tokens = 10
+    response.usage.completion_tokens = 5
+    response.model_dump.return_value = {}
+    client.chat.completions.create.return_value = response
+    return client
+
+
+class TestSamplingControlPolicy:
+    """The shared decision point sends no optional sampling controls."""
+
+    def test_no_sampling_controls_are_sent(self):
+        assert sampling_control_kwargs() == {}
+
+    def test_decision_takes_no_model_input(self):
+        """A policy that cannot see a model name cannot go stale against one."""
+        import inspect
+
+        assert inspect.signature(sampling_control_kwargs).parameters == {}
+
+
+class TestOpenAICompatibleRequests:
+    """Chat Completions single-shot, loop adapter, and finalizers."""
+
+    @pytest.mark.parametrize("model", FUTURE_AND_CURRENT_MODELS)
+    def test_single_shot_omits_temperature(self, model):
+        from theforge.runners.adapters.openai import _run_openai_chat
+
+        client = _openai_chat_client()
+        result = _run_openai_chat("review this", _profile(model=model), client=client)
+
+        assert result.success
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["response_format"]["type"] == "json_schema"
+
+    @pytest.mark.parametrize("model", FUTURE_AND_CURRENT_MODELS)
+    def test_loop_adapter_omits_temperature_and_keeps_tools(self, model):
+        from theforge.runners.adapters.openai import _make_openai_chat_adapter
+
+        client = _openai_chat_client()
+        adapter = _make_openai_chat_adapter(_profile(model=model), None, client=client)
+        adapter([{"role": "user", "content": "go"}], [{"type": "function", "name": "read_file"}])
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["tools"] == [{"type": "function", "name": "read_file"}]
+
+    @pytest.mark.parametrize("model", FUTURE_AND_CURRENT_MODELS)
+    def test_chat_finalizer_omits_temperature_and_keeps_schema(self, model):
+        from theforge.runners.finalizers import _make_openai_chat_finalizer
+
+        client = _openai_chat_client()
+        finalizer = _make_openai_chat_finalizer(_profile(model=model), None, client=client)
+        finalizer([{"role": "user", "content": "go"}])
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["response_format"]["json_schema"]["name"] == "review_output"
+
+    @pytest.mark.parametrize("model", ["deepseek-v3", "deepseek-r1", "deepseek-next"])
+    def test_deepseek_finalizer_omits_temperature_and_keeps_json_mode(self, model):
+        from theforge.runners.finalizers import _make_deepseek_finalizer
+
+        client = _openai_chat_client()
+        finalizer = _make_deepseek_finalizer(
+            _profile(provider="deepseek", model=model), None, client=client
+        )
+        finalizer([{"role": "user", "content": "go"}])
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["response_format"] == {"type": "json_object"}
+
+    @pytest.mark.parametrize("model", ["deepseek-v3", "deepseek-next"])
+    def test_deepseek_loop_adapter_omits_temperature(self, model):
+        from theforge.runners.adapters.deepseek import _make_deepseek_adapter
+
+        client = _openai_chat_client()
+        with patch("theforge.runners.adapters.deepseek._deepseek_client", return_value=client):
+            adapter = _make_deepseek_adapter(_profile(provider="deepseek", model=model), None)
+        adapter([{"role": "user", "content": "go"}], [])
+
+        assert "temperature" not in client.chat.completions.create.call_args.kwargs
+
+
+def _anthropic_modules(client: MagicMock) -> dict:
+    mock_anthropic = MagicMock()
+    mock_anthropic.Anthropic.return_value = client
+    return {"anthropic": mock_anthropic}
+
+
+def _anthropic_tool_response(tool_name: str) -> MagicMock:
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = tool_name
+    block.input = json.loads(REVIEW_JSON)
+    response = MagicMock()
+    response.content = [block]
+    response.usage.input_tokens = 10
+    response.usage.output_tokens = 5
+    response.model_dump.return_value = {}
+    return response
+
+
+class TestAnthropicRequests:
+    """Single-shot, agent-loop turns, and the forced-output finalizer."""
+
+    @pytest.mark.parametrize("model", ["claude-sonnet-4-6", "claude-future-9"])
+    def test_single_shot_omits_temperature_and_keeps_tool_choice(self, model):
+        client = MagicMock()
+        client.messages.create.return_value = _anthropic_tool_response("review_output")
+
+        with patch.dict(sys.modules, _anthropic_modules(client)):
+            from theforge.runners.adapters.anthropic import _run_anthropic
+
+            result = _run_anthropic("review this", _profile(provider="anthropic", model=model))
+
+        assert result.success, result.output
+        kwargs = client.messages.create.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["max_tokens"] == 4096
+        assert kwargs["tool_choice"] == {"type": "tool", "name": "review_output"}
+
+    @pytest.mark.parametrize("model", ["claude-sonnet-4-6", "claude-future-9"])
+    def test_loop_adapter_omits_temperature_and_keeps_tools(self, model):
+        client = MagicMock()
+        response = MagicMock()
+        response.content = []
+        response.usage.input_tokens = 10
+        response.usage.output_tokens = 5
+        client.messages.create.return_value = response
+        tools = [{"name": "read_file", "input_schema": {"type": "object"}}]
+
+        with patch.dict(sys.modules, _anthropic_modules(client)):
+            from theforge.runners.adapters.anthropic import _make_anthropic_adapter
+
+            adapter = _make_anthropic_adapter(_profile(provider="anthropic", model=model), None)
+            adapter([{"role": "user", "content": "go"}], tools)
+
+        kwargs = client.messages.create.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["max_tokens"] == 8192
+        assert kwargs["tools"] == tools
+        assert "tool_choice" not in kwargs
+
+    def test_finalizer_omits_temperature_and_keeps_forced_tool(self):
+        client = MagicMock()
+        client.messages.create.return_value = _anthropic_tool_response("submit_review")
+
+        with patch.dict(sys.modules, _anthropic_modules(client)):
+            from theforge.runners.finalizers import _make_anthropic_finalizer
+
+            finalizer = _make_anthropic_finalizer(
+                _profile(provider="anthropic", model="claude-future-9"), None
+            )
+            finalizer([{"role": "user", "content": "go"}])
+
+        kwargs = client.messages.create.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["max_tokens"] == 8192
+        assert kwargs["tool_choice"] == {"type": "tool", "name": "submit_review"}
+
+
+def _google_modules(client: MagicMock) -> dict:
+    genai_types = MagicMock()
+    genai = MagicMock()
+    genai.Client.return_value = client
+    genai.types = genai_types
+    google = MagicMock()
+    google.genai = genai
+    return {"google": google, "google.genai": genai, "google.genai.types": genai_types}
+
+
+def _google_json_response(text: str) -> MagicMock:
+    response = MagicMock()
+    response.text = text
+    response.usage_metadata = None
+    response.candidates = []
+    response.prompt_feedback = None
+    return response
+
+
+def _google_prose_response() -> MagicMock:
+    """A Gemini turn that returned prose instead of a submit tool call."""
+    part = MagicMock()
+    part.text = "I reviewed it and it looks fine."
+    part.function_call = None
+    candidate = MagicMock()
+    candidate.finish_reason = "STOP"
+    candidate.content = MagicMock()
+    candidate.content.parts = [part]
+    response = MagicMock()
+    response.candidates = [candidate]
+    response.usage_metadata = None
+    response.prompt_feedback = None
+    return response
+
+
+def _all_config_kwargs(modules: dict) -> list[dict]:
+    return [c.kwargs for c in modules["google.genai.types"].GenerateContentConfig.call_args_list]
+
+
+class TestGoogleRequests:
+    """Every GenerateContentConfig this subsystem builds."""
+
+    @pytest.mark.parametrize("plain_text", [True, False])
+    def test_single_shot_omits_temperature(self, plain_text):
+        client = MagicMock()
+        client.models.generate_content.return_value = _google_json_response(REVIEW_JSON)
+        modules = _google_modules(client)
+
+        with patch.dict(sys.modules, modules):
+            from theforge.runners.adapters.google import _run_google
+
+            result = _run_google(
+                "review this",
+                _profile(provider="google", model="gemini-future-1"),
+                plain_text=plain_text,
+            )
+
+        assert result.success, result.output
+        configs = _all_config_kwargs(modules)
+        assert configs and all("temperature" not in c for c in configs)
+        if not plain_text:
+            assert configs[-1]["response_mime_type"] == "application/json"
+            assert "response_schema" in configs[-1]
+
+    def test_loop_adapter_omits_temperature_and_keeps_thinking_config(self):
+        client = MagicMock()
+        client.models.generate_content.return_value = _google_json_response(REVIEW_JSON)
+        modules = _google_modules(client)
+
+        with patch.dict(sys.modules, modules):
+            from theforge.runners.adapters.google import _make_google_adapter
+
+            profile = _profile(
+                provider="google", model="gemini-future-1", phase="dev", thinking_budget=1024
+            )
+            adapter = _make_google_adapter(profile, None)
+            adapter([{"role": "user", "content": "go"}], [])
+
+        configs = _all_config_kwargs(modules)
+        assert configs and all("temperature" not in c for c in configs)
+        assert "thinking_config" in configs[-1]
+
+    def test_mid_loop_finalization_omits_temperature_and_keeps_schema(self):
+        client = MagicMock()
+        client.models.generate_content.side_effect = [
+            _google_prose_response(),
+            _google_json_response(REVIEW_JSON),
+        ]
+        modules = _google_modules(client)
+
+        with patch.dict(sys.modules, modules):
+            from theforge.runners.adapters.google import _make_google_adapter
+
+            adapter = _make_google_adapter(
+                _profile(provider="google", model="gemini-future-1"), None
+            )
+            adapter([{"role": "user", "content": "go"}], [])
+
+        assert client.models.generate_content.call_count == 2
+        configs = _all_config_kwargs(modules)
+        assert all("temperature" not in c for c in configs)
+        assert "response_schema" in configs[-1]
+
+    def test_timeout_finalizer_omits_temperature_and_keeps_schema(self):
+        client = MagicMock()
+        client.models.generate_content.return_value = _google_json_response(REVIEW_JSON)
+        modules = _google_modules(client)
+
+        with patch.dict(sys.modules, modules):
+            from theforge.runners.finalizers import _make_google_finalizer
+
+            finalizer = _make_google_finalizer(
+                _profile(provider="google", model="gemini-future-1"), None
+            )
+            finalizer([{"role": "user", "content": "go"}])
+
+        configs = _all_config_kwargs(modules)
+        assert configs and all("temperature" not in c for c in configs)
+        assert configs[-1]["response_mime_type"] == "application/json"
+        assert "response_schema" in configs[-1]
+
+    def test_explicit_config_kwargs_still_win(self):
+        """The shared policy merges under caller kwargs, never over them."""
+        modules = _google_modules(MagicMock())
+        with patch.dict(sys.modules, modules):
+            from theforge.runners.adapters.google import _make_google_generate_config
+
+            _make_google_generate_config(
+                modules["google.genai.types"],
+                _profile(provider="google", model="gemini-future-1"),
+                response_mime_type="application/json",
+            )
+
+        assert _all_config_kwargs(modules)[-1] == {"response_mime_type": "application/json"}


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change removes temperature from runner request construction through a shared no-op policy and covers the observed future-model failure paths with targeted tests. | [google-gemini-3.5-flash-api] Successfully replaced name-based sampling control guards with a centralized, model-agnostic policy function that omits optional sampling controls across all request construction sites. | [anthropic-haiku-cli] Fix correctly centralizes sampling-control policy to a single decision point, eliminates name-pattern staleness, and validates safety across future model names.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $4.02
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Request construction is unsafe for models the code predates: optional sampling controls are added per call site and gated on name patterns (GitHub Issue #2222)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2222