### PR TITLE
Codex CLI 0.147.0 removed --full-auto, failing every Codex-transport agent at argv parsing

### DIFF
--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -1,7 +1,17 @@
 """Codex (OpenAI) CLI runner.
 
-Invokes `npx @openai/codex exec --json --full-auto` as a subprocess, captures
+Invokes `npx @openai/codex@<pinned> exec --json` as a subprocess, captures
 agent text via a temp file (`-o`), and returns an AgentResult.
+
+The package spec is **version-pinned** (``CODEX_PACKAGE``). An unpinned ``npx``
+spec resolves to whatever npm currently serves, so an upstream release reaches
+this project the moment it publishes, with no commit, no review and no gate. A
+CLI that removes or renames a flag then fails every Codex-transport agent at
+argv parsing — before any model is contacted, so the run costs $0.00 and no
+budget signal fires either. That is how 0.147.0's removal of ``--full-auto``
+took out the reviewer pool and the escalation advisor mid-sprint. Raising the
+pin is a reviewed change like any other, which is the point: the version the
+agents run becomes a fact in the tree rather than a property of the day.
 
 ``--json`` puts codex in machine-readable event mode, which is the ONLY way its
 token usage reaches forge: the human transport prints a bare total that cannot be
@@ -38,6 +48,11 @@ from theforge.workspace_env import build_workspace_env
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
 from .schema_utils import _estimate_cost
+
+# Pinned Codex CLI. See the module docstring for why this is not a floating
+# spec. Both the fresh and the resume argv build from this one constant so the
+# two paths can never drift onto different CLI versions.
+CODEX_PACKAGE = "@openai/codex@0.147.0"
 
 # Emit the cost-unmeasured warning at most once per model to avoid log spam.
 _COST_UNMEASURED_WARNED: set[str] = set()
@@ -99,10 +114,9 @@ def build_argv(
     """
     cmd: list[str] = [
         "npx",
-        "@openai/codex",
+        CODEX_PACKAGE,
         "exec",
         "--json",
-        "--full-auto",
         "--skip-git-repo-check",
         "-m",
         profile.model,
@@ -155,7 +169,7 @@ def build_resume_argv(
     """
     cmd: list[str] = [
         "npx",
-        "@openai/codex",
+        CODEX_PACKAGE,
         "exec",
         "resume",
         "--json",

--- a/tests/contract/test_codex_cli_contract.py
+++ b/tests/contract/test_codex_cli_contract.py
@@ -38,12 +38,19 @@ def _profile(**kwargs) -> ModelProfile:
 
 
 def _replace_npx_with_codex(argv: list[str]) -> list[str]:
-    """Substitute the installed `codex` binary for `npx @openai/codex`.
+    """Substitute the installed `codex` binary for `npx @openai/codex@<pin>`.
 
     Avoids pulling a fresh package via npx on every CI run while still
     exercising the same argv shape the runner produces.
+
+    Matches the package spec by prefix so the runner's version pin does not
+    silently stop matching here — a mismatch would fall through and spawn a real
+    npx download instead of the local binary. Note the tradeoff this substitution
+    makes: it validates the argv *shape* against whatever codex happens to be
+    installed, not against the pinned version the runner actually invokes. A
+    flag removed in the pinned release is therefore not caught here.
     """
-    if argv[:2] == ["npx", "@openai/codex"]:
+    if argv[:1] == ["npx"] and argv[1:2] and argv[1].split("@openai/codex")[0] == "":
         return ["codex", *argv[2:]]
     return argv
 

--- a/tests/fake_bin/npx
+++ b/tests/fake_bin/npx
@@ -65,7 +65,7 @@ def _find_flag(flag: str) -> str | None:
     return None
 
 
-if "@openai/codex" in args:
+if any(a.startswith("@openai/codex") for a in args):
     mode = os.environ.get("FAKE_CODEX_MODE", "happy")
     output_file = _find_flag("-o")
     if mode == "happy":

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -13,6 +13,7 @@ import pytest
 
 from theforge.config import ModelProfile
 from theforge.runners.runner_codex import (
+    CODEX_PACKAGE,
     _agent_text_from_events,
     _classify_codex_launch_failure,
     _CodexUsage,
@@ -163,7 +164,7 @@ class TestCodexSandboxFlag:
                 session_id="sess-abc123",
             )
         cmd = _extract_codex_cmd(mock_run)
-        assert cmd[:4] == ["npx", "@openai/codex", "exec", "resume"]
+        assert cmd[:4] == ["npx", CODEX_PACKAGE, "exec", "resume"]
         assert cmd[-2:] == ["sess-abc123", "-"]
 
     def test_uses_workspace_venv_env(self, tmp_path: Path) -> None:
@@ -463,6 +464,44 @@ class TestCodexResumeSandboxReassertion:
         assert "--full-auto" not in self._resume_cmd(tmp_path, "workspace-write")
         assert "--full-auto" not in self._resume_cmd(tmp_path, "read-only")
         assert "--full-auto" not in self._resume_cmd(tmp_path, "none")
+
+    def test_deprecated_full_auto_flag_dropped_on_fresh_exec(self, tmp_path: Path) -> None:
+        """The fresh path drops it too — 0.147.0 removed the alias outright.
+
+        Dropping it on resume alone left the fresh path passing a flag the CLI
+        later rejected at argv parsing, which fails every Codex agent before the
+        model is contacted, for $0.00 and with no budget signal. The flag was
+        already redundant here: --sandbox is set from the profile below, and the
+        alias only ever meant --sandbox workspace-write.
+        """
+        for mode in ("workspace-write", "read-only", "none"):
+            cmd = build_argv(
+                profile=_make_profile(sandbox_mode=mode),
+                working_dir=tmp_path,
+                output_file=tmp_path / "out.txt",
+                prompt="p",
+            )
+            assert "--full-auto" not in cmd, mode
+
+    def test_codex_package_spec_is_version_pinned(self, tmp_path: Path) -> None:
+        """Both argv paths carry a pinned spec, so npm cannot ship a change here.
+
+        An unpinned spec resolves at invocation time, so an upstream release
+        reaches production with no commit, no review and no gate.
+        """
+        assert "@" in CODEX_PACKAGE.removeprefix("@openai/codex")
+
+        fresh = build_argv(
+            profile=_make_profile(sandbox_mode="workspace-write"),
+            working_dir=tmp_path,
+            output_file=tmp_path / "out.txt",
+            prompt="p",
+        )
+        assert fresh[:2] == ["npx", CODEX_PACKAGE]
+        assert "@openai/codex" not in fresh, "bare unpinned spec must not survive"
+
+        resume = self._resume_cmd(tmp_path, "workspace-write")
+        assert resume[:2] == ["npx", CODEX_PACKAGE]
 
     def test_reassertion_coexists_with_reasoning_override(self, tmp_path: Path) -> None:
         """Both -c overrides are present and each is validated under --strict-config."""

--- a/tests/test_runner_providers.py
+++ b/tests/test_runner_providers.py
@@ -14,7 +14,7 @@ import pytest
 from theforge.agent_types import AgentResult
 from theforge.config import ModelProfile, TransportFallbackConfig
 from theforge.log_level import LogLevel, set_log_level
-from theforge.runners import log_agent_result, run_agent
+from theforge.runners import log_agent_result, run_agent, runner_codex
 
 # Codex spawn seam patched by the tests below.
 _CODEX_RUN_TARGET = "theforge.runners.runner_codex.process_group.run_in_process_group"
@@ -88,9 +88,12 @@ class TestRunCodex:
 
         cmd = mock_run.call_args[0][0]
         assert "npx" in cmd
-        assert "@openai/codex" in cmd
+        assert runner_codex.CODEX_PACKAGE in cmd
         assert "exec" in cmd
-        assert "--full-auto" in cmd
+        # --full-auto was removed in codex 0.147.0. It was also redundant here:
+        # build_argv sets --sandbox from the profile a few lines later, and the
+        # alias only ever meant --sandbox workspace-write.
+        assert "--full-auto" not in cmd
         assert "-m" in cmd
         assert "o4-mini" in cmd
         assert "-C" in cmd


### PR DESCRIPTION
## What broke

Codex 0.147.0 removed the `--full-auto` alias. `runner_codex.build_argv` still passed it, so **every Codex-transport agent failed at argv parsing before the model was contacted** — exit 2, `$0.00` spent, and therefore no budget signal either.

Observed live in run `511425edd2ad`:

```
[REVIEW/openai-gpt-5.5-cli] FAIL | exit=2 | cost=$0.000
npm warn exec The following package was not found and will be installed: @openai/codex@0.147.0
error: unexpected argument '--full-auto' found
```

The review pool silently degraded to a single reviewer, then the escalation advisor failed to launch, so the escalate gate had no advisory report to present and expired against an absent operator. forge's own diagnostics called it correctly at the time: `advisor agent FAILED TO LAUNCH — forge configuration/tool-invocation defect; the model was never contacted`.

## The flag

Already known-deprecated. The **resume** path dropped it and documents why:

> the `--full-auto` alias is intentionally dropped because it is deprecated (codex maps it to `--sandbox workspace-write`) and would contradict an explicit `read-only` override

Only the fresh path kept it, where it was also redundant — `build_argv` sets `--sandbox` from the profile three lines later. A `read-only` profile was launched with `--full-auto --sandbox read-only`: exactly the contradiction that docstring warns about.

## The pin

`npx @openai/codex` resolved at invocation time, so an upstream release reached production with no commit, no review and no gate. Now pinned via one `CODEX_PACKAGE` constant that both argv paths build from, so they cannot drift onto different CLI versions. Raising the pin becomes a reviewed change, and the version the agents run is a fact in the tree rather than a property of the day.

## Why the contract test did not catch it

`tests/contract/test_codex_cli_contract.py` is `cli_contract`-marked — it needs `THEFORGE_RUN_CLI_CONTRACT=1` and sits outside the default gate. It also substitutes whatever `codex` binary is installed for the npx spec, so it validates argv *shape* against an arbitrary local version rather than acceptance by the pinned one. Its docstring now states that tradeoff, and the flag/pin invariants are asserted in the default gate instead.

## Verification

Real CLI at the pinned version, full round trip:

```
{"type":"thread.started",...}
{"type":"item.completed","item":{"type":"agent_message","text":"OK"}}
{"type":"turn.completed","usage":{"input_tokens":14975,"cached_input_tokens":5504,...}}
```

argv parses, model responds, and `turn.completed` still carries the usage split pricing depends on (#2019).

`make gate`: **7501 passed, 32 skipped, 0 failed.**

## Trust state

Hand-authored and hand-reviewed at operator direction, outside the coordinator loop — the defect disabled the OpenAI reviewer and the escalation advisor, so the pipeline could not review its own fix with a full panel. Gate evidence is standalone, not coordinator-owned.