### PR TITLE
An expiring escalate gate discards the advisory recommendation it just produced, so unattended runs fail stories the evidence had already resolved

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -661,6 +661,18 @@ retry:
                              # complexity; the max_* fields above act as the floor
   max_dev_iterations_cap: 0  # hard ceiling for adaptive growth; 0 = same as
   max_review_cycles_cap: 0   # floor (no growth). Set explicitly to opt in.
+  escalate_policy: prompt    # "prompt" | "auto_approve" | "reject" — how an
+                             # escalation is decided while it is open
+  escalate_timeout_policy: preserve  # what an escalate gate that EXPIRES means.
+                             # "preserve" (default) keeps the pending checkpoint
+                             # and waits for an operator — unchanged behaviour.
+                             # "apply_advice" applies the escalation advisor's
+                             # recommendation as if an operator had selected it,
+                             # for unattended overnight runs. A recommendation of
+                             # `elevate`, an unusable/absent report, or one this
+                             # run cannot perform still preserves the story — no
+                             # fallback action is ever substituted. A selection
+                             # that arrives before expiry always governs.
   # More retry knobs exist (plan/plan-review/review transport retries, quorum,
   # degrade policy, …) — see RetryPolicy in src/theforge/config/types.py.
 

--- a/src/theforge/config/__init__.py
+++ b/src/theforge/config/__init__.py
@@ -45,6 +45,9 @@ from .provenance import (
     resolved_config_sha256,
 )
 from .types import (
+    ESCALATE_TIMEOUT_APPLY_ADVICE,
+    ESCALATE_TIMEOUT_POLICIES,
+    ESCALATE_TIMEOUT_PRESERVE,
     SUPPORTED_PROVIDERS,
     AdvisoryConventionsConfig,
     AdvisoryIssueFilingConfig,
@@ -110,6 +113,9 @@ __all__ = [
     "PlanReviewConfig",
     "RecencyConfig",
     "RetryPolicy",
+    "ESCALATE_TIMEOUT_APPLY_ADVICE",
+    "ESCALATE_TIMEOUT_POLICIES",
+    "ESCALATE_TIMEOUT_PRESERVE",
     "SandboxConfig",
     "SlackConfig",
     "SprintBatchConfig",

--- a/src/theforge/config/defaults.py
+++ b/src/theforge/config/defaults.py
@@ -110,6 +110,12 @@ retry:
   max_dev_transport_retries: 1  # retry one transient dev provider failure
   max_plan_transport_retries: 2  # retry transient plan draft/regen provider failures
   max_review_cycles: 2     # full dev→review loops before escalation
+  escalate_policy: prompt  # "prompt" | "auto_approve" | "reject"
+  # What an escalate gate that EXPIRES without an operator selection does.
+  # "preserve" (default) waits for an operator; "apply_advice" applies the
+  # advisory recommendation as if an operator had selected it — except for
+  # `elevate` or no usable recommendation, which still wait.
+  escalate_timeout_policy: preserve  # "preserve" | "apply_advice"
 
 context:
   preflight_budget: 200

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -59,6 +59,8 @@ from .role_derivation import derive_roles
 from .sandbox_capabilities import get_preset
 from .secrets import _parse_notifications
 from .types import (
+    ESCALATE_TIMEOUT_POLICIES,
+    ESCALATE_TIMEOUT_PRESERVE,
     SUPPORTED_PROVIDERS,
     AdvisoryConventionsConfig,
     AdvisoryIssueFilingConfig,
@@ -1188,6 +1190,18 @@ def load_config(config_path: Path) -> ForgeConfig:
 
     # Retry
     retry_data = raw.get("retry", {})
+    # Config loading is an integrity boundary: a typo here silently decides what
+    # an unattended overnight expiry does, so refuse it rather than falling back
+    # (#2279). Only the new field is validated — escalate_policy's existing
+    # tolerance is left exactly as it was so opting in changes nothing else.
+    escalate_timeout_policy = str(
+        retry_data.get("escalate_timeout_policy", ESCALATE_TIMEOUT_PRESERVE)
+    )
+    if escalate_timeout_policy not in ESCALATE_TIMEOUT_POLICIES:
+        raise ValueError(
+            f"retry.escalate_timeout_policy: unknown value {escalate_timeout_policy!r} "
+            f"(expected one of {', '.join(ESCALATE_TIMEOUT_POLICIES)})"
+        )
     retry = RetryPolicy(
         max_dev_iterations=int(retry_data.get("max_dev_iterations", 3)),
         max_dev_transport_retries=int(retry_data.get("max_dev_transport_retries", 1)),
@@ -1225,6 +1239,7 @@ def load_config(config_path: Path) -> ForgeConfig:
         demotion_threshold=int(retry_data.get("demotion_threshold", 2)),
         plan_escalation_threshold=int(retry_data.get("plan_escalation_threshold", 2)),
         escalate_policy=str(retry_data.get("escalate_policy", "prompt")),
+        escalate_timeout_policy=escalate_timeout_policy,
         auto_model_escalation=bool(retry_data.get("auto_model_escalation", False)),
         adaptive_iterations=bool(retry_data.get("adaptive_iterations", True)),
         max_dev_iterations_cap=int(retry_data.get("max_dev_iterations_cap", 0)),

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -660,6 +660,17 @@ class ValidationConfig:
         return None
 
 
+#: ``retry.escalate_timeout_policy`` — what an *expired* escalate gate means.
+#: ``preserve`` keeps today's behaviour (wait for an operator); ``apply_advice``
+#: opts in to applying the advisory recommendation on expiry (#2279).
+ESCALATE_TIMEOUT_PRESERVE = "preserve"
+ESCALATE_TIMEOUT_APPLY_ADVICE = "apply_advice"
+ESCALATE_TIMEOUT_POLICIES: tuple[str, ...] = (
+    ESCALATE_TIMEOUT_PRESERVE,
+    ESCALATE_TIMEOUT_APPLY_ADVICE,
+)
+
+
 @dataclass(frozen=True)
 class RetryPolicy:
     """Retry limits before escalating to human."""
@@ -740,6 +751,21 @@ class RetryPolicy:
         2  # consecutive plan rejections before escalating planner model
     )
     escalate_policy: str = "prompt"  # "prompt" | "auto_approve" | "reject"
+    # What an escalate gate does when it expires with no operator selection.
+    #
+    #   "preserve"     (default) — keep the pending checkpoint and wait for an
+    #                  operator. Unchanged from the behaviour every project has
+    #                  today; a project that has not opted in sees no change.
+    #   "apply_advice" — apply the advisory recommendation the gate just paid for,
+    #                  as if an operator had selected it deliberately. Only a
+    #                  valid report with a non-elevate recommendation this run can
+    #                  actually perform is applied; `elevate`, an absent
+    #                  recommendation, and an advisor that never produced one all
+    #                  fall back to "preserve" (#2279).
+    #
+    # An operator selection that arrives before expiry always governs — this
+    # field only decides what an *expiry* means.
+    escalate_timeout_policy: str = "preserve"  # "preserve" | "apply_advice"
     auto_model_escalation: bool = False  # escalate dev model on persistent P1; disabled by default
     # Adaptive iteration limits: scale max_dev_iterations / max_review_cycles
     # per-story from preflight complexity_score and historical usage. The

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -1008,6 +1008,19 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 "gate_result": state.gate_decisions[-1] if state.gate_decisions else None,
                 "human_decision": state.escalate_decision,
                 "selected_action": state.escalate_selected_action,
+                # WHO or WHAT decided, and — for an expiry — whether the advisory
+                # recommendation was applied or which absence stopped it (#2279).
+                # Recorded so an operator reading a finished run can tell an
+                # action they chose from one applied on their behalf from a gate
+                # still waiting, without inferring it from timestamps.
+                "decision_source": state.escalate_decision_source,
+                "timeout_advice": state.escalate_timeout_advice,
+                "awaiting_operator": state.escalate_decision == "advisory_pending",
+                "advisory_recommendation": (
+                    (state.advisory_report or {}).get("recommendation")
+                    if isinstance(state.advisory_report, dict)
+                    else None
+                ),
                 # A selection the gate refused to carry out. Recorded alongside
                 # (not in place of) human_decision so the audit shows what the
                 # operator chose AND that no outcome was substituted for it

--- a/src/theforge/coordinator/pending_hitl.py
+++ b/src/theforge/coordinator/pending_hitl.py
@@ -292,6 +292,29 @@ def _pending_escalate_gate(
     return decision
 
 
+def cleanup_escalate_pending(
+    task: "TaskStory",
+    config: "ForgeConfig",
+    run_id: str = "",
+) -> None:
+    """Remove the escalate gate's pending checkpoint after it has been resolved.
+
+    :func:`_pending_escalate_gate` preserves (and refreshes) the checkpoint on
+    timeout so an operator can still act on it. When something else resolves that
+    expired gate — today, the opt-in ``retry.escalate_timeout_policy:
+    apply_advice`` applying the advisory recommendation (#2279) — the checkpoint
+    must go, exactly as it does for an explicit selection: a resolved decision
+    that leaves a pending file behind reads as still-awaiting-an-operator.
+
+    Lives here, next to the writer, so the effective run id / project root are
+    resolved by the same rule that wrote the file rather than by a caller's
+    reconstruction of it.
+    """
+    from theforge import pending as _pending
+
+    _pending.cleanup_pending(run_id or task.slug, getattr(config, "project_root", None))
+
+
 def _build_packet_stub(state: "_cs.CoordinatorState", escalate_reason: str) -> "EvidencePacket":
     """Reconstruct a lightweight EvidencePacket from the serialized state payload.
 

--- a/src/theforge/coordinator/remote_gates.py
+++ b/src/theforge/coordinator/remote_gates.py
@@ -87,7 +87,7 @@ def _escalate_gate_remote(
         if timeout_seconds > 0 and waited_so_far >= timeout_seconds:
             _cu._log(
                 f"  ESCALATE gate timed out after {_cu._fmt_duration(waited_so_far)}"
-                " — auto-escalating"
+                " — no decision received; preserving for an operator decision"
             )
             decision = "timeout"
             break

--- a/src/theforge/coordinator/resume_persistence.py
+++ b/src/theforge/coordinator/resume_persistence.py
@@ -201,6 +201,13 @@ def _escalation_block(state: "CoordinatorState") -> dict[str, Any] | None:
     return {
         "decision": state.escalate_decision,
         "selected_action": state.escalate_selected_action,
+        # Provenance of the decision, and — for an expiry — whether the advisory
+        # recommendation was applied or which absence stopped it (#2279). Kept in
+        # the durable record so a resumed run reports the same "who decided this"
+        # as the live one did.
+        "decision_source": state.escalate_decision_source,
+        "timeout_advice": state.escalate_timeout_advice,
+        "awaiting_operator": state.escalate_decision == "advisory_pending",
         # What the operator chose that the gate could not carry out (#2300).
         # Survives the process so the selection is recoverable from the run
         # rather than existing only as a log line.
@@ -654,6 +661,12 @@ def _apply_escalation(state: "CoordinatorState", block: dict[str, Any]) -> bool:
         _set_if_unset(state, "escalate_declined_reason", block.get("declined_reason")) or applied
     )
     applied = _set_if_unset(state, "escalate_reason", block.get("reason")) or applied
+    applied = (
+        _set_if_unset(state, "escalate_decision_source", block.get("decision_source")) or applied
+    )
+    applied = (
+        _set_if_unset(state, "escalate_timeout_advice", block.get("timeout_advice")) or applied
+    )
     applied = _set_if_unset(state, "advisory_report", block.get("advisory_report")) or applied
     applied = (
         _set_if_unset(state, "human_review_waited_seconds", block.get("waited_seconds")) or applied

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -14,12 +14,18 @@ from theforge.assignment import (
     MECHANISM_PERSISTENT_P1_DEV_ESCALATION,
     MECHANISM_RUN_SCOPED_RESET,
 )
-from theforge.config import ForgeConfig, apply_model_info
+from theforge.config import (
+    ESCALATE_TIMEOUT_APPLY_ADVICE,
+    ESCALATE_TIMEOUT_PRESERVE,
+    ForgeConfig,
+    apply_model_info,
+)
 from theforge.coordinator.context_scope import plan_file_list
 from theforge.escalation_advisor import (
     ACTION_FORGE_OPERATIONS,
     ACTION_LABELS,
     ACTION_TAXONOMY,
+    AdvisoryReport,
     action_disposition,
 )
 from theforge.review import (
@@ -36,6 +42,7 @@ from .completion import _append_cycle_history, _finalize_approve
 from .escalate_actions import (
     ACCEPT_UNAVAILABLE_REASON,
     approvable_review_result,
+    available_escalate_actions,
 )
 from .escalation_advisor_flow import run_escalation_advisor
 from .gate_contradiction import asserts_gate_verifiable_failure
@@ -51,6 +58,7 @@ from .notify import (
 from .pending_hitl import (
     _pending_escalate_gate,
     _pending_human_review,
+    cleanup_escalate_pending,
 )
 from .preflight import (
     _escalate_dev_model,
@@ -77,6 +85,21 @@ from .review_context import (
 from .review_pool import _run_review_pool
 from .run_setup import save_trajectory_state
 from .state import (
+    ADVICE_APPLIED,
+    ADVICE_ELEVATE,
+    ADVICE_LAUNCH_FAILURE,
+    ADVICE_NO_RECOMMENDATION,
+    ADVICE_NOT_PERFORMABLE,
+    ADVICE_POLICY_PRESERVE,
+    ADVICE_UNAVAILABLE,
+    ADVICE_UNPARSEABLE,
+    ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT,
+    ESCALATE_SOURCE_NO_INTERACTION,
+    ESCALATE_SOURCE_OPERATOR,
+    ESCALATE_SOURCE_OPERATOR_DECLINED,
+    ESCALATE_SOURCE_POLICY_AUTO_APPROVE,
+    ESCALATE_SOURCE_POLICY_REJECT,
+    ESCALATE_SOURCE_TIMEOUT_PENDING,
     CoordinatorResult,
     CoordinatorState,
     Phase,
@@ -202,6 +225,95 @@ def _record_reviewed_commit_provenance(
     )
 
 
+#: One sentence per reason an opted-in expiry did NOT apply the advice, appended
+#: to the preserve message so the run itself states which situation occurred
+#: rather than leaving it to be reconstructed (#2279). ``ADVICE_POLICY_PRESERVE``
+#: has no entry: a project that did not opt in is seeing its normal behaviour and
+#: has nothing to explain.
+_TIMEOUT_ADVICE_NOTES: dict[str, str] = {
+    ADVICE_ELEVATE: (
+        "The advisor recommended 'elevate' — the taxonomy's answer for a case no "
+        "automated choice fits — so the expiry deliberately made no selection and "
+        "routed this to a human design decision."
+    ),
+    ADVICE_NOT_PERFORMABLE: (
+        "The advisor's recommendation could not be applied because this run cannot "
+        "perform it, and no substitute action was chosen in its place."
+    ),
+    ADVICE_NO_RECOMMENDATION: (
+        "The advisory report recommended no action, so there was nothing to apply — "
+        "an absence of advice, not consent to a fallback."
+    ),
+    ADVICE_UNPARSEABLE: (
+        "The advisor ran but produced no parseable report, so there was no "
+        "recommendation to apply."
+    ),
+    ADVICE_LAUNCH_FAILURE: (
+        "The advisor never launched, so no recommendation was ever produced to apply."
+    ),
+    ADVICE_UNAVAILABLE: (
+        "This gate surface produced no advisory report, so there was no recommendation to apply."
+    ),
+}
+
+
+def _timeout_applies_advice(config: ForgeConfig) -> bool:
+    """True when this project opted in to applying advice at an expired gate.
+
+    Read through ``getattr`` so a ForgeConfig built by an older caller (or a test
+    fixture predating the field) means "preserve" rather than raising — the
+    default is the behaviour every project already has.
+    """
+    return getattr(config.retry, "escalate_timeout_policy", ESCALATE_TIMEOUT_PRESERVE) == (
+        ESCALATE_TIMEOUT_APPLY_ADVICE
+    )
+
+
+def _advice_for_expired_gate(
+    state: CoordinatorState,
+    advisory: "AdvisoryReport | None",
+) -> tuple[str | None, str]:
+    """Decide whether an expired gate can act on the advisory it produced.
+
+    Returns ``(action, status)``: ``action`` is the taxonomy action to apply, or
+    None when the gate must keep waiting; ``status`` is the
+    ``ESCALATE_TIMEOUT_ADVICE_STATUSES`` value naming why.
+
+    Every non-applied outcome is a *preserve*, never a fallback action. An absent
+    recommendation is the absence of advice, not consent to any particular
+    outcome, so the five ways advice can be missing are told apart rather than
+    collapsed into one silent default:
+
+    * the advisor never reached the model (a repairable forge defect),
+    * this gate surface produces no advisory at all (remote / interactive),
+    * the report failed schema validation,
+    * the report is valid but recommends nothing,
+    * the recommendation is real but this run cannot perform it (e.g. ``accept``
+      with no approvable reviewer result), which is the one case where applying
+      it would mean substituting an action nobody chose.
+
+    ``elevate`` is separate from all of those: the taxonomy already treats it as
+    the answer for a case no automated choice fits, so an advisor that returns it
+    has deliberately said "a human decides this" — and the expiry honours that by
+    leaving the story exactly where a non-opted-in project would leave it.
+    """
+    if advisory is None:
+        if state.advisory_launch_failure:
+            return None, ADVICE_LAUNCH_FAILURE
+        return None, ADVICE_UNAVAILABLE
+    if not advisory.ok:
+        return None, ADVICE_UNPARSEABLE
+    recommendation = (advisory.recommendation or "").strip().lower()
+    if not recommendation or recommendation not in ACTION_TAXONOMY:
+        return None, ADVICE_NO_RECOMMENDATION
+    if recommendation == "elevate":
+        return None, ADVICE_ELEVATE
+    performable, _omitted = available_escalate_actions(state, ACTION_TAXONOMY)
+    if recommendation not in performable:
+        return None, ADVICE_NOT_PERFORMABLE
+    return recommendation, ADVICE_APPLIED
+
+
 def _run_escalate_gate(
     state: CoordinatorState,
     config: ForgeConfig,
@@ -293,6 +405,7 @@ def _run_escalate_gate_inner(
     if escalate_policy == "reject":
         state.escalate_decision = "reject"
         state.escalate_reason = escalate_reason
+        state.escalate_decision_source = ESCALATE_SOURCE_POLICY_REJECT
         return _make_escalate_result()
 
     # Policy: auto_approve — short-circuit when gate passed and majority approved
@@ -309,6 +422,7 @@ def _run_escalate_gate_inner(
                 )
                 state.escalate_decision = "approve"
                 state.escalate_reason = escalate_reason
+                state.escalate_decision_source = ESCALATE_SOURCE_POLICY_AUTO_APPROVE
                 _append_cycle_history(state, state.review_results[-1])
                 return _finalize_approve(
                     state,
@@ -331,7 +445,10 @@ def _run_escalate_gate_inner(
                     run_id=run_id,
                 )
 
-    # Determine interaction method
+    # Determine interaction method. `advisory` stays None on every surface that
+    # does not produce a report (remote / interactive / no-interaction), so the
+    # expiry branch below can ask for one without assuming which path ran.
+    advisory: "AdvisoryReport | None" = None
     if _is_pending_file_mode(notify, config):
         # Generate a fresh-context advisory report so the operator selects from the
         # fixed action taxonomy instead of the system auto-rejecting on timeout.
@@ -358,8 +475,44 @@ def _run_escalate_gate_inner(
         # No interaction method available — fall through to reject
         _log("  No interaction method available for escalate gate — rejecting (policy=prompt)")
         decision = "reject"
+        state.escalate_decision_source = ESCALATE_SOURCE_NO_INTERACTION
 
     state.escalate_reason = escalate_reason
+
+    # An expired gate, opted in: apply the advice rather than discarding it.
+    #
+    # Guarded on decision == "timeout" alone, which is exactly "no selection
+    # arrived". A selection that reached the gate before expiry — from the
+    # pending file, ntfy, or the terminal — never enters here, so an operator who
+    # is present always governs, whatever the advisor recommended.
+    if decision == "timeout" and _timeout_applies_advice(config):
+        applied, advice_status = _advice_for_expired_gate(state, advisory)
+        state.escalate_timeout_advice = advice_status
+        if applied is not None:
+            _log(
+                f"  Escalate gate expired with no operator selection — applying the advisory "
+                f"recommendation {applied!r} (retry.escalate_timeout_policy=apply_advice)"
+            )
+            # Resolved, not awaiting: the checkpoint _pending_escalate_gate
+            # refreshed on expiry must go, exactly as it does for an explicit
+            # selection. Leaving it would show a decided story as still pending.
+            cleanup_escalate_pending(task, config, run_id=run_id)
+            decision = applied
+            state.escalate_decision_source = ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+        else:
+            _log(
+                f"  Escalate gate expired — advisory recommendation NOT applied "
+                f"({advice_status}); preserving for an operator decision"
+            )
+    elif decision == "timeout":
+        state.escalate_timeout_advice = ADVICE_POLICY_PRESERVE
+    else:
+        # Anything that is not an expiry came back from a gate surface an
+        # operator was answering, so the outcome is theirs — including a value
+        # the normalisation below rejects. The `or` preserves the
+        # no-interaction attribution set above, which is the one non-expiry
+        # decision no operator made.
+        state.escalate_decision_source = state.escalate_decision_source or ESCALATE_SOURCE_OPERATOR
 
     # Normalise legacy (approve/reject/continue) and taxonomy actions into a
     # coordinator disposition. Taxonomy actions come from the advisory-backed
@@ -391,6 +544,7 @@ def _run_escalate_gate_inner(
             state.escalate_selected_action = selected
             state.escalate_declined_action = selected
             state.escalate_declined_reason = ACCEPT_UNAVAILABLE_REASON
+            state.escalate_decision_source = ESCALATE_SOURCE_OPERATOR_DECLINED
             _log(
                 f"  ⚠ Escalate gate: {selected!r} selected but cannot be performed "
                 f"({ACCEPT_UNAVAILABLE_REASON}) — DECLINED; story left as it was "
@@ -477,6 +631,15 @@ def _run_escalate_gate_inner(
                 "Escalation preserved: an operator action selection is still "
                 "required (no auto-reject)."
             )
+        # Under the opt-in policy the operator asked for advice to be applied, so
+        # NOT applying it is the surprising outcome and has to say which of the
+        # possible absences occurred — an unusable report and a deliberate
+        # `elevate` are the same "still waiting" from the outside, and only one of
+        # them is a defect worth repairing.
+        advice_note = _TIMEOUT_ADVICE_NOTES.get(state.escalate_timeout_advice or "")
+        if advice_note:
+            preserve_message = f"{preserve_message} {advice_note}"
+        state.escalate_decision_source = ESCALATE_SOURCE_TIMEOUT_PENDING
         return _make_escalate_result("advisory_pending", message=preserve_message)
 
     # reject / defer_or_abandon / any unrecognised decision

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -257,6 +257,18 @@ _TIMEOUT_ADVICE_NOTES: dict[str, str] = {
 }
 
 
+def _decided_by_advice(state: CoordinatorState) -> bool:
+    """True when this gate outcome came from advice applied at an expiry.
+
+    The outcome of an applied recommendation is deliberately identical to the
+    operator's — but the *account* of it must not be, or the run would tell the
+    operator they approved something while the record says otherwise (#2279).
+    Read from the same field the audit and resume records publish, so the
+    message and the provenance cannot disagree.
+    """
+    return state.escalate_decision_source == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+
+
 def _timeout_applies_advice(config: ForgeConfig) -> bool:
     """True when this project opted in to applying advice at an expired gate.
 
@@ -575,8 +587,17 @@ def _run_escalate_gate_inner(
             review_cost=state.total_review_cost_measured,
             review_elapsed=0.0,
             message=(
-                f"Task '{task.name}' completed. "
-                f"Human approved via escalate gate after {state.review_cycle} cycle(s). "
+                (
+                    f"Task '{task.name}' completed. "
+                    f"Escalate gate expired with no operator selection and the advisory "
+                    f"recommendation {state.escalate_decision!r} was applied after "
+                    f"{state.review_cycle} cycle(s). "
+                )
+                if _decided_by_advice(state)
+                else (
+                    f"Task '{task.name}' completed. "
+                    f"Human approved via escalate gate after {state.review_cycle} cycle(s). "
+                )
             ),
             run_id=run_id,
         )
@@ -594,12 +615,20 @@ def _run_escalate_gate_inner(
         # auto-reject that discards the work.
         op = ACTION_FORGE_OPERATIONS.get(norm, norm)
         label = ACTION_LABELS.get(norm, norm)
-        _log(f"  Escalate gate: {label} selected — next operation: {op}")
+        by_advice = _decided_by_advice(state)
+        how = "applied from the advisory on expiry" if by_advice else "selected"
+        _log(f"  Escalate gate: {label} {how} — next operation: {op}")
         return _make_escalate_result(
             norm,
             message=(
                 f"Escalation resolved as {label}: {op}. "
-                f"Worktree preserved for the operator to run the named operation."
+                + (
+                    "The gate expired with no operator selection and the advisory "
+                    "recommendation was applied. "
+                    if by_advice
+                    else ""
+                )
+                + "Worktree preserved for the operator to run the named operation."
             ),
         )
 

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -39,6 +39,55 @@ class Phase(Enum):
     ESCALATE = auto()
 
 
+# ── Escalate-gate decision provenance (#2279) ─────────────────────────
+#
+# Every escalate-gate outcome names who or what produced it. The value is
+# recorded on CoordinatorState.escalate_decision_source, carried into the audit
+# record and the resume record, and is the field an operator reads to tell a
+# decision they made from one made for them.
+ESCALATE_SOURCE_OPERATOR = "operator"  # an explicit selection at a gate surface
+ESCALATE_SOURCE_OPERATOR_DECLINED = "operator_declined"  # selection the gate refused
+ESCALATE_SOURCE_POLICY_REJECT = "policy_reject"  # retry.escalate_policy=reject
+ESCALATE_SOURCE_POLICY_AUTO_APPROVE = "policy_auto_approve"  # escalate_policy=auto_approve
+ESCALATE_SOURCE_NO_INTERACTION = "coordinator_no_interaction"  # no gate surface available
+ESCALATE_SOURCE_TIMEOUT_PENDING = "timeout_pending"  # expired; still awaiting an operator
+ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT = "advisor_on_timeout"  # advice applied on expiry
+ESCALATE_DECISION_SOURCES: tuple[str, ...] = (
+    ESCALATE_SOURCE_OPERATOR,
+    ESCALATE_SOURCE_OPERATOR_DECLINED,
+    ESCALATE_SOURCE_POLICY_REJECT,
+    ESCALATE_SOURCE_POLICY_AUTO_APPROVE,
+    ESCALATE_SOURCE_NO_INTERACTION,
+    ESCALATE_SOURCE_TIMEOUT_PENDING,
+    ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT,
+)
+
+# Why the advisory recommendation was (or was not) applied at an expired gate.
+# Only ``applied`` changes the outcome; every other value is a preserve, and
+# they are kept distinct because "the advisor never launched", "it produced
+# nothing parseable", "it recommended nothing", "it recommended elevate", and
+# "it recommended something this run cannot perform" are five different
+# situations with different repairs.
+ADVICE_APPLIED = "applied"
+ADVICE_ELEVATE = "elevate"  # deliberate no-automated-choice signal
+ADVICE_NOT_PERFORMABLE = "not_performable"  # recommendation withheld by this run's state
+ADVICE_NO_RECOMMENDATION = "no_recommendation"  # valid report, empty recommendation
+ADVICE_UNPARSEABLE = "unparseable_report"  # advisor ran, report failed validation
+ADVICE_LAUNCH_FAILURE = "launch_failure"  # advisor never reached the model
+ADVICE_UNAVAILABLE = "advisor_unavailable"  # no advisory on this gate surface at all
+ADVICE_POLICY_PRESERVE = "policy_preserve"  # opt-in not enabled; expiry preserves
+ESCALATE_TIMEOUT_ADVICE_STATUSES: tuple[str, ...] = (
+    ADVICE_APPLIED,
+    ADVICE_ELEVATE,
+    ADVICE_NOT_PERFORMABLE,
+    ADVICE_NO_RECOMMENDATION,
+    ADVICE_UNPARSEABLE,
+    ADVICE_LAUNCH_FAILURE,
+    ADVICE_UNAVAILABLE,
+    ADVICE_POLICY_PRESERVE,
+)
+
+
 _PHASE_NAME_MAP: dict[str, Phase] = {
     "workspace": Phase.WORKSPACE,
     "preflight": Phase.PREFLIGHT,
@@ -791,6 +840,17 @@ class CoordinatorState:
     # recorded, and no downstream reader sees an outcome nobody chose.
     escalate_declined_action: str | None = None
     escalate_declined_reason: str | None = None
+    # WHO or WHAT produced the escalate-gate outcome (#2279). escalate_decision
+    # says what happened; this says who is answerable for it, so an operator
+    # reading a run afterwards can tell an action they chose from one applied on
+    # their behalf from a gate still waiting — without inferring it from
+    # timestamps. One of ESCALATE_DECISION_SOURCES; None until a gate runs.
+    escalate_decision_source: str | None = None
+    # Why the advisory recommendation was or was not applied when a gate expired
+    # (#2279). One of ESCALATE_TIMEOUT_ADVICE_STATUSES; None when no gate
+    # expired. An absent recommendation is the absence of advice, not consent to
+    # any outcome — this field names WHICH absence it was.
+    escalate_timeout_advice: str | None = None
     # The ReviewResult an approval was taken ON, stamped by _finalize_approve
     # when landing is deferred. Landing runs in a later call (and, for sprints, a
     # another thread), and merge-pr needs a review to post; re-deriving it from

--- a/src/theforge/pending.py
+++ b/src/theforge/pending.py
@@ -135,9 +135,14 @@ def poll_pending(
         if sleep_secs > 0:
             time.sleep(sleep_secs)
 
+    # Wording is deliberately neutral about what happens next: this poller is
+    # shared by the human-review, plan-review, and escalate gates, and none of
+    # them auto-escalates on expiry any more. What an expiry MEANS is the
+    # caller's decision (preserve for an operator, or apply advice under
+    # retry.escalate_timeout_policy), so the poller reports only the fact (#2279).
     _cu._log(
         f"  Pending decision timed out after {_cu._fmt_duration(timeout_seconds)}"
-        " — auto-escalating"
+        " — no decision received"
     )
     return "timeout", None
 

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -358,7 +358,7 @@ RULES: tuple[RcaRule, ...] = (
         rule_id="pending_decision_auto_rejected",
         failure_class="operator_gate_timeout",
         role="contributing",
-        description="An operator decision gate timed out and auto-escalated.",
+        description="An operator decision gate timed out with no decision received.",
         patterns=("pending decision timed out after",),
     ),
     RcaRule(

--- a/tests/test_coord_escalate_timeout_advice.py
+++ b/tests/test_coord_escalate_timeout_advice.py
@@ -157,8 +157,13 @@ def _drive_gate(
     launch_failure: bool = False,
     run_id: str = "run-t",
     config=None,
+    finalize_calls: dict | None = None,
 ):
-    """Run the escalate gate with a stubbed advisor + gate surface."""
+    """Run the escalate gate with a stubbed advisor + gate surface.
+
+    ``finalize_calls`` collects the kwargs the approve path hands
+    ``_finalize_approve`` — the completion message an operator ends up reading.
+    """
     config = config or _config(tmp_path, timeout_policy=timeout_policy)
     task = _make_task(tmp_path)
     state = _escalated_state(approvable=approvable)
@@ -177,13 +182,13 @@ def _drive_gate(
 
     monkeypatch.setattr(rp, "run_escalation_advisor", _fake_advisor)
     monkeypatch.setattr(rp, "_pending_escalate_gate", lambda *a, **k: gate_decision)
-    monkeypatch.setattr(
-        rp,
-        "_finalize_approve",
-        lambda *a, **k: CoordinatorResult(
-            success=True, phase=Phase.DONE, state=state, message="approved"
-        ),
-    )
+
+    def _fake_finalize(*a, **k):
+        if finalize_calls is not None:
+            finalize_calls.update(k)
+        return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="approved")
+
+    monkeypatch.setattr(rp, "_finalize_approve", _fake_finalize)
     monkeypatch.setattr(rp, "_append_cycle_history", lambda *a, **k: None)
     monkeypatch.setattr(rp, "_escalate_notify", lambda *a, **k: None)
 
@@ -344,6 +349,60 @@ class TestAppliesAdviceOnExpiry:
         assert result.phase == Phase.DONE
         assert state.escalate_decision == "accept"
         assert state.escalate_decision_source == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+
+    def test_applied_accept_is_not_reported_as_a_human_approval(self, tmp_path, monkeypatch):
+        # The outcome matches a deliberate accept, but the account of it must
+        # not: telling the operator they approved this would contradict the
+        # advisor_on_timeout provenance the same run records.
+        finalize_calls: dict = {}
+        state, _result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("accept"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+            finalize_calls=finalize_calls,
+        )
+        message = finalize_calls["message"]
+        assert "Human approved" not in message
+        assert "advisory recommendation" in message
+        assert "expired" in message
+        assert state.escalate_decision_source == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+
+    def test_operator_accept_is_still_reported_as_a_human_approval(self, tmp_path, monkeypatch):
+        # The un-opted-in / operator-present wording is unchanged.
+        finalize_calls: dict = {}
+        _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="accept",
+            report=_report("defer_or_abandon"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+            finalize_calls=finalize_calls,
+        )
+        assert "Human approved via escalate gate" in finalize_calls["message"]
+
+    def test_applied_named_action_message_names_the_expiry(self, tmp_path, monkeypatch):
+        _state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("land_core_defer_edges"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        assert "advisory recommendation was applied" in result.message
+        assert "Worktree preserved" in result.message
+
+    def test_operator_named_action_message_is_unchanged(self, tmp_path, monkeypatch):
+        _state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="land_core_defer_edges",
+            report=_report("accept"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        assert "advisory recommendation was applied" not in result.message
+        assert "Worktree preserved" in result.message
 
     def test_defer_or_abandon_recommendation_rejects(self, tmp_path, monkeypatch):
         state, result = _drive_gate(

--- a/tests/test_coord_escalate_timeout_advice.py
+++ b/tests/test_coord_escalate_timeout_advice.py
@@ -1,0 +1,633 @@
+"""Seam-level tests for applying advisory advice at an EXPIRED escalate gate.
+
+Covers the coordinator boundary issue #2279 touches:
+
+* ``retry.escalate_timeout_policy`` is opt-in, validated at config load, and
+  defaults to today's preserve-on-expiry behaviour.
+* an opted-in expiry applies a usable, performable recommendation and reaches the
+  same outcome an operator selecting that action deliberately would.
+* ``elevate`` and every flavour of absent advice still preserve the story, and
+  the run states WHICH of those situations occurred.
+* a selection that arrives before expiry governs, whatever the advisor said.
+* decision provenance survives into the audit record and the resume record.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from coord_test_helpers import _make_config, _make_task
+
+from theforge.config import (
+    ESCALATE_TIMEOUT_APPLY_ADVICE,
+    ESCALATE_TIMEOUT_PRESERVE,
+    BackendConfig,
+    NotificationConfig,
+    RetryPolicy,
+)
+from theforge.config.load import load_config
+from theforge.coordinator import review_phase as rp
+from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.resume_persistence import (
+    _apply_escalation,
+    _escalation_block,
+)
+from theforge.coordinator.review_phase import _run_escalate_gate
+from theforge.coordinator.state import (
+    ADVICE_APPLIED,
+    ADVICE_ELEVATE,
+    ADVICE_LAUNCH_FAILURE,
+    ADVICE_NO_RECOMMENDATION,
+    ADVICE_NOT_PERFORMABLE,
+    ADVICE_POLICY_PRESERVE,
+    ADVICE_UNAVAILABLE,
+    ADVICE_UNPARSEABLE,
+    ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT,
+    ESCALATE_SOURCE_OPERATOR,
+    ESCALATE_SOURCE_POLICY_AUTO_APPROVE,
+    ESCALATE_SOURCE_POLICY_REJECT,
+    ESCALATE_SOURCE_TIMEOUT_PENDING,
+    CoordinatorResult,
+    CoordinatorState,
+    Phase,
+)
+from theforge.escalation_advisor import AdvisoryOption, AdvisoryReport
+from theforge.review import ReviewFinding, ReviewResult
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _review(verdict: str = "REQUEST_CHANGES") -> ReviewResult:
+    return ReviewResult(
+        verdict=verdict,
+        summary="one unresolved P2",
+        findings=[
+            ReviewFinding(severity="P2", file="f.py", line=1, observed="edge", suggestion=None)
+        ],
+        story_matches=True,
+        story_mismatches=[],
+        test_adequate=True,
+        test_gaps=[],
+        parse_errors=[],
+        raw_yaml={},
+    )
+
+
+def _report(recommendation: str = "land_core_defer_edges") -> AdvisoryReport:
+    """A valid report recommending ``recommendation``."""
+    return AdvisoryReport(
+        recommendation=recommendation,
+        rationale="gate passes; the remaining P2 is an edge",
+        options=[
+            AdvisoryOption(
+                action=recommendation or "redirect",
+                evidence="gate PASS with one unresolved P2",
+                forge_operation="land-core",
+                risk="the edge ships as a follow-up",
+                consequence="core lands, edge is filed",
+            ),
+        ],
+        parse_errors=[],
+        raw={},
+    )
+
+
+def _unparseable_report() -> AdvisoryReport:
+    return AdvisoryReport(
+        recommendation="",
+        rationale="",
+        options=[],
+        parse_errors=["no <advisory_report> block found"],
+        raw={},
+    )
+
+
+def _empty_recommendation_report() -> AdvisoryReport:
+    """A report that PARSES but names no action — advice absent, not invalid."""
+    return AdvisoryReport(
+        recommendation="",
+        rationale="the evidence supports no single action",
+        options=[],
+        parse_errors=[],
+        raw={},
+    )
+
+
+def _config(tmp_path: Path, *, timeout_policy: str = ESCALATE_TIMEOUT_PRESERVE):
+    """Pending-file HITL config with the escalate-timeout policy under test."""
+    base = _make_config(tmp_path)
+    notifications = NotificationConfig(
+        backend="ntfy",
+        human_review_timeout_seconds=1,
+        backends=(BackendConfig(type="ntfy", url="https://ntfy.sh/t"),),
+    )
+    retry = dataclasses.replace(
+        base.retry,
+        escalate_policy="prompt",
+        escalate_timeout_policy=timeout_policy,
+    )
+    return dataclasses.replace(base, notifications=notifications, retry=retry)
+
+
+def _escalated_state(*, approvable: bool = True) -> CoordinatorState:
+    state = CoordinatorState()
+    state.phase = Phase.ESCALATE
+    state.review_cycle = 5
+    state.story_content = "Body.\n\n## Acceptance criteria\n\n- do the thing\n"
+    rr = _review()
+    if approvable:
+        state.review_results = [rr]
+    state.last_cycle_reviewer_results = [("reviewer-a", rr)]
+    state.error = "Review requested changes after 5 cycles. Max cycles (5) exhausted."
+    return state
+
+
+def _drive_gate(
+    tmp_path,
+    monkeypatch,
+    *,
+    gate_decision: str,
+    report: AdvisoryReport | None,
+    timeout_policy: str = ESCALATE_TIMEOUT_PRESERVE,
+    approvable: bool = True,
+    launch_failure: bool = False,
+    run_id: str = "run-t",
+    config=None,
+):
+    """Run the escalate gate with a stubbed advisor + gate surface."""
+    config = config or _config(tmp_path, timeout_policy=timeout_policy)
+    task = _make_task(tmp_path)
+    state = _escalated_state(approvable=approvable)
+
+    def _fake_advisor(*a, **k):
+        if launch_failure:
+            state.advisory_generated = False
+            state.advisory_launch_failure = True
+            state.advisory_launch_reason = "Not inside a trusted directory"
+            return None
+        if report is None:
+            return None
+        state.advisory_generated = report.ok
+        state.advisory_report = report.to_dict()
+        return report
+
+    monkeypatch.setattr(rp, "run_escalation_advisor", _fake_advisor)
+    monkeypatch.setattr(rp, "_pending_escalate_gate", lambda *a, **k: gate_decision)
+    monkeypatch.setattr(
+        rp,
+        "_finalize_approve",
+        lambda *a, **k: CoordinatorResult(
+            success=True, phase=Phase.DONE, state=state, message="approved"
+        ),
+    )
+    monkeypatch.setattr(rp, "_append_cycle_history", lambda *a, **k: None)
+    monkeypatch.setattr(rp, "_escalate_notify", lambda *a, **k: None)
+
+    result = _run_escalate_gate(
+        state,
+        config,
+        task,
+        tmp_path / "ws",
+        "forge/test",
+        0.0,
+        auto_merge=False,
+        notify=True,
+        logger=None,
+        run_id=run_id,
+    )
+    return state, result
+
+
+# ── the opt-in itself ─────────────────────────────────────────────────────────
+
+
+class TestEscalateTimeoutPolicyConfig:
+    def test_default_is_preserve(self):
+        assert RetryPolicy().escalate_timeout_policy == ESCALATE_TIMEOUT_PRESERVE
+
+    def _write(self, tmp_path: Path, retry_yaml: str) -> Path:
+        path = tmp_path / "forge.yaml"
+        path.write_text(
+            "project: t\n"
+            "workspace:\n"
+            "  create_command: 'mkdir -p {slug}'\n"
+            "  path_pattern: '{slug}'\n"
+            "  branch_pattern: 'forge/{slug}'\n"
+            "validation:\n"
+            "  gate_command: 'make gate'\n"
+            f"{retry_yaml}",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_absent_field_loads_as_preserve(self, tmp_path):
+        config = load_config(self._write(tmp_path, "retry:\n  max_review_cycles: 2\n"))
+        assert config.retry.escalate_timeout_policy == ESCALATE_TIMEOUT_PRESERVE
+
+    def test_apply_advice_loads(self, tmp_path):
+        config = load_config(
+            self._write(tmp_path, "retry:\n  escalate_timeout_policy: apply_advice\n")
+        )
+        assert config.retry.escalate_timeout_policy == ESCALATE_TIMEOUT_APPLY_ADVICE
+
+    def test_unknown_value_is_refused(self, tmp_path):
+        # Config loading is an integrity boundary: a typo here would silently
+        # decide what an unattended overnight expiry does.
+        path = self._write(tmp_path, "retry:\n  escalate_timeout_policy: apply_advise\n")
+        with pytest.raises(ValueError, match="escalate_timeout_policy"):
+            load_config(path)
+
+    def test_escalate_policy_tolerance_is_unchanged(self, tmp_path):
+        # The last AC: existing policies keep their current meanings. The new
+        # validation is deliberately scoped to the new field only.
+        config = load_config(self._write(tmp_path, "retry:\n  escalate_policy: whatever\n"))
+        assert config.retry.escalate_policy == "whatever"
+
+
+# ── default (not opted in) behaviour is untouched ─────────────────────────────
+
+
+class TestDefaultPolicyUnchanged:
+    def test_timeout_still_preserves_when_not_opted_in(self, tmp_path, monkeypatch):
+        state, result = _drive_gate(
+            tmp_path, monkeypatch, gate_decision="timeout", report=_report("land_core_defer_edges")
+        )
+        assert result.success is False
+        assert state.escalate_decision == "advisory_pending"
+        assert state.escalate_selected_action is None
+        assert state.escalate_decision_source == ESCALATE_SOURCE_TIMEOUT_PENDING
+        assert state.escalate_timeout_advice == ADVICE_POLICY_PRESERVE
+        # The un-opted-in message is exactly what it was before this change.
+        assert "advisory report was generated" in result.message
+
+    def test_reject_policy_records_policy_provenance(self, tmp_path, monkeypatch):
+        config = _config(tmp_path)
+        config = dataclasses.replace(
+            config, retry=dataclasses.replace(config.retry, escalate_policy="reject")
+        )
+        state, result = _drive_gate(
+            tmp_path, monkeypatch, gate_decision="timeout", report=None, config=config
+        )
+        assert state.escalate_decision == "reject"
+        assert state.escalate_decision_source == ESCALATE_SOURCE_POLICY_REJECT
+
+    def test_auto_approve_policy_records_policy_provenance(self, tmp_path, monkeypatch):
+        config = _config(tmp_path)
+        config = dataclasses.replace(
+            config, retry=dataclasses.replace(config.retry, escalate_policy="auto_approve")
+        )
+        state = _escalated_state()
+        state.review_results = [_review("APPROVE")]
+        state.last_cycle_reviewer_results = [("reviewer-a", _review("APPROVE"))]
+        state.gate_decisions = ["PASS"]
+        task = _make_task(tmp_path)
+        monkeypatch.setattr(
+            rp,
+            "_finalize_approve",
+            lambda *a, **k: CoordinatorResult(
+                success=True, phase=Phase.DONE, state=state, message="approved"
+            ),
+        )
+        monkeypatch.setattr(rp, "_append_cycle_history", lambda *a, **k: None)
+        monkeypatch.setattr(rp, "_escalate_notify", lambda *a, **k: None)
+        _run_escalate_gate(
+            state,
+            config,
+            task,
+            tmp_path / "ws",
+            "forge/test",
+            0.0,
+            auto_merge=False,
+            notify=True,
+            logger=None,
+            run_id="run-aa",
+        )
+        assert state.escalate_decision == "approve"
+        assert state.escalate_decision_source == ESCALATE_SOURCE_POLICY_AUTO_APPROVE
+
+
+# ── opted in: the recommendation is applied ───────────────────────────────────
+
+
+class TestAppliesAdviceOnExpiry:
+    def test_named_recommendation_is_applied_like_a_deliberate_selection(
+        self, tmp_path, monkeypatch
+    ):
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("land_core_defer_edges"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        # Identical to what an operator selecting land_core_defer_edges gets: the
+        # named disposition, the named forge operation, the worktree preserved.
+        assert state.escalate_decision == "land_core_defer_edges"
+        assert state.escalate_selected_action == "land_core_defer_edges"
+        assert "land-core" in result.message
+        assert state.escalate_decision_source == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+        assert state.escalate_timeout_advice == ADVICE_APPLIED
+
+    def test_accept_recommendation_finalizes_the_approval(self, tmp_path, monkeypatch):
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("accept"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert state.escalate_decision == "accept"
+        assert state.escalate_decision_source == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+
+    def test_defer_or_abandon_recommendation_rejects(self, tmp_path, monkeypatch):
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("defer_or_abandon"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        assert result.success is False
+        assert state.escalate_decision == "reject"
+        assert state.escalate_selected_action == "defer_or_abandon"
+        assert state.escalate_decision_source == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+
+
+# ── opted in: every way advice can be missing still preserves ─────────────────
+
+
+class TestPreservesWhenAdviceCannotBeApplied:
+    def _preserved(self, state, result) -> None:
+        assert result.success is False
+        assert state.escalate_decision == "advisory_pending"
+        assert state.escalate_selected_action is None
+        assert state.escalate_decision_source == ESCALATE_SOURCE_TIMEOUT_PENDING
+
+    def test_elevate_leaves_the_story_awaiting_a_human(self, tmp_path, monkeypatch):
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("elevate"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        self._preserved(state, result)
+        assert state.escalate_timeout_advice == ADVICE_ELEVATE
+        assert "elevate" in result.message
+
+    def test_unparseable_report_preserves_and_says_so(self, tmp_path, monkeypatch):
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_unparseable_report(),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        self._preserved(state, result)
+        assert state.escalate_timeout_advice == ADVICE_UNPARSEABLE
+        assert "no parseable report" in result.message
+
+    def test_empty_recommendation_preserves_and_says_so(self, tmp_path, monkeypatch):
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_empty_recommendation_report(),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        self._preserved(state, result)
+        assert state.escalate_timeout_advice == ADVICE_NO_RECOMMENDATION
+        assert "recommended no action" in result.message
+
+    def test_launch_failure_preserves_and_stays_distinct(self, tmp_path, monkeypatch):
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=None,
+            launch_failure=True,
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        self._preserved(state, result)
+        assert state.escalate_timeout_advice == ADVICE_LAUNCH_FAILURE
+        assert "FAILED TO LAUNCH" in result.message
+        assert "never launched" in result.message
+
+    def test_surface_without_an_advisory_preserves(self, tmp_path, monkeypatch):
+        # Remote/interactive expiry: no advisory is produced there at all, which
+        # is a different absence from an advisor that ran and failed.
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=None,
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        self._preserved(state, result)
+        assert state.escalate_timeout_advice == ADVICE_UNAVAILABLE
+        assert "no advisory report" in result.message
+
+    def test_recommendation_this_run_cannot_perform_is_not_substituted(
+        self, tmp_path, monkeypatch
+    ):
+        # `accept` with no approvable reviewer result: applying it is impossible
+        # and substituting anything else would record an outcome nobody chose.
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("accept"),
+            approvable=False,
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        self._preserved(state, result)
+        assert state.escalate_timeout_advice == ADVICE_NOT_PERFORMABLE
+        assert state.escalate_declined_action is None
+        assert "cannot perform it" in result.message
+
+
+# ── a present operator always governs ─────────────────────────────────────────
+
+
+class TestOperatorSelectionBeatsAdvice:
+    def test_selection_before_expiry_governs_over_a_different_recommendation(
+        self, tmp_path, monkeypatch
+    ):
+        state, result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="defer_or_abandon",  # operator chose this...
+            report=_report("accept"),  # ...advisor recommended this
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        assert state.escalate_selected_action == "defer_or_abandon"
+        assert state.escalate_decision == "reject"
+        assert state.escalate_decision_source == ESCALATE_SOURCE_OPERATOR
+        assert state.escalate_timeout_advice is None
+        assert result.success is False
+
+    def test_pending_file_selection_before_expiry_governs(self, tmp_path, monkeypatch):
+        """Through the real pending gate: a resolved file wins over the advice."""
+        config = _config(tmp_path, timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+        report = _report("accept")
+
+        def _fake_advisor(*a, **k):
+            state.advisory_generated = True
+            state.advisory_report = report.to_dict()
+            return report
+
+        monkeypatch.setattr(rp, "run_escalation_advisor", _fake_advisor)
+        monkeypatch.setattr(rp, "_append_cycle_history", lambda *a, **k: None)
+        monkeypatch.setattr(rp, "_escalate_notify", lambda *a, **k: None)
+
+        with patch("theforge.pending.poll_pending", return_value=("redirect", "t")):
+            with patch("theforge.notify_backends.send_notifications"):
+                result = _run_escalate_gate(
+                    state,
+                    config,
+                    task,
+                    tmp_path / "ws",
+                    "forge/test",
+                    0.0,
+                    auto_merge=False,
+                    notify=True,
+                    logger=None,
+                    run_id="run-sel",
+                )
+
+        assert state.escalate_selected_action == "redirect"
+        assert state.escalate_decision == "redirect"
+        assert state.escalate_decision_source == ESCALATE_SOURCE_OPERATOR
+        assert result.success is False
+
+
+# ── the pending checkpoint tracks whether anything is still owed ──────────────
+
+
+class TestPendingCheckpointLifecycle:
+    def _run_real_gate(self, tmp_path, monkeypatch, *, report, timeout_policy, run_id):
+        config = _config(tmp_path, timeout_policy=timeout_policy)
+        task = _make_task(tmp_path)
+        state = _escalated_state()
+        state.advisory_packet = {"cycles": []}
+
+        def _fake_advisor(*a, **k):
+            state.advisory_generated = report.ok
+            state.advisory_report = report.to_dict()
+            return report
+
+        monkeypatch.setattr(rp, "run_escalation_advisor", _fake_advisor)
+        monkeypatch.setattr(rp, "_append_cycle_history", lambda *a, **k: None)
+        monkeypatch.setattr(rp, "_escalate_notify", lambda *a, **k: None)
+
+        with patch("theforge.pending.poll_pending", return_value=("timeout", None)):
+            with patch("theforge.notify_backends.send_notifications"):
+                _run_escalate_gate(
+                    state,
+                    config,
+                    task,
+                    tmp_path / "ws",
+                    "forge/test",
+                    0.0,
+                    auto_merge=False,
+                    notify=True,
+                    logger=None,
+                    run_id=run_id,
+                )
+        return state, tmp_path / ".forge" / "pending" / f"{run_id}.yaml"
+
+    def test_applied_advice_clears_the_expired_checkpoint(self, tmp_path, monkeypatch):
+        state, pending_file = self._run_real_gate(
+            tmp_path,
+            monkeypatch,
+            report=_report("land_core_defer_edges"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+            run_id="run-applied",
+        )
+        assert state.escalate_decision == "land_core_defer_edges"
+        assert not pending_file.exists(), "a decided story must not look still-pending"
+
+    def test_elevate_leaves_the_checkpoint_for_the_operator(self, tmp_path, monkeypatch):
+        state, pending_file = self._run_real_gate(
+            tmp_path,
+            monkeypatch,
+            report=_report("elevate"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+            run_id="run-elevate",
+        )
+        assert state.escalate_decision == "advisory_pending"
+        assert pending_file.exists()
+        data = yaml.safe_load(pending_file.read_text())
+        assert data["timed_out_awaiting_decision"] is True
+        assert data.get("decision") is None
+
+
+# ── provenance survives into the durable records ──────────────────────────────
+
+
+class TestDecisionProvenanceIsRecorded:
+    def test_audit_record_exposes_source_action_and_pending_status(self, tmp_path, monkeypatch):
+        state, _result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("land_core_defer_edges"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        record = generate_audit_log(
+            _config(tmp_path),
+            _make_task(tmp_path),
+            CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message="m"),
+        )
+        block = record["escalation"]
+        assert block["decision_source"] == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+        assert block["timeout_advice"] == ADVICE_APPLIED
+        assert block["selected_action"] == "land_core_defer_edges"
+        assert block["advisory_recommendation"] == "land_core_defer_edges"
+        assert block["awaiting_operator"] is False
+
+    def test_audit_record_marks_a_still_waiting_gate(self, tmp_path, monkeypatch):
+        state, _result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("elevate"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        record = generate_audit_log(
+            _config(tmp_path),
+            _make_task(tmp_path),
+            CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message="m"),
+        )
+        block = record["escalation"]
+        assert block["awaiting_operator"] is True
+        assert block["decision_source"] == ESCALATE_SOURCE_TIMEOUT_PENDING
+        assert block["timeout_advice"] == ADVICE_ELEVATE
+
+    def test_resume_record_round_trips_provenance(self, tmp_path, monkeypatch):
+        state, _result = _drive_gate(
+            tmp_path,
+            monkeypatch,
+            gate_decision="timeout",
+            report=_report("land_core_defer_edges"),
+            timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
+        )
+        block = _escalation_block(state)
+        assert block is not None
+        assert block["decision_source"] == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+        assert block["timeout_advice"] == ADVICE_APPLIED
+        assert block["awaiting_operator"] is False
+
+        restored = CoordinatorState()
+        assert _apply_escalation(restored, block)
+        assert restored.escalate_decision == "land_core_defer_edges"
+        assert restored.escalate_decision_source == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
+        assert restored.escalate_timeout_advice == ADVICE_APPLIED


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] No P1 regressions found; the cycle-2 wording fix is covered and the opt-in timeout-advice flow satisfies the acceptance criteria. | [google-gemini-3.5-flash-api] Approved the clean, comprehensive implementation of applying escalate-gate advisor recommendation on opted-in timeout, complete with robust seam-level testing and rich provenance tracking. | [anthropic-haiku-cli] Cycle 2 fix ensures message wording matches provenance record; both commits solidly implement the spec with no regressions or new defects.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $17.10
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

An expiring escalate gate discards the advisory recommendation it just produced, so unattended runs fail stories the evidence had already resolved (GitHub Issue #2279)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2279