### PR TITLE
A phase estimate carries more headroom than the allocation it draws from, so an ordinary story is refused funding for its later phases before any phase runs

### DIFF
--- a/src/theforge/coordinator/adaptive_iterations.py
+++ b/src/theforge/coordinator/adaptive_iterations.py
@@ -30,6 +30,25 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from theforge.coordinator.story_budget import (
+    BAND_HEADROOM as _ALLOCATION_HEADROOM,
+)
+from theforge.coordinator.story_budget import (
+    DEV_ESTIMATE_HEADROOM_BASIS_ALLOCATION as ESTIMATE_HEADROOM_BASIS_ALLOCATION,
+)
+from theforge.coordinator.story_budget import (
+    DEV_ESTIMATE_SCOPE_DEV_PHASE as ESTIMATE_SCOPE_DEV_PHASE,
+)
+from theforge.coordinator.story_budget import (
+    DEV_ESTIMATE_SOURCE_BAND as ESTIMATE_SOURCE_BAND,
+)
+from theforge.coordinator.story_budget import (
+    DEV_ESTIMATE_SOURCE_CONFIGURED as ESTIMATE_SOURCE_CONFIGURED,
+)
+from theforge.coordinator.story_budget import (
+    DEV_ESTIMATE_SOURCE_SCORE as ESTIMATE_SOURCE_SCORE,
+)
+
 if TYPE_CHECKING:
     from theforge.config.types import RetryPolicy
 
@@ -44,6 +63,16 @@ _HEADROOM_FACTOR = 1.5
 # Using a flat 1.5x average produced estimates ~2x too tight for LARGE stories.
 _ESTIMATE_HEADROOM_BY_BAND: dict[str, float] = {"small": 1.5, "medium": 2.0, "large": 2.5}
 _MIN_PROFILE_RUNS = 3
+
+# Where a dollar estimate came from. Only ``DEV_ESTIMATE_SOURCE_SCORE``
+# describes the same population as the per-story allocation (see
+# ``story_budget.derive_story_allocation``): one complexity score, all models.
+# The band-and-model estimate summarises a wider, differently-priced set of
+# runs, and the configured fallback summarises nothing observed at all — both
+# are recorded for audit but neither may be subtracted from the allocation.
+# ``ESTIMATE_SCOPE_DEV_PHASE`` records that this figure prices the dev phase
+# while the allocation prices the whole story: same population by score,
+# different phase scope, so the audit never implies one measurement.
 
 
 @dataclass(frozen=True)
@@ -172,6 +201,78 @@ def _percentile(values: list[int], pct: float) -> int:
     return ordered[idx]
 
 
+def _configured_estimate_basis(
+    *,
+    reason: str,
+    complexity_band: str | None,
+    complexity_score: int | None = None,
+) -> dict:
+    """Basis for an estimate that is the configured budget, not an observation."""
+    return {
+        "source": ESTIMATE_SOURCE_CONFIGURED,
+        "band": complexity_band,
+        "complexity_score": complexity_score,
+        "statistic": "configured_budget_usd",
+        "scope": ESTIMATE_SCOPE_DEV_PHASE,
+        "sample_count": 0,
+        "headroom_multiplier": None,
+        "headroom_basis": None,
+        "allocation_comparable": False,
+        "reason": reason,
+    }
+
+
+def _band_estimate_basis(
+    *,
+    complexity_band: str | None,
+    complexity_score: int | None,
+    headroom: float,
+    sample_count: int,
+    reason: str,
+) -> dict:
+    """Basis for the band-and-model estimate: audit-visible, not comparable.
+
+    A band spans several scores and the model filter narrows it to one
+    performer, so this average is drawn from a different and generally more
+    expensive population than the score-scoped allocation. It still sizes
+    nothing but itself here; ``allocation_comparable`` false is what stops it
+    being subtracted from the allocation at seating.
+    """
+    return {
+        "source": ESTIMATE_SOURCE_BAND,
+        "band": complexity_band,
+        "complexity_score": complexity_score,
+        "statistic": "avg_cost_usd",
+        "scope": ESTIMATE_SCOPE_DEV_PHASE,
+        "sample_count": int(sample_count),
+        "headroom_multiplier": headroom,
+        "headroom_basis": "band_headroom",
+        "allocation_comparable": False,
+        "reason": reason,
+    }
+
+
+def _score_estimate_basis(
+    *,
+    complexity_band: str | None,
+    complexity_score: int,
+    sample_count: int,
+) -> dict:
+    """Basis for the score-scoped estimate — the one seating may subtract."""
+    return {
+        "source": ESTIMATE_SOURCE_SCORE,
+        "band": complexity_band,
+        "complexity_score": int(complexity_score),
+        "statistic": "avg_cost_usd",
+        "scope": ESTIMATE_SCOPE_DEV_PHASE,
+        "sample_count": int(sample_count),
+        "headroom_multiplier": _ALLOCATION_HEADROOM,
+        "headroom_basis": ESTIMATE_HEADROOM_BASIS_ALLOCATION,
+        "allocation_comparable": True,
+        "reason": "profile_score_history",
+    }
+
+
 def derive_limits(
     complexity_score: int | None,
     complexity_band: str | None,
@@ -216,10 +317,15 @@ def derive_limits(
         "base_timeout_seconds": base_timeout_seconds,
         "base_dev_cost_estimate_usd": base_cost_estimate_usd,
         "static_dev_max": static_dev_max,
+        "estimate_headroom_factor": None,
     }
 
     if not retry_policy.adaptive_iterations:
         audit["rationale"] = "adaptive_iterations disabled; using static configured limits"
+        audit["dev_cost_estimate_basis"] = _configured_estimate_basis(
+            reason="adaptive_iterations_disabled",
+            complexity_band=complexity_band,
+        )
         return AdaptiveLimits(
             dev_max=static_dev_max,
             review_max=floor_review,
@@ -233,6 +339,10 @@ def derive_limits(
 
     if score is None:
         audit["rationale"] = "no complexity score available; using static configured limits"
+        audit["dev_cost_estimate_basis"] = _configured_estimate_basis(
+            reason="no_complexity_score",
+            complexity_band=complexity_band,
+        )
         return AdaptiveLimits(
             dev_max=static_dev_max,
             review_max=floor_review,
@@ -267,12 +377,34 @@ def derive_limits(
         round(float(profile_stats["avg_cost_usd"]), 6) if profile_stats is not None else None
     )
 
+    # Cost history at this story's own complexity score, across all models —
+    # the same population the per-story allocation is drawn from. Read
+    # independently of the band/model stats above, which keep sizing iterations
+    # and wall-clock.
+    score_cost_stats = None
+    if model_profiles:
+        from theforge.model_profiles import get_dev_score_cost_stats  # noqa: PLC0415
+
+        score_cost_stats = get_dev_score_cost_stats(
+            model_profiles, score, min_runs=_MIN_PROFILE_RUNS
+        )
+    score_runs = int(score_cost_stats["runs"]) if score_cost_stats is not None else 0
+    audit["score_cost_history_runs"] = score_runs
+    audit["score_cost_avg_usd"] = (
+        round(float(score_cost_stats["avg_cost_usd"]), 6) if score_cost_stats is not None else None
+    )
+
     if profile_stats is None:
         chosen_dev = static_dev_max
         chosen_timeout = base_timeout_seconds
         chosen_estimate = base_cost_estimate_usd
         dev_rationale = (
             "insufficient profile history for complexity band; using static configured dev limits"
+        )
+        audit["dev_cost_estimate_basis"] = _configured_estimate_basis(
+            reason="insufficient_profile_history",
+            complexity_band=complexity_band,
+            complexity_score=score,
         )
     else:
         raw_dev = profile_stats["avg_iterations"] * _HEADROOM_FACTOR
@@ -302,6 +434,13 @@ def derive_limits(
         chosen_estimate = _round_money(profile_stats["avg_cost_usd"] * _estimate_headroom)
         audit["profile_raw_dev_max"] = round(raw_dev, 4)
         audit["estimate_headroom_factor"] = _estimate_headroom
+        audit["dev_cost_estimate_basis"] = _band_estimate_basis(
+            complexity_band=complexity_band,
+            complexity_score=score,
+            headroom=_estimate_headroom,
+            sample_count=profile_runs,
+            reason="profile_history",
+        )
         audit["iteration_derived_timeout_seconds"] = iteration_timeout
         audit["profile_max_duration_s"] = round(float(profile_stats.get("max_duration_s", 0.0)), 4)
         audit["profile_max_killed_timeout_s"] = round(
@@ -315,8 +454,7 @@ def derive_limits(
         dev_rationale = (
             f"derived dev limits from {profile_runs} "
             f"{complexity_band or 'unknown'}-band profile runs with "
-            f"{_HEADROOM_FACTOR}x iteration headroom and {_estimate_headroom}x "
-            "cost-estimate headroom"
+            f"{_HEADROOM_FACTOR}x iteration headroom and {_estimate_headroom}x budget headroom"
         )
         if floored_on_kill:
             dev_rationale += (
@@ -332,6 +470,33 @@ def derive_limits(
             )
         else:
             dev_rationale += "; timeout scaled from static per-iteration baseline."
+
+    # The dollar estimate — and only the dollar estimate — prefers the
+    # score-scoped average. Iterations and timeout above stay on the band and
+    # model stats: those size the work the chosen model does. The dollar figure
+    # is reconciled against a score-scoped allocation at seating, so sourcing it
+    # from a wider band (or from one expensive model) makes the subtraction
+    # meaningless and lets the dev phase consume the budget of every phase
+    # after it (#2284).
+    if score_cost_stats is not None:
+        chosen_estimate = _round_money(score_cost_stats["avg_cost_usd"] * _ALLOCATION_HEADROOM)
+        audit["estimate_headroom_factor"] = _ALLOCATION_HEADROOM
+        audit["dev_cost_estimate_basis"] = _score_estimate_basis(
+            complexity_band=complexity_band,
+            complexity_score=score,
+            sample_count=score_runs,
+        )
+        dev_rationale += (
+            f" Dev cost estimate from {score_runs} score-{score} run(s) across all models "
+            f"(avg ${float(score_cost_stats['avg_cost_usd']):.2f} x {_ALLOCATION_HEADROOM}x "
+            "allocation headroom) — the population the story allocation is drawn from."
+        )
+    else:
+        dev_rationale += (
+            f" Dev cost estimate is not comparable with the story allocation "
+            f"(no score-{score} cost history); seating will not subtract it."
+        )
+
     audit["chosen_dev_max"] = chosen_dev
     audit["chosen_dev_timeout_seconds"] = chosen_timeout
     audit["chosen_dev_cost_estimate_usd"] = round(chosen_estimate, 4)

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -496,6 +496,7 @@ def _coordinator_loop(
         _reconciliation = _story_budget.reconcile_review_cycles(
             state.story_allocation,
             dev_cost_estimate_usd=_limits.dev_cost_estimate_usd,
+            dev_cost_estimate_basis=_limits.audit.get("dev_cost_estimate_basis"),
             review_cycle_cost_usd=float(_review_cycle_planning["planned_cost_usd"]),
             review_cycle_planning=_review_cycle_planning,
             requested_review_max=_limits.review_max,
@@ -528,6 +529,7 @@ def _coordinator_loop(
         if _reconciliation["action"] in (
             _story_budget.RECONCILE_REDUCED,
             _story_budget.RECONCILE_UNFUNDABLE,
+            _story_budget.RECONCILE_NONCOMPARABLE_DEV_ESTIMATE,
         ):
             _audit["rationale"] = (
                 f"{_audit.get('rationale', '')} "

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -1081,12 +1081,13 @@ def format_reconciliation(record: dict) -> str:
         # Deliberately not a dollar shortfall. Naming a figure here would invite
         # an operator to raise a budget that was never the constraint — the
         # constraint is that the two numbers do not describe the same runs.
+        allocation_score = record.get("complexity_score")
         return (
             f"review_max left at {record['requested_review_max']}: the dev estimate and the "
             f"allocation are not on a common population, so they were not subtracted. The "
             f"allocation prices complexity score "
-            f"{(record.get('complexity_score') if record.get('complexity_score') is not None else '?')}"
-            f"; the ${float(record['dev_cost_estimate_usd']):.2f} dev estimate is a "
+            f"{allocation_score if allocation_score is not None else '?'}; the "
+            f"${float(record['dev_cost_estimate_usd']):.2f} dev estimate is a "
             f"{_format_dev_estimate_basis(record)}. Nothing reserved for review."
         )
     if action == RECONCILE_AFFORDABLE:

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -38,6 +38,17 @@ REVIEW_CYCLE_PRICE_MIN_SAMPLES = 3
 REVIEW_CYCLE_PRICE_HEADROOM = 1.25
 REVIEW_COST_HISTORY_TAIL = 50
 
+# Where a dev dollar estimate was drawn from. Only the score-scoped source
+# describes the population an allocation prices (one complexity score, all
+# models), so only it may be subtracted from one — see
+# ``_dev_estimate_comparable_to_allocation``. Defined here rather than in
+# ``adaptive_iterations`` because seating is what the vocabulary is for.
+DEV_ESTIMATE_SOURCE_SCORE = "profile_observed_score"
+DEV_ESTIMATE_SOURCE_BAND = "profile_observed_band"
+DEV_ESTIMATE_SOURCE_CONFIGURED = "configured_fallback"
+DEV_ESTIMATE_HEADROOM_BASIS_ALLOCATION = "allocation_headroom"
+DEV_ESTIMATE_SCOPE_DEV_PHASE = "dev_phase"
+
 BASIS_SUBSTRATE_BAND = "substrate_band"
 BASIS_CONFIGURED_FALLBACK = "configured_fallback"
 BASIS_OBSERVED_COMPOSITION = "observed_composition"
@@ -759,6 +770,7 @@ RECONCILE_NO_BAND_HISTORY = "no_band_history"
 RECONCILE_NO_DEV_ESTIMATE = "no_dev_estimate"
 RECONCILE_NO_REVIEW_COST = "no_review_cost"
 RECONCILE_COST_UNKNOWN = "cost_unknown"
+RECONCILE_NONCOMPARABLE_DEV_ESTIMATE = "dev_estimate_not_comparable"
 RECONCILE_AFFORDABLE = "within_allocation"
 RECONCILE_REDUCED = "review_max_reduced"
 RECONCILE_UNFUNDABLE = "review_unfundable"
@@ -768,6 +780,7 @@ def reconcile_review_cycles(
     allocation: dict | None,
     *,
     dev_cost_estimate_usd: float | None,
+    dev_cost_estimate_basis: dict | None = None,
     review_cycle_cost_usd: float | None,
     review_cycle_planning: dict | None = None,
     requested_review_max: int,
@@ -825,6 +838,17 @@ def reconcile_review_cycles(
         "review_cycle_cost_headroom_multiplier": None,
         "review_cycle_cost_reason": None,
         "review_cycle_cost_composition": None,
+        "dev_cost_estimate_basis": None,
+        "dev_cost_estimate_basis_reason": None,
+        "dev_cost_estimate_statistic": None,
+        "dev_cost_estimate_scope": None,
+        "dev_cost_estimate_band": None,
+        "dev_cost_estimate_complexity_score": None,
+        "dev_cost_estimate_sample_count": None,
+        "dev_cost_estimate_headroom_multiplier": None,
+        "dev_cost_estimate_headroom_basis": None,
+        "dev_cost_estimate_comparable": None,
+        "remaining_after_dev_usd": None,
         "reserved_review_cycles": 0,
         "reserved_review_usd": 0.0,
         "action": RECONCILE_AFFORDABLE,
@@ -836,6 +860,9 @@ def reconcile_review_cycles(
         return record
     record["allocation_usd"] = round(allocation_usd, 2)
     record["basis"] = (allocation or {}).get("basis")
+    # The population the allocation prices. Recorded so a reader can see which
+    # score the dev estimate had to match to be subtracted from it.
+    record["complexity_score"] = (allocation or {}).get("complexity_score")
 
     if record["basis"] != BASIS_SUBSTRATE_BAND:
         record["action"] = RECONCILE_NO_BAND_HISTORY
@@ -855,6 +882,23 @@ def reconcile_review_cycles(
         record["action"] = RECONCILE_NO_DEV_ESTIMATE
         return record
     record["dev_cost_estimate_usd"] = round(dev_estimate, 4)
+    if isinstance(dev_cost_estimate_basis, dict):
+        record["dev_cost_estimate_basis"] = dev_cost_estimate_basis.get("source")
+        record["dev_cost_estimate_basis_reason"] = dev_cost_estimate_basis.get("reason")
+        record["dev_cost_estimate_statistic"] = dev_cost_estimate_basis.get("statistic")
+        record["dev_cost_estimate_scope"] = dev_cost_estimate_basis.get("scope")
+        record["dev_cost_estimate_band"] = dev_cost_estimate_basis.get("band")
+        record["dev_cost_estimate_complexity_score"] = dev_cost_estimate_basis.get(
+            "complexity_score"
+        )
+        record["dev_cost_estimate_sample_count"] = dev_cost_estimate_basis.get("sample_count")
+        record["dev_cost_estimate_headroom_multiplier"] = dev_cost_estimate_basis.get(
+            "headroom_multiplier"
+        )
+        record["dev_cost_estimate_headroom_basis"] = dev_cost_estimate_basis.get("headroom_basis")
+        record["dev_cost_estimate_comparable"] = dev_cost_estimate_basis.get(
+            "allocation_comparable"
+        )
 
     try:
         cycle_cost = float(review_cycle_cost_usd)
@@ -878,6 +922,13 @@ def reconcile_review_cycles(
 
     if requested_review_max <= 0:
         record["action"] = RECONCILE_AFFORDABLE
+        return record
+
+    if not _dev_estimate_comparable_to_allocation(dev_cost_estimate_basis, allocation):
+        # Two figures drawn from different populations do not have a difference
+        # worth acting on. Record the decision and change nothing: the requested
+        # permission stands, nothing is reserved, and DEV runs (#2284).
+        record["action"] = RECONCILE_NONCOMPARABLE_DEV_ESTIMATE
         return record
 
     remaining = _balance(allocation_usd - float(spent_so_far_usd) - dev_estimate)
@@ -908,6 +959,66 @@ def reconcile_review_cycles(
         4,
     )
     return record
+
+
+def _dev_estimate_comparable_to_allocation(
+    dev_cost_estimate_basis: dict | None,
+    allocation: dict | None,
+) -> bool:
+    """Whether the dev estimate describes the population the allocation prices.
+
+    Subtracting one figure from another asserts they measure the same thing.
+    The allocation is the observed cost distribution at ONE complexity score
+    across ALL models, with :data:`BAND_HEADROOM` on top. An estimate may be
+    subtracted from it only when it is drawn from that same population and
+    carries that same caution — and when the score it was drawn at is the score
+    this allocation was drawn at. Everything else (a band-and-model average, a
+    configured fallback, an estimate carried over from a differently-scored
+    attempt) is recorded and left alone: an incommensurable subtraction resolves
+    in one direction, and the phase estimated first eats the rest of the story.
+    """
+    if not isinstance(dev_cost_estimate_basis, dict):
+        return False
+    if dev_cost_estimate_basis.get("source") != DEV_ESTIMATE_SOURCE_SCORE:
+        return False
+    if dev_cost_estimate_basis.get("statistic") != "avg_cost_usd":
+        return False
+    if dev_cost_estimate_basis.get("headroom_basis") != DEV_ESTIMATE_HEADROOM_BASIS_ALLOCATION:
+        return False
+    if not dev_cost_estimate_basis.get("allocation_comparable"):
+        return False
+    try:
+        if float(dev_cost_estimate_basis.get("headroom_multiplier")) != BAND_HEADROOM:
+            return False
+    except (TypeError, ValueError):
+        return False
+    try:
+        basis_score = int(dev_cost_estimate_basis.get("complexity_score"))
+        allocation_score = int((allocation or {}).get("complexity_score"))
+    except (TypeError, ValueError):
+        return False
+    return basis_score == allocation_score
+
+
+def _format_dev_estimate_basis(record: dict) -> str:
+    source = record.get("dev_cost_estimate_basis")
+    score = record.get("dev_cost_estimate_complexity_score")
+    samples = record.get("dev_cost_estimate_sample_count")
+    sample_text = f" over {int(samples)} run(s)" if isinstance(samples, (int, float)) else ""
+    if source == DEV_ESTIMATE_SOURCE_SCORE:
+        return f"score-{score} average across all models{sample_text}"
+    if source == DEV_ESTIMATE_SOURCE_BAND:
+        band = record.get("dev_cost_estimate_band")
+        return (
+            f"{band or 'unknown'}-band, single-model average{sample_text}"
+            f"{f'; scored {score}' if score is not None else ''}"
+        )
+    if source == DEV_ESTIMATE_SOURCE_CONFIGURED:
+        reason = record.get("dev_cost_estimate_basis_reason")
+        return f"configured fallback{': ' + str(reason) if reason else ''}"
+    if source:
+        return str(source)
+    return "no recorded basis"
 
 
 def _review_cycle_basis_text(record: dict) -> str:
@@ -965,6 +1076,18 @@ def format_reconciliation(record: dict) -> str:
             f"${float(record['review_cycle_cost_usd']):.2f} review cycle{basis} after a "
             f"${float(record['dev_cost_estimate_usd']):.2f} dev estimate "
             f"(short ${float(record['shortfall_usd']):.2f})."
+        )
+    if action == RECONCILE_NONCOMPARABLE_DEV_ESTIMATE:
+        # Deliberately not a dollar shortfall. Naming a figure here would invite
+        # an operator to raise a budget that was never the constraint — the
+        # constraint is that the two numbers do not describe the same runs.
+        return (
+            f"review_max left at {record['requested_review_max']}: the dev estimate and the "
+            f"allocation are not on a common population, so they were not subtracted. The "
+            f"allocation prices complexity score "
+            f"{(record.get('complexity_score') if record.get('complexity_score') is not None else '?')}"
+            f"; the ${float(record['dev_cost_estimate_usd']):.2f} dev estimate is a "
+            f"{_format_dev_estimate_basis(record)}. Nothing reserved for review."
         )
     if action == RECONCILE_AFFORDABLE:
         return f"allocation funds the permitted {record['requested_review_max']} review cycle(s)."

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -1872,6 +1872,73 @@ def get_dev_complexity_stats(
     }
 
 
+def get_dev_score_cost_stats(
+    profiles: dict,
+    complexity_score: int | None,
+    *,
+    min_runs: int = 3,
+) -> dict[str, float] | None:
+    """Return dev cost stats for ONE complexity score, across every model.
+
+    Deliberately unlike :func:`get_dev_complexity_stats`, which narrows to a
+    complexity *band* and to the profile entries that share the selected
+    model's identity. The per-story allocation is derived from the whole-story
+    costs recorded at the story's complexity *score*, across all models
+    (``audit_substrate.derive_cost_samples_by_score``). A dev projection that
+    is going to be subtracted from that allocation has to describe the same
+    population, so this aggregation keeps the score and drops both the band
+    widening and the model narrowing.
+
+    Cost only: iteration and wall-clock sizing still read the per-band,
+    per-model stats, because those are properties of the model doing the work
+    rather than of the story's complexity.
+
+    Returns ``None`` when fewer than ``min_runs`` runs exist at the score, or
+    when no run at the score had a measurable cost — an unmeasured population
+    cannot be averaged into a dollar figure.
+    """
+    try:
+        score_key = str(int(complexity_score))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    models = (profiles or {}).get("models") or {}
+    if not isinstance(models, dict):
+        return None
+    runs = 0
+    measured_runs = 0
+    cost_sum = 0.0
+    for entry in models.values():
+        if not isinstance(entry, dict):
+            continue
+        dev = entry.get("dev")
+        if not isinstance(dev, dict):
+            continue
+        by_score = dev.get("by_complexity_score")
+        if not isinstance(by_score, dict):
+            continue
+        sc = by_score.get(score_key)
+        if not isinstance(sc, dict):
+            continue
+        entry_runs = int(sc.get("runs", 0))
+        if entry_runs <= 0:
+            continue
+        entry_cost = _metric_sum(sc, entry_runs, "_cost_sum", "avg_cost_usd")
+        if entry_cost is None:
+            return None
+        runs += entry_runs
+        # Same measured-cost arithmetic as the per-band stats: unmeasured runs
+        # must not dilute the average toward zero.
+        measured_runs += entry_runs - int(sc.get("_cost_unknown_runs", 0))
+        cost_sum += entry_cost
+    if runs < min_runs or runs <= 0 or measured_runs <= 0:
+        return None
+    return {
+        "runs": float(runs),
+        "measured_runs": float(measured_runs),
+        "avg_cost_usd": round(cost_sum / measured_runs, 6),
+    }
+
+
 def _matching_profile_entries(
     profiles: dict,
     model_key: str,

--- a/tests/test_adaptive_iterations.py
+++ b/tests/test_adaptive_iterations.py
@@ -276,6 +276,192 @@ def test_insufficient_profile_history_still_uses_review_history_signal(tmp_path:
     assert "review history raised review_max to 4" in result.audit["rationale"]
 
 
+# ── Score-scoped dev cost estimate (#2284) ────────────────────────────────
+
+
+def _profiles_with_score_history(
+    *,
+    score: int = 4,
+    score_runs: int = 26,
+    score_avg_cost: float = 2.32,
+    band: str = "medium",
+    band_avg_cost: float = 4.947,
+    band_runs: int = 194,
+    other_model_runs: int = 0,
+    other_model_avg_cost: float = 0.0,
+):
+    """The issue-2252 shape: cheap score history, expensive band/model history."""
+    profiles = {
+        "models": {
+            "dev": {
+                "dev": {
+                    "by_complexity": {
+                        band: {
+                            "runs": band_runs,
+                            "avg_iterations": 4.0,
+                            "avg_cost_usd": band_avg_cost,
+                        }
+                    },
+                    "by_complexity_score": {
+                        str(score): {
+                            "runs": score_runs,
+                            "avg_iterations": 4.0,
+                            "avg_cost_usd": score_avg_cost,
+                        }
+                    },
+                }
+            }
+        }
+    }
+    if other_model_runs:
+        profiles["models"]["other"] = {
+            "dev": {
+                "by_complexity_score": {
+                    str(score): {
+                        "runs": other_model_runs,
+                        "avg_iterations": 4.0,
+                        "avg_cost_usd": other_model_avg_cost,
+                    }
+                }
+            }
+        }
+    return profiles
+
+
+def test_dev_estimate_uses_score_history_not_the_band_and_model_average(tmp_path: Path):
+    """The two figures seating subtracts must describe the same population.
+
+    Run 076fa19d5fc3 estimated $9.89 (medium band, one model, x2.0) against a
+    $10.18 allocation drawn from 26 score-4 samples whose max was $8.14. The
+    estimate now comes from those same score-4 runs: $2.32 x 1.25.
+    """
+    result = derive_limits(
+        4,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_cost_estimate_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles_with_score_history(),
+    )
+
+    assert result.dev_cost_estimate_usd == 2.9
+    basis = result.audit["dev_cost_estimate_basis"]
+    assert basis["source"] == "profile_observed_score"
+    assert basis["complexity_score"] == 4
+    assert basis["statistic"] == "avg_cost_usd"
+    assert basis["headroom_basis"] == "allocation_headroom"
+    assert basis["headroom_multiplier"] == 1.25
+    assert basis["sample_count"] == 26
+    # The estimate prices the dev phase; the allocation prices the whole story.
+    assert basis["scope"] == "dev_phase"
+    assert basis["allocation_comparable"] is True
+    assert result.audit["score_cost_history_runs"] == 26
+    assert "score-4 run(s) across all models" in result.audit["rationale"]
+
+
+def test_iterations_and_timeout_still_come_from_the_band_and_model_history(tmp_path: Path):
+    """Only the dollar figure moved. Sizing the work stays a model property."""
+    result = derive_limits(
+        4,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_cost_estimate_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles_with_score_history(),
+    )
+
+    # ceil(4.0 * 1.5) = 6 → clamped to the cap of 6; timeout 6 * 300 = 1800.
+    assert result.dev_max == 6
+    assert result.dev_timeout_seconds == 1800
+    assert result.audit["profile_history_runs"] == 194
+    assert result.audit["profile_avg_cost_usd"] == 4.947
+
+
+def test_score_history_is_aggregated_across_models_like_the_allocation(tmp_path: Path):
+    """The allocation spans all models at the score, so the estimate must too."""
+    result = derive_limits(
+        4,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_cost_estimate_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles_with_score_history(
+            score_runs=2, score_avg_cost=4.0, other_model_runs=2, other_model_avg_cost=1.0
+        ),
+    )
+
+    # (2 x $4.00 + 2 x $1.00) / 4 = $2.50, x 1.25 = $3.125.
+    assert result.audit["score_cost_history_runs"] == 4
+    assert result.dev_cost_estimate_usd == 3.125
+
+
+def test_without_score_history_the_estimate_is_recorded_as_not_comparable(tmp_path: Path):
+    """The band estimate is still the best available figure — just not subtractable."""
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_cost_estimate_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles(band="medium", avg_cost=3.0),
+    )
+
+    assert result.dev_cost_estimate_usd == 6.0  # band estimate retained for audit
+    basis = result.audit["dev_cost_estimate_basis"]
+    assert basis["source"] == "profile_observed_band"
+    assert basis["allocation_comparable"] is False
+    assert result.audit["score_cost_history_runs"] == 0
+    assert "not comparable with the story allocation" in result.audit["rationale"]
+
+
+def test_score_history_below_the_run_floor_is_not_used(tmp_path: Path):
+    result = derive_limits(
+        4,
+        "medium",
+        _policy(),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_cost_estimate_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles_with_score_history(score_runs=2),
+    )
+
+    assert result.audit["score_cost_history_runs"] == 0
+    assert result.audit["dev_cost_estimate_basis"]["allocation_comparable"] is False
+
+
+def test_static_fallback_estimate_is_not_comparable_either(tmp_path: Path):
+    result = derive_limits(
+        5,
+        "medium",
+        _policy(adaptive_iterations=False),
+        model_name="dev",
+        base_timeout_seconds=900,
+        base_cost_estimate_usd=10.0,
+        static_dev_max=3,
+        review_history_path=tmp_path / "none",
+        model_profiles=_profiles(),
+    )
+
+    basis = result.audit["dev_cost_estimate_basis"]
+    assert basis["source"] == "configured_fallback"
+    assert basis["allocation_comparable"] is False
+    assert basis["reason"] == "adaptive_iterations_disabled"
+
+
 # ── Budget headroom scaling by complexity band ────────────────────────────
 
 

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -11,6 +11,7 @@ from theforge.model_profiles import (
     apply_run,
     backfill_from_history,
     get_dev_complexity_stats,
+    get_dev_score_cost_stats,
     get_dev_success_rate,
     get_review_signal,
     load_profiles,
@@ -102,6 +103,80 @@ def test_get_dev_complexity_stats_averages_cost_over_measured_runs():
     assert stats["runs"] == 3.0
     # $2.00 over the single measured run, not $2.00/3 = $0.67.
     assert stats["avg_cost_usd"] == 2.0
+
+
+def _score_run(data: dict, *, model: str, score: int, band: str, cost: float | None) -> None:
+    apply_run(
+        data,
+        RunOutcome(
+            complexity=band,
+            complexity_score=score,
+            dev_model=model,
+            dev_success=True,
+            dev_iterations=1,
+            dev_cost_usd=cost,
+        ),
+    )
+
+
+def test_get_dev_score_cost_stats_spans_models_and_keeps_the_score():
+    """Score-scoped cost: one complexity score, every model (#2284).
+
+    The per-story allocation is drawn this way, so a dev estimate that will be
+    subtracted from it has to be drawn the same way — unlike
+    ``get_dev_complexity_stats``, which widens to a band and narrows to one
+    model's identity.
+    """
+    data: dict = {"models": {}}
+    _score_run(data, model="sonnet", score=4, band="medium", cost=2.0)
+    _score_run(data, model="sonnet", score=4, band="medium", cost=3.0)
+    _score_run(data, model="opus", score=4, band="medium", cost=4.0)
+    # Same band, different score — must not be folded in.
+    _score_run(data, model="sonnet", score=6, band="medium", cost=40.0)
+
+    stats = get_dev_score_cost_stats(data, 4, min_runs=3)
+
+    assert stats is not None
+    assert stats["runs"] == 3.0
+    assert stats["avg_cost_usd"] == 3.0
+    # The band-and-model reader over the same profiles sees a costlier set.
+    band_stats = get_dev_complexity_stats(data, "sonnet", "medium", min_runs=1)
+    assert band_stats is not None
+    assert band_stats["avg_cost_usd"] == 15.0
+
+
+def test_get_dev_score_cost_stats_averages_over_measured_runs_only():
+    data: dict = {"models": {}}
+    _score_run(data, model="sonnet", score=4, band="medium", cost=2.0)
+    _score_run(data, model="sonnet", score=4, band="medium", cost=None)
+    _score_run(data, model="sonnet", score=4, band="medium", cost=None)
+
+    stats = get_dev_score_cost_stats(data, 4, min_runs=1)
+
+    assert stats is not None
+    assert stats["runs"] == 3.0
+    assert stats["measured_runs"] == 1.0
+    # $2.00 over the one measured run, not $2.00/3.
+    assert stats["avg_cost_usd"] == 2.0
+
+
+def test_get_dev_score_cost_stats_returns_none_without_enough_history():
+    data: dict = {"models": {}}
+    _score_run(data, model="sonnet", score=4, band="medium", cost=2.0)
+
+    assert get_dev_score_cost_stats(data, 4, min_runs=3) is None
+    assert get_dev_score_cost_stats(data, 9, min_runs=1) is None
+    assert get_dev_score_cost_stats(data, None, min_runs=1) is None
+    assert get_dev_score_cost_stats({}, 4, min_runs=1) is None
+
+
+def test_get_dev_score_cost_stats_returns_none_when_no_run_had_a_measured_cost():
+    """An unmeasured population cannot be averaged into a dollar figure."""
+    data: dict = {"models": {}}
+    for _ in range(3):
+        _score_run(data, model="sonnet", score=4, band="medium", cost=None)
+
+    assert get_dev_score_cost_stats(data, 4, min_runs=1) is None
 
 
 def test_apply_run_averages_across_runs():

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -32,6 +32,7 @@ def _comparable_dev_estimate_basis(score: int = 8, *, sample_count: int = 12) ->
         "allocation_comparable": True,
     }
 
+
 # Observed distribution for score 2 in the issue's table (n=24, median $0.46,
 # p90 $1.08, max $1.35), compressed to the sample floor.
 _SCORE_2_COSTS = [0.21, 0.30, 0.38, 0.46, 0.52, 0.61, 1.08, 1.35]

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -13,6 +13,25 @@ from pathlib import Path
 from theforge.coordinator import audit_substrate as sub
 from theforge.coordinator import story_budget as sb
 
+
+def _comparable_dev_estimate_basis(score: int = 8, *, sample_count: int = 12) -> dict:
+    """A dev estimate on the allocation's own population: score-scoped, all models.
+
+    ``score`` must match the allocation under test — a basis drawn at another
+    score is exactly what seating refuses to subtract (#2284).
+    """
+    return {
+        "source": sb.DEV_ESTIMATE_SOURCE_SCORE,
+        "band": "large",
+        "complexity_score": score,
+        "statistic": "avg_cost_usd",
+        "scope": sb.DEV_ESTIMATE_SCOPE_DEV_PHASE,
+        "sample_count": sample_count,
+        "headroom_basis": sb.DEV_ESTIMATE_HEADROOM_BASIS_ALLOCATION,
+        "headroom_multiplier": sb.BAND_HEADROOM,
+        "allocation_comparable": True,
+    }
+
 # Observed distribution for score 2 in the issue's table (n=24, median $0.46,
 # p90 $1.08, max $1.35), compressed to the sample floor.
 _SCORE_2_COSTS = [0.21, 0.30, 0.38, 0.46, 0.52, 0.61, 1.08, 1.35]
@@ -576,6 +595,7 @@ class TestReviewCycleReconciliation:
         record = sb.reconcile_review_cycles(
             self._allocation(),
             dev_cost_estimate_usd=25.0428,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
             review_cycle_cost_usd=17.55,
             review_cycle_planning=sb.review_cycle_planning_from_samples(
                 [17.55], 17.55, min_samples=1
@@ -604,6 +624,7 @@ class TestReviewCycleReconciliation:
         record = sb.reconcile_review_cycles(
             self._allocation(),
             dev_cost_estimate_usd=25.0428,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
             review_cycle_cost_usd=17.55,
             requested_review_max=5,
             spent_so_far_usd=6.0,
@@ -618,6 +639,7 @@ class TestReviewCycleReconciliation:
         record = sb.reconcile_review_cycles(
             self._allocation(usd=120.0),
             dev_cost_estimate_usd=25.0,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
             review_cycle_cost_usd=17.55,
             requested_review_max=5,
             spent_so_far_usd=0.0,
@@ -630,6 +652,7 @@ class TestReviewCycleReconciliation:
     def test_missing_inputs_are_explicit_no_ops_not_guesses(self) -> None:
         base = dict(
             dev_cost_estimate_usd=25.0,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
             review_cycle_cost_usd=17.55,
             requested_review_max=5,
             spent_so_far_usd=0.0,
@@ -674,6 +697,7 @@ class TestReviewCycleReconciliation:
         record = sb.reconcile_review_cycles(
             allocation,
             dev_cost_estimate_usd=25.0,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
             review_cycle_cost_usd=17.55,
             requested_review_max=5,
             spent_so_far_usd=0.0,
@@ -700,11 +724,145 @@ class TestReviewCycleReconciliation:
         record = sb.reconcile_review_cycles(
             allocation,
             dev_cost_estimate_usd=25.0,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
             review_cycle_cost_usd=17.55,
             requested_review_max=5,
             spent_so_far_usd=0.0,
         )
         assert sb.seating_shortfall(allocation, record, participants=["a"]) is None
+
+    def _issue_2252_allocation(self) -> dict:
+        # Run 076fa19d5fc3: 26 score-4 samples, max $8.14, allocated at 1.25x.
+        return {
+            "allocation_usd": 10.18,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 4,
+            "median_usd": 1.69,
+            "p90_usd": 4.87,
+            "max_usd": 8.14,
+            "sample_count": 26,
+        }
+
+    def test_issue_2252_score_scoped_estimate_keeps_review_fundable(self) -> None:
+        """The score-4 dev average ($2.32) x 1.25 leaves both cycles funded.
+
+        The run that failed subtracted $9.89 — a medium-band, single-model
+        average x 2.0 — from this same $10.18 allocation and refused a $2.42
+        cycle with $0.29 left, before any phase ran (#2284).
+        """
+        record = sb.reconcile_review_cycles(
+            self._issue_2252_allocation(),
+            dev_cost_estimate_usd=2.9,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(4, sample_count=26),
+            review_cycle_cost_usd=2.42,
+            requested_review_max=2,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_AFFORDABLE
+        assert record["remaining_after_dev_usd"] == 7.28
+        assert record["affordable_review_cycles"] == 3
+        assert record["reserved_review_cycles"] == 2
+        assert record["reserved_review_usd"] == 4.84
+        assert sb.seating_shortfall(self._issue_2252_allocation(), record, participants=["a"]) is (
+            None
+        )
+
+    def test_band_and_model_estimate_is_a_no_op_not_a_seating_shortfall(self) -> None:
+        """The exact figures from run 076fa19d5fc3, on their real basis.
+
+        $9.89 is a medium-band, single-model average. Subtracting it from a
+        score-4 allocation is the defect; refusing to subtract it leaves review
+        permitted and DEV free to run.
+        """
+        allocation = self._issue_2252_allocation()
+        record = sb.reconcile_review_cycles(
+            allocation,
+            dev_cost_estimate_usd=9.89,
+            dev_cost_estimate_basis={
+                "source": sb.DEV_ESTIMATE_SOURCE_BAND,
+                "band": "medium",
+                "complexity_score": 4,
+                "statistic": "avg_cost_usd",
+                "scope": sb.DEV_ESTIMATE_SCOPE_DEV_PHASE,
+                "sample_count": 194,
+                "headroom_basis": "band_headroom",
+                "headroom_multiplier": 2.0,
+                "allocation_comparable": False,
+                "reason": "profile_history",
+            },
+            review_cycle_cost_usd=2.42,
+            requested_review_max=2,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_NONCOMPARABLE_DEV_ESTIMATE
+        assert record["reconciled_review_max"] == 2
+        assert record["reserved_review_cycles"] == 0
+        assert record["reserved_review_usd"] == 0.0
+        assert record["remaining_after_dev_usd"] is None
+        assert record["dev_cost_estimate_comparable"] is False
+        assert record["dev_cost_estimate_sample_count"] == 194
+        assert sb.seating_shortfall(allocation, record, participants=["a"]) is None
+
+        message = sb.format_reconciliation(record)
+        assert "not on a common population" in message
+        assert "medium-band, single-model average" in message
+        # A refusal citing dollars invites raising a budget that was never the
+        # constraint, so the message must not read as a shortfall.
+        assert "short $" not in message
+        assert "cannot fund" not in message
+
+    def test_a_configured_fallback_estimate_is_also_not_comparable(self) -> None:
+        record = sb.reconcile_review_cycles(
+            self._issue_2252_allocation(),
+            dev_cost_estimate_usd=9.89,
+            dev_cost_estimate_basis={
+                "source": sb.DEV_ESTIMATE_SOURCE_CONFIGURED,
+                "statistic": "configured_budget_usd",
+                "headroom_basis": None,
+                "headroom_multiplier": None,
+                "allocation_comparable": False,
+                "reason": "insufficient_profile_history",
+            },
+            review_cycle_cost_usd=2.42,
+            requested_review_max=2,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_NONCOMPARABLE_DEV_ESTIMATE
+        assert "configured fallback: insufficient_profile_history" in sb.format_reconciliation(
+            record
+        )
+
+    def test_an_absent_basis_is_not_subtracted(self) -> None:
+        record = sb.reconcile_review_cycles(
+            self._issue_2252_allocation(),
+            dev_cost_estimate_usd=9.89,
+            dev_cost_estimate_basis=None,
+            review_cycle_cost_usd=2.42,
+            requested_review_max=2,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_NONCOMPARABLE_DEV_ESTIMATE
+        assert record["reconciled_review_max"] == 2
+        assert "no recorded basis" in sb.format_reconciliation(record)
+
+    def test_a_score_scoped_estimate_from_another_score_is_not_subtracted(self) -> None:
+        """Same shape, different population — a carried-over estimate."""
+        record = sb.reconcile_review_cycles(
+            self._issue_2252_allocation(),
+            dev_cost_estimate_usd=2.9,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(9, sample_count=26),
+            review_cycle_cost_usd=2.42,
+            requested_review_max=2,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_NONCOMPARABLE_DEV_ESTIMATE
+        assert record["complexity_score"] == 4
+        assert record["dev_cost_estimate_complexity_score"] == 9
 
 
 class TestReviewFundingReservation:
@@ -726,6 +884,7 @@ class TestReviewFundingReservation:
         return sb.reconcile_review_cycles(
             self._allocation(usd),
             dev_cost_estimate_usd=2.38,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(3, sample_count=20),
             review_cycle_cost_usd=1.01,
             requested_review_max=review_max,
             spent_so_far_usd=0.0,
@@ -748,6 +907,7 @@ class TestReviewFundingReservation:
     def test_undecided_and_unfundable_seatings_reserve_nothing(self) -> None:
         base = dict(
             dev_cost_estimate_usd=2.38,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(3, sample_count=20),
             review_cycle_cost_usd=1.01,
             requested_review_max=1,
             spent_so_far_usd=0.0,
@@ -949,6 +1109,7 @@ class TestReviewFundingReservation:
         record = sb.reconcile_review_cycles(
             self._allocation(usd=3.39),
             dev_cost_estimate_usd=2.38,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(3, sample_count=20),
             review_cycle_cost_usd=1.01,
             requested_review_max=1,
             spent_so_far_usd=0.0,

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -91,6 +91,42 @@ def _seed_review_cycle_history(project_root: Path, cycle_costs: list[float]) -> 
         conn.close()
 
 
+def _seed_dev_profile_history(
+    project_root: Path,
+    *,
+    avg_cost_usd: float,
+    avg_iterations: float,
+    complexity_score: int = 9,
+    band_avg_cost_usd: float | None = None,
+) -> None:
+    """Seed dev history at a complexity score, and at the band for sizing.
+
+    ``avg_cost_usd`` is the score-scoped average the seating dev estimate is
+    derived from (#2284); ``band_avg_cost_usd`` is the band-and-model average,
+    which sizes nothing here but is what the defect used to subtract.
+    """
+    profiles = project_root / ".forge" / "model_profiles.yaml"
+    profiles.parent.mkdir(parents=True, exist_ok=True)
+    profiles.write_text(
+        (
+            "models:\n"
+            "  anthropic/sonnet/cli:\n"
+            "    dev:\n"
+            "      by_complexity:\n"
+            "        large:\n"
+            "          runs: 3\n"
+            f"          avg_iterations: {avg_iterations}\n"
+            f"          avg_cost_usd: {band_avg_cost_usd or avg_cost_usd}\n"
+            "      by_complexity_score:\n"
+            f"        '{complexity_score}':\n"
+            "          runs: 3\n"
+            f"          avg_iterations: {avg_iterations}\n"
+            f"          avg_cost_usd: {avg_cost_usd}\n"
+        ),
+        encoding="utf-8",
+    )
+
+
 def _config(tmp_path: Path, budget_usd: float = 50.0):
     cfg_path = tmp_path / "forge.yaml"
     cfg_path.write_text(
@@ -565,6 +601,7 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         # The seating numbers from run 88a7e2cc81eb: $48.02 allocation, a
         # $25.0428 dev estimate, a $17.55-per-cycle panel.
         config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        _seed_dev_profile_history(tmp_path, avg_cost_usd=20.03424, avg_iterations=4.0)
         task = _make_task(tmp_path)
         state = self._seated_state(tmp_path, 48.02)
 
@@ -603,6 +640,7 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         from theforge.coordinator.engine import _coordinator_loop
 
         config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        _seed_dev_profile_history(tmp_path, avg_cost_usd=20.03424, avg_iterations=4.0)
         task = _make_task(tmp_path)
         state = self._seated_state(tmp_path, 30.0)
 
@@ -632,6 +670,7 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
 
         _seed_review_cycle_history(tmp_path, [3.10, 3.64, 4.20])
         config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        _seed_dev_profile_history(tmp_path, avg_cost_usd=20.03424, avg_iterations=4.0)
         task = _make_task(tmp_path)
         state = self._seated_state(tmp_path, 48.02)
 
@@ -663,6 +702,7 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         from theforge.coordinator.engine import _coordinator_loop
 
         config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        _seed_dev_profile_history(tmp_path, avg_cost_usd=20.03424, avg_iterations=4.0)
         task = _make_task(tmp_path)
         state = self._seated_state(tmp_path, 500.0)
 
@@ -708,6 +748,7 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         from theforge.coordinator.engine import _coordinator_loop
 
         config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        _seed_dev_profile_history(tmp_path, avg_cost_usd=20.03424, avg_iterations=4.0)
         task = _make_task(tmp_path)
         state = self._seated_state(tmp_path, 48.02)
         state.story_allocation = {
@@ -736,6 +777,7 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         from theforge.coordinator.state import CoordinatorResult
 
         config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        _seed_dev_profile_history(tmp_path, avg_cost_usd=20.03424, avg_iterations=4.0)
         task = _make_task(tmp_path)
         state = self._seated_state(tmp_path, 48.02)
 
@@ -758,6 +800,94 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
             audit["iterations"]["adaptive_limits"]["review_cycle_planning"]["basis"]
             == sb.BASIS_REVIEW_CEILING_FALLBACK
         )
+
+    def test_non_comparable_configured_dev_estimate_is_recorded_as_a_no_op(
+        self, tmp_path: Path
+    ) -> None:
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path, 48.02)
+
+        class _StopAtDev(Exception):
+            pass
+
+        with patch("theforge.coordinator.engine._run_dev_phase", side_effect=_StopAtDev()):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert record["action"] == sb.RECONCILE_NONCOMPARABLE_DEV_ESTIMATE
+        assert record["dev_cost_estimate_basis"] == sb.DEV_ESTIMATE_SOURCE_CONFIGURED
+        assert record["dev_cost_estimate_comparable"] is False
+        assert record["reserved_review_usd"] == 0.0
+        assert state.adaptive_review_max == record["requested_review_max"]
+        assert state.phase != Phase.ESCALATE
+        assert state.allocation_exhausted is None
+        assert "not on a common population" in state.adaptive_limits_audit["rationale"]
+
+    def test_issue_2284_an_ordinary_story_is_funded_through_review(self, tmp_path: Path) -> None:
+        """Run 076fa19d5fc3, end to end through the seating seam.
+
+        Score-4 allocation ($10.18 from a $8.14 observed max), cheap score-4 dev
+        history ($2.32 average), and expensive medium-band single-model history
+        ($4.947 average — the $9.89 estimate that consumed 97% of the
+        allocation). The dev estimate must come from the score population, so
+        the $2.42 review cycle stays funded and DEV runs (#2284).
+        """
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        _seed_review_cycle_history(tmp_path, [1.90, 1.936, 2.10])
+        config = self._adaptive_config(tmp_path, dev_budget_usd=9.89, reviewer_budget_usd=5.85)
+        _seed_dev_profile_history(
+            tmp_path,
+            avg_cost_usd=2.32,
+            avg_iterations=2.0,
+            complexity_score=4,
+            band_avg_cost_usd=4.947,
+        )
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path, 10.18)
+        state.preflight_complexity = "medium"
+        state.preflight_complexity_score = 4
+        state.story_allocation = {
+            "allocation_usd": 10.18,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 4,
+            "median_usd": 1.69,
+            "p90_usd": 4.87,
+            "max_usd": 8.14,
+            "sample_count": 26,
+        }
+
+        class _StopAtDev(Exception):
+            pass
+
+        reached_dev: dict = {}
+
+        def _fake_dev(*_args, **_kwargs):
+            reached_dev["review_max"] = state.adaptive_review_max
+            raise _StopAtDev()
+
+        with patch("theforge.coordinator.engine._run_dev_phase", _fake_dev):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert record["dev_cost_estimate_basis"] == sb.DEV_ESTIMATE_SOURCE_SCORE
+        assert record["dev_cost_estimate_complexity_score"] == 4
+        assert record["dev_cost_estimate_usd"] == 2.9
+        assert record["action"] in (sb.RECONCILE_AFFORDABLE, sb.RECONCILE_REDUCED)
+        assert record["affordable_review_cycles"] >= 1
+        assert record["reserved_review_cycles"] >= 1
+        # The refusal that fired before any phase ran must not fire.
+        assert state.allocation_exhausted is None
+        assert reached_dev["review_max"] >= 1
 
     @patch("theforge.coordinator.review_pool.log_agent_result")
     @patch("theforge.coordinator.review_pool.run_agent_pool")
@@ -864,6 +994,12 @@ class TestTheSeatedReviewReservationIsHeldAcrossPhases:
 
     def _seated_state(self, tmp_path: Path):
         """State as issue-2252 was seated: $4.12 against a 20-run band."""
+        # Score-3 dev history averaging $1.904: x1.25 allocation headroom is the
+        # $2.38 estimate this class reconciles against, now drawn from the
+        # allocation's own population so seating may subtract it at all (#2284).
+        _seed_dev_profile_history(
+            tmp_path, avg_cost_usd=1.904, avg_iterations=2.0, complexity_score=3
+        )
         state = CoordinatorState(log_dir=tmp_path / "logs")
         state.preflight_complexity = "medium"
         state.preflight_complexity_score = 3


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The implementation keeps seating arithmetic on comparable populations, records non-comparable estimates instead of subtracting them, and has focused unit plus seam coverage for the production failure. | [google-gemini-3.5-flash-api] Scoped the seating dev cost estimate to the story's own complexity score, resolving the pop mismatch seating block.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** unknown (>= $13.02 measured)
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

A phase estimate carries more headroom than the allocation it draws from, so an ordinary story is refused funding for its later phases before any phase runs (GitHub Issue #2284)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2284