### PR TITLE
Review funding is projected at seating but never withheld, so a phase that exceeds its estimate defunds verification anyway

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -306,6 +306,60 @@ def _maybe_recover_failed_challenger(
     return dataclasses.replace(config, dev_profile=winner_profile)
 
 
+def _refuse_dev_without_nonreview_funds(
+    state: CoordinatorState,
+    config: ForgeConfig,
+    task: TaskStory,
+    log_fn: "Callable[[str], None]",
+    logger: StructuredLogger | None,
+) -> CoordinatorResult | None:
+    """Refuse a dev attempt the non-reserved allocation can no longer fund (#2258).
+
+    Money the seating reconciliation committed to verification is not spendable
+    by dev. Once everything the allocation left for non-review work is gone,
+    another dev attempt would draw down the reserved review cycles and leave the
+    work unreviewed — precisely the failure the reservation exists to prevent.
+    Returns ``None`` when the attempt is funded, when no reservation was seated,
+    or when spend is unmeasured; otherwise records the refusal on ``state`` and
+    returns the escalation result the caller must return.
+    """
+    exhausted = _story_budget.nonreview_funding_exhausted(
+        state.review_funding_reservation,
+        state.story_allocation,
+        observed_usd=state.total_cost_measured,
+        review_observed_usd=state.total_review_cost_measured,
+        participants=[config.dev_profile.name],
+    )
+    if exhausted is None:
+        return None
+    state.allocation_exhausted = exhausted
+    state.error = _story_budget.format_shortfall(exhausted, story=task.slug)
+    state.error_type = "allocation_exhausted"
+    state.phase = Phase.ESCALATE
+    log_fn(f"  ⚠ {state.error}")
+    if logger:
+        logger._safe_emit(
+            "allocation_exhausted",
+            phase="DEV",
+            **{
+                key: exhausted.get(key)
+                for key in (
+                    "allocation_usd",
+                    "nonreview_allocation_usd",
+                    "reserved_review_usd",
+                    "reserved_review_cycles",
+                    "observed_usd",
+                )
+            },
+        )
+    return CoordinatorResult(
+        success=False,
+        phase=Phase.ESCALATE,
+        state=state,
+        message=state.error,
+    )
+
+
 def _coordinator_loop(
     state: CoordinatorState,
     config: ForgeConfig,
@@ -443,9 +497,30 @@ def _coordinator_loop(
             requested_review_max=_limits.review_max,
             spent_so_far_usd=state.total_cost_measured,
         )
+        # ── Hold the seated reservation across the phases (#2258) ────────────
+        # The reconciliation above is a projection over an estimate. Nothing
+        # held its conclusion, so a dev phase that overran its estimate spent
+        # the money review had been seated with and review was refused anyway —
+        # in exactly the case verification was most wanted. Record the reserved
+        # portion of the allocation on state: REVIEW funds from it, and DEV is
+        # refused further attempts once the rest of the allocation is gone, so
+        # the decision binds when it is exceeded and not only when it is made.
+        _reservation = {
+            "allocation_usd": _reconciliation.get("allocation_usd"),
+            "reserved_review_usd": _reconciliation.get("reserved_review_usd") or 0.0,
+            "reserved_review_cycles": _reconciliation.get("reserved_review_cycles") or 0,
+            "review_cycle_cost_usd": _reconciliation.get("review_cycle_cost_usd"),
+            "action": _reconciliation.get("action"),
+        }
+        if _reservation["allocation_usd"] is not None and _reservation["reserved_review_usd"]:
+            _reservation["nonreview_allocation_usd"] = round(
+                float(_reservation["allocation_usd"]) - float(_reservation["reserved_review_usd"]),
+                4,
+            )
         _audit = dict(_limits.audit)
         _audit["review_cycle_planning"] = _review_cycle_planning
         _audit["review_cycle_reconciliation"] = _reconciliation
+        _audit["review_funding_reservation"] = _reservation
         if _reconciliation["action"] in (
             _story_budget.RECONCILE_REDUCED,
             _story_budget.RECONCILE_UNFUNDABLE,
@@ -467,6 +542,7 @@ def _coordinator_loop(
         state.adaptive_dev_timeout_seconds = _limits.dev_timeout_seconds
         state.adaptive_dev_cost_estimate_usd = _limits.dev_cost_estimate_usd
         state.adaptive_review_cycle_planning = _review_cycle_planning
+        state.review_funding_reservation = _reservation
         state.adaptive_limits_audit = _limits.audit
 
         if _reconciliation["action"] == _story_budget.RECONCILE_UNFUNDABLE:
@@ -550,6 +626,16 @@ def _coordinator_loop(
                         },
                     }
                 )
+            # ── Non-review funds exhausted (#2258) ────────────────────────
+            # Binds on RETRY attempts only: the first attempt is the one seating
+            # already ruled on, and refusing it here would refuse a story before
+            # it did any work at all.
+            if state.dev_trace_count > 0:
+                _dev_refusal = _refuse_dev_without_nonreview_funds(
+                    state, config, task, _log, logger
+                )
+                if _dev_refusal is not None:
+                    return _dev_refusal
             state.budget.consume(review_cycle=state.review_cycle)
             state.dev_trace_count += 1
             escalation = _run_dev_phase(

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -634,10 +634,18 @@ def _run_review_pool(
                 composition=[p.name for p in pool],
             ).as_dict()
             state.adaptive_review_cycle_planning = review_cycle_planning
-        _shortfall = _story_budget.phase_funding_shortfall(
+        # A cycle the seating reconciliation reserved is funded from that
+        # reservation, not from whatever an overrunning dev phase happened to
+        # leave behind (#2258). Cycles beyond the reserved ones still draw the
+        # general pool, so a story whose dev phase stayed within its estimate
+        # keeps every cycle it has always had. Runs with no reservation —
+        # configured-fallback allocations, no band history — fall through to the
+        # pre-existing whole-allocation check unchanged.
+        _shortfall = _story_budget.reserved_review_shortfall(
+            state.review_funding_reservation,
             state.story_allocation,
-            state.total_cost_measured,
-            phase="review",
+            observed_usd=state.total_cost_measured,
+            review_observed_usd=state.total_review_cost_measured,
             participants=[p.name for p in pool],
             planned_usd=float(review_cycle_planning["planned_cost_usd"]),
         )

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -900,6 +900,14 @@ class CoordinatorState:
     # this exact record first so it cannot re-price a cycle differently after
     # seating already granted it.
     adaptive_review_cycle_planning: dict | None = None
+    # The portion of the allocation seating committed to verification (#2258).
+    # Set from the seating reconciliation; keys mirror its reservation fields
+    # (reserved_review_usd, reserved_review_cycles, review_cycle_cost_usd,
+    # allocation_usd, action). REVIEW funds from this balance and DEV is refused
+    # further attempts once the rest of the allocation is spent, so the seating
+    # decision binds when it is exceeded rather than only when it is computed.
+    # None/empty on runs where the reconciliation reserved nothing.
+    review_funding_reservation: dict | None = None
     adaptive_limits_audit: dict = field(default_factory=dict)
     review_early_terminated: bool = False  # True when early-termination triggered
     workspace_hygiene_audit: list[dict] = field(default_factory=list)

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -563,6 +563,20 @@ def evaluate_allocation(allocation: StoryAllocation, observed_usd: float | None)
     return evaluate_allocation_dict(allocation.as_dict(), observed_usd) or {}
 
 
+def _balance(value: float) -> float:
+    """Round a dollar balance to the precision the funding payloads report.
+
+    Every one of these checks subtracts one dollar figure from another and then
+    decides whether work runs. In binary floating point ``4.12 - 1.01`` is
+    ``3.1100000000000003``, so a phase that has spent its pool to the cent is
+    left holding ``3e-16`` — and a balance of nothing reads as a balance
+    remaining. Comparing at the 4-decimal precision the records already report
+    makes the boundary land where the operator sees it land: exactly-exhausted
+    is exhausted (#2258).
+    """
+    return round(float(value), 4)
+
+
 def phase_funding_shortfall(
     allocation: dict | None,
     observed_usd: float | None,
@@ -588,8 +602,8 @@ def phase_funding_shortfall(
         allocation_usd = float(allocation.get("allocation_usd"))
     except (TypeError, ValueError):
         return None
-    remaining = allocation_usd - float(observed_usd)
-    if remaining >= planned_usd:
+    remaining = _balance(allocation_usd - float(observed_usd))
+    if remaining >= _balance(planned_usd):
         return None
     return {
         "phase": phase,
@@ -597,7 +611,7 @@ def phase_funding_shortfall(
         "planned_usd": round(planned_usd, 4),
         "observed_usd": round(float(observed_usd), 4),
         "allocation_usd": round(allocation_usd, 2),
-        "remaining_usd": round(remaining, 4),
+        "remaining_usd": remaining,
         "basis": allocation.get("basis"),
         "complexity_score": allocation.get("complexity_score"),
         "median_usd": allocation.get("median_usd"),
@@ -660,8 +674,8 @@ def reserved_review_shortfall(
         )
     if review_observed_usd is None:
         return None
-    reserved_remaining = reserved - float(review_observed_usd)
-    if reserved_remaining >= planned_usd:
+    reserved_remaining = _balance(reserved - float(review_observed_usd))
+    if reserved_remaining >= _balance(planned_usd):
         return None
     shortfall = phase_funding_shortfall(
         allocation,
@@ -672,9 +686,9 @@ def reserved_review_shortfall(
     )
     if shortfall is None:
         return None
-    shortfall["reserved_review_usd"] = round(reserved, 4)
+    shortfall["reserved_review_usd"] = _balance(reserved)
     shortfall["reserved_review_cycles"] = (reservation or {}).get("reserved_review_cycles")
-    shortfall["reserved_review_remaining_usd"] = round(reserved_remaining, 4)
+    shortfall["reserved_review_remaining_usd"] = reserved_remaining
     return shortfall
 
 
@@ -707,21 +721,24 @@ def nonreview_funding_exhausted(
         allocation_usd = float((allocation or {}).get("allocation_usd"))
     except (TypeError, ValueError, AttributeError):
         return None
-    nonreview_observed = max(0.0, float(observed_usd) - float(review_observed_usd))
-    ceiling = allocation_usd - reserved
-    remaining = ceiling - nonreview_observed
+    nonreview_observed = _balance(max(0.0, float(observed_usd) - float(review_observed_usd)))
+    ceiling = _balance(allocation_usd - reserved)
+    remaining = _balance(ceiling - nonreview_observed)
+    # Strictly greater: a non-review pool spent to the cent has nothing left to
+    # fund another attempt with, and admitting one would spend the reserved
+    # review balance — the whole point of holding it.
     if remaining > 0:
         return None
     return {
         "phase": phase,
         "participants": list(participants),
         "planned_usd": 0.0,
-        "observed_usd": round(nonreview_observed, 4),
+        "observed_usd": nonreview_observed,
         "allocation_usd": round(allocation_usd, 2),
-        "remaining_usd": round(remaining, 4),
+        "remaining_usd": remaining,
         "nonreview_exhausted": True,
-        "nonreview_allocation_usd": round(ceiling, 4),
-        "reserved_review_usd": round(reserved, 4),
+        "nonreview_allocation_usd": ceiling,
+        "reserved_review_usd": _balance(reserved),
         "reserved_review_cycles": (reservation or {}).get("reserved_review_cycles"),
         "total_observed_usd": round(float(observed_usd), 4),
         "basis": (allocation or {}).get("basis"),
@@ -863,9 +880,14 @@ def reconcile_review_cycles(
         record["action"] = RECONCILE_AFFORDABLE
         return record
 
-    remaining = allocation_usd - float(spent_so_far_usd) - dev_estimate
-    record["remaining_after_dev_usd"] = round(remaining, 4)
-    affordable = 0 if remaining < cycle_cost else int(remaining // cycle_cost)
+    remaining = _balance(allocation_usd - float(spent_so_far_usd) - dev_estimate)
+    record["remaining_after_dev_usd"] = remaining
+    # Counted in whole units of the reported precision rather than by float
+    # division: a remainder that covers a cycle exactly must count as a cycle,
+    # or seating refuses to reserve money the allocation demonstrably holds.
+    _remaining_units = int(round(remaining * 10000))
+    _cycle_units = int(round(cycle_cost * 10000))
+    affordable = 0 if _remaining_units < _cycle_units else _remaining_units // _cycle_units
     record["affordable_review_cycles"] = affordable
     if affordable == 0:
         record["reconciled_review_max"] = int(requested_review_max)

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -607,6 +607,132 @@ def phase_funding_shortfall(
     }
 
 
+# ── Holding the seated review reservation across phases (#2258) ───────────────
+# The seating reconciliation commits part of the allocation to verification.
+# These two helpers are the halves of enforcing that commitment: REVIEW funds
+# from the reserved balance, and DEV stops once everything that was NOT reserved
+# has been spent. Both keep the cost-unknown rule the dispatch-time check
+# already holds — an unmeasured total is a lower bound, and refusing work on a
+# number the run does not have would be a guess.
+
+
+def _reserved_review_usd(reservation: dict | None) -> float:
+    """The reserved review balance on a reservation record, or 0.0."""
+    if not isinstance(reservation, dict):
+        return 0.0
+    try:
+        return max(0.0, float(reservation.get("reserved_review_usd") or 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def reserved_review_shortfall(
+    reservation: dict | None,
+    allocation: dict | None,
+    *,
+    observed_usd: float | None,
+    review_observed_usd: float | None,
+    participants: list[str],
+    planned_usd: float,
+) -> dict | None:
+    """Return a shortfall when a review panel can be funded from neither pool.
+
+    A seated reservation is a floor under verification, not a ceiling on it: the
+    panel runs if the reserved balance still covers it, and — for cycles beyond
+    the reserved ones — if what is left of the whole allocation covers it. Only
+    when both are short is the panel refused, so a story whose dev phase stayed
+    within its estimate keeps every review cycle it has always had.
+
+    ``review_observed_usd`` of ``None`` leaves the reserved balance unknowable,
+    and ``observed_usd`` of ``None`` does the same for the general pool; neither
+    refuses the panel.
+    """
+    reserved = _reserved_review_usd(reservation)
+    if reserved <= 0.0 or not participants:
+        # No reservation to draw on: the caller's pre-existing dispatch-time
+        # check against the whole allocation is the honest answer.
+        return phase_funding_shortfall(
+            allocation,
+            observed_usd,
+            phase="review",
+            participants=participants,
+            planned_usd=planned_usd,
+        )
+    if review_observed_usd is None:
+        return None
+    reserved_remaining = reserved - float(review_observed_usd)
+    if reserved_remaining >= planned_usd:
+        return None
+    shortfall = phase_funding_shortfall(
+        allocation,
+        observed_usd,
+        phase="review",
+        participants=participants,
+        planned_usd=planned_usd,
+    )
+    if shortfall is None:
+        return None
+    shortfall["reserved_review_usd"] = round(reserved, 4)
+    shortfall["reserved_review_cycles"] = (reservation or {}).get("reserved_review_cycles")
+    shortfall["reserved_review_remaining_usd"] = round(reserved_remaining, 4)
+    return shortfall
+
+
+def nonreview_funding_exhausted(
+    reservation: dict | None,
+    allocation: dict | None,
+    *,
+    observed_usd: float | None,
+    review_observed_usd: float | None,
+    participants: list[str],
+    phase: str = "dev",
+) -> dict | None:
+    """Return a shortfall when the non-reserved part of the allocation is gone.
+
+    The other half of holding a reservation: money committed to review must not
+    be spendable by an earlier phase, so once non-review spend has reached
+    ``allocation - reserved``, no further attempt at ``phase`` is funded. The
+    reserved balance is deliberately excluded — it is still there, and it is
+    still review's.
+
+    Returns ``None`` — funded — whenever there is no reservation to protect or
+    spend is unmeasured. The payload reuses the :func:`phase_funding_shortfall`
+    shape so every existing consumer reads it unchanged, and carries
+    ``nonreview_exhausted`` so the operator line can say which pool ran out.
+    """
+    reserved = _reserved_review_usd(reservation)
+    if reserved <= 0.0 or observed_usd is None or review_observed_usd is None:
+        return None
+    try:
+        allocation_usd = float((allocation or {}).get("allocation_usd"))
+    except (TypeError, ValueError, AttributeError):
+        return None
+    nonreview_observed = max(0.0, float(observed_usd) - float(review_observed_usd))
+    ceiling = allocation_usd - reserved
+    remaining = ceiling - nonreview_observed
+    if remaining > 0:
+        return None
+    return {
+        "phase": phase,
+        "participants": list(participants),
+        "planned_usd": 0.0,
+        "observed_usd": round(nonreview_observed, 4),
+        "allocation_usd": round(allocation_usd, 2),
+        "remaining_usd": round(remaining, 4),
+        "nonreview_exhausted": True,
+        "nonreview_allocation_usd": round(ceiling, 4),
+        "reserved_review_usd": round(reserved, 4),
+        "reserved_review_cycles": (reservation or {}).get("reserved_review_cycles"),
+        "total_observed_usd": round(float(observed_usd), 4),
+        "basis": (allocation or {}).get("basis"),
+        "complexity_score": (allocation or {}).get("complexity_score"),
+        "median_usd": (allocation or {}).get("median_usd"),
+        "p90_usd": (allocation or {}).get("p90_usd"),
+        "max_usd": (allocation or {}).get("max_usd"),
+        "sample_count": (allocation or {}).get("sample_count"),
+    }
+
+
 # ── Seating-time reconciliation of permissions against the allocation (#2238) ──
 # Actions a reconciliation can report. The first four are no-ops: the inputs do
 # not admit an honest answer, so the requested permission stands and the record
@@ -637,6 +763,16 @@ def reconcile_review_cycles(
     adaptive dev cost estimate, and the per-cycle cost of the review panel the
     run plans to seat. Returns the audit record of the decision; the caller
     applies it.
+
+    ``reserved_review_usd`` is the portion of the allocation the reconciliation
+    commits to verification: the reconciled cycles priced at the seated
+    per-cycle figure. A projection that nothing withholds is an intention, not a
+    guarantee — an earlier phase that overruns spends the money review was
+    seated with and review is refused anyway (#2258). Reserving it here gives
+    the caller a number to hold: REVIEW funds from it, and further DEV attempts
+    are refused once the rest of the allocation is gone. Nothing is reserved on
+    the no-op actions or on ``review_unfundable`` — there is no decision to
+    hold in the first place.
 
     ``reconciled_review_max`` is the number of review cycles the allocation can
     actually fund. It equals ``requested_review_max`` whenever the inputs do not
@@ -672,6 +808,8 @@ def reconcile_review_cycles(
         "review_cycle_cost_headroom_multiplier": None,
         "review_cycle_cost_reason": None,
         "review_cycle_cost_composition": None,
+        "reserved_review_cycles": 0,
+        "reserved_review_usd": 0.0,
         "action": RECONCILE_AFFORDABLE,
     }
     try:
@@ -736,9 +874,13 @@ def reconcile_review_cycles(
         return record
     if affordable >= requested_review_max:
         record["action"] = RECONCILE_AFFORDABLE
+        record["reserved_review_cycles"] = int(requested_review_max)
+        record["reserved_review_usd"] = round(requested_review_max * cycle_cost, 4)
         return record
     record["reconciled_review_max"] = affordable
     record["action"] = RECONCILE_REDUCED
+    record["reserved_review_cycles"] = affordable
+    record["reserved_review_usd"] = round(affordable * cycle_cost, 4)
     record["shortfall_usd"] = round(
         (requested_review_max - affordable) * cycle_cost - (remaining - affordable * cycle_cost),
         4,
@@ -843,6 +985,19 @@ def seating_shortfall(
 def format_shortfall(shortfall: dict, *, story: str | None = None) -> str:
     """Render the operator-facing allocation-exhausted message."""
     story_label = f"story {story}" if story else "story"
+    if shortfall.get("nonreview_exhausted"):
+        cycles = shortfall.get("reserved_review_cycles")
+        return (
+            f"Story allocation exhausted: {story_label} has spent "
+            f"${float(shortfall['observed_usd']):.2f} of the "
+            f"${float(shortfall['nonreview_allocation_usd']):.2f} its "
+            f"${float(shortfall['allocation_usd']):.2f} allocation leaves for non-review "
+            f"work, so no further {shortfall['phase']} attempt is funded. The remaining "
+            f"${float(shortfall['reserved_review_usd']):.2f} is reserved for the "
+            f"{cycles} review cycle(s) this story was seated with and is not "
+            "available to spend here. Sprint headroom is reported alongside this "
+            "story in the sprint summary."
+        )
     expected = "no band history"
     if shortfall.get("median_usd") is not None:
         expected = (

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -894,6 +894,71 @@ class TestReviewFundingReservation:
         assert "$3.11" in message
         assert "reserved for the 1 review cycle(s)" in message
 
+    def test_a_non_review_pool_spent_to_the_cent_refuses_the_next_attempt(self) -> None:
+        """The boundary binds where the operator sees it: $3.11 of $3.11 is gone.
+
+        ``4.12 - 1.01`` is ``3.1100000000000003`` in binary floating point, so an
+        exactly-exhausted pool used to read as three ten-thousandths of a cent
+        remaining — and the retry it funded would have spent the reserved cycle.
+        """
+        shortfall = sb.nonreview_funding_exhausted(
+            self._reservation(),
+            self._allocation(),
+            observed_usd=3.11,
+            review_observed_usd=0.0,
+            participants=["dev"],
+        )
+
+        assert shortfall is not None
+        assert shortfall["remaining_usd"] == 0.0
+        assert shortfall["nonreview_allocation_usd"] == 3.11
+        assert shortfall["observed_usd"] == 3.11
+        # One cent short of the ceiling is still a funded attempt.
+        assert (
+            sb.nonreview_funding_exhausted(
+                self._reservation(),
+                self._allocation(),
+                observed_usd=3.10,
+                review_observed_usd=0.0,
+                participants=["dev"],
+            )
+            is None
+        )
+
+    def test_a_panel_that_exactly_fits_its_reservation_is_funded(self) -> None:
+        """The same rounding, in the direction that must not refuse work.
+
+        ``3.03 - 2.02`` is ``1.0099999999999998``: a third reserved cycle that
+        fits its reservation to the cent must not be refused for float noise,
+        even when the general pool has nothing left to fall back on.
+        """
+        assert (
+            sb.reserved_review_shortfall(
+                {**self._reservation(), "reserved_review_usd": 3.03, "reserved_review_cycles": 3},
+                {**self._allocation(usd=3.03)},
+                observed_usd=2.02,
+                review_observed_usd=2.02,
+                participants=["a"],
+                planned_usd=1.01,
+            )
+            is None
+        )
+
+    def test_a_remainder_that_exactly_covers_a_cycle_reserves_it(self) -> None:
+        """Seating counts cycles in whole cents, not by float division."""
+        record = sb.reconcile_review_cycles(
+            self._allocation(usd=3.39),
+            dev_cost_estimate_usd=2.38,
+            review_cycle_cost_usd=1.01,
+            requested_review_max=1,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["remaining_after_dev_usd"] == 1.01
+        assert record["action"] == sb.RECONCILE_AFFORDABLE
+        assert record["affordable_review_cycles"] == 1
+        assert record["reserved_review_usd"] == 1.01
+
     def test_review_spend_does_not_count_against_the_dev_pool(self) -> None:
         """A cycle drawing its own reservation must not refuse the next dev attempt."""
         assert (

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -705,3 +705,222 @@ class TestReviewCycleReconciliation:
             spent_so_far_usd=0.0,
         )
         assert sb.seating_shortfall(allocation, record, participants=["a"]) is None
+
+
+class TestReviewFundingReservation:
+    """A seated review cycle is money held, not money hoped for (#2258)."""
+
+    def _allocation(self, usd: float = 4.12) -> dict:
+        # The band from run 9b3fa1bf44a4 / story issue-2252.
+        return {
+            "allocation_usd": usd,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 3,
+            "median_usd": 0.94,
+            "p90_usd": 2.38,
+            "max_usd": 3.30,
+            "sample_count": 20,
+        }
+
+    def _reconcile(self, *, usd: float = 4.12, review_max: int = 1) -> dict:
+        return sb.reconcile_review_cycles(
+            self._allocation(usd),
+            dev_cost_estimate_usd=2.38,
+            review_cycle_cost_usd=1.01,
+            requested_review_max=review_max,
+            spent_so_far_usd=0.0,
+        )
+
+    def test_an_affordable_seating_reserves_the_cycles_it_granted(self) -> None:
+        record = self._reconcile()
+
+        assert record["action"] == sb.RECONCILE_AFFORDABLE
+        assert record["reserved_review_cycles"] == 1
+        assert record["reserved_review_usd"] == 1.01
+
+    def test_a_reduced_seating_reserves_only_what_it_left_permitted(self) -> None:
+        record = self._reconcile(review_max=5)
+
+        assert record["action"] == sb.RECONCILE_REDUCED
+        assert record["reconciled_review_max"] == record["reserved_review_cycles"]
+        assert record["reserved_review_usd"] == round(record["reconciled_review_max"] * 1.01, 4)
+
+    def test_undecided_and_unfundable_seatings_reserve_nothing(self) -> None:
+        base = dict(
+            dev_cost_estimate_usd=2.38,
+            review_cycle_cost_usd=1.01,
+            requested_review_max=1,
+            spent_so_far_usd=0.0,
+        )
+        unfundable = sb.reconcile_review_cycles(self._allocation(usd=3.0), **base)
+        assert unfundable["action"] == sb.RECONCILE_UNFUNDABLE
+        for record in (
+            unfundable,
+            sb.reconcile_review_cycles(None, **base),
+            sb.reconcile_review_cycles(
+                {**self._allocation(), "basis": sb.BASIS_CONFIGURED_FALLBACK}, **base
+            ),
+            sb.reconcile_review_cycles(self._allocation(), **{**base, "spent_so_far_usd": None}),
+            sb.reconcile_review_cycles(self._allocation(), **{**base, "dev_cost_estimate_usd": 0}),
+        ):
+            assert record["reserved_review_cycles"] == 0
+            assert record["reserved_review_usd"] == 0.0
+
+    # ── The reserved balance funds review ────────────────────────────────────
+
+    def _reservation(self, reserved_usd: float = 1.01, cycles: int = 1) -> dict:
+        return {
+            "allocation_usd": 4.12,
+            "reserved_review_usd": reserved_usd,
+            "reserved_review_cycles": cycles,
+            "review_cycle_cost_usd": 1.01,
+            "action": sb.RECONCILE_AFFORDABLE,
+        }
+
+    def test_the_issue_2252_dev_overrun_no_longer_defunds_the_panel(self) -> None:
+        """Dev spent $4.00 of a $4.12 allocation; the reserved cycle still runs."""
+        assert (
+            sb.reserved_review_shortfall(
+                self._reservation(),
+                self._allocation(),
+                observed_usd=4.00,
+                review_observed_usd=0.0,
+                participants=["openai-gpt-5.5-cli"],
+                planned_usd=1.01,
+            )
+            is None
+        )
+        # Without the reservation this is the refusal the issue reports.
+        assert (
+            sb.phase_funding_shortfall(
+                self._allocation(),
+                4.00,
+                phase="review",
+                participants=["openai-gpt-5.5-cli"],
+                planned_usd=1.01,
+            )
+            is not None
+        )
+
+    def test_a_cycle_beyond_the_reservation_may_still_draw_the_general_pool(self) -> None:
+        """The reservation is a floor under verification, not a ceiling on it."""
+        assert (
+            sb.reserved_review_shortfall(
+                self._reservation(),
+                self._allocation(),
+                observed_usd=1.51,  # $0.50 dev + $1.01 of review already run
+                review_observed_usd=1.01,  # the reserved cycle is spent
+                participants=["a"],
+                planned_usd=1.01,
+            )
+            is None
+        )
+
+    def test_a_panel_neither_pool_funds_is_refused_with_the_reserved_figures(self) -> None:
+        shortfall = sb.reserved_review_shortfall(
+            self._reservation(),
+            self._allocation(),
+            observed_usd=4.05,
+            review_observed_usd=1.01,
+            participants=["a"],
+            planned_usd=1.01,
+        )
+
+        assert shortfall is not None
+        assert shortfall["phase"] == "review"
+        assert shortfall["planned_usd"] == 1.01
+        assert shortfall["reserved_review_usd"] == 1.01
+        assert shortfall["reserved_review_remaining_usd"] == 0.0
+
+    def test_no_reservation_falls_through_to_the_whole_allocation_check(self) -> None:
+        for reservation in (None, {}, {"reserved_review_usd": 0.0}):
+            shortfall = sb.reserved_review_shortfall(
+                reservation,
+                self._allocation(),
+                observed_usd=4.00,
+                review_observed_usd=0.0,
+                participants=["a"],
+                planned_usd=1.01,
+            )
+            assert shortfall is not None
+            assert "reserved_review_usd" not in shortfall
+
+    def test_unmeasured_spend_never_refuses_a_review_panel(self) -> None:
+        for observed, review_observed in ((None, 0.0), (4.0, None), (None, None)):
+            assert (
+                sb.reserved_review_shortfall(
+                    self._reservation(),
+                    self._allocation(),
+                    observed_usd=observed,
+                    review_observed_usd=review_observed,
+                    participants=["a"],
+                    planned_usd=1.01,
+                )
+                is None
+            )
+
+    # ── The rest of the allocation is what dev may spend ─────────────────────
+
+    def test_dev_is_funded_while_non_review_money_remains(self) -> None:
+        assert (
+            sb.nonreview_funding_exhausted(
+                self._reservation(),
+                self._allocation(),
+                observed_usd=2.50,
+                review_observed_usd=0.0,
+                participants=["dev"],
+            )
+            is None
+        )
+
+    def test_dev_is_refused_once_only_the_reserved_money_is_left(self) -> None:
+        shortfall = sb.nonreview_funding_exhausted(
+            self._reservation(),
+            self._allocation(),
+            observed_usd=4.00,
+            review_observed_usd=0.0,
+            participants=["dev"],
+        )
+
+        assert shortfall is not None
+        assert shortfall["phase"] == "dev"
+        assert shortfall["nonreview_exhausted"] is True
+        assert shortfall["nonreview_allocation_usd"] == 3.11
+        assert shortfall["observed_usd"] == 4.00
+        assert shortfall["reserved_review_usd"] == 1.01
+
+        message = sb.format_shortfall(shortfall, story="issue-2252")
+        assert "issue-2252" in message
+        assert "$3.11" in message
+        assert "reserved for the 1 review cycle(s)" in message
+
+    def test_review_spend_does_not_count_against_the_dev_pool(self) -> None:
+        """A cycle drawing its own reservation must not refuse the next dev attempt."""
+        assert (
+            sb.nonreview_funding_exhausted(
+                self._reservation(),
+                self._allocation(),
+                observed_usd=3.01,  # $2.00 dev + $1.01 review
+                review_observed_usd=1.01,
+                participants=["dev"],
+            )
+            is None
+        )
+
+    def test_dev_is_never_refused_without_a_reservation_or_a_measured_total(self) -> None:
+        for reservation, observed, review_observed in (
+            (None, 4.0, 0.0),
+            ({"reserved_review_usd": 0.0}, 4.0, 0.0),
+            (self._reservation(), None, 0.0),
+            (self._reservation(), 4.0, None),
+        ):
+            assert (
+                sb.nonreview_funding_exhausted(
+                    reservation,
+                    self._allocation(),
+                    observed_usd=observed,
+                    review_observed_usd=review_observed,
+                    participants=["dev"],
+                )
+                is None
+            )

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -823,3 +823,317 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         assert mock_pool.called is True
         assert sorted(meta.successful) == ["a", "b", "c"]
         assert [float(profile.budget_usd) for profile in config.review_pool] == [5.85, 5.85, 5.85]
+
+
+class TestTheSeatedReviewReservationIsHeldAcrossPhases:
+    """Money committed to review is not spendable by dev (#2258).
+
+    The seating reconciliation (#2238) was a projection evaluated once against
+    a dev ESTIMATE. Nothing held its conclusion, so a dev phase that overran
+    spent the money review had been seated with and the panel was refused at
+    dispatch anyway — run ``9b3fa1bf44a4`` / story ``issue-2252``, seated with
+    an affordable $1.01 cycle against a $4.12 allocation, dev observed $4.00,
+    review refused with ``needs $1.01, $0.12 left``. These tests pin both
+    halves of the fix at the seam: review funds from the reservation, and a
+    later dev attempt is refused once the rest of the allocation is gone.
+    """
+
+    def _config(self, tmp_path: Path):
+        from coord_test_helpers import _make_config, _make_review_profile
+
+        from theforge.config.types import AssignmentConfig, RetryPolicy
+
+        config = _make_config(tmp_path)
+        return dataclasses.replace(
+            config,
+            # The dev band's p90 — the estimate seating reconciles against.
+            dev_profile=dataclasses.replace(config.dev_profile, budget_usd=2.38),
+            # One reviewer at the issue's $1.01 cycle price (no review-cycle
+            # history here, so the ceiling sum is the planning price).
+            review_pool=[_make_review_profile("openai-gpt-5.5-cli", budget_usd=1.01)],
+            synthesis_profile=None,
+            retry=RetryPolicy(
+                max_dev_iterations=3,
+                max_review_cycles=5,
+                max_dev_iterations_cap=6,
+                max_review_cycles_cap=5,
+                adaptive_iterations=True,
+            ),
+            assignment=AssignmentConfig(enabled=True, adaptive_enabled=True),
+        )
+
+    def _seated_state(self, tmp_path: Path):
+        """State as issue-2252 was seated: $4.12 against a 20-run band."""
+        state = CoordinatorState(log_dir=tmp_path / "logs")
+        state.preflight_complexity = "medium"
+        state.preflight_complexity_score = 3
+        state.workspace_path = tmp_path
+        state.branch_name = "feat/issue-2252"
+        state.story_allocation = {
+            "allocation_usd": 4.12,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 3,
+            "median_usd": 0.94,
+            "p90_usd": 2.38,
+            "max_usd": 3.30,
+            "sample_count": 20,
+        }
+        return state
+
+    def _seat(self, tmp_path: Path, config, task):
+        """Run the loop as far as the first DEV dispatch and return the state."""
+        from theforge.coordinator.engine import _coordinator_loop
+
+        state = self._seated_state(tmp_path)
+
+        class _StopAtDev(Exception):
+            pass
+
+        with patch("theforge.coordinator.engine._run_dev_phase", side_effect=_StopAtDev()):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+        return state
+
+    def test_seating_reserves_the_cycle_it_granted_before_dev_runs(self, tmp_path: Path) -> None:
+        from coord_test_helpers import _make_task
+
+        state = self._seat(tmp_path, self._config(tmp_path), _make_task(tmp_path))
+
+        reservation = state.review_funding_reservation
+        assert reservation is not None
+        assert reservation["reserved_review_cycles"] == state.adaptive_review_max
+        assert reservation["reserved_review_usd"] == round(state.adaptive_review_max * 1.01, 4)
+        # What is left for everything that is not review is the allocation
+        # minus the reservation — the number the dev guard binds on.
+        assert reservation["nonreview_allocation_usd"] == round(
+            4.12 - reservation["reserved_review_usd"], 4
+        )
+
+    def test_the_reservation_reaches_the_run_audit(self, tmp_path: Path) -> None:
+        """An operator can see which dollars were withheld, and on what price."""
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.audit import generate_audit_log
+        from theforge.coordinator.state import CoordinatorResult
+
+        config = self._config(tmp_path)
+        task = _make_task(tmp_path)
+        state = self._seat(tmp_path, config, task)
+
+        audit = generate_audit_log(
+            config,
+            task,
+            CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message="x"),
+        )
+        block = audit["iterations"]["adaptive_limits"]["review_funding_reservation"]
+        assert block["allocation_usd"] == 4.12
+        assert block["review_cycle_cost_usd"] == 1.01
+        assert (
+            block["reserved_review_usd"] == state.review_funding_reservation["reserved_review_usd"]
+        )
+        assert block["reserved_review_cycles"] == state.adaptive_review_max
+        assert block["action"] in (sb.RECONCILE_AFFORDABLE, sb.RECONCILE_REDUCED)
+
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_a_dev_overrun_no_longer_defunds_the_seated_review_cycle(
+        self, mock_pool, _mock_log, tmp_path: Path
+    ) -> None:
+        """The issue's exact shape: $4.00 of a $4.12 allocation spent by dev."""
+        from coord_test_helpers import _make_agent_result, _make_task
+
+        from tests.test_coord_routing_recovery import APPROVE_YAML
+        from theforge.coordinator.review_pool import _run_review_pool
+        from theforge.coordinator.state import ReviewCycleMetadata
+
+        config = self._config(tmp_path)
+        task = _make_task(tmp_path)
+        state = self._seat(tmp_path, config, task)
+
+        # Dev overruns its $2.38 estimate and the band's $3.30 observed max.
+        state.dev_results.append(_make_agent_result(cost_usd=4.00, profile_name="dev"))
+        assert state.total_cost_measured == 4.00
+        # Under the old whole-allocation check this is the refusal the issue
+        # reports: $0.12 left against a $1.01 panel.
+        assert (
+            sb.phase_funding_shortfall(
+                state.story_allocation,
+                state.total_cost_measured,
+                phase="review",
+                participants=["openai-gpt-5.5-cli"],
+                planned_usd=1.01,
+            )
+            is not None
+        )
+
+        mock_pool.return_value = [
+            _make_agent_result(
+                success=True,
+                output=APPROVE_YAML,
+                profile_name="openai-gpt-5.5-cli",
+                cost_usd=0.98,
+            )
+        ]
+        meta = ReviewCycleMetadata(pool_models=[], successful=[], failed=[], synthesized=False)
+        workspace = tmp_path / "ws"
+        workspace.mkdir(exist_ok=True)
+        _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=True,
+        )
+
+        # The full planned panel runs, funded from the reservation.
+        assert state.allocation_exhausted is None
+        assert state.phase != Phase.ESCALATE
+        assert mock_pool.called is True
+        assert meta.successful == ["openai-gpt-5.5-cli"]
+
+    @patch("theforge.coordinator.review_pool.log_agent_result")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    def test_a_panel_neither_pool_can_fund_is_still_refused(
+        self, mock_pool, _mock_log, tmp_path: Path
+    ) -> None:
+        """The reservation is a floor under verification, not a blank cheque."""
+        from coord_test_helpers import _make_agent_result, _make_task
+
+        from theforge.coordinator.review_pool import _run_review_pool
+        from theforge.coordinator.state import ReviewCycleMetadata
+
+        config = self._config(tmp_path)
+        task = _make_task(tmp_path)
+        state = self._seat(tmp_path, config, task)
+
+        # The reserved cycles have all been spent AND the allocation is gone.
+        reserved = float(state.review_funding_reservation["reserved_review_usd"])
+        state.review_agent_results.append(
+            _make_agent_result(cost_usd=reserved, profile_name="openai-gpt-5.5-cli")
+        )
+        state.dev_results.append(_make_agent_result(cost_usd=4.05 - reserved, profile_name="dev"))
+
+        meta = ReviewCycleMetadata(pool_models=[], successful=[], failed=[], synthesized=False)
+        workspace = tmp_path / "ws"
+        workspace.mkdir(exist_ok=True)
+        _run_review_pool(
+            state,
+            config,
+            task,
+            "story",
+            workspace,
+            "branch",
+            meta,
+            notify=False,
+            enforce_budgets=True,
+        )
+
+        assert mock_pool.called is False
+        assert state.error_type == "allocation_exhausted"
+        assert state.allocation_exhausted["reserved_review_usd"] == round(reserved, 4)
+        assert state.allocation_exhausted["reserved_review_remaining_usd"] == 0.0
+
+    def test_a_later_dev_attempt_is_refused_once_non_review_funds_are_gone(
+        self, tmp_path: Path
+    ) -> None:
+        """The other half: the overrunning phase is stopped, not the checker."""
+        from coord_test_helpers import _make_agent_result, _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+        from theforge.coordinator.state import RetryReason
+
+        config = self._config(tmp_path)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path)
+        calls: list[float | None] = []
+
+        def _overrunning_dev(_state, *_args, **_kwargs):
+            calls.append(_state.total_cost_measured)
+            # Spend nearly the whole allocation, then ask for another attempt.
+            _state.dev_results.append(_make_agent_result(cost_usd=4.00, profile_name="dev"))
+            _state.retry_reason = RetryReason.TIMEOUT_RESUME
+            return None
+
+        with patch("theforge.coordinator.engine._run_dev_phase", _overrunning_dev):
+            result = _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        # The first attempt ran — seating had already ruled it fundable. The
+        # retry did not: it would have drawn down the reserved review cycle.
+        assert calls == [0.0]
+        assert result.success is False
+        assert result.phase == Phase.ESCALATE
+        assert state.error_type == "allocation_exhausted"
+        assert state.allocation_exhausted["nonreview_exhausted"] is True
+        assert state.allocation_exhausted["phase"] == "dev"
+        assert "reserved for the" in state.error
+        # The reserved money is still there for the review that never ran.
+        assert state.total_review_cost_measured == 0.0
+
+    def test_a_dev_retry_within_the_non_review_pool_is_untouched(self, tmp_path: Path) -> None:
+        """A story that stays inside its estimate keeps every attempt it had."""
+        from coord_test_helpers import _make_agent_result, _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+        from theforge.coordinator.state import RetryReason
+
+        config = self._config(tmp_path)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path)
+        calls: list[float | None] = []
+
+        class _StopAtSecondDev(Exception):
+            pass
+
+        def _modest_dev(_state, *_args, **_kwargs):
+            if calls:
+                raise _StopAtSecondDev()
+            calls.append(_state.total_cost_measured)
+            _state.dev_results.append(_make_agent_result(cost_usd=0.40, profile_name="dev"))
+            _state.retry_reason = RetryReason.TIMEOUT_RESUME
+            return None
+
+        with patch("theforge.coordinator.engine._run_dev_phase", _modest_dev):
+            with pytest.raises(_StopAtSecondDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        assert state.allocation_exhausted is None
+
+    def test_a_configured_fallback_run_keeps_the_pre_existing_dispatch_check(
+        self, tmp_path: Path
+    ) -> None:
+        """No band history reserves nothing, so nothing changes for those runs."""
+        from coord_test_helpers import _make_agent_result, _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+        from theforge.coordinator.state import RetryReason
+
+        config = self._config(tmp_path)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path)
+        state.story_allocation = {
+            **state.story_allocation,
+            "basis": sb.BASIS_CONFIGURED_FALLBACK,
+        }
+        calls: list[int] = []
+
+        class _StopAtSecondDev(Exception):
+            pass
+
+        def _overrunning_dev(_state, *_args, **_kwargs):
+            if calls:
+                raise _StopAtSecondDev()
+            calls.append(1)
+            _state.dev_results.append(_make_agent_result(cost_usd=4.00, profile_name="dev"))
+            _state.retry_reason = RetryReason.TIMEOUT_RESUME
+            return None
+
+        with patch("theforge.coordinator.engine._run_dev_phase", _overrunning_dev):
+            with pytest.raises(_StopAtSecondDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        assert state.review_funding_reservation["reserved_review_usd"] == 0.0
+        assert state.allocation_exhausted is None

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -1073,6 +1073,54 @@ class TestTheSeatedReviewReservationIsHeldAcrossPhases:
         # The reserved money is still there for the review that never ran.
         assert state.total_review_cost_measured == 0.0
 
+    def test_a_dev_attempt_landing_exactly_on_the_ceiling_refuses_the_retry(
+        self, tmp_path: Path
+    ) -> None:
+        """Exactly-exhausted is exhausted, at the seam as well as in arithmetic.
+
+        The dev phase spends the non-review pool to the cent — $3.11 of the
+        $4.12 allocation, with $1.01 reserved. Float subtraction leaves that
+        looking like a positive balance, and the retry it admits spends the
+        reserved cycle.
+        """
+        from coord_test_helpers import _make_agent_result, _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+        from theforge.coordinator.state import RetryReason
+
+        config = self._config(tmp_path)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path)
+        calls: list[float | None] = []
+
+        def _exact_ceiling_dev(_state, *_args, **_kwargs):
+            calls.append(_state.total_cost_measured)
+            _state.dev_results.append(_make_agent_result(cost_usd=3.11, profile_name="dev"))
+            _state.retry_reason = RetryReason.TIMEOUT_RESUME
+            return None
+
+        with patch("theforge.coordinator.engine._run_dev_phase", _exact_ceiling_dev):
+            result = _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        assert state.review_funding_reservation["nonreview_allocation_usd"] == 3.11
+        assert calls == [0.0]
+        assert result.phase == Phase.ESCALATE
+        assert state.error_type == "allocation_exhausted"
+        assert state.allocation_exhausted["remaining_usd"] == 0.0
+        # The reserved cycle is intact — that is what the refusal bought.
+        assert state.total_review_cost_measured == 0.0
+        assert (
+            sb.reserved_review_shortfall(
+                state.review_funding_reservation,
+                state.story_allocation,
+                observed_usd=state.total_cost_measured,
+                review_observed_usd=state.total_review_cost_measured,
+                participants=["openai-gpt-5.5-cli"],
+                planned_usd=1.01,
+            )
+            is None
+        )
+
     def test_a_dev_retry_within_the_non_review_pool_is_untouched(self, tmp_path: Path) -> None:
         """A story that stays inside its estimate keeps every attempt it had."""
         from coord_test_helpers import _make_agent_result, _make_task


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Cycle 1's exact-boundary P1 is resolved, and I found no blocking regressions in the reservation, dispatch, or audit paths. | [google-gemini-3.5-flash-api] The implementation successfully holds the seated review reservation across phases and ensures the boundary binds at the exact cent, resolving the prior P1 finding. | [anthropic-haiku-cli] Cycle 1 P1 on floating-point boundary condition is fixed via _balance() helper applied consistently to all four funding comparisons. No regressions detected.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $13.28
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Review funding is projected at seating but never withheld, so a phase that exceeds its estimate defunds verification anyway (GitHub Issue #2258)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2258