### PR TITLE
A cancelled required check is recorded as a failed one, so a queued PR is abandoned as decided-red without its change ever having been tested

### DIFF
--- a/src/theforge/sprint/ci_checks.py
+++ b/src/theforge/sprint/ci_checks.py
@@ -7,21 +7,49 @@ import logging
 import subprocess
 import time
 from pathlib import Path
+from typing import NamedTuple
 
 log = logging.getLogger(__name__)
 _POLL_INTERVAL_SECONDS = 15
 _PASS_CONCLUSIONS = {"success", "neutral"}
-_FAIL_CONCLUSIONS = {
+#: Conclusions that mean the check ran and judged the change against it. Only
+#: these are evidence *against* a change; everything else is an absence of
+#: evidence (issue #2270).
+_JUDGED_FAIL_CONCLUSIONS = {
     "failure",
-    "cancelled",
-    "timed_out",
     "action_required",
-    "startup_failure",
-    "stale",
     # GraphQL StatusContext state for a hard-errored legacy status.
     "error",
 }
+#: Terminal conclusions that end a check without judging the change: the run was
+#: interrupted, superseded, or never really started. Naming them is documentation
+#: — any conclusion outside the pass/judged-fail tables is treated the same way,
+#: because an unrecognised outcome is not a verdict either.
+_UNJUDGED_CONCLUSIONS = {
+    "cancelled",
+    "timed_out",
+    "stale",
+    "startup_failure",
+    "skipped",
+}
 _PENDING_STATUSES = {"queued", "in_progress", "pending", "waiting", "requested"}
+
+
+class CheckSummary(NamedTuple):
+    """Required-check state split by *what the check said about the change*.
+
+    ``failing`` holds checks that ran and rejected the change; ``unjudged`` holds
+    checks that reached a terminal state without producing a verdict. The two
+    call for opposite operator actions — change the code versus dispatch the
+    check again — so they must never collapse into one bucket. ``unjudged`` is a
+    subset of ``pending``: a check with no verdict is still something the caller
+    is waiting on, so the wait budget, not a merge failure, governs it.
+    """
+
+    status: str
+    failing: list[str]
+    pending: list[str]
+    unjudged: list[str]
 
 
 def _gh_json(project_root: Path, args: list[str]) -> object:
@@ -55,7 +83,7 @@ def _gh_text(project_root: Path, args: list[str]) -> str:
 
 def _summarize_required_checks(
     required_checks: list[str], check_runs: object, statuses: object
-) -> tuple[str, list[str], list[str]]:
+) -> CheckSummary:
     run_map: dict[str, tuple[str | None, str | None]] = {}
     for run in check_runs if isinstance(check_runs, list) else []:
         if not isinstance(run, dict):
@@ -77,28 +105,40 @@ def _summarize_required_checks(
     passing: list[str] = []
     failing: list[str] = []
     pending: list[str] = []
+    unjudged: list[str] = []
     for name in required_checks:
         run_status, run_conclusion = run_map.get(name, (None, None))
         legacy_state = status_map.get(name)
         if run_conclusion in _PASS_CONCLUSIONS or legacy_state in _PASS_CONCLUSIONS:
             passing.append(name)
             continue
-        if run_conclusion in _FAIL_CONCLUSIONS or legacy_state in _FAIL_CONCLUSIONS:
+        if run_conclusion in _JUDGED_FAIL_CONCLUSIONS or legacy_state in _JUDGED_FAIL_CONCLUSIONS:
             failing.append(name)
             continue
-        if (
-            run_status in _PENDING_STATUSES
-            or legacy_state in _PENDING_STATUSES
-            or name not in run_map
-            and name not in status_map
-        ):
-            pending.append(name)
-            continue
         pending.append(name)
-    return (
+        # A check that is merely queued or running has not stopped, so it is not
+        # unjudged yet — the wait budget covers it. A check that reached any
+        # other terminal outcome stopped without a verdict.
+        still_running = run_status in _PENDING_STATUSES or legacy_state in _PENDING_STATUSES
+        concluded = run_conclusion is not None or legacy_state is not None
+        if concluded and not still_running:
+            unjudged.append(name)
+            if (
+                run_conclusion not in _UNJUDGED_CONCLUSIONS
+                and legacy_state not in _UNJUDGED_CONCLUSIONS
+            ):
+                log.debug(
+                    "Unrecognised terminal outcome for required check %s "
+                    "(conclusion=%r legacy_state=%r); treating as unjudged",
+                    name,
+                    run_conclusion,
+                    legacy_state,
+                )
+    return CheckSummary(
         "pass" if len(passing) == len(required_checks) else "fail" if failing else "pending",
         failing,
         pending,
+        unjudged,
     )
 
 
@@ -169,29 +209,48 @@ def _normalize_rollup(rollup: object) -> tuple[list[dict], list[dict]]:
     return check_runs, statuses
 
 
-def failing_required_pr_checks(project_root: Path, pr_url: str, base_branch: str) -> list[str]:
-    """Names of ``pr_url``'s required checks that have terminally failed.
+class PrCheckState(NamedTuple):
+    """What ``pr_url``'s required checks have decided about the change so far."""
 
-    Returns an empty list when nothing is decided-red *and* when the required
-    check set or the PR's rollup cannot be resolved: an un-answerable probe must
-    leave the caller waiting rather than abandon a PR on missing information.
+    #: Checks that ran and rejected the change. A PR carrying any of these can
+    #: never merge, so the caller may abandon the wait.
+    failing: list[str]
+    #: Checks that stopped without a verdict (cancelled, superseded, interrupted,
+    #: or an outcome we cannot recognise). These say nothing about the change,
+    #: so the caller keeps waiting on the merge budget instead.
+    unjudged: list[str]
+
+
+def required_pr_check_state(project_root: Path, pr_url: str, base_branch: str) -> PrCheckState:
+    """Terminal state of ``pr_url``'s required checks, split by verdict.
+
+    Returns an empty state when nothing is decided *and* when the required check
+    set or the PR's rollup cannot be resolved: an un-answerable probe must leave
+    the caller waiting rather than abandon a PR on missing information.
     """
     try:
         owner_repo = _resolve_owner_repo(project_root)
         required_checks = _required_check_contexts(project_root, owner_repo, base_branch)
         if not required_checks:
-            return []
+            return PrCheckState([], [])
         rollup = _gh_json(
             project_root,
             ["pr", "view", pr_url, "--json", "statusCheckRollup", "--jq", ".statusCheckRollup"],
         )
     except Exception as exc:  # gh missing, network flake, unparseable payload
         log.debug("Unable to resolve required check status for %s: %s", pr_url, exc)
-        return []
+        return PrCheckState([], [])
 
     check_runs, statuses = _normalize_rollup(rollup)
-    _, failing, _ = _summarize_required_checks(required_checks, check_runs, statuses)
-    return failing
+    summary = _summarize_required_checks(required_checks, check_runs, statuses)
+    log.debug(
+        "PR check state %s failing=%s unjudged=%s pending=%s",
+        pr_url,
+        summary.failing,
+        summary.unjudged,
+        summary.pending,
+    )
+    return PrCheckState(summary.failing, summary.unjudged)
 
 
 def poll_required_checks(project_root: Path, base_branch: str, timeout_seconds: int) -> dict:
@@ -234,15 +293,16 @@ def poll_required_checks(project_root: Path, base_branch: str, timeout_seconds: 
             project_root,
             ["api", f"repos/{owner_repo}/commits/{sha}/status", "--jq", ".statuses"],
         )
-        summary, failing, pending = _summarize_required_checks(
+        summary, failing, pending, unjudged = _summarize_required_checks(
             required_checks, check_runs, statuses
         )
         log.debug(
-            "CI poll sha=%s required=%s failing=%s pending=%s",
+            "CI poll sha=%s required=%s failing=%s pending=%s unjudged=%s",
             sha,
             required_checks,
             failing,
             pending,
+            unjudged,
         )
         if summary == "pass":
             return {
@@ -260,14 +320,20 @@ def poll_required_checks(project_root: Path, base_branch: str, timeout_seconds: 
             }
         if time.monotonic() >= deadline:
             pending_checks = ", ".join(pending)
+            # An interrupted check never judged the change, so it is reported as
+            # an absent verdict to be re-dispatched, never as a red result.
+            unjudged_note = (
+                f" No verdict was produced by: {', '.join(unjudged)}." if unjudged else ""
+            )
             return {
                 "status": "timeout",
                 "sha": sha,
                 "failing_checks": [],
+                "unjudged_checks": unjudged,
                 "message": (
                     "Timed out after "
                     f"{timeout_seconds}s waiting for required CI checks on {sha}: "
-                    f"{pending_checks}."
+                    f"{pending_checks}.{unjudged_note}"
                 ),
             }
         time.sleep(_POLL_INTERVAL_SECONDS)

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -1472,8 +1472,18 @@ def _merge_failed_action(story: dict, ref: str) -> str:
     the recorded error text is the evidence that distinguishes them. Naming a
     merge conflict unconditionally (the prior behavior) is wrong whenever the PR
     was mergeable and merely red, or merely slow — issue #1946.
+
+    A check that stopped without judging the change is a fourth case, and the
+    opposite of a red one: nothing is known to be wrong with the code, so the
+    recovery is to dispatch the check again — issue #2270.
     """
     error = (_nonempty(story.get("error")) or "").lower()
+    if "never produced a verdict" in error:
+        return (
+            f"re-dispatch the required checks named in {ref}'s merge failure — they "
+            "stopped without judging the change (cancelled, superseded, or interrupted), "
+            "so the change itself is untested, not rejected"
+        )
     if "required checks failed" in error:
         return (
             f"fix the required checks named in {ref}'s merge failure, then re-run the "

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -78,7 +78,7 @@ from .audit import (
 )
 from .auth_gate import enforce_sprint_auth_readiness
 from .budget import evaluate_budget
-from .ci_checks import failing_required_pr_checks, poll_required_checks
+from .ci_checks import PrCheckState, poll_required_checks, required_pr_check_state
 from .collision import (
     batch_group_id,
     compute_batch_groups,
@@ -2861,18 +2861,18 @@ def _abnormal_story_result(
     return CoordinatorResult(success=False, phase=phase, state=state, message=message)
 
 
-def _failing_required_pr_checks(pr_url: str, project_root: Path, base_branch: str) -> list[str]:
-    """Required checks on ``pr_url`` that have reached a terminal failing state.
+def _required_pr_check_state(pr_url: str, project_root: Path, base_branch: str) -> PrCheckState:
+    """Terminal state of ``pr_url``'s required checks, split by verdict.
 
     Thin seam over :mod:`theforge.sprint.ci_checks` so the queued-PR wait can be
-    tested without a live ``gh``. Never raises: an unanswerable probe returns no
-    failures, which keeps the caller waiting instead of abandoning a PR whose
+    tested without a live ``gh``. Never raises: an unanswerable probe returns an
+    empty state, which keeps the caller waiting instead of abandoning a PR whose
     check state we could not read.
     """
     try:
-        return failing_required_pr_checks(project_root, pr_url, base_branch)
+        return required_pr_check_state(project_root, pr_url, base_branch)
     except Exception:  # pragma: no cover - ci_checks already fails soft
-        return []
+        return PrCheckState([], [])
 
 
 def _poll_queued_pr(
@@ -2895,8 +2895,16 @@ def _poll_queued_pr(
     merge-wait budget and then misreports the outcome as a queue timeout (issue
     #1946); such a PR returns ``checks_failed`` immediately, carrying the names
     of the failing checks. The wait budget is reserved for *pending* checks.
+
+    Only a check that ran and rejected the change counts as decided-red. A check
+    that stopped without a verdict — cancelled by a platform incident, superseded,
+    or ended in an outcome we cannot recognise — is an absence of evidence about
+    the change, so it keeps the wait running and is named in the timeout result
+    instead. Abandoning such a PR as red sends the operator to debug a change that
+    was never tested (issue #2270).
     """
     deadline = time.monotonic() + timeout_seconds
+    unjudged_seen: dict[str, None] = {}  # ordered set of check names
     while True:
         try:
             proc = subprocess.run(
@@ -2919,14 +2927,20 @@ def _poll_queued_pr(
             elif state == "CLOSED":
                 return {"status": "closed"}
             elif base_branch is not None:
-                failing = _failing_required_pr_checks(pr_url, project_root, base_branch)
-                if failing:
+                checks = _required_pr_check_state(pr_url, project_root, base_branch)
+                if checks.failing:
                     return {
                         "status": "checks_failed",
-                        "failing_checks": ", ".join(failing),
+                        "failing_checks": ", ".join(checks.failing),
                     }
+                unjudged_seen.update(dict.fromkeys(checks.unjudged))
 
         if time.monotonic() >= deadline:
+            if unjudged_seen:
+                return {
+                    "status": "timeout",
+                    "unjudged_checks": ", ".join(unjudged_seen),
+                }
             return {"status": "timeout"}
         time.sleep(30)
 
@@ -2938,13 +2952,22 @@ def _queued_pr_failure_message(
 
     The cause string is the only evidence downstream RCA has, so each terminal
     status gets its own wording: "timed out" is reserved for an actual deadline
-    expiry, and a decided-red PR names the required checks that failed.
+    expiry, and a decided-red PR names the required checks that failed. A wait
+    that expired on checks which stopped without ever judging the change says so
+    explicitly, because that is recovered by dispatching the checks again rather
+    than by changing the code (issue #2270).
     """
     status = poll_result.get("status", "unknown")
     if status == "checks_failed":
         failing = poll_result.get("failing_checks") or "unknown"
         return f"Queued PR required checks failed ({failing}): {pr_url}"
     if status == "timeout":
+        unjudged = poll_result.get("unjudged_checks")
+        if unjudged:
+            return (
+                f"Queued PR required checks never produced a verdict ({unjudged}) "
+                f"within {timeout_seconds}s: {pr_url}"
+            )
         return f"Queued PR timed out after {timeout_seconds}s: {pr_url}"
     return f"Queued PR {status}: {pr_url}"
 
@@ -5700,10 +5723,15 @@ def run_sprint(
                 )
                 if ci_result["status"] in {"fail", "timeout"}:
                     failing = ", ".join(ci_result["failing_checks"]) or "pending required checks"
+                    # A check that stopped without a verdict is not a red result;
+                    # naming it keeps the halt reason honest about what is known
+                    # versus merely unknown (#2270).
+                    unjudged = ", ".join(ci_result.get("unjudged_checks") or [])
                     stopped_reason = (
                         "Required CI checks "
                         f"{ci_result['status']} after merging {slug} "
                         f"at {ci_result['sha']}: {failing}"
+                        + (f" (no verdict produced by: {unjudged})" if unjudged else "")
                     )
                     ci_halt_slug = slug
                     _log(

--- a/tests/test_ci_checks.py
+++ b/tests/test_ci_checks.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-from theforge.sprint.ci_checks import failing_required_pr_checks, poll_required_checks
+import pytest
+
+from theforge.sprint.ci_checks import poll_required_checks, required_pr_check_state
+
+
+def failing_required_pr_checks(project_root: Path, pr_url: str, base_branch: str) -> list[str]:
+    """Judged-failure names only — keeps the pre-#2270 assertions readable."""
+    return required_pr_check_state(project_root, pr_url, base_branch).failing
 
 
 class _Proc:
@@ -181,3 +188,103 @@ def test_failing_required_pr_checks_empty_when_branch_unprotected(tmp_path: Path
 
     with patch("theforge.sprint.ci_checks.subprocess.run", side_effect=responses):
         assert failing_required_pr_checks(tmp_path, "https://github.com/x/y/pull/1", "main") == []
+
+
+@pytest.mark.parametrize(
+    "conclusion", ["CANCELLED", "TIMED_OUT", "STALE", "STARTUP_FAILURE", "SKIPPED"]
+)
+def test_interrupted_required_check_is_unjudged_not_failing(
+    tmp_path: Path, conclusion: str
+) -> None:
+    """Issue #2270: a check that stopped without judging the change is an absence
+    of evidence about it, never evidence against it."""
+    rollup = (
+        f'[{{"__typename":"CheckRun","name":"gate","status":"COMPLETED",'
+        f'"conclusion":"{conclusion}"}},'
+        '{"__typename":"CheckRun","name":"lint","status":"COMPLETED","conclusion":"SUCCESS"}]'
+    )
+
+    with patch(
+        "theforge.sprint.ci_checks.subprocess.run", side_effect=_pr_check_responses(rollup)
+    ):
+        state = required_pr_check_state(tmp_path, "https://github.com/x/y/pull/1", "main")
+
+    assert state.failing == []
+    assert state.unjudged == ["gate"]
+
+
+def test_unrecognised_conclusion_is_unjudged_not_failing(tmp_path: Path) -> None:
+    """An outcome the table does not know is not a verdict either: the safer
+    default in both directions is 'no judgement yet'."""
+    rollup = (
+        '[{"__typename":"CheckRun","name":"gate","status":"COMPLETED",'
+        '"conclusion":"SOME_NEW_GITHUB_OUTCOME"},'
+        '{"__typename":"CheckRun","name":"lint","status":"COMPLETED","conclusion":"SUCCESS"}]'
+    )
+
+    with patch(
+        "theforge.sprint.ci_checks.subprocess.run", side_effect=_pr_check_responses(rollup)
+    ):
+        state = required_pr_check_state(tmp_path, "https://github.com/x/y/pull/1", "main")
+
+    assert state.failing == []
+    assert state.unjudged == ["gate"]
+
+
+def test_judged_failures_still_reported_as_failing(tmp_path: Path) -> None:
+    """The reclassification must not disarm the decided-red path: a check that
+    ran and rejected the change is still a failure."""
+    rollup = (
+        '[{"__typename":"CheckRun","name":"gate","status":"COMPLETED","conclusion":"FAILURE"},'
+        '{"__typename":"CheckRun","name":"lint","status":"COMPLETED",'
+        '"conclusion":"ACTION_REQUIRED"}]'
+    )
+
+    with patch(
+        "theforge.sprint.ci_checks.subprocess.run", side_effect=_pr_check_responses(rollup)
+    ):
+        state = required_pr_check_state(tmp_path, "https://github.com/x/y/pull/1", "main")
+
+    assert state.failing == ["gate", "lint"]
+    assert state.unjudged == []
+
+
+def test_running_check_is_pending_not_unjudged(tmp_path: Path) -> None:
+    """A check that has not stopped has not failed to judge — the wait budget,
+    not the unjudged bucket, covers it."""
+    rollup = (
+        '[{"__typename":"CheckRun","name":"gate","status":"IN_PROGRESS","conclusion":null},'
+        '{"__typename":"CheckRun","name":"lint","status":"COMPLETED","conclusion":"SUCCESS"}]'
+    )
+
+    with patch(
+        "theforge.sprint.ci_checks.subprocess.run", side_effect=_pr_check_responses(rollup)
+    ):
+        state = required_pr_check_state(tmp_path, "https://github.com/x/y/pull/1", "main")
+
+    assert state == ([], [])
+
+
+def test_poll_required_checks_cancelled_check_times_out_not_fails(tmp_path: Path) -> None:
+    """A cancelled required check on the base branch converges on the existing
+    wait-budget expiry, and the recorded message says no verdict was produced."""
+    responses = [
+        _Proc('{"nameWithOwner":"acme/repo"}'),
+        _Proc("deadbeef"),
+        _Proc('["tests"]'),
+        _Proc('[{"name":"tests","status":"completed","conclusion":"cancelled"}]'),
+        _Proc("[]"),
+    ]
+    monotonic_values = [0.0, 301.0]
+
+    with (
+        patch("theforge.sprint.ci_checks.subprocess.run", side_effect=responses),
+        patch("theforge.sprint.ci_checks.time.monotonic", side_effect=monotonic_values),
+        patch("theforge.sprint.ci_checks.time.sleep"),
+    ):
+        result = poll_required_checks(tmp_path, "main", 300)
+
+    assert result["status"] == "timeout"
+    assert result["failing_checks"] == []
+    assert result["unjudged_checks"] == ["tests"]
+    assert "No verdict was produced by: tests." in result["message"]

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -24,6 +24,7 @@ from theforge.config import (
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.review import ReviewResult
 from theforge.sprint import load_sprint_manifest, run_sprint
+from theforge.sprint.ci_checks import PrCheckState
 from theforge.sprint.dag import StoryDAG, build_dag
 from theforge.sprint.lock import integration_lock
 from theforge.sprint.runner import _classify_and_record, _run_fresh
@@ -1920,8 +1921,8 @@ class TestQueuedMergePolling:
                 return_value=MagicMock(returncode=0, stdout="OPEN", stderr=""),
             ),
             patch(
-                "theforge.sprint.runner._failing_required_pr_checks",
-                return_value=["gate", "lint"],
+                "theforge.sprint.runner._required_pr_check_state",
+                return_value=PrCheckState(["gate", "lint"], []),
             ),
             patch("theforge.sprint.runner.time.sleep") as sleep,
         ):
@@ -1948,7 +1949,10 @@ class TestQueuedMergePolling:
 
         with (
             patch("theforge.sprint.runner.subprocess.run", side_effect=_fake_run),
-            patch("theforge.sprint.runner._failing_required_pr_checks", return_value=[]) as probe,
+            patch(
+                "theforge.sprint.runner._required_pr_check_state",
+                return_value=PrCheckState([], []),
+            ) as probe,
             patch("theforge.sprint.runner.time.sleep") as sleep,
         ):
             result = _poll_queued_pr(
@@ -1974,7 +1978,10 @@ class TestQueuedMergePolling:
                 "theforge.sprint.runner.subprocess.run",
                 return_value=MagicMock(returncode=0, stdout="OPEN", stderr=""),
             ),
-            patch("theforge.sprint.runner._failing_required_pr_checks", return_value=[]),
+            patch(
+                "theforge.sprint.runner._required_pr_check_state",
+                return_value=PrCheckState([], []),
+            ),
             patch("theforge.sprint.runner.time.sleep"),
             patch(
                 "theforge.sprint.runner.time.monotonic", side_effect=lambda: next(monotonic_values)
@@ -2007,6 +2014,55 @@ class TestQueuedMergePolling:
             _queued_pr_failure_message({"status": "closed"}, url, 3600)
             == f"Queued PR closed: {url}"
         )
+
+    def test_poll_queued_pr_keeps_waiting_on_a_cancelled_required_check(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #2270: a cancelled check never judged the change, so it must not
+        abandon the PR as decided-red — the wait budget governs it, and the
+        expiry names the checks that produced no verdict."""
+
+        from theforge.sprint.runner import _poll_queued_pr
+
+        monotonic_values = iter([0, 1, 31, 61])
+        with (
+            patch(
+                "theforge.sprint.runner.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="OPEN", stderr=""),
+            ),
+            patch(
+                "theforge.sprint.runner._required_pr_check_state",
+                return_value=PrCheckState([], ["gate (3.12)"]),
+            ),
+            patch("theforge.sprint.runner.time.sleep") as sleep,
+            patch(
+                "theforge.sprint.runner.time.monotonic", side_effect=lambda: next(monotonic_values)
+            ),
+        ):
+            result = _poll_queued_pr(
+                "https://github.com/x/y/pull/1",
+                tmp_path,
+                60,
+                base_branch="main",
+            )
+
+        assert result == {"status": "timeout", "unjudged_checks": "gate (3.12)"}
+        assert sleep.called  # it waited rather than abandoning on the first poll
+
+    def test_queued_pr_failure_message_separates_unjudged_from_failed(self) -> None:
+        """The recorded reason is what the operator reads to decide whether the
+        work is salvageable, so an unjudged check must not read as a red one."""
+
+        from theforge.sprint.runner import _queued_pr_failure_message
+
+        url = "https://github.com/x/y/pull/7"
+        message = _queued_pr_failure_message(
+            {"status": "timeout", "unjudged_checks": "gate (3.12)"}, url, 3600
+        )
+        assert message == (
+            f"Queued PR required checks never produced a verdict (gate (3.12)) within 3600s: {url}"
+        )
+        assert "required checks failed" not in message
 
     def test_poll_queued_pr_waits_for_origin_main_when_base_branch_set(
         self, tmp_path: Path

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -1939,6 +1939,34 @@ def test_merge_failed_check_failure_guidance_names_the_checks(tmp_path: Path) ->
     assert "iteration budget" not in actions
 
 
+def test_merge_failed_unjudged_check_guidance_says_re_dispatch(tmp_path: Path) -> None:
+    """Issue #2270: a check that stopped without judging the change must send the
+    operator to re-dispatch it, not to debug a change that was never tested."""
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-2258",
+                    "outcome": "MERGE_FAILED",
+                    "error": (
+                        "Queued PR required checks never produced a verdict (gate (3.12)) "
+                        "within 3600s: https://github.com/x/y/pull/2269"
+                    ),
+                }
+            ]
+        ),
+    )
+    entry = _build(d)["stories"]["issue-2258"]
+    actions = " ".join(entry["recommended_next_actions"]).lower()
+
+    assert entry["primary_failure_class"] == "merge_failed"
+    assert "re-dispatch" in actions
+    assert "decided-red" not in actions
+    assert "merge conflict" not in actions
+
+
 def test_merge_failed_timeout_guidance_points_at_the_wait_budget(tmp_path: Path) -> None:
     d = _sprint_dir(tmp_path)
     _write(


### PR DESCRIPTION
## Summary

The change separates unjudged required-check outcomes from real failures through the queued-PR poll, recorded reason, and RCA guidance, with targeted regression coverage passing.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $0.75
- **Dev iterations:** 0
- **Tests:** N/A

## Findings

_No findings._

## Story

A cancelled required check is recorded as a failed one, so a queued PR is abandoned as decided-red without its change ever having been tested (GitHub Issue #2270)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2270