### PR TITLE
The cheapest complexity band cannot fund a single review cycle, so a story is refused before it runs regardless of how it behaves

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -487,11 +487,18 @@ def _coordinator_loop(
         # explicit headroom, not from the reviewers' execution ceilings. The
         # exact seated figure is persisted on state so dispatch cannot silently
         # re-price the same granted cycle later in the run.
+        #
+        # The story's complexity score goes in because the allocation this price
+        # is about to be subtracted from is scoped to that score (#2287). Pricing
+        # verification from the review population at large charges a small story
+        # for verifying an average one, and at the cheapest band that alone
+        # exceeds the whole allocation.
         _reviewer_names = [profile.name for profile in config.review_pool]
         _review_cycle_planning = _story_budget.derive_review_cycle_planning_price(
             config.project_root,
             configured_ceiling_usd=sum(float(p.budget_usd) for p in config.review_pool),
             composition=_reviewer_names,
+            complexity_score=state.preflight_complexity_score,
         ).as_dict()
         _reconciliation = _story_budget.reconcile_review_cycles(
             state.story_allocation,
@@ -530,6 +537,7 @@ def _coordinator_loop(
             _story_budget.RECONCILE_REDUCED,
             _story_budget.RECONCILE_UNFUNDABLE,
             _story_budget.RECONCILE_NONCOMPARABLE_DEV_ESTIMATE,
+            _story_budget.RECONCILE_NONCOMPARABLE_REVIEW_COST,
         ):
             _audit["rationale"] = (
                 f"{_audit.get('rationale', '')} "

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -655,6 +655,7 @@ def _run_review_pool(
                 config.project_root,
                 configured_ceiling_usd=configured_ceiling_usd,
                 composition=[p.name for p in pool],
+                complexity_score=state.preflight_complexity_score,
             ).as_dict()
             state.adaptive_review_cycle_planning = review_cycle_planning
         # A cycle the seating reconciliation reserved is funded from that

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -51,19 +51,31 @@ DEV_ESTIMATE_SCOPE_DEV_PHASE = "dev_phase"
 
 BASIS_SUBSTRATE_BAND = "substrate_band"
 BASIS_CONFIGURED_FALLBACK = "configured_fallback"
+BASIS_OBSERVED_SCORE = "observed_complexity_score"
 BASIS_OBSERVED_COMPOSITION = "observed_composition"
 BASIS_OBSERVED_REVIEW_CYCLE = "observed_review_cycle"
 BASIS_OBSERVED_SPARSE = "observed_sparse"
 BASIS_REVIEW_CEILING_FALLBACK = "ceiling_fallback"
 
 # The rungs of the review-cycle pricing ladder, most specific first. A price is
-# "observed" on any of the first three: all describe measured spend, and differ
+# "observed" on any of the first four: all describe measured spend, and differ
 # only in which population was measurable. The ceiling is not a price at all —
 # it is a permission — so it sits outside this set and is reached only when
 # nothing has ever been observed.
 OBSERVED_REVIEW_CYCLE_BASES = frozenset(
-    {BASIS_OBSERVED_COMPOSITION, BASIS_OBSERVED_REVIEW_CYCLE, BASIS_OBSERVED_SPARSE}
+    {
+        BASIS_OBSERVED_SCORE,
+        BASIS_OBSERVED_COMPOSITION,
+        BASIS_OBSERVED_REVIEW_CYCLE,
+        BASIS_OBSERVED_SPARSE,
+    }
 )
+
+# The one rung whose population is the population a band-derived allocation
+# prices: review spend recorded on stories that scored the same complexity.
+# Only a price from this rung may be subtracted from such an allocation hard
+# enough to refuse the story — see ``_review_price_comparable_to_allocation``.
+COMPARABLE_REVIEW_CYCLE_BASES = frozenset({BASIS_OBSERVED_SCORE})
 
 STATUS_WITHIN = "within_allocation"
 STATUS_EXCEEDED = "allocation_exceeded"
@@ -119,7 +131,15 @@ class StoryAllocation:
 
 @dataclass(frozen=True)
 class ReviewCyclePlanningPrice:
-    """Planned per-cycle review price plus the evidence it was derived from."""
+    """Planned per-cycle review price plus the evidence it was derived from.
+
+    ``complexity_score`` is the score the samples were *scoped to* — set only on
+    the score-scoped rung, and ``None`` on every wider one. That distinction is
+    what makes a price comparable to a band-derived allocation or not, so it is
+    recorded rather than inferred. ``requested_complexity_score`` is the score
+    the caller asked for regardless of which rung answered, so an operator can
+    see that a score was known and the history for it was not there.
+    """
 
     planned_cost_usd: float
     basis: str
@@ -132,6 +152,8 @@ class ReviewCyclePlanningPrice:
     reason: str = ""
     excluded_for_taint: int = 0
     composition: tuple[str, ...] | None = None
+    complexity_score: int | None = None
+    requested_complexity_score: int | None = None
 
     @property
     def derived(self) -> bool:
@@ -150,6 +172,8 @@ class ReviewCyclePlanningPrice:
             "reason": self.reason,
             "excluded_for_taint": self.excluded_for_taint,
             "composition": list(self.composition) if self.composition else None,
+            "complexity_score": self.complexity_score,
+            "requested_complexity_score": self.requested_complexity_score,
         }
 
 
@@ -298,6 +322,8 @@ def review_cycle_planning_from_samples(
     derived_basis: str = BASIS_OBSERVED_REVIEW_CYCLE,
     scope_suffix: str = "",
     composition: tuple[str, ...] | None = None,
+    complexity_score: int | None = None,
+    requested_complexity_score: int | None = None,
 ) -> ReviewCyclePlanningPrice:
     """Return the deterministic planning price for one review cycle.
 
@@ -333,6 +359,7 @@ def review_cycle_planning_from_samples(
             ),
             excluded_for_taint=excluded_for_taint,
             composition=composition,
+            requested_complexity_score=requested_complexity_score,
         )
 
     median = percentile(usable, 0.5)
@@ -361,6 +388,7 @@ def review_cycle_planning_from_samples(
             ),
             excluded_for_taint=excluded_for_taint,
             composition=composition,
+            requested_complexity_score=requested_complexity_score,
         )
 
     planned = min(
@@ -382,6 +410,8 @@ def review_cycle_planning_from_samples(
         ),
         excluded_for_taint=excluded_for_taint,
         composition=composition,
+        complexity_score=complexity_score,
+        requested_complexity_score=requested_complexity_score,
     )
 
 
@@ -418,10 +448,29 @@ def _record_cycle_compositions(rec: dict) -> dict:
     return compositions
 
 
+def _record_complexity_score(rec: dict) -> int | None:
+    """The preflight complexity score of one audit record, or ``None``.
+
+    A review cycle has no score of its own — the score is a property of the
+    story whose run the cycle belongs to — so score scoping is a record-level
+    filter, and the whole record's cycles are admitted or excluded together.
+    Mirrors the coercion ``audit_substrate._flat_fields`` uses for the indexed
+    ``complexity_score`` column so both read the same records the same way.
+    """
+    preflight = rec.get("preflight")
+    raw = preflight.get("complexity_score") if isinstance(preflight, dict) else None
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    return None
+
+
 def _extract_review_cycle_cost_samples(
     records: list[dict],
     *,
     composition: tuple[str, ...] | None = None,
+    complexity_score: int | None = None,
 ) -> tuple[list[float], int]:
     """Return measured per-cycle review costs from prior audit records.
 
@@ -430,6 +479,11 @@ def _extract_review_cycle_cost_samples(
     — an unjoinable cycle is not evidence about any particular panel — but is
     still counted in the unfiltered population, where it remains evidence about
     review as an activity.
+
+    With ``complexity_score``, only cycles belonging to runs that scored exactly
+    that complexity are returned. A run with no recorded score is excluded from
+    a scored query for the same reason an unjoinable panel is: it is not
+    evidence about any particular score.
     """
     samples: list[float] = []
     excluded_for_taint = 0
@@ -438,6 +492,8 @@ def _extract_review_cycle_cost_samples(
             continue
         if str(rec.get("trust_status") or "").lower() == "tainted":
             excluded_for_taint += 1
+            continue
+        if complexity_score is not None and _record_complexity_score(rec) != complexity_score:
             continue
         iterations = rec.get("iterations")
         if not isinstance(iterations, dict):
@@ -466,17 +522,29 @@ def derive_review_cycle_planning_price(
     *,
     configured_ceiling_usd: float,
     composition: list[str] | tuple[str, ...] | None = None,
+    complexity_score: int | None = None,
     min_samples: int = REVIEW_CYCLE_PRICE_MIN_SAMPLES,
     headroom_multiplier: float = REVIEW_CYCLE_PRICE_HEADROOM,
 ) -> ReviewCyclePlanningPrice:
     """Read observed review-cycle spend from the substrate and derive one price.
 
-    Descends the ladder most-specific first. The panel a story will actually
-    seat is the best predictor of what its cycles cost — a three-reviewer panel
-    and a two-reviewer panel are different quantities, and averaging them
-    misprices both — so that history governs whenever it can support a price.
-    Below the floor the same phase's cost across every panel still describes
-    review, and only a total absence of observation reaches the ceiling.
+    Descends the ladder most-specific first:
+
+    1. ``complexity_score`` — review spend on stories that scored the same. This
+       rung is first because it is the only one drawn from the population a
+       band-derived allocation prices. Verification of a score-2 story costs
+       what verifying score-2 stories has cost; charging it the review
+       population's average charges it for verifying work it is not (#2287).
+    2. ``composition`` — the panel a story will actually seat is the best
+       predictor of what its cycles cost among stories of every size: a
+       three-reviewer panel and a two-reviewer panel are different quantities,
+       and averaging them misprices both.
+    3. review at large — the same phase's cost across every score and panel
+       still describes review.
+
+    Only a total absence of observation reaches the ceiling. ``complexity_score``
+    is optional and defaults to ``None``, which leaves the ladder exactly as it
+    was for callers that do not know a score.
     """
     from theforge.coordinator import audit_substrate  # noqa: PLC0415
 
@@ -501,9 +569,31 @@ def derive_review_cycle_planning_price(
                 conn.close()
 
     panel = composition_key(composition)
+    try:
+        score = None if complexity_score is None else int(complexity_score)
+    except (TypeError, ValueError):
+        score = None
     planning: ReviewCyclePlanningPrice | None = None
 
-    if panel is not None:
+    if score is not None:
+        score_samples, score_excluded = _extract_review_cycle_cost_samples(
+            records, complexity_score=score
+        )
+        if len(score_samples) >= min_samples:
+            planning = review_cycle_planning_from_samples(
+                score_samples,
+                configured_ceiling_usd,
+                excluded_for_taint=score_excluded,
+                min_samples=min_samples,
+                headroom_multiplier=headroom_multiplier,
+                derived_basis=BASIS_OBSERVED_SCORE,
+                scope_suffix=f" on stories at complexity score {score}",
+                composition=panel,
+                complexity_score=score,
+                requested_complexity_score=score,
+            )
+
+    if planning is None and panel is not None:
         panel_samples, panel_excluded = _extract_review_cycle_cost_samples(
             records, composition=panel
         )
@@ -517,6 +607,7 @@ def derive_review_cycle_planning_price(
                 derived_basis=BASIS_OBSERVED_COMPOSITION,
                 scope_suffix=" run by this exact panel",
                 composition=panel,
+                requested_complexity_score=score,
             )
 
     if planning is None:
@@ -528,6 +619,7 @@ def derive_review_cycle_planning_price(
             min_samples=min_samples,
             headroom_multiplier=headroom_multiplier,
             composition=panel,
+            requested_complexity_score=score,
         )
 
     if reason_prefix:
@@ -771,6 +863,7 @@ RECONCILE_NO_DEV_ESTIMATE = "no_dev_estimate"
 RECONCILE_NO_REVIEW_COST = "no_review_cost"
 RECONCILE_COST_UNKNOWN = "cost_unknown"
 RECONCILE_NONCOMPARABLE_DEV_ESTIMATE = "dev_estimate_not_comparable"
+RECONCILE_NONCOMPARABLE_REVIEW_COST = "review_cost_not_comparable"
 RECONCILE_AFFORDABLE = "within_allocation"
 RECONCILE_REDUCED = "review_max_reduced"
 RECONCILE_UNFUNDABLE = "review_unfundable"
@@ -812,6 +905,14 @@ def reconcile_review_cycles(
     ``review_unfundable`` when not even one cycle fits, which is the case the
     caller must refuse before dev spends.
 
+    Refusing takes a price on the allocation's own terms. When nothing fits but
+    the review price was borrowed from a population wider than the score the
+    allocation prices, the action is ``review_cost_not_comparable`` instead: the
+    permission stands, nothing is reserved, and the mismatch is recorded on
+    ``review_cycle_cost_comparable`` (#2287). Otherwise the cheapest complexity
+    band is refused as a matter of arithmetic between two unrelated populations,
+    and no story scoring that low can ever run.
+
     Only a band-derived allocation governs here. The configured fallback is by
     construction one pass through every role (see ``_configured_story_budget``),
     so it funds exactly one review cycle for arithmetic reasons that say nothing
@@ -838,6 +939,9 @@ def reconcile_review_cycles(
         "review_cycle_cost_headroom_multiplier": None,
         "review_cycle_cost_reason": None,
         "review_cycle_cost_composition": None,
+        "review_cycle_cost_complexity_score": None,
+        "review_cycle_cost_requested_complexity_score": None,
+        "review_cycle_cost_comparable": None,
         "dev_cost_estimate_basis": None,
         "dev_cost_estimate_basis_reason": None,
         "dev_cost_estimate_statistic": None,
@@ -919,6 +1023,16 @@ def reconcile_review_cycles(
         )
         record["review_cycle_cost_reason"] = review_cycle_planning.get("reason")
         record["review_cycle_cost_composition"] = review_cycle_planning.get("composition")
+        record["review_cycle_cost_complexity_score"] = review_cycle_planning.get(
+            "complexity_score"
+        )
+        record["review_cycle_cost_requested_complexity_score"] = review_cycle_planning.get(
+            "requested_complexity_score"
+        )
+    review_price_comparable = _review_price_comparable_to_allocation(
+        review_cycle_planning, allocation
+    )
+    record["review_cycle_cost_comparable"] = review_price_comparable
 
     if requested_review_max <= 0:
         record["action"] = RECONCILE_AFFORDABLE
@@ -942,6 +1056,16 @@ def reconcile_review_cycles(
     record["affordable_review_cycles"] = affordable
     if affordable == 0:
         record["reconciled_review_max"] = int(requested_review_max)
+        if not review_price_comparable:
+            # Nothing fits — but the price that says so was borrowed from a
+            # wider population than the allocation prices. A figure drawn from
+            # bigger work describes bigger work, and refusing a story on it
+            # asserts something the observation does not support (#2287).
+            # Record the mismatch and change nothing: the requested permission
+            # stands, nothing is reserved, and the dispatch-time check against
+            # measured spend remains the honest refusal if money really runs out.
+            record["action"] = RECONCILE_NONCOMPARABLE_REVIEW_COST
+            return record
         record["action"] = RECONCILE_UNFUNDABLE
         record["shortfall_usd"] = round(cycle_cost - remaining, 4)
         return record
@@ -1000,6 +1124,34 @@ def _dev_estimate_comparable_to_allocation(
     return basis_score == allocation_score
 
 
+def _review_price_comparable_to_allocation(
+    review_cycle_planning: dict | None,
+    allocation: dict | None,
+) -> bool:
+    """Whether the review price describes the population the allocation prices.
+
+    The same test the dev estimate has to pass, applied to the other side of the
+    subtraction. A band-derived allocation is the observed cost distribution at
+    ONE complexity score; a review price may be subtracted from it hard enough
+    to refuse the story only when it, too, was measured on stories at that
+    score. Every wider rung — the seated panel across all sizes, review at
+    large, a sparse handful, the configured ceiling — is recorded and left to
+    reduce or to fund, but never to refuse: the difference between a $1.69
+    allocation and a $3.21 price drawn from review of far larger stories is a
+    fact about the two populations, not about this story.
+    """
+    if not isinstance(review_cycle_planning, dict):
+        return False
+    if review_cycle_planning.get("basis") not in COMPARABLE_REVIEW_CYCLE_BASES:
+        return False
+    try:
+        price_score = int(review_cycle_planning.get("complexity_score"))
+        allocation_score = int((allocation or {}).get("complexity_score"))
+    except (TypeError, ValueError):
+        return False
+    return price_score == allocation_score
+
+
 def _format_dev_estimate_basis(record: dict) -> str:
     source = record.get("dev_cost_estimate_basis")
     score = record.get("dev_cost_estimate_complexity_score")
@@ -1036,10 +1188,15 @@ def _review_cycle_basis_text(record: dict) -> str:
     if isinstance(sample_count, (int, float)):
         sample_text = f" over {int(sample_count)} cycle(s)"
 
-    if basis in (BASIS_OBSERVED_COMPOSITION, BASIS_OBSERVED_REVIEW_CYCLE):
+    if basis in (BASIS_OBSERVED_SCORE, BASIS_OBSERVED_COMPOSITION, BASIS_OBSERVED_REVIEW_CYCLE):
         median = record.get("review_cycle_cost_median_usd")
         if median is not None and headroom is not None:
-            scope = "this panel" if basis == BASIS_OBSERVED_COMPOSITION else "review at large"
+            if basis == BASIS_OBSERVED_SCORE:
+                scope = f"complexity score {record.get('review_cycle_cost_complexity_score')}"
+            elif basis == BASIS_OBSERVED_COMPOSITION:
+                scope = "this panel"
+            else:
+                scope = "review at large"
             return (
                 f" (observed median ${float(median):.2f} x "
                 f"{float(headroom):.2f} headroom{sample_text}, {scope})"
@@ -1089,6 +1246,22 @@ def format_reconciliation(record: dict) -> str:
             f"{allocation_score if allocation_score is not None else '?'}; the "
             f"${float(record['dev_cost_estimate_usd']):.2f} dev estimate is a "
             f"{_format_dev_estimate_basis(record)}. Nothing reserved for review."
+        )
+    if action == RECONCILE_NONCOMPARABLE_REVIEW_COST:
+        # Deliberately not a dollar shortfall, for the same reason the dev-side
+        # message is not: the constraint is the scope of the price, not the size
+        # of the budget. Raising the budget would not make this comparison mean
+        # anything, and recording review history at this score would.
+        allocation_score = record.get("complexity_score")
+        return (
+            f"review_max left at {record['requested_review_max']}: no review cycle fits the "
+            f"${float(record['allocation_usd']):.2f} allocation at "
+            f"${float(record['review_cycle_cost_usd']):.2f} each{basis}, but that price and the "
+            f"allocation are not on a common population, so the story was not refused. The "
+            f"allocation prices complexity score "
+            f"{allocation_score if allocation_score is not None else '?'}; no review history at "
+            f"that score was available to price against. Nothing reserved for review; the "
+            f"dispatch-time check against measured spend still applies."
         )
     if action == RECONCILE_AFFORDABLE:
         return f"allocation funds the permitted {record['requested_review_max']} review cycle(s)."

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -33,6 +33,35 @@ def _comparable_dev_estimate_basis(score: int = 8, *, sample_count: int = 12) ->
     }
 
 
+def _comparable_review_planning(
+    cost_usd: float,
+    score: int = 8,
+    *,
+    sample_count: int = 6,
+) -> dict:
+    """A review price on the allocation's own population: score-scoped history.
+
+    ``score`` must match the allocation under test — a price drawn from the
+    review population at large is exactly what seating refuses to refuse a
+    story on (#2287).
+    """
+    return {
+        "planned_cost_usd": cost_usd,
+        "basis": sb.BASIS_OBSERVED_SCORE,
+        "fallback_configured_usd": cost_usd,
+        "sample_count": sample_count,
+        "median_usd": round(cost_usd / sb.REVIEW_CYCLE_PRICE_HEADROOM, 4),
+        "p90_usd": cost_usd,
+        "max_usd": cost_usd,
+        "headroom_multiplier": sb.REVIEW_CYCLE_PRICE_HEADROOM,
+        "reason": "test fixture: score-scoped review history",
+        "excluded_for_taint": 0,
+        "composition": None,
+        "complexity_score": score,
+        "requested_complexity_score": score,
+    }
+
+
 # Observed distribution for score 2 in the issue's table (n=24, median $0.46,
 # p90 $1.08, max $1.35), compressed to the sample floor.
 _SCORE_2_COSTS = [0.21, 0.30, 0.38, 0.46, 0.52, 0.61, 1.08, 1.35]
@@ -488,6 +517,122 @@ class TestReviewCyclePricingLadder:
         assert planning.basis == sb.BASIS_OBSERVED_REVIEW_CYCLE
         assert planning.planned_cost_usd == 3.00
 
+    def test_the_story_own_score_governs_over_the_review_population(self, tmp_path: Path) -> None:
+        """A score-2 story is priced from verifying score-2 stories (#2287).
+
+        The defect in the raw: review at large is dominated by far larger work,
+        so a small story is allocated as small and charged as average.
+        """
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(
+                    run_id="small",
+                    score=2,
+                    cost=1.35,
+                    review_cycle_costs=[0.40, 0.44, 0.48],
+                    review_pools=[_PAIR, _PAIR, _PAIR],
+                ),
+                _record(
+                    run_id="big",
+                    score=9,
+                    cost=40.64,
+                    review_cycle_costs=[3.20, 3.21, 3.30, 3.40],
+                    review_pools=[_TRIO, _TRIO, _TRIO, _TRIO],
+                ),
+            ],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=17.55, composition=_TRIO, complexity_score=2
+        )
+
+        assert planning.basis == sb.BASIS_OBSERVED_SCORE
+        assert planning.derived is True
+        assert planning.complexity_score == 2
+        assert planning.requested_complexity_score == 2
+        assert planning.sample_count == 3
+        assert planning.planned_cost_usd == round(0.44 * 1.25, 4)
+        assert "at complexity score 2" in planning.reason
+        # The seated panel's own history would have priced this at $4.01 — nine
+        # times what verifying a story this size has ever cost.
+        assert planning.planned_cost_usd < 3.21
+
+    def test_a_score_without_enough_review_history_falls_to_the_wider_rungs(
+        self, tmp_path: Path
+    ) -> None:
+        """A score below the floor is not guessed at, and the fallback is recorded."""
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(run_id="small", score=2, cost=1.35, review_cycle_costs=[0.40]),
+                _record(
+                    run_id="big",
+                    score=9,
+                    cost=40.64,
+                    review_cycle_costs=[4.00, 4.00, 4.00],
+                    review_pools=[_TRIO, _TRIO, _TRIO],
+                ),
+            ],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=17.55, composition=_TRIO, complexity_score=2
+        )
+
+        assert planning.basis == sb.BASIS_OBSERVED_COMPOSITION
+        # Not scoped to the score, and the record says the score was known and
+        # unmatched rather than never asked for.
+        assert planning.complexity_score is None
+        assert planning.requested_complexity_score == 2
+
+    def test_a_score_free_caller_gets_the_pre_existing_ladder(self, tmp_path: Path) -> None:
+        """The score rung is opt-in: callers with no score see today's behavior."""
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(
+                    run_id="small",
+                    score=2,
+                    cost=1.35,
+                    review_cycle_costs=[0.40, 0.44, 0.48],
+                    review_pools=[_TRIO, _TRIO, _TRIO],
+                ),
+            ],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=17.55, composition=_TRIO
+        )
+
+        assert planning.basis == sb.BASIS_OBSERVED_COMPOSITION
+        assert planning.complexity_score is None
+        assert planning.requested_complexity_score is None
+
+    def test_a_run_with_no_recorded_score_is_not_evidence_about_any_score(
+        self, tmp_path: Path
+    ) -> None:
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(
+                    run_id="unscored", score=None, cost=4.0, review_cycle_costs=[1.0, 1.0, 1.0]
+                ),
+                _record(run_id="scored", score=2, cost=1.0, review_cycle_costs=[0.40]),
+            ],
+        )
+
+        planning = sb.derive_review_cycle_planning_price(
+            tmp_path, configured_ceiling_usd=17.55, complexity_score=2
+        )
+
+        # Only one score-2 cycle exists; the three unscored ones do not join it,
+        # so the score rung is below its floor and review at large answers with
+        # all four cycles.
+        assert planning.basis == sb.BASIS_OBSERVED_REVIEW_CYCLE
+        assert planning.complexity_score is None
+        assert planning.sample_count == 4
+
     def test_no_history_whatsoever_reaches_the_ceiling(self, tmp_path: Path) -> None:
         _seed_substrate(
             tmp_path,
@@ -627,11 +772,13 @@ class TestReviewCycleReconciliation:
             dev_cost_estimate_usd=25.0428,
             dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
             review_cycle_cost_usd=17.55,
+            review_cycle_planning=_comparable_review_planning(17.55),
             requested_review_max=5,
             spent_so_far_usd=6.0,
         )
 
         assert record["action"] == sb.RECONCILE_UNFUNDABLE
+        assert record["review_cycle_cost_comparable"] is True
         assert record["affordable_review_cycles"] == 0
         assert record["spent_so_far_usd"] == 6.0
         assert record["shortfall_usd"] == round(17.55 - (48.02 - 6.0 - 25.0428), 4)
@@ -693,6 +840,113 @@ class TestReviewCycleReconciliation:
         ):
             assert record["reconciled_review_max"] == record["requested_review_max"]
 
+    def _score_2_allocation(self) -> dict:
+        """The issue's own figures: 8 score-2 samples, max $1.35, allocated 1.25x."""
+        return {
+            "allocation_usd": 1.69,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 2,
+            "median_usd": 0.46,
+            "p90_usd": 1.35,
+            "max_usd": 1.35,
+            "sample_count": 8,
+        }
+
+    def _wider_review_planning(self, cost_usd: float = 3.21) -> dict:
+        """A price from review at large, with the score it could not be scoped to."""
+        return sb.ReviewCyclePlanningPrice(
+            planned_cost_usd=cost_usd,
+            basis=sb.BASIS_OBSERVED_REVIEW_CYCLE,
+            fallback_configured_usd=17.55,
+            sample_count=31,
+            median_usd=round(cost_usd / sb.REVIEW_CYCLE_PRICE_HEADROOM, 4),
+            p90_usd=cost_usd,
+            max_usd=cost_usd,
+            requested_complexity_score=2,
+        ).as_dict()
+
+    def test_a_price_borrowed_from_bigger_work_does_not_refuse_a_small_story(self) -> None:
+        """The issue: $1.69 allocation vs a $3.21 review-population price (#2287).
+
+        Every story at the cheapest scored band was refused before it ran, on a
+        subtraction between an allocation scoped to its own score and a price
+        scoped to review as a whole. Nothing about the story entered into it.
+        """
+        record = sb.reconcile_review_cycles(
+            self._score_2_allocation(),
+            dev_cost_estimate_usd=0.67,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(2, sample_count=8),
+            review_cycle_cost_usd=3.21,
+            review_cycle_planning=self._wider_review_planning(),
+            requested_review_max=3,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_NONCOMPARABLE_REVIEW_COST
+        # Nothing fits — and that is exactly what is not acted on.
+        assert record["affordable_review_cycles"] == 0
+        assert record["review_cycle_cost_comparable"] is False
+        assert record["review_cycle_cost_complexity_score"] is None
+        assert record["review_cycle_cost_requested_complexity_score"] == 2
+        # The permission stands and nothing is reserved: the dispatch-time check
+        # against measured spend remains the honest refusal.
+        assert record["reconciled_review_max"] == 3
+        assert record["reserved_review_cycles"] == 0
+        assert record["reserved_review_usd"] == 0.0
+        assert "shortfall_usd" not in record
+        # No seating refusal is emitted for it.
+        assert sb.seating_shortfall(self._score_2_allocation(), record, participants=["a"]) is None
+
+        message = sb.format_reconciliation(record)
+        assert "not on a common population" in message
+        assert "complexity score 2" in message
+
+    def test_a_comparable_price_that_cannot_fund_a_cycle_still_refuses(self) -> None:
+        """Genuine exhaustion survives: the guard is scope, not size (#2238)."""
+        record = sb.reconcile_review_cycles(
+            self._score_2_allocation(),
+            dev_cost_estimate_usd=0.67,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(2, sample_count=8),
+            review_cycle_cost_usd=3.21,
+            review_cycle_planning=_comparable_review_planning(3.21, 2),
+            requested_review_max=3,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_UNFUNDABLE
+        assert record["review_cycle_cost_comparable"] is True
+        assert record["shortfall_usd"] == round(3.21 - (1.69 - 0.67), 4)
+
+    def test_a_wider_price_that_still_funds_a_cycle_is_acted_on_normally(self) -> None:
+        """Non-comparability only suppresses refusal — reduction is unaffected."""
+        record = sb.reconcile_review_cycles(
+            self._allocation(),
+            dev_cost_estimate_usd=25.0428,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
+            review_cycle_cost_usd=17.55,
+            review_cycle_planning=self._wider_review_planning(17.55),
+            requested_review_max=5,
+            spent_so_far_usd=0.0,
+        )
+
+        assert record["action"] == sb.RECONCILE_REDUCED
+        assert record["review_cycle_cost_comparable"] is False
+        assert record["reconciled_review_max"] == 1
+        assert record["reserved_review_usd"] == 17.55
+
+    def test_a_score_scoped_price_reads_as_such_in_the_operator_line(self) -> None:
+        record = sb.reconcile_review_cycles(
+            self._allocation(),
+            dev_cost_estimate_usd=25.0428,
+            dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
+            review_cycle_cost_usd=17.55,
+            review_cycle_planning=_comparable_review_planning(17.55),
+            requested_review_max=5,
+            spent_so_far_usd=0.0,
+        )
+
+        assert "complexity score 8" in sb.format_reconciliation(record)
+
     def test_unfundable_seating_reports_the_existing_shortfall_shape(self) -> None:
         allocation = self._allocation(usd=30.0)
         record = sb.reconcile_review_cycles(
@@ -700,6 +954,7 @@ class TestReviewCycleReconciliation:
             dev_cost_estimate_usd=25.0,
             dev_cost_estimate_basis=_comparable_dev_estimate_basis(),
             review_cycle_cost_usd=17.55,
+            review_cycle_planning=_comparable_review_planning(17.55),
             requested_review_max=5,
             spent_so_far_usd=0.0,
         )
@@ -910,6 +1165,7 @@ class TestReviewFundingReservation:
             dev_cost_estimate_usd=2.38,
             dev_cost_estimate_basis=_comparable_dev_estimate_basis(3, sample_count=20),
             review_cycle_cost_usd=1.01,
+            review_cycle_planning=_comparable_review_planning(1.01, 3),
             requested_review_max=1,
             spent_so_far_usd=0.0,
         )

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -61,19 +61,21 @@ def _seed_band(project_root: Path, score: int, costs: list[float]) -> None:
         conn.close()
 
 
-def _seed_review_cycle_history(project_root: Path, cycle_costs: list[float]) -> None:
+def _seed_review_cycle_history(
+    project_root: Path, cycle_costs: list[float], *, complexity_score: int = 5
+) -> None:
     runs = sub.runs_dir(project_root)
     runs.mkdir(parents=True, exist_ok=True)
     records = []
     for index, cycle_cost in enumerate(cycle_costs):
         rec = {
-            "run_id": f"review-cycle-{index}",
-            "task": {"slug": f"review-cycle-{index}", "name": "seed"},
+            "run_id": f"review-cycle-s{complexity_score}-{index}",
+            "task": {"slug": f"review-cycle-s{complexity_score}-{index}", "name": "seed"},
             "outcome": {"success": True, "final_phase": "DONE"},
             "timing": {"started_at": "2026-03-01T10:00:00+00:00", "duration_seconds": 60.0},
             "cost": {"total_usd": cycle_cost},
             "totals": {"cost_usd": cycle_cost, "duration_s": 60.0},
-            "preflight": {"complexity": "medium", "complexity_score": 5},
+            "preflight": {"complexity": "medium", "complexity_score": complexity_score},
             "iterations": {
                 "review_cycles_total": 1,
                 "review_loop": [{"iteration": 1, "cost_usd": cycle_cost}],
@@ -641,6 +643,10 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
 
         config = self._adaptive_config(tmp_path, dev_budget_usd=25.0428, reviewer_budget_usd=5.85)
         _seed_dev_profile_history(tmp_path, avg_cost_usd=20.03424, avg_iterations=4.0)
+        # Review history AT THIS STORY'S OWN SCORE, so the price refusing it is
+        # drawn from the population its allocation is drawn from (#2287). A
+        # refusal is only honest on comparable figures.
+        _seed_review_cycle_history(tmp_path, [8.00, 8.00, 8.00], complexity_score=9)
         task = _make_task(tmp_path)
         state = self._seated_state(tmp_path, 30.0)
 
@@ -655,13 +661,13 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         assert state.error_type == "allocation_exhausted"
         assert state.allocation_exhausted is not None
         assert state.allocation_exhausted["participants"] == ["a", "b", "c"]
-        assert state.allocation_exhausted["planned_usd"] == 17.55
+        assert state.allocation_exhausted["planned_usd"] == round(8.00 * 1.25, 4)
         assert "test-task" in state.error
         assert "Decided at seating" in state.error
-        assert (
-            state.adaptive_limits_audit["review_cycle_reconciliation"]["action"]
-            == sb.RECONCILE_UNFUNDABLE
-        )
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert record["action"] == sb.RECONCILE_UNFUNDABLE
+        assert record["review_cycle_cost_basis"] == sb.BASIS_OBSERVED_SCORE
+        assert record["review_cycle_cost_comparable"] is True
 
     def test_seating_uses_observed_review_cycle_price_plus_headroom(self, tmp_path: Path) -> None:
         from coord_test_helpers import _make_task
@@ -693,6 +699,103 @@ class TestSeatingReconcilesPermissionsWithTheAllocation:
         assert state.adaptive_limits_audit["review_cycle_planning"]["reason"] == (
             "derived from median observed review-cycle spend $3.64 x 1.25 headroom over 3 cycle(s)"
         )
+
+    def _cheapest_band_state(self, tmp_path: Path):
+        """The issue's own story: score 2, $1.69 allocation (max $1.35 x 1.25)."""
+        state = CoordinatorState()
+        state.preflight_complexity = "small"
+        state.preflight_complexity_score = 2
+        state.workspace_path = tmp_path
+        state.branch_name = "feat/test"
+        state.story_allocation = {
+            "allocation_usd": 1.69,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 2,
+            "median_usd": 0.46,
+            "p90_usd": 1.35,
+            "max_usd": 1.35,
+            "sample_count": 8,
+        }
+        return state
+
+    def test_seating_prices_review_at_the_story_own_complexity_score(self, tmp_path: Path) -> None:
+        """The coordinator hands its score to the pricing call before seating (#2287).
+
+        With review history at the story's own score, verification is charged at
+        what verifying stories this size has cost — and the cheapest band funds
+        its cycles instead of being refused.
+        """
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        config = self._adaptive_config(tmp_path, dev_budget_usd=0.67, reviewer_budget_usd=5.85)
+        _seed_dev_profile_history(
+            tmp_path, avg_cost_usd=0.536, avg_iterations=2.0, complexity_score=2
+        )
+        # Verifying score-2 stories has cost ~$0.24/cycle; review at large runs
+        # an order of magnitude higher and is seeded alongside it.
+        _seed_review_cycle_history(tmp_path, [0.22, 0.24, 0.26], complexity_score=2)
+        _seed_review_cycle_history(tmp_path, [3.10, 3.64, 4.20], complexity_score=9)
+        task = _make_task(tmp_path)
+        state = self._cheapest_band_state(tmp_path)
+
+        class _StopAtDev(Exception):
+            pass
+
+        with patch("theforge.coordinator.engine._run_dev_phase", side_effect=_StopAtDev()):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        planning = state.adaptive_review_cycle_planning
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert planning["basis"] == sb.BASIS_OBSERVED_SCORE
+        assert planning["complexity_score"] == 2
+        assert planning["planned_cost_usd"] == round(0.24 * 1.25, 4)
+        assert record["review_cycle_cost_comparable"] is True
+        # The story is scheduled AND can pay for its own verification.
+        assert record["action"] in (sb.RECONCILE_AFFORDABLE, sb.RECONCILE_REDUCED)
+        assert state.adaptive_review_max >= 1
+        assert record["reserved_review_cycles"] >= 1
+        assert state.allocation_exhausted is None
+
+    def test_the_cheapest_band_is_not_refused_on_a_price_borrowed_from_bigger_work(
+        self, tmp_path: Path
+    ) -> None:
+        """The reported defect: no score-2 story could run, whatever it did (#2287)."""
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.engine import _coordinator_loop
+
+        config = self._adaptive_config(tmp_path, dev_budget_usd=0.67, reviewer_budget_usd=5.85)
+        _seed_dev_profile_history(
+            tmp_path, avg_cost_usd=0.536, avg_iterations=2.0, complexity_score=2
+        )
+        # Review history exists only for far larger stories: $3.21 a cycle,
+        # nearly twice the whole $1.69 allocation.
+        _seed_review_cycle_history(tmp_path, [2.50, 2.568, 2.70], complexity_score=9)
+        task = _make_task(tmp_path)
+        state = self._cheapest_band_state(tmp_path)
+
+        class _StopAtDev(Exception):
+            pass
+
+        with patch("theforge.coordinator.engine._run_dev_phase", side_effect=_StopAtDev()):
+            with pytest.raises(_StopAtDev):
+                _coordinator_loop(state, config, task, "story", task_start=0.0)
+
+        planning = state.adaptive_review_cycle_planning
+        record = state.adaptive_limits_audit["review_cycle_reconciliation"]
+        assert planning["basis"] != sb.BASIS_OBSERVED_SCORE
+        assert planning["requested_complexity_score"] == 2
+        assert record["affordable_review_cycles"] == 0
+        assert record["action"] == sb.RECONCILE_NONCOMPARABLE_REVIEW_COST
+        assert record["review_cycle_cost_comparable"] is False
+        # Not refused before it ran: dev was reached, the permission stands, and
+        # the mismatch is on the audit trail where an operator can act on it.
+        assert state.allocation_exhausted is None
+        assert state.adaptive_review_max == record["requested_review_max"]
+        assert "not on a common population" in state.adaptive_limits_audit["rationale"]
 
     def test_a_sufficient_allocation_leaves_the_permitted_cycles_intact(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change satisfies the bug contract: score-scoped review pricing is used when available, non-comparable fallback pricing is audited without causing seating refusal, and comparable zero-cycle cases still stop before DEV. | [google-gemini-3.5-flash-api] Successfully reviewed the implementation for score-scoped review pricing and non-comparable review price safety.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $8.96
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

The cheapest complexity band cannot fund a single review cycle, so a story is refused before it runs regardless of how it behaves (GitHub Issue #2287)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2287