### PR TITLE
A story held on a collision gate displays as stalled, so a deliberate wait is indistinguishable from a hang

### DIFF
--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -25,6 +25,7 @@ from theforge.cli.status_run_helpers import live_sprint_run_ids as _live_sprint_
 
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 STALL_CHAR = "·"
+GATE_CHAR = "⏸"
 DONE_CHAR = "✓"
 FAIL_CHAR = "✗"
 WAIT_CHAR = " "
@@ -213,7 +214,7 @@ def render_frame(
     per-slug cost so the next frame can compute deltas.
     """
     from theforge.cli.sprint_status import _format_story_cell, display_sprint_status
-    from theforge.sprint.status_reader import read_live_status
+    from theforge.sprint.status_reader import COLLISION_GATE_STAGE, read_live_status
 
     # Persist the GitHub title cache across frames so titles fetched on frame 1
     # are reused on every subsequent frame (zero re-fetch).
@@ -278,7 +279,14 @@ def render_frame(
             stalled = age > stall_threshold
 
         status = getattr(e, "status", "waiting")
-        if status == "running":
+        # A story held at its plan gate is waiting by design and emits no
+        # events, so its age crossing the stall threshold means nothing. Report
+        # the wait, not a warning the operator cannot act on (#2235).
+        gated = status == "running" and getattr(e, "stage", "") == COLLISION_GATE_STAGE
+        if gated:
+            label = f"{GATE_CHAR} gated"
+            act = _c(label, DIM, color)
+        elif status == "running":
             if stalled:
                 label = f"{STALL_CHAR} stalled"
                 act = _c(label, DIM, color)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1737,6 +1737,50 @@ CLAIM_PRESERVED = "preserved for operator decision"
 _QUEUED_CLAIM_PROBE_SECONDS = 30.0
 
 
+#: Live-state detail keys describing why a story's plan gate is being held.
+#: Written while the hold is in force and cleared when it ends, so the status
+#: view can tell a deliberate wait from a story that stopped moving (#2235).
+GATE_HOLD_BLOCKERS_KEY = "collision_gate_blockers"
+GATE_HOLD_FILES_KEY = "collision_gate_files"
+GATE_HOLD_CLAIMS_KEY = "collision_gate_claims"
+GATE_HOLD_DETAIL_KEYS = (
+    GATE_HOLD_BLOCKERS_KEY,
+    GATE_HOLD_FILES_KEY,
+    GATE_HOLD_CLAIMS_KEY,
+)
+
+
+def _make_gate_hold_publisher(
+    state_writer: "SprintStateWriter | None",
+) -> "Callable[[str, dict | None], None]":
+    """Return a ``gate_hold_fn`` that writes gate holds into the live state file.
+
+    Gate servicing runs on a 2s tick; only *changes* are written, so a hold that
+    lasts twenty minutes costs one state write, not six hundred. Updates go
+    through ``detail_updates``, which merges — writing ``detail`` would replace
+    the dict wholesale and erase co-resident keys such as the reviewer event
+    timestamp the EVENT AGE column reads (#2235).
+    """
+    published: dict[str, dict] = {}
+
+    def _publish(slug: str, payload: dict | None) -> None:
+        if state_writer is None:
+            return
+        if payload is None:
+            # Only clear a hold this publisher actually wrote: every opened gate
+            # calls through here, and most were never held.
+            if published.pop(slug, None) is None:
+                return
+            state_writer.update(slug, detail_updates=dict.fromkeys(GATE_HOLD_DETAIL_KEYS, None))
+            return
+        if published.get(slug) == payload:
+            return
+        published[slug] = payload
+        state_writer.update(slug, phase="PLAN_DONE", detail_updates=dict(payload))
+
+    return _publish
+
+
 def _release_plan_gates(
     plan_done: dict[str, str],
     file_footprints: dict[str, set[str]],
@@ -1744,11 +1788,19 @@ def _release_plan_gates(
     active: dict[str, object],
     phase_lock: threading.Lock,
     collision_claims: "dict[str, str] | None" = None,
+    gate_hold_fn: "Callable[[str, dict | None], None] | None" = None,
 ) -> list[str]:
     """Check newly-planned stories and release their gates if no file overlap.
 
     Called from the scheduling loop — both the poll interval and after a future
     completes — to avoid deadlock when gated workers block in _run_fresh.
+
+    *gate_hold_fn* publishes the reason a gate is being held into the story's
+    live state — ``fn(slug, payload)`` while the hold is in force, ``fn(slug,
+    None)`` once it ends. A gated worker emits no events of its own, so without
+    this the wait is indistinguishable from a hang in the status view (#2235).
+    It must never be called while *phase_lock* is held: the publisher writes
+    through the worker state path, which takes that same non-reentrant lock.
 
     *collision_claims* maps slug -> claim reason for stories that are past their
     plan gate. A claim, not worker liveness, is what holds a file: a story that
@@ -1780,6 +1832,24 @@ def _release_plan_gates(
                 held[other_slug] = shared
         return held
 
+    def _publish_hold(slug: str, blockers: "dict[str, set[str]] | None") -> None:
+        """Record (or clear) why *slug*'s gate is held, for the status view."""
+        if gate_hold_fn is None:
+            return
+        if not blockers:
+            gate_hold_fn(slug, None)
+            return
+        gate_hold_fn(
+            slug,
+            {
+                GATE_HOLD_BLOCKERS_KEY: sorted(blockers),
+                GATE_HOLD_FILES_KEY: sorted(set().union(*blockers.values())),
+                GATE_HOLD_CLAIMS_KEY: {
+                    blocker: claims.get(blocker, CLAIM_IN_DEV) for blocker in sorted(blockers)
+                },
+            },
+        )
+
     with phase_lock:
         pd_snapshot = dict(plan_done)
 
@@ -1798,11 +1868,13 @@ def _release_plan_gates(
                     f"WARNING: {pd_slug} overlaps with active stories on: "
                     f"{', '.join(sorted(overlap))}"
                 )
+                _publish_hold(pd_slug, blockers)
             else:
                 gate = plan_gates.pop(pd_slug, None)
                 if gate is not None:
                     gate.set()
                 claims[pd_slug] = CLAIM_IN_DEV
+                _publish_hold(pd_slug, None)
 
     # Re-check deferred gates (conflicting story may have finished)
     stood_down: list[str] = []
@@ -1814,6 +1886,7 @@ def _release_plan_gates(
             gate.set()
             del plan_gates[deferred_slug]
             claims[deferred_slug] = CLAIM_IN_DEV
+            _publish_hold(deferred_slug, None)
             continue
         # Every blocker is preserved, undecided work that no longer has a
         # worker or a landing path in this run: the gate cannot open here.
@@ -1830,7 +1903,10 @@ def _release_plan_gates(
                 f"work from {', '.join(sorted(blockers))} on {', '.join(overlap)} — "
                 "the collision gate cannot open in this run"
             )
+            _publish_hold(deferred_slug, None)
             stood_down.append(deferred_slug)
+            continue
+        _publish_hold(deferred_slug, blockers)
     return stood_down
 
 
@@ -5475,6 +5551,8 @@ def run_sprint(
         _log(f"✗ {slug}: queued PR {poll_result['status']} ({context})")
         return "failed"
 
+    _publish_gate_hold = _make_gate_hold_publisher(_state_writer)
+
     def _service_plan_gates() -> None:
         """Release openable plan gates and stand down the unopenable ones."""
         # A CLAIM_PENDING_LANDING claim is resolvable *in this run*, but only
@@ -5500,7 +5578,13 @@ def run_sprint(
                 _resolve_queued_pr(_q_slug, blocking=False, context="holding a collision gate")
 
         for _sd_slug in _release_plan_gates(
-            plan_done, file_footprints, plan_gates, active, phase_lock, collision_claims
+            plan_done,
+            file_footprints,
+            plan_gates,
+            active,
+            phase_lock,
+            collision_claims,
+            gate_hold_fn=_publish_gate_hold,
         ):
             _sd_gate = plan_gates.pop(_sd_slug, None)
             gate_stood_down[_sd_slug] = (

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1760,6 +1760,12 @@ def _make_gate_hold_publisher(
     through ``detail_updates``, which merges — writing ``detail`` would replace
     the dict wholesale and erase co-resident keys such as the reviewer event
     timestamp the EVENT AGE column reads (#2235).
+
+    This writes straight to ``SprintStateWriter``, which serializes on its own
+    lock. It deliberately does *not* route through ``_make_worker_phase_fn``:
+    that path takes the scheduler's ``phase_lock``, and a publisher that did so
+    would couple every gate-service tick to the worker-state lock. See
+    ``_release_plan_gates`` for the ordering rule that keeps this true.
     """
     published: dict[str, dict] = {}
 
@@ -1799,8 +1805,15 @@ def _release_plan_gates(
     live state — ``fn(slug, payload)`` while the hold is in force, ``fn(slug,
     None)`` once it ends. A gated worker emits no events of its own, so without
     this the wait is indistinguishable from a hang in the status view (#2235).
-    It must never be called while *phase_lock* is held: the publisher writes
-    through the worker state path, which takes that same non-reentrant lock.
+
+    Ordering rule: *gate_hold_fn* is never invoked while *phase_lock* is held.
+    This function takes *phase_lock* only around the ``plan_done`` snapshot; all
+    publish calls sit outside it. ``phase_lock`` is a plain non-reentrant
+    ``Lock``, and the worker state path (``_make_worker_phase_fn``) takes it to
+    write live state — so a publisher wired through that path, or a publish call
+    moved under the snapshot's ``with`` block, would deadlock the scheduler.
+    ``test_publisher_may_take_phase_lock_without_deadlocking`` enforces this
+    mechanically rather than leaving it to this comment.
 
     *collision_claims* maps slug -> claim reason for stories that are past their
     plan gate. A claim, not worker liveness, is what holds a file: a story that

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -497,6 +497,38 @@ def _render_intake_drop_detail(final_outcome: str, detail_data: dict) -> str:
     return " ".join(parts)
 
 
+#: Stage reported for a story the scheduler is deliberately holding at its plan
+#: gate because its planned files overlap another story's. A held story emits no
+#: events, so without this the wait reads as a stall (#2235).
+COLLISION_GATE_STAGE = "collision gate"
+
+#: How many overlapping paths to name before summarising the rest.
+_GATE_FILE_PREVIEW = 3
+
+
+def _collision_gate_detail(detail_data: dict) -> str | None:
+    """Describe a held collision gate, or None when no hold is recorded."""
+    blockers = detail_data.get("collision_gate_blockers")
+    if not isinstance(blockers, list):
+        return None
+    blocker_names = [b for b in blockers if isinstance(b, str) and b]
+    if not blocker_names:
+        return None
+
+    files = detail_data.get("collision_gate_files")
+    paths = [f for f in files if isinstance(f, str) and f] if isinstance(files, list) else []
+
+    text = f"held behind {', '.join(blocker_names)}"
+    if paths:
+        shown = [Path(p).name for p in paths[:_GATE_FILE_PREVIEW]]
+        remaining = len(paths) - len(shown)
+        files_str = ", ".join(shown)
+        if remaining > 0:
+            files_str += f" +{remaining} more"
+        text += f" on {files_str}"
+    return text
+
+
 def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None]:
     phase_val = story.get("phase")
     status_val = story.get("status", "waiting")
@@ -566,6 +598,13 @@ def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None
         if status_val == "failed" and phase_val:
             return "", phase_val, complexity
         return "", "—", complexity
+
+    if phase_val == "PLAN_DONE":
+        # The scheduler chose this wait and recorded why. Say so, rather than
+        # letting the story age out as generic inactivity (#2235).
+        gate_detail = _collision_gate_detail(detail_data)
+        if gate_detail:
+            return COLLISION_GATE_STAGE, gate_detail, complexity
 
     if phase_val == "PLAN":
         current = detail_data.get("plan_attempt")

--- a/tests/test_sprint_collision_gate_visibility.py
+++ b/tests/test_sprint_collision_gate_visibility.py
@@ -1,0 +1,285 @@
+"""A held collision gate reads as a deliberate wait, not as a stall (issue #2235).
+
+The scheduler already knew which story blocked the gate and on which files —
+that reason only ever reached the run log, so the status view aged the gated
+story out as ``stalled`` with a "has not moved in a while" hint. These tests
+cover the whole seam: the scheduler publishing the hold into live state, the
+status reader turning it into a ``collision gate`` stage, and watch mode
+rendering it as gated rather than stalled.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from theforge.cli import status_watch
+from theforge.sprint.runner import (
+    CLAIM_IN_DEV,
+    CLAIM_PRESERVED,
+    GATE_HOLD_DETAIL_KEYS,
+    _make_gate_hold_publisher,
+    _release_plan_gates,
+)
+from theforge.sprint.state_writer import SprintStateWriter
+from theforge.sprint.status_reader import COLLISION_GATE_STAGE, read_live_status
+
+
+def _record_holds() -> tuple[list[tuple[str, dict | None]], object]:
+    calls: list[tuple[str, dict | None]] = []
+
+    def _fn(slug: str, payload: dict | None) -> None:
+        calls.append((slug, payload))
+
+    return calls, _fn
+
+
+class TestSchedulerPublishesGateHold:
+    def test_newly_detected_overlap_publishes_blockers_and_files(self) -> None:
+        calls, fn = _record_holds()
+        plan_done = {"story-b": "/tmp/ws-b"}
+        file_footprints: dict[str, set[str]] = {"story-a": {"src/shared.py", "src/only-a.py"}}
+        gate_b = threading.Event()
+        plan_gates = {"story-b": gate_b}
+        active: dict[str, object] = {"story-a": MagicMock(), "story-b": MagicMock()}
+
+        with patch(
+            "theforge.sprint.runner._extract_plan_footprint",
+            return_value={"src/shared.py"},
+        ):
+            _release_plan_gates(
+                plan_done,
+                file_footprints,
+                plan_gates,
+                active,
+                threading.Lock(),
+                {"story-a": CLAIM_IN_DEV},
+                gate_hold_fn=fn,
+            )
+
+        assert not gate_b.is_set()
+        # The detection pass and the deferred re-check both report the same hold
+        # in one call; the publisher collapses repeats, so only the payload matters.
+        assert {slug for slug, _ in calls} == {"story-b"}
+        assert all(
+            payload
+            == {
+                "collision_gate_blockers": ["story-a"],
+                # Only the shared path — story-a's other file is not a blocker.
+                "collision_gate_files": ["src/shared.py"],
+                "collision_gate_claims": {"story-a": CLAIM_IN_DEV},
+            }
+            for _slug, payload in calls
+        )
+
+    def test_still_deferred_gate_republishes_its_hold(self) -> None:
+        calls, fn = _record_holds()
+        file_footprints = {
+            "story-a": {"src/shared.py"},
+            "story-b": {"src/shared.py"},
+        }
+        plan_gates = {"story-b": threading.Event()}
+
+        _release_plan_gates(
+            {},
+            file_footprints,
+            plan_gates,
+            {"story-a": MagicMock(), "story-b": MagicMock()},
+            threading.Lock(),
+            {"story-a": CLAIM_IN_DEV},
+            gate_hold_fn=fn,
+        )
+
+        assert calls[0][0] == "story-b"
+        assert calls[0][1] is not None
+        assert calls[0][1]["collision_gate_blockers"] == ["story-a"]
+
+    def test_opened_gate_clears_the_hold(self) -> None:
+        calls, fn = _record_holds()
+        gate_b = threading.Event()
+        plan_gates = {"story-b": gate_b}
+
+        # story-a has finished and holds no claim, so nothing blocks story-b.
+        _release_plan_gates(
+            {},
+            {"story-a": {"src/shared.py"}, "story-b": {"src/shared.py"}},
+            plan_gates,
+            {"story-b": MagicMock()},
+            threading.Lock(),
+            {},
+            gate_hold_fn=fn,
+        )
+
+        assert gate_b.is_set()
+        assert calls == [("story-b", None)]
+
+    def test_stand_down_clears_the_hold(self) -> None:
+        calls, fn = _record_holds()
+        plan_gates = {"story-b": threading.Event()}
+
+        stood_down = _release_plan_gates(
+            {},
+            {"story-a": {"src/shared.py"}, "story-b": {"src/shared.py"}},
+            plan_gates,
+            {"story-b": MagicMock()},
+            threading.Lock(),
+            {"story-a": CLAIM_PRESERVED},
+            gate_hold_fn=fn,
+        )
+
+        assert stood_down == ["story-b"]
+        assert calls == [("story-b", None)]
+
+
+class TestGateHoldPublisher:
+    def _writer(self, tmp_path: Path) -> SprintStateWriter:
+        (tmp_path / ".forge" / "runs").mkdir(parents=True)
+        writer = SprintStateWriter("run-x", tmp_path, "sprint")
+        writer.init([{"slug": "story-b", "path": "story-b", "status": "running"}])
+        return writer
+
+    def test_hold_merges_into_detail_without_erasing_co_resident_keys(
+        self, tmp_path: Path
+    ) -> None:
+        writer = self._writer(tmp_path)
+        writer.update("story-b", detail_updates={"last_reviewer_event_ts": 1234.0})
+
+        publish = _make_gate_hold_publisher(writer)
+        publish("story-b", {"collision_gate_blockers": ["story-a"]})
+
+        detail = writer.story_state.get("story-b").detail
+        assert detail["last_reviewer_event_ts"] == 1234.0
+        assert detail["collision_gate_blockers"] == ["story-a"]
+
+    def test_repeated_identical_hold_writes_once(self, tmp_path: Path) -> None:
+        writer = self._writer(tmp_path)
+        publish = _make_gate_hold_publisher(writer)
+        payload = {"collision_gate_blockers": ["story-a"]}
+
+        with patch.object(writer, "update", wraps=writer.update) as spy:
+            publish("story-b", payload)
+            publish("story-b", dict(payload))
+            publish("story-b", dict(payload))
+
+        assert spy.call_count == 1
+
+    def test_clear_only_writes_for_a_story_that_was_held(self, tmp_path: Path) -> None:
+        writer = self._writer(tmp_path)
+        publish = _make_gate_hold_publisher(writer)
+
+        with patch.object(writer, "update", wraps=writer.update) as spy:
+            publish("story-b", None)
+            assert spy.call_count == 0
+
+            publish("story-b", {"collision_gate_blockers": ["story-a"]})
+            publish("story-b", None)
+
+        assert spy.call_count == 2
+        detail = writer.story_state.get("story-b").detail
+        assert all(detail.get(key) is None for key in GATE_HOLD_DETAIL_KEYS)
+
+
+class TestLiveStatusSeam:
+    """Scheduler → .state file → read_live_status → watch frame, end to end."""
+
+    def _held_state(self, tmp_path: Path) -> SprintStateWriter:
+        (tmp_path / ".forge" / "runs").mkdir(parents=True)
+        writer = SprintStateWriter("run-x", tmp_path, "sprint")
+        writer.init(
+            [
+                {"slug": "story-a", "path": "story-a", "status": "running", "phase": "DEV"},
+                {
+                    "slug": "story-b",
+                    "path": "story-b",
+                    "status": "running",
+                    "phase": "PLAN_DONE",
+                },
+            ]
+        )
+        gate_b = threading.Event()
+        _release_plan_gates(
+            {},
+            {
+                "story-a": {"src/theforge/model_profiles.py"},
+                "story-b": {"src/theforge/model_profiles.py"},
+            },
+            {"story-b": gate_b},
+            {"story-a": MagicMock(), "story-b": MagicMock()},
+            threading.Lock(),
+            {"story-a": CLAIM_IN_DEV},
+            gate_hold_fn=_make_gate_hold_publisher(writer),
+        )
+        assert not gate_b.is_set()
+        return writer
+
+    def test_read_live_status_reports_a_collision_gate_stage(self, tmp_path: Path) -> None:
+        self._held_state(tmp_path)
+
+        entries = read_live_status("run-x", tmp_path) or []
+        held = next(e for e in entries if e.slug == "story-b")
+
+        # Still running — the wait is inside the story, not a separate outcome.
+        assert held.status == "running"
+        assert held.stage == COLLISION_GATE_STAGE
+        assert "story-a" in held.detail
+        assert "model_profiles.py" in held.detail
+
+        # An ungated story is untouched.
+        other = next(e for e in entries if e.slug == "story-a")
+        assert other.stage != COLLISION_GATE_STAGE
+
+    def test_watch_renders_a_stale_gated_story_as_gated_not_stalled(self, tmp_path: Path) -> None:
+        self._held_state(tmp_path)
+        entries = read_live_status("run-x", tmp_path) or []
+        held = [e for e in entries if e.slug == "story-b"]
+
+        state: dict = {"costs": {}, "interval": 2.0}
+        with (
+            patch("theforge.cli.sprint_status.display_sprint_status", return_value=0),
+            patch("theforge.sprint.status_reader.read_live_status", return_value=held),
+            patch.object(status_watch, "_last_audit_mtime", return_value=1000.0),
+        ):
+            text, _ok, _err = status_watch.render_frame(
+                "run-x",
+                tmp_path,
+                state,
+                frame_idx=0,
+                color=False,
+                # 22 minutes past the last event — far beyond the stall threshold.
+                now_fn=lambda: 1000.0 + 22 * 60,
+            )
+
+        assert "gated" in text
+        assert "stalled" not in text
+        # The event age stays visible: the operator still sees how long the wait
+        # has run, just without the warning that it needs investigating.
+        assert "22m00s" in text
+
+    def test_ordinary_stale_running_story_still_reports_stalled(self, tmp_path: Path) -> None:
+        from theforge.sprint.status_reader import StoryStatusEntry
+
+        entry = StoryStatusEntry(
+            slug="story-c",
+            path="story-c",
+            status="running",
+            phase="DEV",
+            cost_usd=0.0,
+        )
+        state: dict = {"costs": {}, "interval": 2.0}
+        with (
+            patch("theforge.cli.sprint_status.display_sprint_status", return_value=0),
+            patch("theforge.sprint.status_reader.read_live_status", return_value=[entry]),
+            patch.object(status_watch, "_last_audit_mtime", return_value=1000.0),
+        ):
+            text, _ok, _err = status_watch.render_frame(
+                "run-x",
+                tmp_path,
+                state,
+                frame_idx=0,
+                color=False,
+                now_fn=lambda: 1000.0 + 22 * 60,
+            )
+
+        assert "stalled" in text
+        assert "Hint:" in text

--- a/tests/test_sprint_collision_gate_visibility.py
+++ b/tests/test_sprint_collision_gate_visibility.py
@@ -132,6 +132,216 @@ class TestSchedulerPublishesGateHold:
         assert calls == [("story-b", None)]
 
 
+class TestGateHoldPublishOrdering:
+    """_release_plan_gates must never publish while holding ``phase_lock``.
+
+    ``phase_lock`` is a plain non-reentrant ``Lock`` and the worker state path
+    (``_make_worker_phase_fn``) takes it to write live state. A publish call
+    moved under the ``plan_done`` snapshot's ``with`` block would wedge the
+    whole scheduling loop, which is exactly the failure a gate-visibility fix
+    must not introduce. These tests take the real lock from inside the
+    publisher, so a violation deadlocks and trips the timeout instead of
+    depending on a docstring being read.
+    """
+
+    def _lock_taking_publisher(
+        self, phase_lock: threading.Lock
+    ) -> tuple[list[tuple[str, dict | None]], object]:
+        calls: list[tuple[str, dict | None]] = []
+
+        def _fn(slug: str, payload: dict | None) -> None:
+            # Mirrors _make_worker_phase_fn._update, which does exactly this.
+            acquired = phase_lock.acquire(timeout=5.0)
+            assert acquired, (
+                f"gate_hold_fn({slug!r}) was called while phase_lock was held — "
+                "_release_plan_gates must publish outside its snapshot block"
+            )
+            try:
+                calls.append((slug, payload))
+            finally:
+                phase_lock.release()
+
+        return calls, _fn
+
+    def _run(
+        self,
+        *,
+        plan_done: dict[str, str],
+        file_footprints: dict[str, set[str]],
+        plan_gates: dict[str, threading.Event],
+        active: dict[str, object],
+        claims: dict[str, str],
+    ) -> list[tuple[str, dict | None]]:
+        """Run _release_plan_gates on a worker thread; fail if it does not finish.
+
+        The assertion inside the publisher only fires if ``acquire`` *returns*.
+        Running on a thread with a join timeout also catches a genuine hard
+        deadlock, where nothing returns at all.
+        """
+        phase_lock = threading.Lock()
+        calls, fn = self._lock_taking_publisher(phase_lock)
+        error: list[BaseException] = []
+
+        def _target() -> None:
+            try:
+                _release_plan_gates(
+                    plan_done,
+                    file_footprints,
+                    plan_gates,
+                    active,
+                    phase_lock,
+                    claims,
+                    gate_hold_fn=fn,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                error.append(exc)
+
+        thread = threading.Thread(target=_target, daemon=True)
+        thread.start()
+        thread.join(timeout=10.0)
+        assert not thread.is_alive(), "_release_plan_gates deadlocked on phase_lock"
+        if error:
+            raise error[0]
+        return calls
+
+    def test_publisher_may_take_phase_lock_without_deadlocking(self) -> None:
+        """Newly-detected overlap: the branch the reviewer flagged."""
+        with patch(
+            "theforge.sprint.runner._extract_plan_footprint",
+            return_value={"src/shared.py"},
+        ):
+            calls = self._run(
+                plan_done={"story-b": "/tmp/ws-b"},
+                file_footprints={"story-a": {"src/shared.py"}},
+                plan_gates={"story-b": threading.Event()},
+                active={"story-a": MagicMock(), "story-b": MagicMock()},
+                claims={"story-a": CLAIM_IN_DEV},
+            )
+
+        # Both the detection pass and the deferred re-check report the hold in
+        # this single pass, so this one case covers two of the four call sites.
+        assert calls, "the held gate published nothing"
+        assert {slug for slug, _ in calls} == {"story-b"}
+        assert all(payload is not None for _slug, payload in calls)
+
+    def test_gate_open_publishes_outside_phase_lock(self) -> None:
+        """The other in-snapshot-loop branch: a gate that opens on first sight."""
+        gate = threading.Event()
+        with patch(
+            "theforge.sprint.runner._extract_plan_footprint",
+            return_value={"src/only-b.py"},
+        ):
+            self._run(
+                plan_done={"story-b": "/tmp/ws-b"},
+                file_footprints={"story-a": {"src/shared.py"}},
+                plan_gates={"story-b": gate},
+                active={"story-a": MagicMock(), "story-b": MagicMock()},
+                claims={"story-a": CLAIM_IN_DEV},
+            )
+
+        assert gate.is_set()
+
+    def test_deferred_recheck_publishes_outside_phase_lock(self) -> None:
+        """Both deferred-loop branches: still held, and released."""
+        held = self._run(
+            plan_done={},
+            file_footprints={"story-a": {"src/shared.py"}, "story-b": {"src/shared.py"}},
+            plan_gates={"story-b": threading.Event()},
+            active={"story-a": MagicMock(), "story-b": MagicMock()},
+            claims={"story-a": CLAIM_IN_DEV},
+        )
+        assert {slug for slug, _ in held} == {"story-b"}
+
+        released_gate = threading.Event()
+        self._run(
+            plan_done={},
+            file_footprints={"story-a": {"src/shared.py"}, "story-b": {"src/shared.py"}},
+            plan_gates={"story-b": released_gate},
+            active={"story-b": MagicMock()},
+            claims={},
+        )
+        assert released_gate.is_set()
+
+    def test_stand_down_publishes_outside_phase_lock(self) -> None:
+        plan_gates = {"story-b": threading.Event()}
+        self._run(
+            plan_done={},
+            file_footprints={"story-a": {"src/shared.py"}, "story-b": {"src/shared.py"}},
+            plan_gates=plan_gates,
+            active={"story-b": MagicMock()},
+            claims={"story-a": CLAIM_PRESERVED},
+        )
+
+    def test_real_publisher_and_writer_complete_under_a_held_phase_lock_regime(
+        self, tmp_path: Path
+    ) -> None:
+        """End to end with no test double in the publish path at all.
+
+        Real SprintStateWriter, real state file, real threads: the scheduler
+        thread publishes while a second thread cycles ``phase_lock`` the way a
+        worker's state updates do. The run must finish and the hold must land
+        on disk.
+        """
+        (tmp_path / ".forge" / "runs").mkdir(parents=True)
+        writer = SprintStateWriter("run-x", tmp_path, "sprint")
+        writer.init(
+            [
+                {"slug": "story-a", "path": "story-a", "status": "running", "phase": "DEV"},
+                {
+                    "slug": "story-b",
+                    "path": "story-b",
+                    "status": "running",
+                    "phase": "PLAN_DONE",
+                },
+            ]
+        )
+        phase_lock = threading.Lock()
+        stop = threading.Event()
+
+        def _worker_state_churn() -> None:
+            # Stands in for _make_worker_phase_fn._update on another story.
+            while not stop.is_set():
+                with phase_lock:
+                    writer.update("story-a", detail_updates={"files_touched": 1})
+
+        churn = threading.Thread(target=_worker_state_churn, daemon=True)
+        churn.start()
+        try:
+            error: list[BaseException] = []
+
+            def _schedule() -> None:
+                try:
+                    _release_plan_gates(
+                        {},
+                        {
+                            "story-a": {"src/shared.py"},
+                            "story-b": {"src/shared.py"},
+                        },
+                        {"story-b": threading.Event()},
+                        {"story-a": MagicMock(), "story-b": MagicMock()},
+                        phase_lock,
+                        {"story-a": CLAIM_IN_DEV},
+                        gate_hold_fn=_make_gate_hold_publisher(writer),
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    error.append(exc)
+
+            thread = threading.Thread(target=_schedule, daemon=True)
+            thread.start()
+            thread.join(timeout=10.0)
+            assert not thread.is_alive(), "gate servicing deadlocked against worker state writes"
+            if error:
+                raise error[0]
+        finally:
+            stop.set()
+            churn.join(timeout=5.0)
+
+        entries = read_live_status("run-x", tmp_path) or []
+        held = next(e for e in entries if e.slug == "story-b")
+        assert held.stage == COLLISION_GATE_STAGE
+        assert "story-a" in held.detail
+
+
 class TestGateHoldPublisher:
     def _writer(self, tmp_path: Path) -> SprintStateWriter:
         (tmp_path / ".forge" / "runs").mkdir(parents=True)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior cycle P1s are resolved, and I found no P1 regressions in the current diff. | [google-gemini-3.5-flash-api] The implementation successfully resolves both prior P1 findings with robust thread-safety, updated docstrings, and comprehensive test coverage. | [anthropic-haiku-cli] Both cycle 1 findings have been resolved. The misleading docstring that prompted the false-positive lock-ordering P1 has been corrected with precise claims about which lock is held where and why, and the ordering rule is now enforced mechanically by real-threading tests that would deadlock on violation. The gate visibility feature itself meets its acceptance criterion across all code paths.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $9.10
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

A story held on a collision gate displays as stalled, so a deliberate wait is indistinguishable from a hang (GitHub Issue #2235)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2235