### PR TITLE
Two re-entry paths resume a stopped story differently, and which one is chosen decides whether review runs

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -77,6 +77,10 @@ forge run stories/add-auth.md --from review --fg
 
 **`--resume`**
 Use this when a run was interrupted and you want automatic state detection.
+`--resume` continues from the pipeline state an earlier attempt recorded, which
+includes any escalate-gate decision — see
+[Choosing a re-entry path](#choosing-a-re-entry-path) before resuming a story
+whose review loop was still owed a cycle.
 
 **`--until` / `--from`**
 Use these for partial workflows, inspection checkpoints, or explicit re-entry
@@ -97,7 +101,9 @@ forge review --issue <N> [flags]
 ```
 
 **Use this when:** You implemented or fixed something in a worktree and want to
-run review without re-running PLAN/DEV.
+run review without re-running PLAN/DEV. This is also the path that *runs* an
+outstanding review cycle on a story that stopped mid-pipeline — `forge sprint
+--resume` may skip it. See [Choosing a re-entry path](#choosing-a-re-entry-path).
 
 Name the **story**, not the worktree. A story sourced from a GitHub issue is
 never written to disk, so `--issue N` is the only way to review one — it reads
@@ -367,6 +373,26 @@ When the owning process is gone, stories whose last recorded phase said
 `running` are reported as `interrupted` (their last known phase is retained in
 the PHASE column as history). Interrupted work is not progressing — resume the
 sprint rather than waiting on it.
+
+### Outstanding phases and re-entry
+
+A story that stopped mid-pipeline can still owe a phase. When it does, its row
+carries two extra lines derived from the coordinator's persisted resume record —
+no run is started, so this costs nothing:
+
+```
+✗ issue-2239   failed   REVIEW   ...   review cycle 1 REQUEST_CHANGES
+    outstanding: REVIEW cycle 2 not run
+    re-entry: forge review runs REVIEW cycle 2; forge sprint --resume recovers
+              escalation decision land_core/defer_edges and skips REVIEW
+```
+
+`outstanding:` names what has *not* run — this is what distinguishes a story
+with an unrun review cycle from one whose review completed with APPROVE (which
+shows neither line). `re-entry:` appears only where the two paths disagree; see
+[Choosing a re-entry path](#choosing-a-re-entry-path). The same two lines are
+printed under a pending decision whose story is in that state, so the
+pending-decision surface cannot hide an unrun review cycle.
 
 ### Operator-action queue
 
@@ -885,6 +911,44 @@ forge migrate-profiles --dry-run # print the migration report without writing
 | Provider crashed / timed out mid-phase | Reruns the crashed phase | Safe; phases are idempotent |
 | Stale worktree from previous run | Resumes from last confirmed phase | May produce unexpected results if the story changed |
 | Manual human edits made to worktree | Resumes from VALIDATE | Coordinator sees the edited state |
+| Escalate-gate decision recorded, next review cycle unrun | Recovers the decision and continues from it — REVIEW does not run | Use `forge review` instead when you want that cycle to run. See below |
+
+### Choosing a re-entry path
+
+`forge review` and `forge sprint --resume` (equally, `forge run --resume`) both
+re-enter a stopped story, and they do different things:
+
+- **`forge review`** runs the review phase against the worktree. It runs a
+  review cycle; it does not consult the recorded pipeline state.
+- **`forge sprint --resume`** re-enters the pipeline and *recovers* what an
+  earlier attempt recorded — preflight, routing, plan review, and any
+  escalate-gate decision — then continues from what that state says. If the
+  recovered state is a decision, resume continues from the decision, not from
+  the unfinished phase.
+
+Those diverge whenever a story stopped with both a recorded escalate-gate
+decision and a review cycle it never ran — for example: gate PASS after a fix,
+review cycle 1 returned REQUEST_CHANGES, cycle 2 never ran, escalation decision
+`land_core_defer_edges` recorded.
+
+| You want | Use | What happens |
+|---|---|---|
+| The unrun review cycle to execute against the fix | `forge review <story>` | Review cycle 2 runs; the recorded decision is not consulted |
+| To honor the recorded pipeline state (the decision you already made) | `forge sprint --resume` / `forge run --resume` | Resume continues from `land_core_defer_edges` and proceeds to landing; **no review runs** |
+
+Neither is a default: choosing between them is choosing whether the work gets
+reviewed. Check `forge status` first — a story in this state prints an
+`outstanding:` line naming the unrun cycle and a `re-entry:` line naming what
+each path would do. Resume itself reports the same thing before it spends
+anything, on its `↺ RESUME` lines:
+
+```
+  ↺ RESUME   recovered phase record: escalation
+  ↺ RESUME   acting on escalation decision land_core / defer_edges (from run 20260807-...)
+  ↺ RESUME   outstanding: REVIEW cycle 2 has not run (last verdict REQUEST_CHANGES, gate PASS)
+  ↺ RESUME   this resume continues from that decision and will NOT run REVIEW —
+             `forge review` runs REVIEW cycle 2 instead
+```
 
 **Force a clean restart:**
 

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -939,15 +939,27 @@ review cycle 1 returned REQUEST_CHANGES, cycle 2 never ran, escalation decision
 Neither is a default: choosing between them is choosing whether the work gets
 reviewed. Check `forge status` first — a story in this state prints an
 `outstanding:` line naming the unrun cycle and a `re-entry:` line naming what
-each path would do. Resume itself reports the same thing before it spends
-anything, on its `↺ RESUME` lines:
+each path would do. Whichever you run reports the same thing before it spends
+anything, on its `↺ RESUME` lines — stated for the path you actually invoked.
+
+`forge sprint --resume` / `forge run --resume`:
 
 ```
   ↺ RESUME   recovered phase record: escalation
-  ↺ RESUME   acting on escalation decision land_core / defer_edges (from run 20260807-...)
+  ↺ RESUME   recovered escalation decision land_core / defer_edges (from run 20260807-...)
   ↺ RESUME   outstanding: REVIEW cycle 2 has not run (last verdict REQUEST_CHANGES, gate PASS)
   ↺ RESUME   this resume continues from that decision and will NOT run REVIEW —
              `forge review` runs REVIEW cycle 2 instead
+```
+
+`forge review` — same recovered state, and it is the path that runs the cycle:
+
+```
+  ↺ RESUME   recovered phase record: escalation
+  ↺ RESUME   recovered escalation decision land_core / defer_edges (from run 20260807-...)
+  ↺ RESUME   outstanding: REVIEW cycle 2 has not run (last verdict REQUEST_CHANGES, gate PASS)
+  ↺ RESUME   `forge review` runs REVIEW cycle 2 now —
+             `forge sprint --resume` would continue from that decision and skip it
 ```
 
 **Force a clean restart:**

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -394,6 +394,18 @@ shows neither line). `re-entry:` appears only where the two paths disagree; see
 printed under a pending decision whose story is in that state, so the
 pending-decision surface cannot hide an unrun review cycle.
 
+A **completed** sprint renders the postmortem digest instead of the table, and
+carries the same facts as its own section — printed whether or not an RCA
+artifact exists, because what a story still owes is not a failure
+classification:
+
+```
+OUTSTANDING (1)
+  ✗ #2239  REVIEW cycle 2 not run
+       re-entry: forge review runs REVIEW cycle 2; forge sprint --resume recovers
+                 escalation decision land_core/defer_edges and skips REVIEW
+```
+
 ### Operator-action queue
 
 ```bash

--- a/src/theforge/cli/reentry_display.py
+++ b/src/theforge/cli/reentry_display.py
@@ -1,0 +1,66 @@
+"""Operator-facing rendering of a stopped story's re-entry disclosure.
+
+``forge status`` has three surfaces that can be the one an operator is looking
+at when they decide how to re-enter a stopped story: the live/crashed sprint
+table (``cli/sprint_status.py``), the completed-sprint postmortem digest
+(``cli/sprint_digest.py``), and the pending-decision list (``cli/status.py``).
+A story with an unrun review cycle has to be distinguishable from one whose
+review completed on *all* of them — a disclosure present on two of three is a
+disclosure the operator can miss by looking at the wrong one (#2239).
+
+This module is the single formatter for that. The judgement itself is not made
+here: :mod:`theforge.coordinator.resume_persistence` derives it from the story's
+persisted resume record, and this only lays the result out. Best-effort by
+inheritance — the loader returns None for an absent or unreadable record, so a
+status view never fails on a missing sidecar.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def load_reentry_display(project_root: Path | None, slug: str) -> tuple[list[str], str] | None:
+    """Return ``(outstanding_phases, reentry_note)`` for ``slug``, or None.
+
+    None means there is nothing to disclose: no record, no review progress in
+    it, or a review that completed. ``reentry_note`` is empty when both re-entry
+    paths would do the same thing, even though a phase is still outstanding.
+    """
+    if project_root is None or not slug:
+        return None
+    try:
+        from theforge.coordinator.resume_persistence import (  # noqa: PLC0415
+            describe_outstanding_phases,
+            describe_reentry_paths,
+            load_reentry_analysis,
+        )
+
+        analysis = load_reentry_analysis(Path(project_root), slug)
+    except Exception:
+        return None
+    if not analysis:
+        return None
+    phases = describe_outstanding_phases(analysis)
+    note = describe_reentry_paths(analysis)
+    if not phases and not note:
+        return None
+    return phases, note
+
+
+def reentry_lines(project_root: Path | None, slug: str, *, indent: str = "    ") -> list[str]:
+    """Ready-to-print ``outstanding:`` / ``re-entry:`` lines for ``slug``.
+
+    Empty list when there is nothing to disclose, so a caller can splice the
+    result into its own layout without a conditional.
+    """
+    loaded = load_reentry_display(project_root, slug)
+    if loaded is None:
+        return []
+    phases, note = loaded
+    lines: list[str] = []
+    if phases:
+        lines.append(f"{indent}outstanding: {', '.join(phases)}")
+    if note:
+        lines.append(f"{indent}re-entry: {note}")
+    return lines

--- a/src/theforge/cli/review.py
+++ b/src/theforge/cli/review.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from theforge.cli.shared import _build_task, _find_config, _write_audit
 from theforge.config import load_config
 from theforge.coordinator.engine import run_from_review
+from theforge.coordinator.run_setup import REENTRY_MODE_REVIEW
 from theforge.coordinator.util import set_log_level as coordinator_set_log_level
 from theforge.runners import LogLevel
 from theforge.runners import set_log_level as runner_set_log_level
@@ -110,6 +111,11 @@ def cmd_review(args: object) -> int:
         workspace_path,
         auto_merge=auto_merge,
         notify=not args.no_notify,
+        # This command runs the review phase. The shared resume setup would
+        # otherwise disclose the *pipeline resume's* behaviour — that a
+        # recovered escalation decision means REVIEW is skipped — from the one
+        # command that is about to run it (#2239).
+        reentry_mode=REENTRY_MODE_REVIEW,
     )
 
     # Write audit log

--- a/src/theforge/cli/sprint_digest.py
+++ b/src/theforge/cli/sprint_digest.py
@@ -10,9 +10,10 @@
   do next.
 
 The digest is a pure *renderer*. Its interface to the rest of the system is the
-two artifacts it reads — ``sprint-summary.yaml`` (the LANDED accounting) and
-``sprint-rca.yaml`` (the recovery signals). It never invokes the RCA engine and
-never touches live coordinator state; that keeps it implementable and testable
+artifacts it reads — ``sprint-summary.yaml`` (the LANDED accounting),
+``sprint-rca.yaml`` (the recovery signals), and the per-story resume record
+(what re-entering the story would do). It never invokes the RCA engine and never
+touches live coordinator state; that keeps it implementable and testable
 independently of both the live renderer and the classifier.
 
 Layout for a completed sprint with one or more non-DONE stories::
@@ -25,6 +26,11 @@ Layout for a completed sprint with one or more non-DONE stories::
     ALREADY LANDED (skipped as merged) (n)
       ✓ #NNNN  —  —  <title>
            landed before this run — skipped as already merged
+
+    OUTSTANDING (n)
+      ✗ #NNNN  REVIEW cycle 2 not run
+           re-entry: forge review runs REVIEW cycle 2; forge sprint --resume
+                     recovers escalation decision <d> and skips REVIEW
 
     FAILED — <primary_failure_class> (n)
       ✗ #NNNN  $cost  elapsed  <title>
@@ -53,6 +59,7 @@ from pathlib import Path
 
 import yaml
 
+from theforge.cli.reentry_display import load_reentry_display
 from theforge.sprint.rca import DONE_OUTCOMES, RCA_FILENAME
 from theforge.sprint.status_reader import (
     _elapsed_seconds_from_bounds,
@@ -131,6 +138,12 @@ def display_sprint_digest(run_id: str, project_root: Path) -> int:
     # All-DONE sprint: tighter LANDED-only digest, no recovery sections.
     if not non_done:
         return 0
+
+    # Before the RCA branch, and before the missing-RCA early return below: a
+    # phase the story still owes is a fact about the story, not a classification
+    # of why it failed, so it must not depend on an RCA artifact existing. This
+    # is the digest's answer to "what will re-entering do" (#2239).
+    _print_outstanding(non_done, project_root)
 
     resolved_run_id = str(sprint_block.get("run_id") or run_id)
     rca = _read_digest_rca(summary_path.parent, resolved_run_id)
@@ -307,6 +320,41 @@ def _print_shape_gate_skips(summary: dict) -> None:
             )
         if isinstance(threshold, int):
             print(f"       (stuck threshold: {threshold})")
+
+
+def _print_outstanding(non_done: list[dict], project_root: Path) -> None:
+    """Render phases the stopped stories still owe, and what re-entry would do.
+
+    Reads the coordinator's persisted resume record — a third on-disk artifact
+    alongside the summary and the RCA, still no live state and still no engine
+    invocation, so the digest stays a pure renderer.
+
+    Without this the postmortem is the *default* rendering for a completed
+    sprint (``forge status`` with no run id lands here) and the one that says
+    nothing about an unrun review cycle: the operator reads a failure
+    classification, reaches for ``forge sprint --resume`` because it reads as
+    "continue what you were doing", and never learns it would continue from a
+    recorded decision instead of running the review (#2239).
+    """
+    rows: list[tuple[dict, list[str], str]] = []
+    for story in non_done:
+        slug = str(story.get("slug") or "")
+        loaded = load_reentry_display(project_root, slug)
+        if loaded is None:
+            continue
+        phases, note = loaded
+        if not phases:
+            continue
+        rows.append((story, phases, note))
+    if not rows:
+        return
+
+    print()
+    print(f"OUTSTANDING ({len(rows)})")
+    for story, phases, note in rows:
+        print(f"  ✗ {_story_ref(story)}  {', '.join(phases)}")
+        if note:
+            print(f"       re-entry: {note}")
 
 
 def _print_failed_by_class(non_done: list[dict], rca_stories: dict) -> None:

--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -205,7 +205,7 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
                 file=sys.stderr,
             )
             return 1
-        entries = read_completed_status(summary_path)
+        entries = read_completed_status(summary_path, project_root)
         sprint_name = _read_sprint_name_from_summary(summary_path)
         # Read aggregate metrics from the completed summary.
         try:
@@ -501,6 +501,16 @@ def _print_story_line(
             f"{detail_lines[index] if index < len(detail_lines) else ''}"
         )
         print(f"{prefix}{line}")
+
+    # Re-entry disclosure, below the columns rather than in DETAIL: it is about
+    # what has *not* run and what running each re-entry path would do, which the
+    # detail column (last-known progress) cannot say without lying about it.
+    outstanding = list(getattr(entry, "outstanding_phases", None) or [])
+    if outstanding:
+        print(f"{prefix}    outstanding: {', '.join(outstanding)}")
+    reentry_note = getattr(entry, "reentry_note", "")
+    if reentry_note:
+        print(f"{prefix}    re-entry: {reentry_note}")
 
 
 def _format_sprint_phase(

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -623,26 +623,9 @@ def _pending_reentry_lines(project_root: Path, story: str) -> list[str]:
     """
     if not story or story == "?":
         return []
-    try:
-        from theforge.coordinator.resume_persistence import (  # noqa: PLC0415
-            describe_reentry_paths,
-            load_reentry_analysis,
-        )
+    from theforge.cli.reentry_display import reentry_lines  # noqa: PLC0415
 
-        analysis = load_reentry_analysis(project_root, story)
-    except Exception:
-        return []
-    if not analysis:
-        return []
-    lines: list[str] = []
-    cycle = analysis.get("outstanding_review_cycle")
-    if analysis.get("outstanding_phases"):
-        cycle_str = f"REVIEW cycle {cycle} not run" if cycle else "REVIEW not run"
-        lines.append(f"    outstanding: {cycle_str}")
-    note = describe_reentry_paths(analysis)
-    if note:
-        lines.append(f"    re-entry: {note}")
-    return lines
+    return reentry_lines(project_root, story, indent="    ")
 
 
 def _show_pending_decisions(pending_mod: object, project_root: Path) -> None:

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -611,6 +611,40 @@ def _print_pending_reason(reason: str) -> None:
         print(f"{prefix}{line}")
 
 
+def _pending_reentry_lines(project_root: Path, story: str) -> list[str]:
+    """Re-entry disclosure lines for a pending decision's story, if any.
+
+    A pending decision names a choice the operator is about to make, but not
+    that the story behind it stopped with a review cycle unrun — so acting on
+    the decision (which is what `forge sprint --resume` does) skips a review
+    that `forge review` would run.  Hiding that here would make the
+    pending-decision surface the one place the operator looks and the one place
+    the fact is missing (#2239).
+    """
+    if not story or story == "?":
+        return []
+    try:
+        from theforge.coordinator.resume_persistence import (  # noqa: PLC0415
+            describe_reentry_paths,
+            load_reentry_analysis,
+        )
+
+        analysis = load_reentry_analysis(project_root, story)
+    except Exception:
+        return []
+    if not analysis:
+        return []
+    lines: list[str] = []
+    cycle = analysis.get("outstanding_review_cycle")
+    if analysis.get("outstanding_phases"):
+        cycle_str = f"REVIEW cycle {cycle} not run" if cycle else "REVIEW not run"
+        lines.append(f"    outstanding: {cycle_str}")
+    note = describe_reentry_paths(analysis)
+    if note:
+        lines.append(f"    re-entry: {note}")
+    return lines
+
+
 def _show_pending_decisions(pending_mod: object, project_root: Path) -> None:
     """Print the pending-decisions section."""
     pending_entries = pending_mod.list_pending(project_root)
@@ -650,6 +684,8 @@ def _show_pending_decisions(pending_mod: object, project_root: Path) -> None:
                 print(f"    options: {opts_str}")
             if created_at:
                 print(f"    created: {created_at}")
+            for line in _pending_reentry_lines(project_root, str(story)):
+                print(line)
     else:
         print("\nPending decisions: (none)")
 

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -199,7 +199,11 @@ from .review_phase import (  # noqa: E402
     _run_review_only_phase,
     _run_review_phase,
 )
-from .run_setup import _rebase_onto_main, _setup_resume_entry  # noqa: E402,I001
+from .run_setup import (  # noqa: E402,I001
+    REENTRY_MODE_PIPELINE_RESUME,
+    _rebase_onto_main,
+    _setup_resume_entry,
+)
 from .validate_phase import (  # noqa: E402
     _run_validate_phase,
     _ValidateOutcome,
@@ -1526,6 +1530,7 @@ def _run_resume_coordinator(
     stop_event: "threading.Event | None" = None,
     base_lands_locally: bool | None = None,
     lands_in_project_root: bool | None = None,
+    reentry_mode: str = REENTRY_MODE_PIPELINE_RESUME,
 ) -> CoordinatorResult:
     """Shared body for run_from_review and run_from_dev.
 
@@ -1552,6 +1557,7 @@ def _run_resume_coordinator(
         initial_phase=initial_phase,
         notify=notify,
         run_id=run_id,
+        reentry_mode=reentry_mode,
     )
     if isinstance(setup, CoordinatorResult):
         return setup
@@ -1793,6 +1799,7 @@ def run_from_review(
     stop_event: "threading.Event | None" = None,
     base_lands_locally: bool | None = None,
     lands_in_project_root: bool | None = None,
+    reentry_mode: str = REENTRY_MODE_PIPELINE_RESUME,
 ) -> CoordinatorResult:
     """Start at REVIEW on an existing worktree, then iterate DEV→VALIDATE→REVIEW as needed.
 
@@ -1814,6 +1821,10 @@ def run_from_review(
             merges into the project-root checkout, used by the landing
             precondition. The sprint scheduler supplies it; None derives it from
             auto_merge and config.
+        reentry_mode: Which operator-facing command re-entered. ``forge review``
+            passes REENTRY_MODE_REVIEW so the resume disclosure states that this
+            path *runs* an outstanding review cycle; a ``--resume`` triage that
+            lands here is a pipeline resume and keeps the default.
     """
     return _run_resume_coordinator(
         config,
@@ -1821,6 +1832,7 @@ def run_from_review(
         workspace_path,
         initial_phase=Phase.REVIEW,
         skip_dev_first_iter=True,
+        reentry_mode=reentry_mode,
         interactive=interactive,
         auto_merge=auto_merge,
         notify=notify,

--- a/src/theforge/coordinator/resume_persistence.py
+++ b/src/theforge/coordinator/resume_persistence.py
@@ -480,6 +480,20 @@ def analyze_reentry(record: dict[str, Any] | None) -> dict[str, Any]:
     }
 
 
+def describe_outstanding_phases(analysis: dict[str, Any]) -> list[str]:
+    """Operator-facing names for the phases the story stopped still owing.
+
+    One phrasing, so the status table, the completed-sprint digest and the
+    pending-decision list cannot describe the same record differently.  Empty
+    when nothing is outstanding.
+    """
+    phases = list(analysis.get("outstanding_phases") or [])
+    cycle = analysis.get("outstanding_review_cycle")
+    if phases == ["REVIEW"] and cycle:
+        return [f"REVIEW cycle {cycle} not run"]
+    return phases
+
+
 def describe_reentry_paths(analysis: dict[str, Any]) -> str:
     """One-line operator-facing sentence naming each re-entry path's effect.
 

--- a/src/theforge/coordinator/resume_persistence.py
+++ b/src/theforge/coordinator/resume_persistence.py
@@ -63,6 +63,27 @@ PHASE_BLOCKS: tuple[str, ...] = (
     "timeout_escalation",
 )
 
+#: Sibling key carrying what review has and has not done for the story.
+#:
+#: Deliberately *not* a member of :data:`PHASE_BLOCKS`: nothing restores it onto
+#: a resumed ``CoordinatorState``, so it must never appear in
+#: ``recovered_phases`` (which names phases lifted off disk) nor decide whether
+#: a record is usable.  It exists so a reader can tell "the next review cycle
+#: has not run" from "review completed" without re-deriving either from the
+#: worktree (#2239).  Additive: a record written before this key existed simply
+#: lacks it, and classification then reports the obligation as *unknown* rather
+#: than inventing a completed review.
+REVIEW_PROGRESS_KEY = "review_progress"
+
+#: Verdicts that end the review loop.  Anything else recorded as the latest
+#: verdict means the loop was still owed another cycle when the attempt stopped.
+_TERMINAL_REVIEW_VERDICTS = frozenset({"APPROVE", "REJECT"})
+
+#: Values of ``review_obligation`` in :func:`classify_review_obligation`.
+REVIEW_OBLIGATION_UNKNOWN = "unknown"
+REVIEW_OBLIGATION_NONE = "none"
+REVIEW_OBLIGATION_CYCLE_NOT_RUN = "cycle_not_run"
+
 _SAFE_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
@@ -188,6 +209,36 @@ def _escalation_block(state: "CoordinatorState") -> dict[str, Any] | None:
     }
 
 
+def _review_progress_block(state: "CoordinatorState") -> dict[str, Any] | None:
+    """What review had done for this story when the attempt stopped, or None.
+
+    Counters and the latest verdict only — never a judgement.  The judgement is
+    :func:`classify_review_obligation`, so every surface that reads this record
+    (resume startup, ``forge status``, the pending-decision list) derives the
+    same answer from the same facts instead of each inventing its own.
+
+    Returns None when review has neither run nor been budgeted, so a record for
+    a story that never reached REVIEW carries no misleading zeroes.
+    """
+    latest_verdict: str | None = None
+    if state.review_results:
+        latest_verdict = getattr(state.review_results[-1], "verdict", None)
+    reviewer_cycles = state.reviewer_cycles_run
+    if not reviewer_cycles and not state.review_results and latest_verdict is None:
+        return None
+    return {
+        "reviewer_cycles_run": reviewer_cycles,
+        "review_cycles_spent": state.review_cycles_spent,
+        "review_cycle": state.review_cycle,
+        "validate_opened_review_cycles": state.validate_opened_review_cycles,
+        "recorded_review_results": len(state.review_results),
+        "latest_review_verdict": latest_verdict,
+        "last_gate_decision": state.last_gate_decision,
+        "last_gate_commit": state.last_gate_commit,
+        "gate_runs": state.gate_runs,
+    }
+
+
 def capture_phase_blocks(state: "CoordinatorState") -> dict[str, Any]:
     """Return every phase block this state currently carries (absent ones omitted)."""
     blocks: dict[str, Any] = {}
@@ -209,6 +260,9 @@ def capture_phase_blocks(state: "CoordinatorState") -> dict[str, Any]:
     timeout_escalation = _jsonable(state.timeout_escalation_audit)
     if timeout_escalation:
         blocks["timeout_escalation"] = timeout_escalation
+    review_progress = _review_progress_block(state)
+    if review_progress is not None:
+        blocks[REVIEW_PROGRESS_KEY] = review_progress
     return blocks
 
 
@@ -263,7 +317,10 @@ def save_resume_record(
     None instead of raising into the phase that called it.
     """
     blocks = capture_phase_blocks(state)
-    if not blocks:
+    # Review progress is evidence *about* a record, not a record of its own: a
+    # story with review counters but no recovered phase output still gets no
+    # sidecar, exactly as before this key existed.
+    if not any(name != REVIEW_PROGRESS_KEY for name in blocks):
         return None
     try:
         path = resume_record_path(project_root, slug)
@@ -326,6 +383,150 @@ def validate_resume_record(
     if recorded_hash != story_content_hash(story_content):
         return False, "story_content_changed"
     return True, "story_content_match"
+
+
+# ── Re-entry analysis ────────────────────────────────────────────────────
+#
+# Two commands re-enter a stopped story and do materially different things:
+# ``forge review`` runs the review phase, ``forge sprint --resume`` recovers the
+# phase records this module holds and continues from what they say.  When those
+# records carry an escalate-gate decision *and* the review loop was still owed a
+# cycle, the two paths disagree about whether the work gets reviewed.  The
+# analysis below is the single derivation of that fact; every surface that tells
+# an operator about it reads from here rather than re-deriving it (#2239).
+
+
+def classify_review_obligation(record: dict[str, Any] | None) -> dict[str, Any]:
+    """Return what the review loop still owes for the story ``record`` describes.
+
+    ``review_obligation`` is one of:
+
+    * ``cycle_not_run`` — a review cycle concluded without ending the loop, so
+      the next cycle is outstanding.  ``outstanding_review_cycle`` names it.
+    * ``none``          — review reached a terminal verdict; nothing outstanding.
+    * ``unknown``       — the record carries no review progress (it predates
+      :data:`REVIEW_PROGRESS_KEY`, or the story never reached REVIEW).  Reported
+      as unknown rather than as ``none``: absence of evidence is not evidence
+      that review completed.
+    """
+    unknown: dict[str, Any] = {
+        "review_obligation": REVIEW_OBLIGATION_UNKNOWN,
+        "outstanding_review_cycle": None,
+        "latest_review_verdict": None,
+        "reviewer_cycles_run": None,
+        "last_gate_decision": None,
+    }
+    if not isinstance(record, dict):
+        return unknown
+    block = record.get(REVIEW_PROGRESS_KEY)
+    if not isinstance(block, dict) or not block:
+        return unknown
+
+    verdict = block.get("latest_review_verdict")
+    verdict = verdict.strip() if isinstance(verdict, str) else None
+    cycles_run = block.get("reviewer_cycles_run")
+    if not isinstance(cycles_run, int) or isinstance(cycles_run, bool):
+        cycles_run = None
+    gate_decision = block.get("last_gate_decision")
+    gate_decision = gate_decision if isinstance(gate_decision, str) and gate_decision else None
+
+    if not verdict:
+        obligation = REVIEW_OBLIGATION_UNKNOWN
+        outstanding = None
+    elif verdict.upper() in _TERMINAL_REVIEW_VERDICTS:
+        obligation = REVIEW_OBLIGATION_NONE
+        outstanding = None
+    else:
+        obligation = REVIEW_OBLIGATION_CYCLE_NOT_RUN
+        outstanding = (cycles_run or 0) + 1
+    return {
+        "review_obligation": obligation,
+        "outstanding_review_cycle": outstanding,
+        "latest_review_verdict": verdict,
+        "reviewer_cycles_run": cycles_run,
+        "last_gate_decision": gate_decision,
+    }
+
+
+def analyze_reentry(record: dict[str, Any] | None) -> dict[str, Any]:
+    """Describe what re-entering the story ``record`` describes would do.
+
+    Independent of any live ``CoordinatorState`` so the status surface can answer
+    the question without starting a run — that is the point of the acceptance
+    criterion it serves: the operator sees this *before* spending anything.
+
+    ``skips_review`` is the disclosure that matters: a recorded escalate-gate
+    decision plus an outstanding review cycle means ``forge sprint --resume``
+    continues from the decision and never runs the cycle, while ``forge review``
+    runs it.
+    """
+    review = classify_review_obligation(record)
+    escalation = (record or {}).get("escalation") if isinstance(record, dict) else None
+    escalation = escalation if isinstance(escalation, dict) else {}
+    decision = escalation.get("decision") or None
+    selected_action = escalation.get("selected_action") or None
+
+    outstanding_phases: list[str] = []
+    if review["review_obligation"] == REVIEW_OBLIGATION_CYCLE_NOT_RUN:
+        outstanding_phases.append("REVIEW")
+
+    return {
+        **review,
+        "escalation_decision": decision,
+        "escalation_selected_action": selected_action,
+        "outstanding_phases": outstanding_phases,
+        "skips_review": bool(decision) and bool(outstanding_phases),
+        "source_run_id": (record or {}).get("run_id") if isinstance(record, dict) else None,
+    }
+
+
+def describe_reentry_paths(analysis: dict[str, Any]) -> str:
+    """One-line operator-facing sentence naming each re-entry path's effect.
+
+    Empty when nothing about the re-entry differs between the two paths — the
+    line is only worth printing where the choice changes what runs.
+    """
+    if not analysis.get("skips_review"):
+        return ""
+    cycle = analysis.get("outstanding_review_cycle")
+    cycle_str = f"REVIEW cycle {cycle}" if cycle else "the outstanding REVIEW cycle"
+    decision = analysis.get("escalation_decision")
+    action = analysis.get("escalation_selected_action")
+    decision_str = f"{decision}/{action}" if action else str(decision)
+    return (
+        f"forge review runs {cycle_str}; "
+        f"forge sprint --resume recovers escalation decision {decision_str} and skips REVIEW"
+    )
+
+
+def _reentry_impact(record: dict[str, Any], recovered: list[str]) -> dict[str, Any] | None:
+    """The re-entry analysis, but only when *this* recovery acts on it.
+
+    Returns None unless the escalate-gate decision was genuinely lifted off disk
+    onto this attempt's state — a decision this attempt produced itself is not a
+    recovery, and reporting it as one would make the disclosure noise.
+    """
+    if "escalation" not in recovered:
+        return None
+    analysis = analyze_reentry(record)
+    if not analysis["skips_review"]:
+        return None
+    return analysis
+
+
+def load_reentry_analysis(project_root: Path, slug: str) -> dict[str, Any] | None:
+    """Re-entry analysis for a story's persisted record, or None when there is none.
+
+    Best-effort like everything else here: a story with no record, or a record
+    that says nothing about review, yields None rather than an error.
+    """
+    record = load_resume_record(project_root, slug)
+    if record is None:
+        return None
+    analysis = analyze_reentry(record)
+    if analysis["review_obligation"] == REVIEW_OBLIGATION_UNKNOWN and not analysis["skips_review"]:
+        return None
+    return analysis
 
 
 # ── Restore ──────────────────────────────────────────────────────────────
@@ -509,6 +710,10 @@ def recover_phase_state(
     * ``unavailable`` — no record on disk for this story.
     * ``rejected``    — a record exists but does not describe this story text.
     * ``not_needed``  — a usable record added nothing this attempt lacked.
+
+    ``reentry_impact`` carries the re-entry analysis when the recovery changes
+    which phases run — today, when a recovered escalate-gate decision means the
+    outstanding review cycle will not be run.  None otherwise.
     """
     record = load_resume_record(project_root, slug)
     if record is None:
@@ -517,6 +722,7 @@ def recover_phase_state(
             "reason": "no_record",
             "recovered_phases": [],
             "source_run_id": None,
+            "reentry_impact": None,
         }
 
     usable, reason = validate_resume_record(record, story_content=story_content)
@@ -526,6 +732,7 @@ def recover_phase_state(
             "reason": reason,
             "recovered_phases": [],
             "source_run_id": record.get("run_id"),
+            "reentry_impact": None,
         }
 
     recovered = apply_resume_record_to_state(state, record)
@@ -535,4 +742,5 @@ def recover_phase_state(
         "recovered_phases": recovered,
         "source_run_id": record.get("run_id"),
         "recorded_phases": [name for name in PHASE_BLOCKS if record.get(name)],
+        "reentry_impact": _reentry_impact(record, recovered),
     }

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -442,14 +442,30 @@ def _rebase_onto_main(worktree_path: str, base_branch: str, logger) -> tuple[boo
     return True, ""
 
 
-def _report_reentry_impact(recovery: dict) -> None:
+#: Which re-entry path is running.  Both reach this module through the same
+#: ``_setup_resume_entry``, and they do different things with the same recovered
+#: state, so the disclosure below has to know which one it is speaking for
+#: (#2239).
+#:
+#: * ``review``          — ``forge review``: enters at REVIEW and runs the cycle.
+#: * ``pipeline_resume`` — ``forge run --resume`` / ``forge sprint --resume``:
+#:   re-enters the pipeline and continues from whatever the recovered state says,
+#:   which for a recorded escalate-gate decision means landing, not REVIEW.
+REENTRY_MODE_REVIEW = "review"
+REENTRY_MODE_PIPELINE_RESUME = "pipeline_resume"
+
+
+def _report_reentry_impact(recovery: dict, *, reentry_mode: str) -> None:
     """State, before the loop spends anything, a recovery that changes what runs.
 
     The generic "recovered phase record: escalation" line above names *what* was
-    lifted off disk but not what acting on it costs the operator: a recovered
-    escalate-gate decision continues from that decision, so a review cycle that
-    never ran never will.  ``forge review`` is the path that runs it.  Split
-    across short lines to match the surrounding RESUME output (#2239).
+    lifted off disk but not what acting on it means for the outstanding review
+    cycle — and that differs by path.  ``forge review`` enters at REVIEW and runs
+    the cycle; a pipeline resume continues from the recovered decision, so a
+    cycle that never ran never will.  Reporting one path's behaviour from the
+    other would be worse than saying nothing: the operator would be told review
+    is being skipped by the very command about to run it.  Split across short
+    lines to match the surrounding RESUME output (#2239).
     """
     impact = recovery.get("reentry_impact")
     if not impact:
@@ -459,7 +475,7 @@ def _report_reentry_impact(recovery: dict) -> None:
     action = impact.get("escalation_selected_action")
     decision_str = f"{decision} / {action}" if action else str(decision)
     source = recovery.get("source_run_id") or "an earlier attempt"
-    _cu._log(f"  ↺ RESUME   acting on escalation decision {decision_str} (from {source})")
+    _cu._log(f"  ↺ RESUME   recovered escalation decision {decision_str} (from {source})")
 
     cycle = impact.get("outstanding_review_cycle")
     cycle_str = f"REVIEW cycle {cycle}" if cycle else "the next REVIEW cycle"
@@ -477,10 +493,17 @@ def _report_reentry_impact(recovery: dict) -> None:
     if context:
         outstanding = f"{outstanding} ({context})"
     _cu._log(outstanding)
-    _cu._log(
-        f"  ↺ RESUME   this resume continues from that decision and will NOT run REVIEW — "
-        f"`forge review` runs {cycle_str} instead"
-    )
+
+    if reentry_mode == REENTRY_MODE_REVIEW:
+        _cu._log(
+            f"  ↺ RESUME   `forge review` runs {cycle_str} now — "
+            f"`forge sprint --resume` would continue from that decision and skip it"
+        )
+    else:
+        _cu._log(
+            f"  ↺ RESUME   this resume continues from that decision and will NOT run REVIEW — "
+            f"`forge review` runs {cycle_str} instead"
+        )
 
 
 def _setup_resume_entry(
@@ -491,11 +514,18 @@ def _setup_resume_entry(
     initial_phase: Phase,
     notify: bool,
     run_id: str | None,
+    reentry_mode: str = REENTRY_MODE_PIPELINE_RESUME,
 ) -> tuple[CoordinatorState, StructuredLogger, str, str, float] | CoordinatorResult:
     """Shared setup for run_from_review / run_from_dev.
 
     Returns (state, logger, branch_name, story_content, task_start) on success,
     or a CoordinatorResult on failure (worktree missing).
+
+    ``reentry_mode`` names which operator-facing command is re-entering, because
+    the two do different things with the same recovered state.  It defaults to
+    the pipeline resume: the entry function alone cannot distinguish them (a
+    ``--resume`` triage can pick ``run_from_review`` too), so ``forge review``
+    declares itself and everything else is a resume.
     """
     # No preflight verdict is seeded here. A resumed attempt does not run
     # preflight, but "this process did not run it" is not the same claim as
@@ -598,13 +628,18 @@ def _setup_resume_entry(
         slug=task.slug,
         story_content=story_content,
     )
+    # Stamp the path onto the impact before it reaches the audit: which command
+    # re-entered decides what the recovered decision does to REVIEW, so an audit
+    # reader tracing the disclosure needs the same fact the disclosure used.
+    if isinstance(_recovery.get("reentry_impact"), dict):
+        _recovery["reentry_impact"]["reentry_mode"] = reentry_mode
     state.phase_recovery = _recovery
     logger._safe_emit("phase_recovery", phase="RESUME", **_recovery)
     if _recovery["status"] == "recovered":
         _cu._log(
             f"  ↺ RESUME   recovered phase record: {', '.join(_recovery['recovered_phases'])}"
         )
-        _report_reentry_impact(_recovery)
+        _report_reentry_impact(_recovery, reentry_mode=reentry_mode)
     elif _recovery["status"] == "rejected":
         _cu._log(
             f"  ⚠ RESUME   persisted phase record rejected ({_recovery['reason']}) — "

--- a/src/theforge/coordinator/run_setup.py
+++ b/src/theforge/coordinator/run_setup.py
@@ -442,6 +442,47 @@ def _rebase_onto_main(worktree_path: str, base_branch: str, logger) -> tuple[boo
     return True, ""
 
 
+def _report_reentry_impact(recovery: dict) -> None:
+    """State, before the loop spends anything, a recovery that changes what runs.
+
+    The generic "recovered phase record: escalation" line above names *what* was
+    lifted off disk but not what acting on it costs the operator: a recovered
+    escalate-gate decision continues from that decision, so a review cycle that
+    never ran never will.  ``forge review`` is the path that runs it.  Split
+    across short lines to match the surrounding RESUME output (#2239).
+    """
+    impact = recovery.get("reentry_impact")
+    if not impact:
+        return
+
+    decision = impact.get("escalation_decision")
+    action = impact.get("escalation_selected_action")
+    decision_str = f"{decision} / {action}" if action else str(decision)
+    source = recovery.get("source_run_id") or "an earlier attempt"
+    _cu._log(f"  ↺ RESUME   acting on escalation decision {decision_str} (from {source})")
+
+    cycle = impact.get("outstanding_review_cycle")
+    cycle_str = f"REVIEW cycle {cycle}" if cycle else "the next REVIEW cycle"
+    verdict = impact.get("latest_review_verdict")
+    gate = impact.get("last_gate_decision")
+    context = ", ".join(
+        part
+        for part in (
+            f"last verdict {verdict}" if verdict else "",
+            f"gate {gate}" if gate else "",
+        )
+        if part
+    )
+    outstanding = f"  ↺ RESUME   outstanding: {cycle_str} has not run"
+    if context:
+        outstanding = f"{outstanding} ({context})"
+    _cu._log(outstanding)
+    _cu._log(
+        f"  ↺ RESUME   this resume continues from that decision and will NOT run REVIEW — "
+        f"`forge review` runs {cycle_str} instead"
+    )
+
+
 def _setup_resume_entry(
     config: ForgeConfig,
     task: TaskStory,
@@ -563,6 +604,7 @@ def _setup_resume_entry(
         _cu._log(
             f"  ↺ RESUME   recovered phase record: {', '.join(_recovery['recovered_phases'])}"
         )
+        _report_reentry_impact(_recovery)
     elif _recovery["status"] == "rejected":
         _cu._log(
             f"  ⚠ RESUME   persisted phase record rejected ({_recovery['reason']}) — "

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -33,6 +33,45 @@ class StoryStatusEntry:
     complexity_score: int | None = None
     model: str | None = None
     last_event_ts: float | None = None
+    # Phases the story stopped still owing, derived from its persisted resume
+    # record (e.g. ``["REVIEW"]`` when a review cycle concluded REQUEST_CHANGES
+    # and the next one never ran). Read-only display data (#2239).
+    outstanding_phases: list[str] = field(default_factory=list)
+    # What each re-entry path would do, when they disagree — empty otherwise.
+    # An operator choosing between `forge review` and `forge sprint --resume` is
+    # choosing whether the work gets reviewed, so the choice is stated here
+    # rather than left to be discovered by running one.
+    reentry_note: str = ""
+
+
+def _reentry_display(project_root: Path | None, slug: str) -> tuple[list[str], str]:
+    """Return ``(outstanding_phases, reentry_note)`` for ``slug``.
+
+    Reads the coordinator's persisted resume record — the same record a resume
+    would recover — so status answers "what does this story still owe, and what
+    will re-entering do" without starting a run.  Best-effort: any unreadable or
+    absent record yields empty display fields rather than an error, because a
+    status view that fails on a missing sidecar is worse than one that says
+    nothing about it.
+    """
+    if project_root is None or not slug:
+        return [], ""
+    try:
+        from theforge.coordinator.resume_persistence import (  # noqa: PLC0415
+            describe_reentry_paths,
+            load_reentry_analysis,
+        )
+
+        analysis = load_reentry_analysis(Path(project_root), slug)
+    except Exception:
+        return [], ""
+    if not analysis:
+        return [], ""
+    phases = list(analysis.get("outstanding_phases") or [])
+    cycle = analysis.get("outstanding_review_cycle")
+    if phases == ["REVIEW"] and cycle:
+        phases = [f"REVIEW cycle {cycle} not run"]
+    return phases, describe_reentry_paths(analysis)
 
 
 def _follow_redirect_chain(run_id: str, project_root: Path, max_hops: int = 20) -> str:
@@ -875,13 +914,21 @@ def _allocation_detail(allocation: object) -> str:
     return "; ".join(parts)
 
 
-def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
+def read_completed_status(
+    summary_path: Path,
+    project_root: Path | None = None,
+) -> list[StoryStatusEntry]:
     """Parse a sprint-summary.yaml and return per-story status entries.
 
     Enriches each entry with ``bundle_candidate`` and ``batch_group`` read from
     the per-story coordinator audit at ``<sprint-log-dir>/<slug>/audit.yaml``.
     The summary entry wins for ``batch_group`` when it carries one; the audit is
     the fallback for summaries written before the story's group was stamped.
+
+    ``project_root`` is optional because the resume records that answer "what
+    does this story still owe" live under ``<project_root>/.forge``, which a
+    summary path alone cannot locate.  Omit it and the re-entry fields stay
+    empty; every other field is unaffected.
     """
     try:
         with open(summary_path, encoding="utf-8") as f:
@@ -950,6 +997,7 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
 
         dev_model_raw = story.get("dev_model")
         model_val = dev_model_raw if isinstance(dev_model_raw, str) and dev_model_raw else None
+        outstanding_phases, reentry_note = _reentry_display(project_root, slug)
 
         entries.append(
             StoryStatusEntry(
@@ -970,6 +1018,8 @@ def read_completed_status(summary_path: Path) -> list[StoryStatusEntry]:
                 complexity=complexity,
                 complexity_score=complexity_score,
                 model=model_val,
+                outstanding_phases=outstanding_phases,
+                reentry_note=reentry_note,
             )
         )
 
@@ -1058,6 +1108,8 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
             if isinstance(_ts, (int, float)):
                 _last_event_ts = float(_ts)
 
+        outstanding_phases, reentry_note = _reentry_display(project_root, slug)
+
         entries.append(
             StoryStatusEntry(
                 slug=slug,
@@ -1075,6 +1127,8 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
                 complexity_score=complexity_score,
                 model=model_val,
                 last_event_ts=_last_event_ts,
+                outstanding_phases=outstanding_phases,
+                reentry_note=reentry_note,
             )
         )
         if slug:
@@ -1093,6 +1147,7 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
             detail = _nonempty_str(story.get("verdict")) or outcome
             if outcome in {"SKIPPED", "DROPPED", "ALREADY_DONE"} or depends_on:
                 _, detail, _ = _stage_and_detail_from_completed_story(story, None)
+            outstanding_phases, reentry_note = _reentry_display(project_root, slug)
             entries.append(
                 StoryStatusEntry(
                     slug=slug,
@@ -1114,6 +1169,8 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
                     stage=_format_terminal_stage(story.get("iteration_usage")),
                     detail=detail,
                     complexity=None,
+                    outstanding_phases=outstanding_phases,
+                    reentry_note=reentry_note,
                 )
             )
             seen_slugs.add(slug)

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -58,6 +58,7 @@ def _reentry_display(project_root: Path | None, slug: str) -> tuple[list[str], s
         return [], ""
     try:
         from theforge.coordinator.resume_persistence import (  # noqa: PLC0415
+            describe_outstanding_phases,
             describe_reentry_paths,
             load_reentry_analysis,
         )
@@ -67,11 +68,7 @@ def _reentry_display(project_root: Path | None, slug: str) -> tuple[list[str], s
         return [], ""
     if not analysis:
         return [], ""
-    phases = list(analysis.get("outstanding_phases") or [])
-    cycle = analysis.get("outstanding_review_cycle")
-    if phases == ["REVIEW"] and cycle:
-        phases = [f"REVIEW cycle {cycle} not run"]
-    return phases, describe_reentry_paths(analysis)
+    return describe_outstanding_phases(analysis), describe_reentry_paths(analysis)
 
 
 def _follow_redirect_chain(run_id: str, project_root: Path, max_hops: int = 20) -> str:

--- a/tests/test_reentry_disclosure.py
+++ b/tests/test_reentry_disclosure.py
@@ -10,12 +10,14 @@ decision and never runs it.
 Both behaviours are defensible; neither was discoverable. These tests cover the
 one derivation of that fact (``classify_review_obligation`` /
 ``analyze_reentry``) and each surface that must state it before an operator
-spends anything: resume's own startup output, the sprint status view, and the
-pending-decision list (#2239).
+spends anything: resume's own startup output on both paths, the live sprint
+status view, the completed-sprint postmortem digest, and the pending-decision
+list (#2239).
 """
 
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -452,6 +454,103 @@ class TestStatusDistinguishesUnrunReview:
         out = capsys.readouterr().out
         assert "outstanding: REVIEW cycle 2 not run" in out
         assert "re-entry: forge review runs REVIEW cycle 2" in out
+
+
+def _write_digest_summary(tmp_path: Path, slug: str, run_id: str, *, rca: bool) -> None:
+    """A completed sprint with one escalated story, optionally classified."""
+    log_dir = tmp_path / ".forge" / "logs" / "sprint-1"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "sprint-summary.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "sprint": {"name": "sprint-1", "run_id": run_id, "total_cost_usd": 1.0},
+                "stories": [{"slug": slug, "path": "Issue #2239", "outcome": "ESCALATED"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    if rca:
+        (log_dir / "sprint-rca.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "sprint_run_id": run_id,
+                    "stories": {slug: {"primary_failure_class": "review_unresolved"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+class TestCompletedSprintDigestDisclosesOutstandingReview:
+    """``forge status`` with no run id renders the postmortem digest for a
+    completed sprint. That is the default surface an operator reads before
+    choosing a re-entry path, so it cannot be the one that omits the choice."""
+
+    def _render(self, tmp_path: Path) -> str:
+        from theforge.cli.sprint_digest import display_sprint_digest
+
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            rc = display_sprint_digest("run-1", tmp_path)
+        assert rc == 0, buf.getvalue()
+        return buf.getvalue()
+
+    def test_digest_names_the_unrun_cycle_and_both_paths(self, tmp_path: Path) -> None:
+        _write_record(tmp_path, "issue-2239", _stopped_state())
+        _write_digest_summary(tmp_path, "issue-2239", "run-1", rca=True)
+
+        out = self._render(tmp_path)
+
+        assert "OUTSTANDING (1)" in out
+        assert "REVIEW cycle 2 not run" in out
+        assert "re-entry: forge review runs REVIEW cycle 2" in out
+        assert "skips REVIEW" in out
+
+    def test_disclosure_does_not_wait_on_an_rca_artifact(self, tmp_path: Path) -> None:
+        """A phase the story still owes is a fact about the story, not a failure
+        classification — the missing-RCA branch returns early, so the disclosure
+        has to be printed before it."""
+        _write_record(tmp_path, "issue-2239", _stopped_state())
+        _write_digest_summary(tmp_path, "issue-2239", "run-1", rca=False)
+
+        out = self._render(tmp_path)
+
+        assert "No RCA artifact yet" in out
+        assert "OUTSTANDING (1)" in out
+        assert "REVIEW cycle 2 not run" in out
+
+    def test_completed_review_adds_no_section(self, tmp_path: Path) -> None:
+        _write_record(tmp_path, "issue-2239", _stopped_state(verdict="APPROVE"))
+        _write_digest_summary(tmp_path, "issue-2239", "run-1", rca=True)
+
+        out = self._render(tmp_path)
+
+        assert "OUTSTANDING" not in out
+        assert "re-entry:" not in out
+
+    def test_no_resume_record_adds_no_section(self, tmp_path: Path) -> None:
+        _write_digest_summary(tmp_path, "issue-2239", "run-1", rca=True)
+
+        out = self._render(tmp_path)
+
+        assert "OUTSTANDING" not in out
+
+    def test_status_routes_a_completed_sprint_to_the_digest(self, tmp_path: Path, capsys) -> None:
+        """The seam the finding was about: `forge status` with no run id picks
+        the digest, not the telemetry table, for a completed sprint."""
+        from theforge.cli.status import _render_status_blocks
+
+        _write_record(tmp_path, "issue-2239", _stopped_state())
+        _write_digest_summary(tmp_path, "issue-2239", "run-1", rca=True)
+        (tmp_path / ".forge" / "runs").mkdir(parents=True, exist_ok=True)
+
+        with patch("theforge.cli.status._is_sprint_run", return_value=True):
+            _render_status_blocks(["run-1"], tmp_path)
+
+        out = capsys.readouterr().out
+        assert "OUTSTANDING (1)" in out
+        assert "REVIEW cycle 2 not run" in out
 
 
 class TestPendingDecisionsCarryTheSameWarning:

--- a/tests/test_reentry_disclosure.py
+++ b/tests/test_reentry_disclosure.py
@@ -1,0 +1,418 @@
+"""Two re-entry paths, one disclosure of which one skips review.
+
+``forge review`` runs the review phase against a worktree. ``forge sprint
+--resume`` recovers the phase records an earlier attempt produced and continues
+from what they say — including a recorded escalate-gate decision. From a story
+that stopped with an unrun review cycle *and* a recorded decision, those produce
+different outcomes: the first runs the cycle, the second continues from the
+decision and never runs it.
+
+Both behaviours are defensible; neither was discoverable. These tests cover the
+one derivation of that fact (``classify_review_obligation`` /
+``analyze_reentry``) and each surface that must state it before an operator
+spends anything: resume's own startup output, the sprint status view, and the
+pending-decision list (#2239).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+from coord_test_helpers import _make_agent_result, _make_config, patch_gate_shell
+
+from theforge.coordinator.engine import run_from_review
+from theforge.coordinator.resume_persistence import (
+    RECORD_VERSION,
+    REVIEW_PROGRESS_KEY,
+    analyze_reentry,
+    capture_phase_blocks,
+    classify_review_obligation,
+    describe_reentry_paths,
+    load_reentry_analysis,
+    recover_phase_state,
+    resume_record_path,
+    save_resume_record,
+)
+from theforge.coordinator.state import CoordinatorState
+from theforge.review import ReviewResult
+from theforge.task import TaskStory
+
+STORY_CONTENT = "# Test\n\nDo the thing."
+
+APPROVE_YAML = (
+    "```yaml\nverdict: APPROVE\nsummary: ok\nfindings: []\n"
+    "story_compliance:\n  matches_spec: true\n"
+    "test_coverage:\n  adequate: true\n"
+    "ac_verification:\n  - criterion: c\n    status: VERIFIED\n"
+    "    evidence: e\n```\n"
+)
+
+
+def _review_result(verdict: str) -> ReviewResult:
+    return ReviewResult(
+        verdict=verdict,
+        summary="s",
+        findings=[],
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+def _stopped_state(verdict: str = "REQUEST_CHANGES") -> CoordinatorState:
+    """The observed stopped state: gate PASS after a fix, cycle 1 REQUEST_CHANGES,
+    cycle 2 never ran, and an escalate-gate decision recorded against the story."""
+    state = CoordinatorState()
+    state.review_cycle = 1
+    state.review_results.append(_review_result(verdict))
+    state.last_gate_decision = "PASS"
+    state.last_gate_commit = "abc1234"
+    state.gate_runs = 2
+    state.escalate_decision = "land_core_defer_edges"
+    state.escalate_selected_action = "land_core"
+    state.escalate_reason = "review cycles exhausted"
+    return state
+
+
+def _write_record(project_root: Path, slug: str, state: CoordinatorState) -> Path:
+    path = save_resume_record(
+        project_root,
+        state,
+        slug=slug,
+        story_content=STORY_CONTENT,
+        run_id="prior-run",
+    )
+    assert path is not None
+    return path
+
+
+class TestReviewObligationClassification:
+    """The record must say which of the two states the story is in — or say it
+    does not know. Silence must never read as "review completed"."""
+
+    def test_unrun_cycle_is_named_with_its_number(self, tmp_path: Path) -> None:
+        _write_record(tmp_path, "test-story", _stopped_state())
+        record = json.loads(resume_record_path(tmp_path, "test-story").read_text())
+
+        obligation = classify_review_obligation(record)
+
+        assert obligation["review_obligation"] == "cycle_not_run"
+        assert obligation["outstanding_review_cycle"] == 2
+        assert obligation["latest_review_verdict"] == "REQUEST_CHANGES"
+        assert obligation["last_gate_decision"] == "PASS"
+
+    def test_completed_review_owes_nothing(self, tmp_path: Path) -> None:
+        _write_record(tmp_path, "test-story", _stopped_state(verdict="APPROVE"))
+        record = json.loads(resume_record_path(tmp_path, "test-story").read_text())
+
+        obligation = classify_review_obligation(record)
+
+        assert obligation["review_obligation"] == "none"
+        assert obligation["outstanding_review_cycle"] is None
+
+    def test_record_without_review_progress_reports_unknown(self) -> None:
+        """A record written before this key existed knows nothing about review.
+        Reporting that as "none" would claim a review completed on no evidence."""
+        record = {"version": RECORD_VERSION, "escalation": {"decision": "land_core"}}
+
+        obligation = classify_review_obligation(record)
+
+        assert obligation["review_obligation"] == "unknown"
+        assert obligation["outstanding_review_cycle"] is None
+        assert analyze_reentry(record)["skips_review"] is False
+
+    def test_review_progress_is_not_a_recovered_phase(self, tmp_path: Path) -> None:
+        """Nothing restores review progress onto a resumed state, so it must not
+        appear in ``recovered_phases`` — that list names phases lifted off disk."""
+        _write_record(tmp_path, "test-story", _stopped_state())
+
+        recovery = recover_phase_state(
+            tmp_path, CoordinatorState(), slug="test-story", story_content=STORY_CONTENT
+        )
+
+        assert REVIEW_PROGRESS_KEY not in recovery["recovered_phases"]
+        assert REVIEW_PROGRESS_KEY not in recovery["recorded_phases"]
+
+    def test_review_progress_alone_never_creates_a_record(self, tmp_path: Path) -> None:
+        """Review counters are evidence about a record, not a record: a story
+        with no recoverable phase output still writes no sidecar."""
+        state = CoordinatorState()
+        state.review_cycle = 1
+        state.review_results.append(_review_result("REQUEST_CHANGES"))
+
+        assert set(capture_phase_blocks(state)) == {REVIEW_PROGRESS_KEY}
+        assert save_resume_record(tmp_path, state, slug="s", story_content=STORY_CONTENT) is None
+
+
+class TestReentryAnalysis:
+    """``skips_review`` is the disclosure; it needs both halves to be true."""
+
+    def test_decision_plus_unrun_cycle_skips_review(self, tmp_path: Path) -> None:
+        _write_record(tmp_path, "test-story", _stopped_state())
+
+        analysis = load_reentry_analysis(tmp_path, "test-story")
+
+        assert analysis is not None
+        assert analysis["skips_review"] is True
+        assert analysis["outstanding_phases"] == ["REVIEW"]
+        assert analysis["escalation_decision"] == "land_core_defer_edges"
+        assert analysis["escalation_selected_action"] == "land_core"
+
+        note = describe_reentry_paths(analysis)
+        assert "forge review runs REVIEW cycle 2" in note
+        assert "forge sprint --resume" in note
+        assert "skips REVIEW" in note
+
+    def test_completed_review_states_no_divergence(self, tmp_path: Path) -> None:
+        _write_record(tmp_path, "test-story", _stopped_state(verdict="APPROVE"))
+
+        analysis = load_reentry_analysis(tmp_path, "test-story")
+
+        assert analysis is not None
+        assert analysis["skips_review"] is False
+        assert analysis["outstanding_phases"] == []
+        assert describe_reentry_paths(analysis) == ""
+
+    def test_unrun_cycle_without_a_decision_is_not_a_skip(self, tmp_path: Path) -> None:
+        """Nothing stands in for the cycle, so resume does not skip it — the
+        paths agree and there is nothing to disclose."""
+        state = _stopped_state()
+        state.escalate_decision = None
+        state.escalate_selected_action = None
+        state.preflight_verdict = "PROCEED"
+        _write_record(tmp_path, "test-story", state)
+
+        analysis = load_reentry_analysis(tmp_path, "test-story")
+
+        assert analysis is not None
+        assert analysis["skips_review"] is False
+        assert analysis["outstanding_phases"] == ["REVIEW"]
+
+    def test_missing_record_yields_no_analysis(self, tmp_path: Path) -> None:
+        assert load_reentry_analysis(tmp_path, "never-ran") is None
+
+
+class TestResumeReportsThePathItTakes:
+    """Resume must state the recovered state it acts on when that state changes
+    which phases run — before the coordinator loop spends anything."""
+
+    def test_recovery_carries_the_impact(self, tmp_path: Path) -> None:
+        _write_record(tmp_path, "test-story", _stopped_state())
+
+        recovery = recover_phase_state(
+            tmp_path, CoordinatorState(), slug="test-story", story_content=STORY_CONTENT
+        )
+
+        assert recovery["status"] == "recovered"
+        assert "escalation" in recovery["recovered_phases"]
+        impact = recovery["reentry_impact"]
+        assert impact is not None
+        assert impact["escalation_decision"] == "land_core_defer_edges"
+        assert impact["outstanding_review_cycle"] == 2
+
+    def test_no_impact_when_this_attempt_made_its_own_decision(self, tmp_path: Path) -> None:
+        """A decision this attempt produced is not a recovery; reporting it as
+        one would make the disclosure noise on every escalating run."""
+        _write_record(tmp_path, "test-story", _stopped_state())
+        live = CoordinatorState()
+        live.escalate_decision = "reject"
+
+        recovery = recover_phase_state(
+            tmp_path, live, slug="test-story", story_content=STORY_CONTENT
+        )
+
+        assert recovery["reentry_impact"] is None
+
+    def test_report_names_both_paths(self, capsys) -> None:
+        from theforge.coordinator.run_setup import _report_reentry_impact
+
+        _report_reentry_impact(
+            {
+                "status": "recovered",
+                "source_run_id": "prior-run",
+                "recovered_phases": ["escalation"],
+                "reentry_impact": {
+                    "escalation_decision": "land_core_defer_edges",
+                    "escalation_selected_action": "land_core",
+                    "outstanding_review_cycle": 2,
+                    "latest_review_verdict": "REQUEST_CHANGES",
+                    "last_gate_decision": "PASS",
+                },
+            }
+        )
+
+        out = capsys.readouterr().err
+        assert "land_core_defer_edges / land_core" in out
+        assert "prior-run" in out
+        assert "outstanding: REVIEW cycle 2 has not run" in out
+        assert "REQUEST_CHANGES" in out
+        assert "will NOT run REVIEW" in out
+        assert "`forge review` runs REVIEW cycle 2" in out
+
+    def test_report_is_silent_without_an_impact(self, capsys) -> None:
+        from theforge.coordinator.run_setup import _report_reentry_impact
+
+        _report_reentry_impact({"status": "recovered", "reentry_impact": None})
+
+        assert capsys.readouterr().err == ""
+
+
+def _shell(cmd: str, cwd, **kwargs):
+    if "--oneline" in cmd and "git log" in cmd:
+        return (True, "abc1234 feat: work", 0, False)
+    if "git status --porcelain" in cmd:
+        return (True, "", 0, False)
+    return (True, "OK", 0, False)
+
+
+class TestResumeSeamReportsBeforeItSpends:
+    """Seam test across the resume boundary: the disclosure has to reach the
+    operator from the real entry point, before the coordinator loop runs."""
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell(side_effect=_shell)
+    def test_run_from_review_discloses_the_skipped_review(
+        self, _mock_shell, _mock_dev, mock_pool, tmp_path: Path, capsys
+    ) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text(STORY_CONTENT, encoding="utf-8")
+        config = _make_config(tmp_path)
+        task = TaskStory(name="Test Story", story_path=spec, slug="test-story")
+        workspace = tmp_path / "test-story"
+        workspace.mkdir()
+        _write_record(tmp_path, "test-story", _stopped_state())
+        mock_pool.side_effect = lambda **kwargs: [
+            _make_agent_result(success=True, output=APPROVE_YAML, profile_name=p.name)
+            for p in kwargs["profiles"]
+        ]
+
+        result = run_from_review(config, task, workspace, cached_preflight_state=None)
+
+        out = capsys.readouterr().err
+        assert "recovered phase record: escalation" in out
+        assert "acting on escalation decision land_core_defer_edges" in out
+        assert "outstanding: REVIEW cycle 2 has not run" in out
+        assert "will NOT run REVIEW" in out
+        assert result.state.phase_recovery["reentry_impact"] is not None
+
+
+def _write_sprint_summary(tmp_path: Path, slug: str) -> Path:
+    log_dir = tmp_path / ".forge" / "logs" / "sprint-1"
+    log_dir.mkdir(parents=True)
+    summary = log_dir / "sprint-summary.yaml"
+    summary.write_text(
+        yaml.dump(
+            {
+                "sprint": {"name": "s"},
+                "stories": [{"slug": slug, "path": slug, "outcome": "ESCALATED"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return summary
+
+
+class TestStatusDistinguishesUnrunReview:
+    """An unrun review cycle must be visible in the status surface, and must not
+    look like a review that completed."""
+
+    def test_unrun_cycle_is_surfaced(self, tmp_path: Path) -> None:
+        from theforge.sprint.status_reader import read_completed_status
+
+        _write_record(tmp_path, "test-story", _stopped_state())
+        summary = _write_sprint_summary(tmp_path, "test-story")
+
+        entries = read_completed_status(summary, tmp_path)
+
+        assert entries[0].outstanding_phases == ["REVIEW cycle 2 not run"]
+        assert "forge review runs REVIEW cycle 2" in entries[0].reentry_note
+
+    def test_completed_review_shows_neither_line(self, tmp_path: Path) -> None:
+        from theforge.sprint.status_reader import read_completed_status
+
+        _write_record(tmp_path, "test-story", _stopped_state(verdict="APPROVE"))
+        summary = _write_sprint_summary(tmp_path, "test-story")
+
+        entries = read_completed_status(summary, tmp_path)
+
+        assert entries[0].outstanding_phases == []
+        assert entries[0].reentry_note == ""
+
+    def test_reader_without_a_project_root_still_works(self, tmp_path: Path) -> None:
+        """The re-entry fields need ``.forge``; every other field must not."""
+        from theforge.sprint.status_reader import read_completed_status
+
+        _write_record(tmp_path, "test-story", _stopped_state())
+        summary = _write_sprint_summary(tmp_path, "test-story")
+
+        entries = read_completed_status(summary)
+
+        assert entries[0].slug == "test-story"
+        assert entries[0].outstanding_phases == []
+
+    def test_story_row_prints_both_lines(self, tmp_path: Path, capsys) -> None:
+        from theforge.cli.sprint_status import _print_story_line
+        from theforge.sprint.status_reader import read_completed_status
+
+        _write_record(tmp_path, "test-story", _stopped_state())
+        summary = _write_sprint_summary(tmp_path, "test-story")
+        entry = read_completed_status(summary, tmp_path)[0]
+
+        _print_story_line(entry, {"failed": "✗"}, indent=0, title_cache={})
+
+        out = capsys.readouterr().out
+        assert "outstanding: REVIEW cycle 2 not run" in out
+        assert "re-entry: forge review runs REVIEW cycle 2" in out
+
+
+class TestPendingDecisionsCarryTheSameWarning:
+    """The pending-decision list is where an operator looks when a story is
+    waiting on them; it must not be the one place the unrun cycle is missing."""
+
+    def test_pending_entry_names_the_unrun_cycle(self, tmp_path: Path, capsys) -> None:
+        from theforge.cli.status import _show_pending_decisions
+
+        _write_record(tmp_path, "test-story", _stopped_state())
+
+        class _Pending:
+            @staticmethod
+            def list_pending(project_root):
+                return [
+                    {
+                        "run_id": "prior-run",
+                        "story": "test-story",
+                        "phase": "ESCALATE",
+                        "options": ["accept", "reject"],
+                    }
+                ]
+
+        _show_pending_decisions(_Pending, tmp_path)
+
+        out = capsys.readouterr().out
+        assert "outstanding: REVIEW cycle 2 not run" in out
+        assert "skips REVIEW" in out
+
+    def test_pending_entry_for_a_completed_review_stays_quiet(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        from theforge.cli.status import _show_pending_decisions
+
+        _write_record(tmp_path, "test-story", _stopped_state(verdict="APPROVE"))
+
+        class _Pending:
+            @staticmethod
+            def list_pending(project_root):
+                return [{"run_id": "prior-run", "story": "test-story", "phase": "ESCALATE"}]
+
+        _show_pending_decisions(_Pending, tmp_path)
+
+        out = capsys.readouterr().out
+        assert "outstanding:" not in out
+        assert "re-entry:" not in out

--- a/tests/test_reentry_disclosure.py
+++ b/tests/test_reentry_disclosure.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import yaml
 from coord_test_helpers import _make_agent_result, _make_config, patch_gate_shell
@@ -35,6 +35,11 @@ from theforge.coordinator.resume_persistence import (
     recover_phase_state,
     resume_record_path,
     save_resume_record,
+)
+from theforge.coordinator.run_setup import (
+    REENTRY_MODE_PIPELINE_RESUME,
+    REENTRY_MODE_REVIEW,
+    _report_reentry_impact,
 )
 from theforge.coordinator.state import CoordinatorState
 from theforge.review import ReviewResult
@@ -78,6 +83,21 @@ def _stopped_state(verdict: str = "REQUEST_CHANGES") -> CoordinatorState:
     state.escalate_selected_action = "land_core"
     state.escalate_reason = "review cycles exhausted"
     return state
+
+
+#: A recovery block carrying the impact, as ``recover_phase_state`` returns it.
+_RECOVERY = {
+    "status": "recovered",
+    "source_run_id": "prior-run",
+    "recovered_phases": ["escalation"],
+    "reentry_impact": {
+        "escalation_decision": "land_core_defer_edges",
+        "escalation_selected_action": "land_core",
+        "outstanding_review_cycle": 2,
+        "latest_review_verdict": "REQUEST_CHANGES",
+        "last_gate_decision": "PASS",
+    },
+}
 
 
 def _write_record(project_root: Path, slug: str, state: CoordinatorState) -> Path:
@@ -229,23 +249,8 @@ class TestResumeReportsThePathItTakes:
 
         assert recovery["reentry_impact"] is None
 
-    def test_report_names_both_paths(self, capsys) -> None:
-        from theforge.coordinator.run_setup import _report_reentry_impact
-
-        _report_reentry_impact(
-            {
-                "status": "recovered",
-                "source_run_id": "prior-run",
-                "recovered_phases": ["escalation"],
-                "reentry_impact": {
-                    "escalation_decision": "land_core_defer_edges",
-                    "escalation_selected_action": "land_core",
-                    "outstanding_review_cycle": 2,
-                    "latest_review_verdict": "REQUEST_CHANGES",
-                    "last_gate_decision": "PASS",
-                },
-            }
-        )
+    def test_pipeline_resume_report_says_review_will_not_run(self, capsys) -> None:
+        _report_reentry_impact(_RECOVERY, reentry_mode=REENTRY_MODE_PIPELINE_RESUME)
 
         out = capsys.readouterr().err
         assert "land_core_defer_edges / land_core" in out
@@ -255,10 +260,23 @@ class TestResumeReportsThePathItTakes:
         assert "will NOT run REVIEW" in out
         assert "`forge review` runs REVIEW cycle 2" in out
 
-    def test_report_is_silent_without_an_impact(self, capsys) -> None:
-        from theforge.coordinator.run_setup import _report_reentry_impact
+    def test_review_report_says_this_path_runs_the_cycle(self, capsys) -> None:
+        """The same recovered state, the other path. Telling the operator review
+        is being skipped by the command about to run it is worse than silence."""
+        _report_reentry_impact(_RECOVERY, reentry_mode=REENTRY_MODE_REVIEW)
 
-        _report_reentry_impact({"status": "recovered", "reentry_impact": None})
+        out = capsys.readouterr().err
+        assert "recovered escalation decision land_core_defer_edges / land_core" in out
+        assert "outstanding: REVIEW cycle 2 has not run" in out
+        assert "`forge review` runs REVIEW cycle 2 now" in out
+        assert "`forge sprint --resume` would continue from that decision and skip it" in out
+        assert "will NOT run REVIEW" not in out
+
+    def test_report_is_silent_without_an_impact(self, capsys) -> None:
+        _report_reentry_impact(
+            {"status": "recovered", "reentry_impact": None},
+            reentry_mode=REENTRY_MODE_PIPELINE_RESUME,
+        )
 
         assert capsys.readouterr().err == ""
 
@@ -273,14 +291,10 @@ def _shell(cmd: str, cwd, **kwargs):
 
 class TestResumeSeamReportsBeforeItSpends:
     """Seam test across the resume boundary: the disclosure has to reach the
-    operator from the real entry point, before the coordinator loop runs."""
+    operator from the real entry point, before the coordinator loop runs — and
+    it has to describe the path that is actually running."""
 
-    @patch("theforge.coordinator.review_pool.run_agent_pool")
-    @patch("theforge.coordinator.dev_phase.run_agent")
-    @patch_gate_shell(side_effect=_shell)
-    def test_run_from_review_discloses_the_skipped_review(
-        self, _mock_shell, _mock_dev, mock_pool, tmp_path: Path, capsys
-    ) -> None:
+    def _run(self, tmp_path: Path, mock_pool, **kwargs):
         spec = tmp_path / "spec.md"
         spec.write_text(STORY_CONTENT, encoding="utf-8")
         config = _make_config(tmp_path)
@@ -288,19 +302,87 @@ class TestResumeSeamReportsBeforeItSpends:
         workspace = tmp_path / "test-story"
         workspace.mkdir()
         _write_record(tmp_path, "test-story", _stopped_state())
-        mock_pool.side_effect = lambda **kwargs: [
+        mock_pool.side_effect = lambda **kw: [
             _make_agent_result(success=True, output=APPROVE_YAML, profile_name=p.name)
-            for p in kwargs["profiles"]
+            for p in kw["profiles"]
         ]
+        return run_from_review(config, task, workspace, cached_preflight_state=None, **kwargs)
 
-        result = run_from_review(config, task, workspace, cached_preflight_state=None)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell(side_effect=_shell)
+    def test_pipeline_resume_discloses_the_skipped_review(
+        self, _mock_shell, _mock_dev, mock_pool, tmp_path: Path, capsys
+    ) -> None:
+        result = self._run(tmp_path, mock_pool)
 
         out = capsys.readouterr().err
         assert "recovered phase record: escalation" in out
-        assert "acting on escalation decision land_core_defer_edges" in out
+        assert "recovered escalation decision land_core_defer_edges" in out
         assert "outstanding: REVIEW cycle 2 has not run" in out
         assert "will NOT run REVIEW" in out
-        assert result.state.phase_recovery["reentry_impact"] is not None
+        impact = result.state.phase_recovery["reentry_impact"]
+        assert impact is not None
+        assert impact["reentry_mode"] == REENTRY_MODE_PIPELINE_RESUME
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell(side_effect=_shell)
+    def test_forge_review_does_not_claim_it_skips_review(
+        self, _mock_shell, _mock_dev, mock_pool, tmp_path: Path, capsys
+    ) -> None:
+        """The reported symptom of the shared-setup bug: ``forge review`` enters
+        at REVIEW and runs the outstanding cycle, so it must never print the
+        pipeline resume's skip wording."""
+        result = self._run(tmp_path, mock_pool, reentry_mode=REENTRY_MODE_REVIEW)
+
+        out = capsys.readouterr().err
+        assert "outstanding: REVIEW cycle 2 has not run" in out
+        assert "`forge review` runs REVIEW cycle 2 now" in out
+        assert "will NOT run REVIEW" not in out
+        assert result.state.phase_recovery["reentry_impact"]["reentry_mode"] == (
+            REENTRY_MODE_REVIEW
+        )
+
+    def test_forge_review_command_declares_its_mode(self, tmp_path: Path) -> None:
+        """The wiring the disclosure depends on: ``cmd_review`` is the only
+        caller that is definitely the review path, so it is where the mode is
+        declared. A ``--resume`` triage reaching run_from_review is a resume."""
+        import argparse
+
+        from theforge.cli.review import cmd_review
+
+        config = MagicMock()
+        config.project_root = tmp_path
+        config.workspace.path_pattern = ".forge/worktrees/{slug}"
+        config.review_pool = [MagicMock(model="m", name="r")]
+        story = tmp_path / "story.md"
+        story.write_text(STORY_CONTENT, encoding="utf-8")
+        args = argparse.Namespace(
+            story=str(story),
+            issue=None,
+            slug="test-story",
+            config=None,
+            worktree=str(tmp_path / "test-story"),
+            auto_merge=False,
+            verbose=False,
+            no_notify=True,
+        )
+        result = MagicMock()
+        result.success = True
+        result.message = "APPROVE"
+        result.state.total_cost = 0.0
+
+        with (
+            patch("theforge.cli.review._find_config", return_value=tmp_path / "forge.yaml"),
+            patch("theforge.cli.review.load_config", return_value=config),
+            patch("theforge.cli.review._write_audit", return_value=tmp_path / "audit.yaml"),
+            patch("theforge.cli.review.run_from_review", return_value=result) as mock_run,
+            patch("pathlib.Path.exists", return_value=True),
+        ):
+            cmd_review(args)
+
+        assert mock_run.call_args.kwargs["reentry_mode"] == REENTRY_MODE_REVIEW
 
 
 def _write_sprint_summary(tmp_path: Path, slug: str) -> Path:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Cycle 1 and Cycle 2 P1s are resolved; the focused re-entry disclosure tests pass and I found no blocking regressions. | [google-gemini-3.5-flash-api] The changes fully satisfy all acceptance criteria, resolve the prior P1 findings, and have comprehensive test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $30.63
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

Two re-entry paths resume a stopped story differently, and which one is chosen decides whether review runs (GitHub Issue #2239)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2239