### PR TITLE
Models this project validated are reachable only from project configuration, so a consumer starting from shipped defaults does not get them

### DIFF
--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -517,6 +517,30 @@ def _format_config(
                 lines.append(f"  field provenance for {model_id}:")
                 lines.append(f"    {'forge.yaml:':<12}{', '.join(declared) or '(none)'}")
                 lines.append(f"    {'builtin:':<12}{', '.join(overlaid)}")
+        # A model defined on both sides resolves from forge.yaml, but "the
+        # declaration wins" is not the whole answer: it re-derives its own pricing
+        # attribution, and attribution gates the prices routing reads. Say whether
+        # deleting the declaration would change selection, so that is a stated fact
+        # rather than something the operator finds out by deleting it.
+        if config.model_registry_duplicates:
+            lines.append("  also defined in the shipped catalog (forge.yaml wins):")
+            for duplicate in config.model_registry_duplicates:
+                if duplicate.is_redundant:
+                    verdict = "identical — safe to remove"
+                elif duplicate.routing_differs:
+                    verdict = "ROUTING DIFFERS — removing it changes model selection"
+                else:
+                    verdict = "same routing; differs only in attribution recorded"
+                lines.append(f"    {duplicate.canonical_id:<32}{verdict}")
+                for difference in duplicate.describe():
+                    lines.append(f"      {difference}")
+                if duplicate.routing_differs:
+                    warnings_list.append(
+                        f"{duplicate.canonical_id} is declared in forge.yaml and also shipped in "
+                        "the catalog, and the two resolve to different routing "
+                        f"({'; '.join(d.describe() for d in duplicate.routing_differences)}) — "
+                        "removing the declaration would change model selection"
+                    )
         lines.append("")
 
     # ── DERIVED ROLES (v0.8 simple mode) ─────────────────────────────────

--- a/src/theforge/config/data/models.yaml
+++ b/src/theforge/config/data/models.yaml
@@ -72,6 +72,26 @@ models:
       input_per_mtok: 15.00
       output_per_mtok: 75.00
 
+  # Cheap tier for the Anthropic adapter (#2252, promoted from a forge.yaml
+  # project declaration where it has run since #2207). Already billed inside
+  # invocations as a component model before this promotion. dev_capable and
+  # phase_eligibility are stated explicitly, as they were at the project
+  # layer, rather than left to the (permissive) built-in default — it has run
+  # history for preflight/review only.
+  - provider: anthropic
+    model: haiku
+    transport: {kind: cli}
+    routing:
+      tier: cheap
+      capability: 6
+      cost_rank: 1
+      cost_rank_basis: vendor-tier
+      dev_capable: false
+      phase_eligibility: [preflight, review]
+    cost:
+      input_per_mtok: 1.00
+      output_per_mtok: 5.00
+
   # ── OpenAI (Codex CLI) ───────────────────────────────────────────────
   #
   # Unlike the Claude-CLI shorthands above, these model strings are the identity
@@ -113,6 +133,21 @@ models:
       input_per_mtok: 15.00
       output_per_mtok: 120.00
       pricing_provenance: gpt-5.4-pro
+
+  # OpenAI's recommended coding model (#2252, promoted from a forge.yaml
+  # `models.custom` overlay it has run under since #1184). Identifier verified
+  # live against the model's own served identity; billed under this same name.
+  - provider: openai
+    model: gpt-5.5
+    transport: {kind: cli}
+    routing:
+      tier: strong
+      capability: 9
+      cost_rank: 3
+    cost:
+      input_per_mtok: 5.00
+      output_per_mtok: 30.00
+      pricing_provenance: gpt-5.5
 
   # ── OpenAI (API) ─────────────────────────────────────────────────────
   - provider: openai
@@ -214,6 +249,22 @@ models:
       input_per_mtok: 1.25
       output_per_mtok: 10.00
       pricing_provenance: gemini-2.5-pro
+
+  # Google re-entry (#2252, promoted from a forge.yaml `models.custom` overlay
+  # it has run under since #1598). Adopted after gemini-3.1-pro-preview was
+  # benched for a reviewer that completed without calling submit_review;
+  # 3.5-flash beats it on the agentic/tool-call-chaining axes that mattered.
+  - provider: google
+    model: gemini-3.5-flash
+    transport: {kind: api}
+    routing:
+      tier: strong
+      capability: 9
+      cost_rank: 2
+    cost:
+      input_per_mtok: 1.50
+      output_per_mtok: 9.00
+      pricing_provenance: gemini-3.5-flash
 
   # ── Google (Gemini CLI — explicit opt-in) ────────────────────────────
   - provider: google

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -417,6 +417,36 @@ def _parse_custom_model_registry(
     return registry, aliases, field_sources
 
 
+def _agent_spec_routing_matches(a: AgentSpec, b: AgentSpec) -> bool:
+    """True when two specs dispatch identically, ignoring attribution labels.
+
+    A ``models.custom`` declaration is resolved standalone (see
+    :func:`_parse_custom_model_registry`), so it never inherits a built-in
+    entry's fields the way an inline ``models.enabled`` overlay does — even a
+    declaration that transcribes a promoted entry's own routing policy and
+    cost seeds re-derives its own ``pricing_provenance``/``cost_rank_basis``
+    (``forge.yaml``/``price:forge.yaml`` rather than the shipped entry's
+    attributed identity), since ``resolve_project`` has no built-in to inherit
+    the label from. That is a difference in *how the band is explained*, not
+    in what it resolves to, so it is compared on the fields that actually
+    decide dispatch: tier, capability, cost band, dev eligibility, phase
+    eligibility, endpoint and price.
+    """
+    return (
+        a.provider == b.provider
+        and a.model == b.model
+        and a.transport == b.transport
+        and a.routing.tier == b.routing.tier
+        and a.routing.capability == b.routing.capability
+        and a.routing.cost_rank == b.routing.cost_rank
+        and a.routing.dev_capable == b.routing.dev_capable
+        and a.routing.phase_eligibility == b.routing.phase_eligibility
+        and a.base_url == b.base_url
+        and a.input_cost_per_mtok == b.input_cost_per_mtok
+        and a.output_cost_per_mtok == b.output_cost_per_mtok
+    )
+
+
 def _merge_model_registry(
     custom_registry: dict[str, AgentSpec],
     override_ids: frozenset[str] = frozenset(),
@@ -427,10 +457,22 @@ def _merge_model_registry(
     a ``models.custom`` declaration carrying ``override: true``, or an inline
     ``models.enabled`` mapping (which names the model *and* selects it in one
     place, so refining a built-in entry there is unambiguous).
+
+    A declaration that duplicates a built-in identity with a *different*
+    routing policy or cost seed is still rejected outright — that is a real
+    redefinition, and requires ``override: true`` to say so on purpose. One
+    that duplicates it with the *same* values is redundant rather than
+    conflicting (the shipped catalog now carries a promoted copy of what the
+    declaration already said), so it is allowed through unchanged.
     """
     merged = dict(AGENT_REGISTRY)
     for canonical_id, spec in custom_registry.items():
-        if canonical_id in AGENT_REGISTRY and canonical_id not in override_ids:
+        builtin_spec = AGENT_REGISTRY.get(canonical_id)
+        if (
+            builtin_spec is not None
+            and canonical_id not in override_ids
+            and not _agent_spec_routing_matches(spec, builtin_spec)
+        ):
             raise ValueError(
                 f"forge.yaml 'models.custom' declares {canonical_id!r}, which duplicates a "
                 "built-in model identity. Set override: true to replace the built-in entry "

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -34,6 +34,7 @@ from .model_catalog import (
     parse_transport_block,
     resolve_project,
 )
+from .model_duplicates import DuplicateDeclaration, compare_duplicate_declaration
 from .model_identity import MODEL_TIERS
 from .models import (
     AGENT_REGISTRY,
@@ -417,69 +418,72 @@ def _parse_custom_model_registry(
     return registry, aliases, field_sources
 
 
-def _agent_spec_routing_matches(a: AgentSpec, b: AgentSpec) -> bool:
-    """True when two specs dispatch identically, ignoring attribution labels.
-
-    A ``models.custom`` declaration is resolved standalone (see
-    :func:`_parse_custom_model_registry`), so it never inherits a built-in
-    entry's fields the way an inline ``models.enabled`` overlay does — even a
-    declaration that transcribes a promoted entry's own routing policy and
-    cost seeds re-derives its own ``pricing_provenance``/``cost_rank_basis``
-    (``forge.yaml``/``price:forge.yaml`` rather than the shipped entry's
-    attributed identity), since ``resolve_project`` has no built-in to inherit
-    the label from. That is a difference in *how the band is explained*, not
-    in what it resolves to, so it is compared on the fields that actually
-    decide dispatch: tier, capability, cost band, dev eligibility, phase
-    eligibility, endpoint and price.
-    """
-    return (
-        a.provider == b.provider
-        and a.model == b.model
-        and a.transport == b.transport
-        and a.routing.tier == b.routing.tier
-        and a.routing.capability == b.routing.capability
-        and a.routing.cost_rank == b.routing.cost_rank
-        and a.routing.dev_capable == b.routing.dev_capable
-        and a.routing.phase_eligibility == b.routing.phase_eligibility
-        and a.base_url == b.base_url
-        and a.input_cost_per_mtok == b.input_cost_per_mtok
-        and a.output_cost_per_mtok == b.output_cost_per_mtok
-    )
-
-
 def _merge_model_registry(
     custom_registry: dict[str, AgentSpec],
     override_ids: frozenset[str] = frozenset(),
-) -> dict[str, AgentSpec]:
+) -> tuple[dict[str, AgentSpec], tuple[DuplicateDeclaration, ...]]:
     """Merge built-in and forge.yaml model registries.
+
+    Returns ``(merged, duplicates)``. ``duplicates`` describes every canonical
+    identity defined on *both* sides, whether or not it was permitted, so a
+    duplicate declaration is never resolved silently — see
+    :mod:`theforge.config.model_duplicates` for why a duplicate is not assumed
+    inert.
 
     ``override_ids`` are canonical identities the operator is allowed to replace:
     a ``models.custom`` declaration carrying ``override: true``, or an inline
     ``models.enabled`` mapping (which names the model *and* selects it in one
     place, so refining a built-in entry there is unambiguous).
 
-    A declaration that duplicates a built-in identity with a *different*
-    routing policy or cost seed is still rejected outright — that is a real
-    redefinition, and requires ``override: true`` to say so on purpose. One
-    that duplicates it with the *same* values is redundant rather than
-    conflicting (the shipped catalog now carries a promoted copy of what the
-    declaration already said), so it is allowed through unchanged.
+    The guard is scoped to a duplicate that actually *changes dispatch*. That is
+    the case ``override: true`` exists to make deliberate, and refusing it is
+    what stops a project from redefining a shipped model by accident. A
+    declaration that resolves to the same routing as the shipped entry is not
+    redefining anything — it restates it, which is the state a configuration is
+    left in when a model it declared gets promoted into the catalog it already
+    matched. Refusing *that* would mean promoting a model breaks every
+    configuration that already declared it, so it loads and is reported instead.
     """
     merged = dict(AGENT_REGISTRY)
+    duplicates: list[DuplicateDeclaration] = []
     for canonical_id, spec in custom_registry.items():
         builtin_spec = AGENT_REGISTRY.get(canonical_id)
-        if (
-            builtin_spec is not None
-            and canonical_id not in override_ids
-            and not _agent_spec_routing_matches(spec, builtin_spec)
-        ):
-            raise ValueError(
-                f"forge.yaml 'models.custom' declares {canonical_id!r}, which duplicates a "
-                "built-in model identity. Set override: true to replace the built-in entry "
-                "explicitly."
-            )
+        if builtin_spec is not None:
+            duplicate = compare_duplicate_declaration(canonical_id, spec, builtin_spec)
+            duplicates.append(duplicate)
+            if duplicate.routing_differs and canonical_id not in override_ids:
+                differences = "; ".join(
+                    difference.describe() for difference in duplicate.routing_differences
+                )
+                raise ValueError(
+                    f"forge.yaml 'models.custom' declares {canonical_id!r}, which duplicates a "
+                    "built-in model identity and resolves to different routing "
+                    f"({differences}). Set override: true to replace the built-in entry "
+                    "explicitly."
+                )
         merged[canonical_id] = spec
-    return merged
+    return merged, tuple(sorted(duplicates, key=lambda d: d.canonical_id))
+
+
+def _log_duplicate_declarations(duplicates: tuple[DuplicateDeclaration, ...]) -> None:
+    """Warn about a duplicate declaration whose presence changes routing.
+
+    An operator deciding whether a declaration is safe to delete cannot see this
+    from the file: both halves name the same model with the same numbers, and the
+    difference is which identity those numbers are *attributed* to. Warning at
+    load time puts it in the log for every entry point, and ``check-config``
+    captures ``theforge.config`` warnings into its own WARNINGS section.
+    """
+    for duplicate in duplicates:
+        if not duplicate.routing_differs:
+            continue
+        log.warning(
+            "forge.yaml declares %s, which the shipped catalog also defines, and the two "
+            "resolve to different routing (%s). Removing the declaration would change "
+            "model selection.",
+            duplicate.canonical_id,
+            "; ".join(difference.describe() for difference in duplicate.routing_differences),
+        )
 
 
 def _validate_selected_models(models: list[str], registry: dict[str, AgentSpec]) -> None:
@@ -1043,6 +1047,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         key: {field: "builtin" for field in PROVENANCE_FIELDS} for key in AGENT_REGISTRY
     }
     custom_models: tuple[str, ...] = ()
+    model_registry_duplicates: tuple[DuplicateDeclaration, ...] = ()
     if "models" in raw:
         (
             models_list,
@@ -1071,7 +1076,10 @@ def load_config(config_path: Path) -> ForgeConfig:
             for decl_key, identity in overlay_aliases.items()
             if custom_raw.get(decl_key, {}).get("override", False)
         )
-        model_registry = _merge_model_registry(custom_registry, override_ids)
+        model_registry, model_registry_duplicates = _merge_model_registry(
+            custom_registry, override_ids
+        )
+        _log_duplicate_declarations(model_registry_duplicates)
         custom_models = tuple(sorted(custom_registry))
         model_registry_sources.update({key: "forge.yaml" for key in custom_registry})
         model_registry_field_sources.update({**overlay_field_sources, **inline_field_sources})
@@ -1777,6 +1785,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         model_registry=model_registry,
         model_registry_sources=model_registry_sources,
         model_registry_field_sources=model_registry_field_sources,
+        model_registry_duplicates=model_registry_duplicates,
         custom_models=custom_models,
         diagnose=diagnose_cfg,
     )

--- a/src/theforge/config/model_duplicates.py
+++ b/src/theforge/config/model_duplicates.py
@@ -1,0 +1,145 @@
+"""Comparing a project model declaration against the shipped entry it duplicates.
+
+When the same canonical identity is defined in both the shipped catalog and
+``forge.yaml``, the duplicate is *not* automatically inert. A project
+declaration is resolved on its own terms, so it re-derives its own pricing
+attribution: figures the operator wrote in ``forge.yaml`` are attributed to
+``forge.yaml``, while the shipped entry's figures carry whatever the catalog
+attributed them to — which for a vendor shorthand (``anthropic/haiku/cli``) is
+*nothing at all*. Attribution is a routing input, not a label: it gates
+``effective_*_cost_per_mtok``, which is what the cost band and the price
+tie-break read (see :mod:`theforge.config.pricing`). So an entry that looks
+character-for-character redundant can still route differently depending on which
+half of the configuration defined it.
+
+This module makes that difference computable, and therefore reportable. It
+separates two kinds of divergence:
+
+- **routing** differences — values something actually selects on. These change
+  dispatch, so a duplicate that has them is a redefinition rather than a
+  restatement.
+- **attribution** differences — what a figure is attributed to and what a cost
+  band is explained by. These are recorded and reported, but nothing selects on
+  them directly; they matter because they *produce* the routing differences
+  above, which is why both are reported together.
+
+Stdlib-only apart from the identity leaf, so it stays importable from anywhere
+in the config package (CONVENTIONS: pure-data types live in low-dependency
+modules).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .model_identity import AgentSpec
+
+# Values routing genuinely selects on.
+#
+# The two ``effective_*`` entries are the reason this list is not just
+# ``RoutingPolicy``'s fields: they are attribution-gated views of the stored
+# price (``None`` whenever the figures cannot be tied to the billed identity), so
+# they are where a difference in *attribution* becomes a difference in
+# *behaviour*. Comparing the raw price literals here instead would report a
+# routing change for two entries whose prices routing is not allowed to read.
+_ROUTING_READS: tuple[tuple[str, Callable[[AgentSpec], Any]], ...] = (
+    ("tier", lambda s: s.routing.tier),
+    ("capability", lambda s: s.routing.capability),
+    ("cost_rank", lambda s: s.routing.cost_rank),
+    ("dev_capable", lambda s: s.routing.dev_capable),
+    ("phase_eligibility", lambda s: tuple(sorted(s.routing.phase_eligibility))),
+    ("base_url", lambda s: s.base_url),
+    ("effective_input_cost_per_mtok", lambda s: s.effective_input_cost_per_mtok),
+    ("effective_output_cost_per_mtok", lambda s: s.effective_output_cost_per_mtok),
+)
+
+# Recorded and reported, but nothing selects on them directly. The stored price
+# literals sit here rather than under routing on purpose: an unattributable
+# literal is carried for reference and is invisible to routing, so two entries
+# may disagree about it while dispatching identically.
+_ATTRIBUTION_READS: tuple[tuple[str, Callable[[AgentSpec], Any]], ...] = (
+    ("pricing_provenance", lambda s: s.pricing_provenance),
+    ("cost_rank_basis", lambda s: s.routing.cost_rank_basis),
+    ("input_cost_per_mtok", lambda s: s.input_cost_per_mtok),
+    ("output_cost_per_mtok", lambda s: s.output_cost_per_mtok),
+)
+
+
+@dataclass(frozen=True)
+class FieldDifference:
+    """One field on which the two definitions of an identity disagree.
+
+    Values are held as ``repr`` strings so the record stays JSON-able and
+    digest-stable — it is carried on :class:`~theforge.config.types.ForgeConfig`
+    and therefore participates in the resolved-configuration digest.
+    """
+
+    field: str
+    project: str
+    builtin: str
+
+    def describe(self) -> str:
+        return f"{self.field}: forge.yaml={self.project} builtin={self.builtin}"
+
+
+@dataclass(frozen=True)
+class DuplicateDeclaration:
+    """How a project declaration compares to the shipped entry it duplicates."""
+
+    canonical_id: str
+    routing_differences: tuple[FieldDifference, ...] = ()
+    attribution_differences: tuple[FieldDifference, ...] = ()
+
+    @property
+    def routing_differs(self) -> bool:
+        """True when removing or keeping the declaration changes dispatch."""
+        return bool(self.routing_differences)
+
+    @property
+    def is_redundant(self) -> bool:
+        """True when the declaration restates the shipped entry exactly.
+
+        Redundant in the strong sense: nothing about the resolved entry —
+        including what its figures are attributed to — depends on which half of
+        the configuration defined it, so removing it is a no-op.
+        """
+        return not self.routing_differences and not self.attribution_differences
+
+    def describe(self) -> tuple[str, ...]:
+        """Return one human-readable line per difference, routing first."""
+        return tuple(
+            difference.describe()
+            for difference in (*self.routing_differences, *self.attribution_differences)
+        )
+
+
+def compare_duplicate_declaration(
+    canonical_id: str,
+    project: AgentSpec,
+    builtin: AgentSpec,
+) -> DuplicateDeclaration:
+    """Compare a project-declared entry against the shipped entry of one identity.
+
+    Answers the two questions an operator holding a duplicate declaration has:
+    would routing behave differently without it, and where did the resolved
+    entry's figures come from.
+    """
+    routing: list[FieldDifference] = []
+    attribution: list[FieldDifference] = []
+    for bucket, reads in ((routing, _ROUTING_READS), (attribution, _ATTRIBUTION_READS)):
+        for field_name, read in reads:
+            project_value, builtin_value = read(project), read(builtin)
+            if project_value != builtin_value:
+                bucket.append(
+                    FieldDifference(
+                        field=field_name,
+                        project=repr(project_value),
+                        builtin=repr(builtin_value),
+                    )
+                )
+    return DuplicateDeclaration(
+        canonical_id=canonical_id,
+        routing_differences=tuple(routing),
+        attribution_differences=tuple(attribution),
+    )

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from .provenance import ConfigProvenance
 
 if TYPE_CHECKING:
+    from .model_duplicates import DuplicateDeclaration
     from .models import AgentDef, AgentSpec, TransportSpec
 
 SUPPORTED_PROVIDERS = {"anthropic", "openai", "google", "deepseek"}
@@ -1246,6 +1247,14 @@ class ForgeConfig:
     # part of a shipped definition readable rather than opaque. Empty for a
     # directly-constructed config that never went through load_config().
     model_registry_field_sources: dict[str, dict[str, str]] = field(default_factory=dict)
+    # Canonical identities defined in *both* the shipped catalog and forge.yaml,
+    # with how the two definitions differ. A duplicate declaration is not assumed
+    # inert: a project declaration re-derives its own pricing attribution, and
+    # attribution gates the prices routing reads, so an apparently redundant
+    # declaration can still change selection. Recorded here (and therefore in the
+    # resolved-config digest) so the difference is a stated fact rather than
+    # something an operator discovers by deleting the declaration.
+    model_registry_duplicates: tuple[DuplicateDeclaration, ...] = ()
     custom_models: tuple[str, ...] = ()
     diagnose: DiagnoseConfig = field(default_factory=DiagnoseConfig)
     # Identity of the configuration this object represents (#2056). Populated by

--- a/tests/test_invocation_ledger.py
+++ b/tests/test_invocation_ledger.py
@@ -102,11 +102,16 @@ def test_ledger_records_configured_resolved_and_billed_separately() -> None:
     assert ledger["resolved_primary_identity"]["raw"] == "claude-opus-5"
     billed = [c["identity"]["raw"] for c in ledger["billed_components"]]
     assert billed == ["claude-opus-5", "claude-haiku-4-5"]
-    # The component the operator never configured and the catalog does not know
-    # is still recorded, with its own cost attached to it rather than folded in.
+    # The component the operator never configured is still recorded, with its own
+    # cost attached to it rather than folded into the primary's. Its identity now
+    # resolves canonically: being billed as a component while absent from the
+    # catalog was the gap #2252 closed by promoting anthropic/haiku/cli into it.
+    # A spelling the catalog genuinely does not know still reports "unresolved"
+    # — see test_divergence_falls_back_to_raw_spellings_when_neither_canonicalizes.
     haiku = ledger["billed_components"][1]
     assert haiku["cost_usd"] == 0.010
-    assert haiku["identity"]["resolution"] == "unresolved"
+    assert haiku["identity"]["resolution"] == "canonical"
+    assert haiku["identity"]["identity"] == "anthropic/haiku/cli"
 
 
 def test_ledger_records_run_conditions_and_usage_by_class() -> None:

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -407,11 +407,11 @@ class TestExistingShapesStillLoad:
             {
                 "project": "p",
                 "models": {
-                    "enabled": ["anthropic/sonnet/cli", "openai/gpt-5.5/cli"],
+                    "enabled": ["anthropic/sonnet/cli", "openai/gpt-5.9/cli"],
                     "custom": {
-                        "gpt-5.5": {
+                        "gpt-5.9": {
                             "provider": "openai",
-                            "model": "gpt-5.5",
+                            "model": "gpt-5.9",
                             "tier": "strong",
                             "input_cost_per_mtok": 1.5,
                             "output_cost_per_mtok": 12.0,
@@ -422,13 +422,13 @@ class TestExistingShapesStillLoad:
             },
         )
         config = load_config(path)
-        spec = (config.model_registry or {})["openai/gpt-5.5/cli"]
+        spec = (config.model_registry or {})["openai/gpt-5.9/cli"]
         assert spec.tier == "strong"
         assert spec.capability == 9  # still derived from tier
         assert spec.dev_capable is True
         assert spec.cost_rank == 2  # banded from the operator-declared price
         assert spec.pricing_provenance == PRICING_PROVENANCE_OPERATOR_DECLARED
-        assert config.model_registry_sources["openai/gpt-5.5/cli"] == "forge.yaml"
+        assert config.model_registry_sources["openai/gpt-5.9/cli"] == "forge.yaml"
 
     def test_models_enabled_can_still_select_a_custom_declaration_by_its_key(self, tmp_path):
         """The operator-chosen declaration key stays a valid selector."""
@@ -437,11 +437,11 @@ class TestExistingShapesStillLoad:
             {
                 "project": "p",
                 "models": {
-                    "enabled": ["anthropic/sonnet/cli", "gpt-5.5"],
+                    "enabled": ["anthropic/sonnet/cli", "gpt-5.9"],
                     "custom": {
-                        "gpt-5.5": {
+                        "gpt-5.9": {
                             "provider": "openai",
-                            "model": "gpt-5.5",
+                            "model": "gpt-5.9",
                             "tier": "strong",
                             "input_cost_per_mtok": 1.5,
                             "output_cost_per_mtok": 12.0,
@@ -452,8 +452,8 @@ class TestExistingShapesStillLoad:
             },
         )
         config = load_config(path)
-        assert "openai/gpt-5.5/cli" in config.models
-        assert "gpt-5.5" not in config.models
+        assert "openai/gpt-5.9/cli" in config.models
+        assert "gpt-5.9" not in config.models
 
     def test_models_custom_provider_alias_tokens_still_normalize(self, tmp_path):
         path = _write(
@@ -889,11 +889,11 @@ class TestFieldLevelProvenance:
             {
                 "project": "p",
                 "models": {
-                    "enabled": ["anthropic/sonnet/cli", "gpt-5.5"],
+                    "enabled": ["anthropic/sonnet/cli", "gpt-5.9"],
                     "custom": {
-                        "gpt-5.5": {
+                        "gpt-5.9": {
                             "provider": "openai",
-                            "model": "gpt-5.5",
+                            "model": "gpt-5.9",
                             "tier": "strong",
                             "input_cost_per_mtok": 1.5,
                             "output_cost_per_mtok": 12.0,
@@ -903,5 +903,5 @@ class TestFieldLevelProvenance:
                 "budget_usd": 30.0,
             },
         )
-        sources = load_config(path).model_registry_field_sources["openai/gpt-5.5/cli"]
+        sources = load_config(path).model_registry_field_sources["openai/gpt-5.9/cli"]
         assert set(sources.values()) == {SOURCE_PROJECT}

--- a/tests/test_model_duplicates.py
+++ b/tests/test_model_duplicates.py
@@ -1,0 +1,142 @@
+"""Comparing a project declaration against the shipped entry it duplicates (#2252).
+
+Promoting a model into the shipped catalog leaves any configuration that already
+declared it holding a duplicate. These tests pin what such a duplicate is allowed
+to be assumed: not inert. A project declaration re-derives its own pricing
+attribution, attribution gates the prices routing reads, so two definitions that
+name the same model with the same numbers can still dispatch differently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from theforge.config.model_duplicates import compare_duplicate_declaration
+from theforge.config.model_identity import AgentSpec, RoutingPolicy, transport_for
+from theforge.config.pricing import (
+    COST_BAND_BASIS_VENDOR_TIER,
+    PRICING_PROVENANCE_OPERATOR_DECLARED,
+    price_tiebreak_signal_for,
+)
+
+
+def _spec(**kwargs) -> AgentSpec:
+    routing_kwargs = {
+        "tier": "cheap",
+        "capability": 6,
+        "cost_rank": 1,
+        "cost_rank_basis": COST_BAND_BASIS_VENDOR_TIER,
+    }
+    for key in ("tier", "capability", "cost_rank", "cost_rank_basis", "dev_capable"):
+        if key in kwargs:
+            routing_kwargs[key] = kwargs.pop(key)
+    if "phase_eligibility" in kwargs:
+        routing_kwargs["phase_eligibility"] = frozenset(kwargs.pop("phase_eligibility"))
+    base = {
+        "provider": "anthropic",
+        "model": "haiku",
+        "transport": transport_for("anthropic", "cli"),
+        "routing": RoutingPolicy(**routing_kwargs),
+        "input_cost_per_mtok": 1.00,
+        "output_cost_per_mtok": 5.00,
+        "pricing_provenance": None,
+    }
+    base.update(kwargs)
+    return AgentSpec(**base)
+
+
+def test_an_exact_restatement_is_reported_as_redundant():
+    builtin = _spec()
+    duplicate = compare_duplicate_declaration("anthropic/haiku/cli", _spec(), builtin)
+    assert duplicate.is_redundant
+    assert not duplicate.routing_differs
+    assert duplicate.describe() == ()
+
+
+def test_attribution_alone_differing_is_reported_without_claiming_a_routing_change():
+    """Both sides attributable to *something*, same figures → same tie-break.
+
+    This is the shape of a promoted entry whose declaration transcribed it: the
+    catalog attributes the price to the billed identity, the declaration to
+    ``forge.yaml``. Routing reads the same numbers either way.
+    """
+    builtin = _spec(
+        pricing_provenance="claude-haiku-4-5", cost_rank_basis="price:claude-haiku-4-5"
+    )
+    project = _spec(
+        pricing_provenance=PRICING_PROVENANCE_OPERATOR_DECLARED,
+        cost_rank_basis="price:forge.yaml",
+    )
+    duplicate = compare_duplicate_declaration("anthropic/haiku/cli", project, builtin)
+    assert not duplicate.routing_differs
+    assert not duplicate.is_redundant  # reported, not silently equated
+    fields = {d.field for d in duplicate.attribution_differences}
+    assert fields == {"pricing_provenance", "cost_rank_basis"}
+    assert price_tiebreak_signal_for(project) == price_tiebreak_signal_for(builtin)
+
+
+def test_an_unattributed_shipped_entry_versus_a_declared_price_is_a_routing_difference():
+    """The case that makes a duplicate declaration load-bearing.
+
+    A vendor shorthand ships unattributed, so routing ignores its literal. The
+    same entry declared in forge.yaml attributes the figures to the operator, so
+    routing *does* read them — the price tie-break moves from "behind every priced
+    candidate" to a real number. Same identity, same numbers on the page,
+    different selection.
+    """
+    builtin = _spec(pricing_provenance=None, cost_rank_basis=COST_BAND_BASIS_VENDOR_TIER)
+    project = _spec(
+        pricing_provenance=PRICING_PROVENANCE_OPERATOR_DECLARED,
+        cost_rank_basis="price:forge.yaml",
+    )
+    duplicate = compare_duplicate_declaration("anthropic/haiku/cli", project, builtin)
+    assert duplicate.routing_differs
+    routing_fields = {d.field for d in duplicate.routing_differences}
+    assert routing_fields == {
+        "effective_input_cost_per_mtok",
+        "effective_output_cost_per_mtok",
+    }
+    # And the difference is real, not notional.
+    assert price_tiebreak_signal_for(builtin) == float("inf")
+    assert price_tiebreak_signal_for(project) == 5.0
+
+
+def test_an_unattributable_literal_differing_is_not_a_routing_difference():
+    """Routing cannot read either figure, so disagreeing about them changes nothing."""
+    builtin = _spec(input_cost_per_mtok=1.00)
+    project = _spec(input_cost_per_mtok=99.00)
+    duplicate = compare_duplicate_declaration("anthropic/haiku/cli", project, builtin)
+    assert not duplicate.routing_differs
+    assert {d.field for d in duplicate.attribution_differences} == {"input_cost_per_mtok"}
+
+
+@pytest.mark.parametrize(
+    "field_name,value",
+    [
+        ("tier", "strong"),
+        ("capability", 9),
+        ("cost_rank", 3),
+        ("dev_capable", False),
+        ("phase_eligibility", ["review"]),
+    ],
+)
+def test_every_selection_field_counts_as_a_routing_difference(field_name, value):
+    duplicate = compare_duplicate_declaration(
+        "anthropic/haiku/cli", _spec(**{field_name: value}), _spec()
+    )
+    assert duplicate.routing_differs
+    assert field_name in {d.field for d in duplicate.routing_differences}
+
+
+def test_a_different_endpoint_counts_as_a_routing_difference():
+    project = replace(_spec(), base_url="http://localhost:11434/v1")
+    duplicate = compare_duplicate_declaration("anthropic/haiku/cli", project, _spec())
+    assert duplicate.routing_differs
+    assert "base_url" in {d.field for d in duplicate.routing_differences}
+
+
+def test_a_difference_names_both_sides_so_the_report_is_readable():
+    duplicate = compare_duplicate_declaration("anthropic/haiku/cli", _spec(tier="strong"), _spec())
+    assert "tier: forge.yaml='strong' builtin='cheap'" in duplicate.describe()

--- a/tests/test_pricing_provenance.py
+++ b/tests/test_pricing_provenance.py
@@ -121,7 +121,9 @@ def test_provenance_survives_the_projections_routing_reads():
 # ── Built-in registry attribution ──────────────────────────────────────
 
 
-@pytest.mark.parametrize("key", ["anthropic/opus/cli", "anthropic/sonnet/cli"])
+@pytest.mark.parametrize(
+    "key", ["anthropic/opus/cli", "anthropic/sonnet/cli", "anthropic/haiku/cli"]
+)
 def test_cli_shorthand_entries_are_unattributed(key):
     """The Claude CLI resolves these identities at invocation, so their stored
     literal cannot be attributed to what is billed."""
@@ -135,7 +137,11 @@ def test_every_other_priced_builtin_entry_records_its_attribution():
         for key, spec in AGENT_REGISTRY.items()
         if spec.input_cost_per_mtok is not None and spec.pricing_provenance is None
     }
-    assert unattributed == {"anthropic/opus/cli", "anthropic/sonnet/cli"}
+    assert unattributed == {
+        "anthropic/opus/cli",
+        "anthropic/sonnet/cli",
+        "anthropic/haiku/cli",
+    }
 
 
 def test_local_endpoint_entries_are_attributed_to_the_endpoint():

--- a/tests/test_profiles_migration.py
+++ b/tests/test_profiles_migration.py
@@ -146,8 +146,8 @@ def test_concrete_anthropic_cli_version_resolves_to_the_family_shorthand():
 
 
 def test_family_match_is_gated_on_the_registry_slot_existing():
-    # No ``anthropic/haiku/cli`` slot in the catalog → unresolved, not guessed.
-    assert canonical_id_for_legacy_key("claude-haiku-4-5") is None
+    # No ``anthropic/turbo/cli`` slot in the catalog → unresolved, not guessed.
+    assert canonical_id_for_legacy_key("claude-turbo-4-5") is None
     # An API hint contradicts the CLI-only heuristic.
     assert canonical_id_for_legacy_key("claude-sonnet-4-6", {"transport_used": "api"}) is None
 

--- a/tests/test_promoted_models_catalog.py
+++ b/tests/test_promoted_models_catalog.py
@@ -1,144 +1,370 @@
 """Promotion of validated project-only models into the shipped catalog (#2252).
 
 ``openai/gpt-5.5/cli``, ``google/gemini-3.5-flash/api`` and ``anthropic/haiku/cli``
-existed only as ``forge.yaml`` declarations even though this project routes to them
-daily. These tests pin the two properties that make the promotion safe:
+existed only as ``forge.yaml`` declarations even though this project routes to
+them daily, so a consumer enabling the shipped defaults could not reach them.
 
-- the three identities resolve from the packaged catalog alone, with no project
-  declaration required;
-- a ``forge.yaml`` that still carries the now-redundant declaration (this
-  project's own config is not touched by the promotion) keeps loading and keeps
-  resolving to the same dispatch-relevant routing/cost — while a declaration that
-  actually disagrees with the promoted entry is still rejected without
-  ``override: true``.
+Promotion leaves this project's own configuration holding a duplicate of each
+(removing them is separate operator work, sequenced after a release carrying the
+catalog entries). These tests pin both halves of that: the entries resolve from
+the catalog alone, and the duplicate declarations left behind are resolved
+*visibly* — including the one whose presence genuinely changes routing.
 """
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 import yaml
 
+from theforge.cli.check_config import cmd_check_config
 from theforge.config import load_config
 from theforge.config.model_catalog import load_packaged_catalog
 from theforge.config.models import AGENT_REGISTRY
+from theforge.config.pricing import price_tiebreak_signal_for
+from theforge.config.role_derivation import derive_roles
+
+PROMOTED = ("openai/gpt-5.5/cli", "google/gemini-3.5-flash/api", "anthropic/haiku/cli")
 
 
 def _write(tmp_path: Path, body: dict) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     path = tmp_path / "forge.yaml"
     path.write_text(yaml.dump(body), encoding="utf-8")
     return path
 
 
-def test_the_three_promoted_identities_resolve_from_the_packaged_catalog_alone():
-    catalog = load_packaged_catalog()
-    assert catalog == AGENT_REGISTRY
-
-    gpt_55 = catalog["openai/gpt-5.5/cli"]
-    assert (gpt_55.tier, gpt_55.capability, gpt_55.cost_rank) == ("strong", 9, 3)
-    assert (gpt_55.input_cost_per_mtok, gpt_55.output_cost_per_mtok) == (5.00, 30.00)
-    assert gpt_55.pricing_provenance == "gpt-5.5"
-
-    gemini_35_flash = catalog["google/gemini-3.5-flash/api"]
-    assert (gemini_35_flash.tier, gemini_35_flash.capability, gemini_35_flash.cost_rank) == (
-        "strong",
-        9,
-        2,
-    )
-    assert (gemini_35_flash.input_cost_per_mtok, gemini_35_flash.output_cost_per_mtok) == (
-        1.50,
-        9.00,
-    )
-
-    haiku = catalog["anthropic/haiku/cli"]
-    assert (haiku.tier, haiku.capability, haiku.cost_rank) == ("cheap", 6, 1)
-    assert haiku.dev_capable is False
-    assert haiku.phase_eligibility == frozenset({"preflight", "review"})
-    # A CLI shorthand: unattributed, same as sonnet/opus.
-    assert haiku.pricing_provenance is None
-
-
-def test_a_project_config_needs_no_declaration_to_resolve_them(tmp_path):
-    path = _write(
-        tmp_path,
-        {
-            "project": "p",
-            "models": ["anthropic/sonnet/cli", "openai/gpt-5.5/cli", "anthropic/haiku/cli"],
-            "budget_usd": 30.0,
+def _runnable(tmp_path: Path, models: dict | list) -> dict:
+    return {
+        "project": "p",
+        "models": models,
+        "budget_usd": 30.0,
+        "workspace": {
+            "create_command": "true",
+            "path_pattern": str(tmp_path / "{slug}"),
+            "branch_pattern": "x/{slug}",
         },
-    )
-    config = load_config(path)
-    assert "openai/gpt-5.5/cli" in config.models
-    assert "anthropic/haiku/cli" in config.models
-    assert config.model_registry_sources["openai/gpt-5.5/cli"] == "builtin"
+        "validation": {"gate_command": "true"},
+    }
 
 
-def test_a_redundant_project_declaration_still_loads_and_resolves_identically(tmp_path):
-    """The exact overlay shape this project's own forge.yaml carries today.
+# ── The entries are reachable from the shipped defaults ───────────────────
 
-    No ``override: true`` is set — the promotion must not force that change.
+
+class TestReachableFromShippedDefaults:
+    def test_the_three_identities_resolve_from_the_packaged_catalog_alone(self):
+        catalog = load_packaged_catalog()
+        assert catalog == AGENT_REGISTRY
+        for model_id in PROMOTED:
+            assert model_id in catalog, model_id
+
+    def test_each_promoted_entry_carries_the_policy_it_was_validated_under(self):
+        catalog = load_packaged_catalog()
+
+        gpt_55 = catalog["openai/gpt-5.5/cli"]
+        assert (gpt_55.tier, gpt_55.capability, gpt_55.cost_rank) == ("strong", 9, 3)
+        assert (gpt_55.input_cost_per_mtok, gpt_55.output_cost_per_mtok) == (5.00, 30.00)
+        assert gpt_55.pricing_provenance == "gpt-5.5"
+
+        flash = catalog["google/gemini-3.5-flash/api"]
+        assert (flash.tier, flash.capability, flash.cost_rank) == ("strong", 9, 2)
+        assert (flash.input_cost_per_mtok, flash.output_cost_per_mtok) == (1.50, 9.00)
+        assert flash.pricing_provenance == "gemini-3.5-flash"
+
+        haiku = catalog["anthropic/haiku/cli"]
+        assert (haiku.tier, haiku.capability, haiku.cost_rank) == ("cheap", 6, 1)
+        assert haiku.dev_capable is False
+        assert haiku.phase_eligibility == frozenset({"preflight", "review"})
+        # A CLI shorthand resolves at invocation, so its literal is unattributed
+        # and routing ignores it — same rule sonnet/opus ship under.
+        assert haiku.pricing_provenance is None
+
+    def test_a_consumer_declaring_none_of_them_still_resolves_them(self, tmp_path):
+        path = _write(tmp_path, _runnable(tmp_path, ["anthropic/sonnet/cli", *PROMOTED]))
+        config = load_config(path)
+        for model_id in PROMOTED:
+            assert model_id in config.models
+            assert config.model_registry_sources[model_id] == "builtin"
+        assert config.model_registry_duplicates == ()
+
+    def test_the_newest_openai_tier_is_no_longer_a_generation_behind(self):
+        """The gap the story is about, stated as the property that closed it."""
+        openai_cli = {
+            spec.model
+            for key, spec in AGENT_REGISTRY.items()
+            if spec.provider == "openai" and spec.transport.kind == "cli"
+        }
+        assert "gpt-5.5" in openai_cli
+        # And a cheap-tier Anthropic option now exists at all.
+        assert any(
+            spec.provider == "anthropic" and spec.tier == "cheap"
+            for spec in AGENT_REGISTRY.values()
+        )
+
+    def test_an_unconfirmed_identifier_was_not_promoted(self):
+        """The gpt-5.6 family is blocked pending an adapter fix — it must not ship."""
+        models = {spec.model for spec in AGENT_REGISTRY.values()}
+        assert not {m for m in models if m.startswith("gpt-5.6")}
+
+
+# ── A duplicate declaration is resolved visibly, not silently ─────────────
+
+
+class TestDuplicateDeclarationsAreReported:
+    def _declared(self, tmp_path: Path, declaration: dict) -> dict:
+        return _runnable(
+            tmp_path,
+            {
+                "enabled": ["anthropic/sonnet/cli", "openai/gpt-5.5/cli"],
+                "custom": {"openai/gpt-5.5/cli": declaration},
+            },
+        )
+
+    def test_a_transcribed_declaration_loads_and_reports_the_attribution_it_moved(self, tmp_path):
+        """The exact overlay shape this project's forge.yaml carries today.
+
+        No ``override: true`` — promoting a model must not break a configuration
+        that already declared it. But the entry is not silently equated with the
+        shipped one: the declaration attributes the figures to ``forge.yaml``,
+        and that is reported.
+        """
+        path = _write(
+            tmp_path,
+            self._declared(
+                tmp_path,
+                {
+                    "provider": "openai",
+                    "model": "gpt-5.5",
+                    "transport": {"kind": "cli"},
+                    "tier": "strong",
+                    "input_cost_per_mtok": 5.00,
+                    "output_cost_per_mtok": 30.00,
+                },
+            ),
+        )
+        config = load_config(path)
+        (duplicate,) = config.model_registry_duplicates
+        assert duplicate.canonical_id == "openai/gpt-5.5/cli"
+        # Routing is unaffected: both sides attribute the same figures to
+        # *something*, so the price tie-break reads the same number.
+        assert not duplicate.routing_differs
+        # But it is not claimed to be inert either.
+        assert not duplicate.is_redundant
+        assert {d.field for d in duplicate.attribution_differences} == {
+            "pricing_provenance",
+            "cost_rank_basis",
+        }
+        spec = (config.model_registry or {})["openai/gpt-5.5/cli"]
+        assert spec.pricing_provenance == "forge.yaml"
+        assert price_tiebreak_signal_for(spec) == price_tiebreak_signal_for(
+            AGENT_REGISTRY["openai/gpt-5.5/cli"]
+        )
+
+    def test_a_declaration_that_changes_routing_still_needs_override(self, tmp_path):
+        path = _write(
+            tmp_path,
+            self._declared(
+                tmp_path,
+                {
+                    "provider": "openai",
+                    "model": "gpt-5.5",
+                    "transport": {"kind": "cli"},
+                    "tier": "strong",
+                    "input_cost_per_mtok": 1.5,
+                    "output_cost_per_mtok": 12.0,
+                },
+            ),
+        )
+        with pytest.raises(ValueError, match="duplicates a built-in model id"):
+            load_config(path)
+
+    def test_the_refusal_names_the_routing_field_that_moved(self, tmp_path):
+        path = _write(
+            tmp_path,
+            self._declared(
+                tmp_path,
+                {
+                    "provider": "openai",
+                    "model": "gpt-5.5",
+                    "transport": {"kind": "cli"},
+                    "tier": "strong",
+                    "input_cost_per_mtok": 1.5,
+                    "output_cost_per_mtok": 12.0,
+                },
+            ),
+        )
+        with pytest.raises(ValueError, match="cost_rank"):
+            load_config(path)
+
+    def test_a_routing_changing_duplicate_that_is_permitted_is_warned_about(
+        self, tmp_path, caplog
+    ):
+        """An inline ``models.enabled`` mapping may overlay a shipped entry.
+
+        It is permitted, so it must not raise — but the difference cannot be
+        silent, which is the whole point of reporting rather than refusing.
+        This is the haiku shape: a declared price on an entry the catalog ships
+        unattributed.
+        """
+        path = _write(
+            tmp_path,
+            _runnable(
+                tmp_path,
+                {
+                    "enabled": [
+                        "anthropic/sonnet/cli",
+                        {
+                            "provider": "anthropic",
+                            "model": "haiku",
+                            "transport": {"kind": "cli"},
+                            "routing": {
+                                "tier": "cheap",
+                                "capability": 6,
+                                "cost_rank": 1,
+                                "dev_capable": False,
+                                "phase_eligibility": ["preflight", "review"],
+                            },
+                            "cost": {"input_per_mtok": 1.00, "output_per_mtok": 5.00},
+                        },
+                    ]
+                },
+            ),
+        )
+        with caplog.at_level("WARNING", logger="theforge.config"):
+            config = load_config(path)
+        (duplicate,) = config.model_registry_duplicates
+        assert duplicate.canonical_id == "anthropic/haiku/cli"
+        assert duplicate.routing_differs
+        assert {d.field for d in duplicate.routing_differences} == {
+            "effective_input_cost_per_mtok",
+            "effective_output_cost_per_mtok",
+        }
+        assert "would change model selection" in caplog.text
+
+    def test_check_config_states_which_duplicates_are_safe_to_remove(self, tmp_path, capsys):
+        """The report has an operator-facing consumer, not just a struct."""
+        path = _write(
+            tmp_path,
+            self._declared(
+                tmp_path,
+                {
+                    "provider": "openai",
+                    "model": "gpt-5.5",
+                    "transport": {"kind": "cli"},
+                    "tier": "strong",
+                    "input_cost_per_mtok": 5.00,
+                    "output_cost_per_mtok": 30.00,
+                },
+            ),
+        )
+        args = argparse.Namespace(config=str(path))
+        with patch("theforge.cli.check_config.check_agent_auth", return_value=(True, "")):
+            cmd_check_config(args)
+        out = capsys.readouterr().out
+        assert "also defined in the shipped catalog (forge.yaml wins):" in out
+        assert "openai/gpt-5.5/cli" in out
+        assert "differs only in attribution recorded" in out
+        assert "pricing_provenance: forge.yaml='forge.yaml' builtin='gpt-5.5'" in out
+
+
+# ── Seam: config resolution → routing ─────────────────────────────────────
+
+
+class TestRoutingSeam:
+    """Config→routing propagation, per the seam-test convention.
+
+    The claim under test is behavioural, not structural: whether an operator who
+    deletes a duplicate declaration gets the same selection as one who keeps it.
     """
-    path = _write(
-        tmp_path,
-        {
-            "project": "p",
-            "models": {
-                "enabled": ["anthropic/sonnet/cli", "openai/gpt-5.5/cli"],
-                "custom": {
-                    "openai/gpt-5.5/cli": {
-                        "provider": "openai",
-                        "model": "gpt-5.5",
-                        "transport": {"kind": "cli"},
-                        "tier": "strong",
-                        "input_cost_per_mtok": 5.00,
-                        "output_cost_per_mtok": 30.00,
-                    }
-                },
-            },
-            "budget_usd": 30.0,
-        },
-    )
-    config = load_config(path)
-    spec = (config.model_registry or {})["openai/gpt-5.5/cli"]
-    builtin = AGENT_REGISTRY["openai/gpt-5.5/cli"]
-    assert (spec.tier, spec.capability, spec.cost_rank, spec.dev_capable) == (
-        builtin.tier,
-        builtin.capability,
-        builtin.cost_rank,
-        builtin.dev_capable,
-    )
-    assert (spec.input_cost_per_mtok, spec.output_cost_per_mtok) == (
-        builtin.input_cost_per_mtok,
-        builtin.output_cost_per_mtok,
-    )
 
+    def _roles(self, path: Path):
+        config = load_config(path)
+        return (
+            derive_roles(
+                config.models,
+                {},
+                budget_usd=config.models_budget_usd or 30.0,
+                complexity="MEDIUM",
+                registry=config.model_registry,
+            ),
+            config,
+        )
 
-def test_a_declaration_that_actually_disagrees_with_the_promoted_entry_still_needs_override(
-    tmp_path,
-):
-    path = _write(
-        tmp_path,
-        {
-            "project": "p",
-            "models": {
-                "enabled": ["anthropic/sonnet/cli", "openai/gpt-5.5/cli"],
-                "custom": {
-                    "openai/gpt-5.5/cli": {
-                        "provider": "openai",
-                        "model": "gpt-5.5",
-                        "transport": {"kind": "cli"},
-                        "tier": "strong",
-                        "input_cost_per_mtok": 1.5,
-                        "output_cost_per_mtok": 12.0,
-                    }
+    def test_removing_an_attribution_only_duplicate_leaves_selection_unchanged(self, tmp_path):
+        enabled = ["anthropic/sonnet/cli", "openai/gpt-5.5/cli", "openai/gpt-5.4-mini/cli"]
+        with_declaration = _write(
+            tmp_path / "a",
+            _runnable(
+                tmp_path,
+                {
+                    "enabled": enabled,
+                    "custom": {
+                        "openai/gpt-5.5/cli": {
+                            "provider": "openai",
+                            "model": "gpt-5.5",
+                            "transport": {"kind": "cli"},
+                            "tier": "strong",
+                            "input_cost_per_mtok": 5.00,
+                            "output_cost_per_mtok": 30.00,
+                        }
+                    },
                 },
-            },
-            "budget_usd": 30.0,
-        },
-    )
-    try:
-        load_config(path)
-    except ValueError as exc:
-        assert "override: true" in str(exc)
-    else:
-        raise AssertionError("expected a genuinely conflicting declaration to be rejected")
+            ),
+        )
+        without = _write(tmp_path / "b", _runnable(tmp_path, {"enabled": enabled}))
+
+        kept, kept_config = self._roles(with_declaration)
+        removed, _ = self._roles(without)
+
+        def _picks(roles) -> tuple:
+            return (
+                roles.dev.ref.model,
+                roles.preflight.ref.model,
+                roles.plan.ref.model,
+                tuple(p.ref.model for p in roles.review_pool),
+            )
+
+        assert _picks(kept) == _picks(removed)
+        # And the config says so rather than leaving it to be discovered.
+        assert not kept_config.model_registry_duplicates[0].routing_differs
+
+    def test_the_haiku_duplicate_really_does_move_the_price_tiebreak(self, tmp_path):
+        """Why the report exists: this one is not safe to delete silently."""
+        path = _write(
+            tmp_path,
+            _runnable(
+                tmp_path,
+                {
+                    "enabled": [
+                        "anthropic/sonnet/cli",
+                        {
+                            "provider": "anthropic",
+                            "model": "haiku",
+                            "transport": {"kind": "cli"},
+                            "cost": {"input_per_mtok": 1.00, "output_per_mtok": 5.00},
+                        },
+                    ]
+                },
+            ),
+        )
+        declared = (load_config(path).model_registry or {})["anthropic/haiku/cli"]
+        shipped = AGENT_REGISTRY["anthropic/haiku/cli"]
+        # Shipped: unattributed, so it sorts behind every priced cheap-tier peer.
+        assert price_tiebreak_signal_for(shipped) == float("inf")
+        # Declared: routing reads the figures, so it competes on price.
+        assert price_tiebreak_signal_for(declared) == 5.0
+
+    def test_a_catalog_only_consumer_gets_the_promoted_models_in_its_pool(self, tmp_path):
+        """The consumer-facing point of promotion, at the routing seam."""
+        path = _write(
+            tmp_path,
+            _runnable(tmp_path, ["anthropic/sonnet/cli", "openai/gpt-5.5/cli"]),
+        )
+        roles, _ = self._roles(path)
+        chosen = {roles.dev.ref.model, roles.plan.ref.model, roles.preflight.ref.model} | {
+            p.ref.model for p in roles.review_pool
+        }
+        assert "gpt-5.5" in chosen

--- a/tests/test_promoted_models_catalog.py
+++ b/tests/test_promoted_models_catalog.py
@@ -1,0 +1,144 @@
+"""Promotion of validated project-only models into the shipped catalog (#2252).
+
+``openai/gpt-5.5/cli``, ``google/gemini-3.5-flash/api`` and ``anthropic/haiku/cli``
+existed only as ``forge.yaml`` declarations even though this project routes to them
+daily. These tests pin the two properties that make the promotion safe:
+
+- the three identities resolve from the packaged catalog alone, with no project
+  declaration required;
+- a ``forge.yaml`` that still carries the now-redundant declaration (this
+  project's own config is not touched by the promotion) keeps loading and keeps
+  resolving to the same dispatch-relevant routing/cost — while a declaration that
+  actually disagrees with the promoted entry is still rejected without
+  ``override: true``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from theforge.config import load_config
+from theforge.config.model_catalog import load_packaged_catalog
+from theforge.config.models import AGENT_REGISTRY
+
+
+def _write(tmp_path: Path, body: dict) -> Path:
+    path = tmp_path / "forge.yaml"
+    path.write_text(yaml.dump(body), encoding="utf-8")
+    return path
+
+
+def test_the_three_promoted_identities_resolve_from_the_packaged_catalog_alone():
+    catalog = load_packaged_catalog()
+    assert catalog == AGENT_REGISTRY
+
+    gpt_55 = catalog["openai/gpt-5.5/cli"]
+    assert (gpt_55.tier, gpt_55.capability, gpt_55.cost_rank) == ("strong", 9, 3)
+    assert (gpt_55.input_cost_per_mtok, gpt_55.output_cost_per_mtok) == (5.00, 30.00)
+    assert gpt_55.pricing_provenance == "gpt-5.5"
+
+    gemini_35_flash = catalog["google/gemini-3.5-flash/api"]
+    assert (gemini_35_flash.tier, gemini_35_flash.capability, gemini_35_flash.cost_rank) == (
+        "strong",
+        9,
+        2,
+    )
+    assert (gemini_35_flash.input_cost_per_mtok, gemini_35_flash.output_cost_per_mtok) == (
+        1.50,
+        9.00,
+    )
+
+    haiku = catalog["anthropic/haiku/cli"]
+    assert (haiku.tier, haiku.capability, haiku.cost_rank) == ("cheap", 6, 1)
+    assert haiku.dev_capable is False
+    assert haiku.phase_eligibility == frozenset({"preflight", "review"})
+    # A CLI shorthand: unattributed, same as sonnet/opus.
+    assert haiku.pricing_provenance is None
+
+
+def test_a_project_config_needs_no_declaration_to_resolve_them(tmp_path):
+    path = _write(
+        tmp_path,
+        {
+            "project": "p",
+            "models": ["anthropic/sonnet/cli", "openai/gpt-5.5/cli", "anthropic/haiku/cli"],
+            "budget_usd": 30.0,
+        },
+    )
+    config = load_config(path)
+    assert "openai/gpt-5.5/cli" in config.models
+    assert "anthropic/haiku/cli" in config.models
+    assert config.model_registry_sources["openai/gpt-5.5/cli"] == "builtin"
+
+
+def test_a_redundant_project_declaration_still_loads_and_resolves_identically(tmp_path):
+    """The exact overlay shape this project's own forge.yaml carries today.
+
+    No ``override: true`` is set — the promotion must not force that change.
+    """
+    path = _write(
+        tmp_path,
+        {
+            "project": "p",
+            "models": {
+                "enabled": ["anthropic/sonnet/cli", "openai/gpt-5.5/cli"],
+                "custom": {
+                    "openai/gpt-5.5/cli": {
+                        "provider": "openai",
+                        "model": "gpt-5.5",
+                        "transport": {"kind": "cli"},
+                        "tier": "strong",
+                        "input_cost_per_mtok": 5.00,
+                        "output_cost_per_mtok": 30.00,
+                    }
+                },
+            },
+            "budget_usd": 30.0,
+        },
+    )
+    config = load_config(path)
+    spec = (config.model_registry or {})["openai/gpt-5.5/cli"]
+    builtin = AGENT_REGISTRY["openai/gpt-5.5/cli"]
+    assert (spec.tier, spec.capability, spec.cost_rank, spec.dev_capable) == (
+        builtin.tier,
+        builtin.capability,
+        builtin.cost_rank,
+        builtin.dev_capable,
+    )
+    assert (spec.input_cost_per_mtok, spec.output_cost_per_mtok) == (
+        builtin.input_cost_per_mtok,
+        builtin.output_cost_per_mtok,
+    )
+
+
+def test_a_declaration_that_actually_disagrees_with_the_promoted_entry_still_needs_override(
+    tmp_path,
+):
+    path = _write(
+        tmp_path,
+        {
+            "project": "p",
+            "models": {
+                "enabled": ["anthropic/sonnet/cli", "openai/gpt-5.5/cli"],
+                "custom": {
+                    "openai/gpt-5.5/cli": {
+                        "provider": "openai",
+                        "model": "gpt-5.5",
+                        "transport": {"kind": "cli"},
+                        "tier": "strong",
+                        "input_cost_per_mtok": 1.5,
+                        "output_cost_per_mtok": 12.0,
+                    }
+                },
+            },
+            "budget_usd": 30.0,
+        },
+    )
+    try:
+        load_config(path)
+    except ValueError as exc:
+        assert "override: true" in str(exc)
+    else:
+        raise AssertionError("expected a genuinely conflicting declaration to be rejected")


### PR DESCRIPTION
## Summary

The reviewed change satisfies the model promotion and duplicate-reporting criteria; no blocking defects were found.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $9.59
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Models this project validated are reachable only from project configuration, so a consumer starting from shipped defaults does not get them (GitHub Issue #2252)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2252