### PR TITLE
A configured transport fallback never reaches an adaptively-routed phase, so dev keeps spending iterations against a provider that has stopped answering

### DIFF
--- a/src/theforge/agent_types.py
+++ b/src/theforge/agent_types.py
@@ -67,6 +67,17 @@ class AgentResult:
     transport_fallback_fired: bool = False  # invocation switched transport mid-attempt
     transport_fallback_reason: str | None = None  # classifier reason that triggered fallback
     transport_used: str | None = None  # transport that actually ran last: "cli" or "api"
+    # Why an *eligible* transport fallback was never attempted. A recorded
+    # ``transport_fallback_reason`` with ``fired=False`` states an intention;
+    # this field states the outcome, so the audit says why nothing happened
+    # rather than leaving the operator to infer it (#2298). None whenever a
+    # fallback fired, or when the failure was never fallback-eligible.
+    transport_fallback_not_applied_reason: str | None = None
+    # The reset time the provider stated alongside a quota refusal, verbatim
+    # (e.g. "Aug 8th, 2026 7:59 AM"). Present only when the provider named one:
+    # that is the difference between a failure worth retrying and one that is
+    # certain to repeat until the stated time.
+    provider_quota_reset_at: str | None = None
     # Best-effort observed tool calls, retained even when the run crashes/times
     # out so downstream phases can salvage the exploration a failed agent did.
     # Each entry is {"tool": <name>, "target": <path/pattern or None>}. Empty

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -24,9 +24,11 @@ from .config import (
     AssignmentConfig,
     ModelProfile,
     ReasoningEffortConfig,
+    TransportFallbackConfig,
 )
 from .config.auth import check_agent_auth
 from .config.pricing import price_tiebreak_signal_for
+from .config.profiles import _apply_transport_fallback
 from .routing import (
     KNOB_EFFORT,
     KNOB_NONE,
@@ -1739,14 +1741,23 @@ def _agent_to_profile(
     *,
     role: str,
     allowed_tools: tuple[str, ...] = (),
+    transport_fallbacks: dict[str, TransportFallbackConfig] | None = None,
 ) -> ModelProfile:
-    """Convert AgentDef to ModelProfile with appropriate defaults."""
+    """Convert AgentDef to ModelProfile with appropriate defaults.
+
+    ``transport_fallbacks`` is the operator's resolved provider→API fallback
+    configuration. It is applied here, at the one boundary where routing turns a
+    catalog agent into a runnable profile, so a phase whose model was *selected*
+    survives a provider outage on the same terms as a phase whose model was
+    *declared* (#2298). A fallback the catalog entry states explicitly wins: the
+    configured provider-level entry only fills an otherwise-empty slot.
+    """
     if not allowed_tools:
         if role == "dev":
             allowed_tools = DEFAULT_DEV_PROFILE.allowed_tools
         else:
             allowed_tools = DEFAULT_REVIEW_PROFILE.allowed_tools
-    return ModelProfile(
+    profile = ModelProfile(
         name=agent.name,
         cli=agent.cli,
         provider=agent.provider,
@@ -1761,6 +1772,9 @@ def _agent_to_profile(
         registry_id=agent.registry_id,
         registry_source=agent.registry_source,
     )
+    if transport_fallbacks and profile.api_fallback is None:
+        profile = _apply_transport_fallback(profile, transport_fallbacks)
+    return profile
 
 
 # ── Routing explainability (#1391) ─────────────────────────────────────
@@ -2805,6 +2819,7 @@ def apply_post_plan_checkpoint(
     reasoning_effort: str | None = None,
     domains: list[str] | None = None,
     recency: object | None = None,
+    transport_fallbacks: dict[str, TransportFallbackConfig] | None = None,
 ) -> AssignmentDecision:
     """Re-evaluate ONLY the dev tier after plan-review completes (#1387).
 
@@ -2963,7 +2978,7 @@ def apply_post_plan_checkpoint(
         rationale="plan_review_clean_medium",
         final_tier=target_tier,
     )
-    new_dev = _agent_to_profile(target_agent, role="dev")
+    new_dev = _agent_to_profile(target_agent, role="dev", transport_fallbacks=transport_fallbacks)
     if dev_block is not None:
         # Overwrite the unified routing rationale (#1389): the post-plan
         # checkpoint is the concrete demotion that fired on this story, so the
@@ -3132,11 +3147,17 @@ def assign_models(
     excluded_for_taint: int = 0,
     sprint_exploration_budget: int | None = None,
     explore_rng: random.Random | None = None,
+    transport_fallbacks: dict[str, TransportFallbackConfig] | None = None,
 ) -> AssignmentDecision:
     """Pure deterministic function — no LLM, no I/O.
 
     Returns an AssignmentDecision with model profiles for each phase.
     explicit_profiles keys: "preflight", "planner", "dev", "code_review", "plan_review"
+
+    ``transport_fallbacks`` is the operator's resolved provider→API fallback map
+    (``ForgeConfig.transport_fallbacks``). Routed profiles receive it exactly as
+    role-declared profiles do at config load, so a phase's outage survival does
+    not depend on whether its model was named or selected (#2298).
 
     ``unhealthy_models`` is the set of agent names whose latest provider-shape
     failure (capacity, rate-limit, 5xx, quota) is still within the health
@@ -3392,7 +3413,9 @@ def assign_models(
                     dev_agent = sorted(agents, key=lambda a: a.budget_usd)[0]
                     rationale["dev"] += " (fallback: cheapest, no auth checked)"
         dev_selected_tier = dev_agent.tier
-        dev_profile = _agent_to_profile(dev_agent, role="dev")
+        dev_profile = _agent_to_profile(
+            dev_agent, role="dev", transport_fallbacks=transport_fallbacks
+        )
 
         # ── Challenger-sampling exploration (#325, ADR-0006 clause 8) ──────
         # The single sanctioned deviation from deterministic routing. Only
@@ -3416,7 +3439,9 @@ def assign_models(
             if _exp.route_agent is not None:
                 dev_agent = _exp.route_agent
                 dev_selected_tier = dev_agent.tier
-                dev_profile = _agent_to_profile(dev_agent, role="dev")
+                dev_profile = _agent_to_profile(
+                    dev_agent, role="dev", transport_fallbacks=transport_fallbacks
+                )
                 _dev_effective_tier = dev_agent.tier
                 if _dev_exploration.get("mode") == "challenger":
                     # Challenger-tier budget envelope (clause 8): the run spends
@@ -3465,6 +3490,7 @@ def assign_models(
             agent,
             role="preflight",
             allowed_tools=DEFAULT_PREFLIGHT_PROFILE.allowed_tools,
+            transport_fallbacks=transport_fallbacks,
         )
         rationale["preflight"] = f"tier {tier} (${agent.budget_usd:.2f})"
 
@@ -3495,7 +3521,9 @@ def assign_models(
         if agent is None:
             authed = [a for a in agents if _has_auth(a, secrets)]
             agent = sorted(authed or agents, key=lambda a: -a.budget_usd)[0]
-        planner_profile = _agent_to_profile(agent, role="review")
+        planner_profile = _agent_to_profile(
+            agent, role="review", transport_fallbacks=transport_fallbacks
+        )
         if score is not None:
             rationale["planner"] = (
                 f"complexity score {score} → tier {tier} (${agent.budget_usd:.2f})"
@@ -3549,7 +3577,10 @@ def assign_models(
             value_signals_out=_pr_value_signals,
             value_audit=_pr_value_audit,
         )
-        plan_reviewers = [_agent_to_profile(a, role="review") for a in selected]
+        plan_reviewers = [
+            _agent_to_profile(a, role="review", transport_fallbacks=transport_fallbacks)
+            for a in selected
+        ]
         providers = [a.effective_provider for a in selected]
         score_note = f", complexity score {score}" if score is not None else ""
         shortfall_note = (
@@ -3613,7 +3644,10 @@ def assign_models(
             value_audit=_cr_value_audit,
             value_phase="code_review",
         )
-        code_reviewers = [_agent_to_profile(a, role="review") for a in selected]
+        code_reviewers = [
+            _agent_to_profile(a, role="review", transport_fallbacks=transport_fallbacks)
+            for a in selected
+        ]
         providers = [a.effective_provider for a in selected]
         score_note = f", complexity score {score}" if score is not None else ""
         shortfall_note = (

--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import logging
 from collections.abc import Iterator
+from dataclasses import replace as _dc_replace
 from typing import TYPE_CHECKING, Any
 
 from .auth import check_agent_auth
@@ -635,6 +636,12 @@ def _apply_transport_fallback(
 
     Reads ``transport.kind`` — not the legacy cli/provider pair — to decide what
     a profile currently dispatches through.
+
+    Rebuilt with :func:`dataclasses.replace` rather than a hand-enumerated
+    constructor call: every field this helper does not name would otherwise be
+    silently reset to its default, which is how ``phase`` was once lost and how
+    ``registry_id``/``registry_source`` would be lost now that adaptively routed
+    (catalog-sourced) profiles pass through here (#2298).
     """
     if profile.mode != "cli":
         return profile
@@ -644,26 +651,4 @@ def _apply_transport_fallback(
     fallback = fallbacks.get(provider)
     if fallback is None:
         return profile
-    return ModelProfile(
-        name=profile.name,
-        cli=profile.cli,
-        provider=profile.provider,
-        model=profile.model,
-        budget_usd=profile.budget_usd,
-        timeout_seconds=profile.timeout_seconds,
-        allowed_tools=profile.allowed_tools,
-        timeout_medium_seconds=profile.timeout_medium_seconds,
-        timeout_large_seconds=profile.timeout_large_seconds,
-        reasoning_effort=profile.reasoning_effort,
-        thinking_budget=profile.thinking_budget,
-        review_role=profile.review_role,
-        base_url=profile.base_url,
-        max_tool_output_bytes=profile.max_tool_output_bytes,
-        max_iterations=profile.max_iterations,
-        fallback_models=profile.fallback_models,
-        api_fallback=fallback,
-        github_handle=profile.github_handle,
-        phase=profile.phase,
-        sandbox_mode=profile.sandbox_mode,
-        transport=profile.transport,
-    )
+    return _dc_replace(profile, api_fallback=fallback)

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -34,6 +34,8 @@ from theforge.task import (
 from theforge.traces import write_trace
 
 from .agent_failure import (
+    CATEGORY_TRANSPORT,
+    AgentInvocationFailure,
     classify_agent_failure,
     mark_infrastructure_abort,
     record_invocation_failure,
@@ -265,6 +267,34 @@ def _runner_display_name(config: ForgeConfig) -> str:
     return config.dev_profile.cli or config.dev_profile.provider or config.dev_profile.name
 
 
+def _unrecoverable_provider_quota(result: object) -> str | None:
+    """Explain a dev failure that is certain to repeat, or return None (#2298).
+
+    Certainty needs all three facts together: the provider refused on quota, it
+    named the moment that quota resets, and no configured transport fallback was
+    applicable. A quota refusal without a stated reset time may clear on its own,
+    so repeating it is reasonable; one that names its reset time will not, and
+    spending the remaining iteration budget re-asking is a choice the run should
+    not make on its own.
+    """
+    from theforge.agent_types import AgentResult as _AgentResult  # noqa: PLC0415
+
+    if not isinstance(result, _AgentResult):
+        raise TypeError(f"Expected AgentResult, got {type(result)}")
+    if result.success or result.transport_fallback_fired:
+        return None
+    if not result.cli_quota_error_observed:
+        return None
+    if not result.provider_quota_reset_at:
+        return None
+    if not result.transport_fallback_not_applied_reason:
+        return None
+    return (
+        f"provider quota exhausted until {result.provider_quota_reset_at}; "
+        f"{result.transport_fallback_not_applied_reason}"
+    )
+
+
 def _is_transient_dev_failure(
     result: object, runner_failure: tuple[str, str] | None = None
 ) -> bool:
@@ -274,6 +304,11 @@ def _is_transient_dev_failure(
     if not isinstance(result, _AgentResult):
         raise TypeError(f"Expected AgentResult, got {type(result)}")
     if result.success or result.startup_failure or runner_failure is not None:
+        return False
+    # A quota refusal with a stated reset time and no applicable fallback is the
+    # one provider failure that is known not to be transient — retrying it before
+    # the stated time reproduces it by construction (#2298).
+    if _unrecoverable_provider_quota(result) is not None:
         return False
     failure_code = (result.failure_code or "").lower()
     if failure_code in {"rate_limit", "provider_internal_error", "connection_reset"}:
@@ -1472,6 +1507,64 @@ def _run_dev_phase(
                         iteration=state.dev_iteration,
                         reason=_failure_detail,
                     )
+        # ── Provider quota exhausted with no applicable fallback (#2298) ─
+        # The provider stated when its limit resets and no configured transport
+        # fallback applied, so every remaining iteration would re-ask a provider
+        # that has already answered. Stop here instead of spending the budget to
+        # rediscover the same refusal. This is an infrastructure abort, not an
+        # escalation: no model judged this story, so the run must not leave a
+        # story-quality verdict — or router-teaching evidence — behind it.
+        _quota_halt = _unrecoverable_provider_quota(dev_result)
+        if _quota_halt is not None:
+            _quota_failure = AgentInvocationFailure(
+                phase="DEV",
+                category=CATEGORY_TRANSPORT,
+                exit_code=dev_result.exit_code,
+                failure_code=dev_result.failure_code,
+                detail=_quota_halt,
+                profile_name=getattr(config.dev_profile, "name", None),
+                extra={
+                    "provider_quota_reset_at": dev_result.provider_quota_reset_at,
+                    "transport_fallback_reason": dev_result.transport_fallback_reason,
+                    "transport_fallback_not_applied_reason": (
+                        dev_result.transport_fallback_not_applied_reason
+                    ),
+                },
+            )
+            record_invocation_failure(state, _quota_failure)
+            state.phase = Phase.ESCALATE
+            state.error = (
+                f"Dev provider refused on quota and no transport fallback was "
+                f"applicable ({_quota_halt}) — halting rather than spending the "
+                f"remaining {state.budget.remaining()} iteration(s) against a "
+                "provider that has stopped answering"
+            )
+            mark_infrastructure_abort(state, _quota_failure, message=state.error)
+            record_dev_iteration_telemetry(
+                state,
+                workspace_path,
+                max_iterations=state.adaptive_dev_max or config.retry.max_dev_iterations,
+                gate_result="DEV_PROVIDER_QUOTA_EXHAUSTED",
+            )
+            _log(f"✗ ABORT   {state.error}")
+            if logger:
+                logger._safe_emit(
+                    "infrastructure_abort",
+                    phase="DEV",
+                    reason=state.error,
+                    category=_quota_failure.category,
+                    provider_quota_reset_at=dev_result.provider_quota_reset_at,
+                    transport_fallback_not_applied_reason=(
+                        dev_result.transport_fallback_not_applied_reason
+                    ),
+                )
+            return CoordinatorResult(
+                success=False,
+                phase=state.phase,
+                state=state,
+                message=state.error,
+                infrastructure_failure=True,
+            )
         # ── Timeout retry (iterations remaining) ─────────────────────────
         # A per-iteration timeout is a retryable failure, not a terminal
         # escalation. Running out of time is not the same event as crashing or

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -663,6 +663,7 @@ def _apply_post_plan_dev_checkpoint(
         reasoning_effort=_reasoning_effort,
         domains=_domains,
         recency=_recency,
+        transport_fallbacks=config.transport_fallbacks,
     )
     state._adaptive_decision = _updated
     if _updated.routing_decision:

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -1375,6 +1375,7 @@ def _apply_preflight_config(
             domains=list(state.preflight_domains or []),
             excluded_for_taint=_excluded_for_taint,
             sprint_exploration_budget=explore_budget,
+            transport_fallbacks=config.transport_fallbacks,
         )
 
     _explore_remaining = _explore_budget.remaining_budget(

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -9,6 +9,7 @@ Provider-specific runners live in dedicated modules:
 
 from __future__ import annotations
 
+import re
 import subprocess
 import threading
 import time
@@ -180,6 +181,34 @@ _CLI_MODEL_FALLBACK_PATTERNS = (
 # fallback_models lists for CLI profiles.
 _KNOWN_CLI_NAMES = frozenset({"claude", "codex", "gemini", "ghaw"})
 
+# Quota refusals that name a reset moment. A limit with a stated reset time is a
+# different fact from a limit without one: repeating the first is certain to
+# reproduce it until that time, so the coordinator is entitled to stop rather
+# than spend the remaining budget re-asking (#2298). Deliberately does NOT match
+# the vague "try again later" — that carries no such certainty.
+_CLI_QUOTA_RESET_PATTERNS = (
+    re.compile(r"try again (?:at|after|on)\s+([^.\n]{3,80})", re.IGNORECASE),
+    re.compile(r"(?:limit |quota )?resets?\s+(?:at|on|in)\s+([^.\n]{3,80})", re.IGNORECASE),
+    re.compile(r"available again\s+(?:at|on|in)\s+([^.\n]{3,80})", re.IGNORECASE),
+)
+
+
+def _parse_quota_reset(output: str) -> str | None:
+    """Return the reset moment a quota refusal stated, or None if it stated none."""
+    for pattern in _CLI_QUOTA_RESET_PATTERNS:
+        match = pattern.search(output)
+        if match:
+            return match.group(1).strip().rstrip(",;")
+    return None
+
+
+def _fallback_unavailable_reason(profile: ModelProfile) -> str:
+    """Explain why no transport fallback could be attempted for ``profile``."""
+    provider = profile.provider_family or profile.provider or "unknown"
+    if profile.api_fallback is None and not profile.fallback_models:
+        return f"no transport fallback configured for provider {provider!r}"
+    return f"no configured fallback for provider {provider!r} resolved to an API transport"
+
 
 @dataclass(frozen=True)
 class _CliFallbackDecision:
@@ -332,6 +361,24 @@ def _maybe_run_api_fallback(
     reason = decision.reason
 
     def _annotate_cli_result(cli_result: AgentResult) -> AgentResult:
+        """Annotate a failure for which no fallback was ever attempted.
+
+        The failure was classified as fallback-eligible, so recording only the
+        reason would describe a decision without its outcome. Say why nothing
+        was attempted, and — for a quota refusal that named its own reset time —
+        carry that time forward so the coordinator can tell a failure certain to
+        repeat from one merely likely to (#2298).
+        """
+        not_applied = _fallback_unavailable_reason(profile)
+        reset_at = (
+            _parse_quota_reset(cli_result.output or "")
+            if decision.cli_quota_error_observed
+            else None
+        )
+        _log(
+            f"  ⚠ {cli_label} CLI failed ({reason}); no transport fallback applied "
+            f"— {not_applied}" + (f"; provider stated reset at {reset_at}" if reset_at else "")
+        )
         return replace(
             cli_result,
             model_config=model_config,
@@ -339,6 +386,8 @@ def _maybe_run_api_fallback(
             cli_quota_error_observed=decision.cli_quota_error_observed,
             transport_fallback_fired=False,
             transport_fallback_reason=reason,
+            transport_fallback_not_applied_reason=not_applied,
+            provider_quota_reset_at=reset_at,
             transport_used="cli",
         )
 

--- a/tests/test_routed_transport_fallback_seam.py
+++ b/tests/test_routed_transport_fallback_seam.py
@@ -1,0 +1,494 @@
+"""Seam coverage for configured transport fallbacks on adaptively routed phases.
+
+Issue #2298. A configured ``transport_fallback`` was attached only to profiles
+built from *role declarations* at config load. Adaptive routing sources its
+profiles from the model catalog, so the dev phase — the long, expensive,
+iterating one — ran with ``api_fallback=None`` no matter how the operator had
+configured the provider. Two paths that arrive at the same model must not
+disagree about what happens when that model's provider stops answering.
+
+The second half of the story: where a fallback is eligible and cannot be
+applied, the run must say so, and must not keep spending iterations against a
+provider that stated when its limit resets.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from theforge.agent_types import AgentResult  # noqa: E402
+from theforge.assignment import (  # noqa: E402
+    AssignmentConfig,
+    apply_post_plan_checkpoint,
+    assign_models,
+)
+from theforge.config import (  # noqa: E402
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    AgentDef,
+    ForgeConfig,
+    LogConfig,
+    ModelProfile,
+    RetryPolicy,
+    TransportFallbackConfig,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import CoordinatorState, Phase  # noqa: E402
+from theforge.task import TaskStory  # noqa: E402
+
+_OPENAI_FALLBACK = TransportFallbackConfig(
+    provider="openai",
+    model="gpt-5.4",
+    timeout_seconds=1800,
+)
+_FALLBACKS = {"openai": _OPENAI_FALLBACK}
+
+# The verbatim provider refusal from the reported run.
+_QUOTA_OUTPUT = (
+    "You've hit your usage limit. Upgrade to Pro or try again at Aug 8th, 2026 7:59 AM."
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_api_keys(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+
+
+def _assign_cfg(**kwargs) -> AssignmentConfig:
+    defaults = dict(
+        enabled=True,
+        min_reviewers=1,
+        max_reviewers=1,
+        prefer_cross_provider=False,
+        max_cost_per_story_usd=1000.0,
+        escalation_memory=True,
+    )
+    defaults.update(kwargs)
+    return AssignmentConfig(**defaults)
+
+
+def _catalog_agents(api_fallback: TransportFallbackConfig | None = None) -> list[AgentDef]:
+    """A catalog pool whose entries carry no api_fallback of their own.
+
+    This is the shape the bug reproduced against: the catalog agent named
+    ``openai-gpt-5.4-cli`` resolves ``api_fallback`` to None even though the
+    role-declared profile for the very same model has one.
+    """
+    return [
+        AgentDef(
+            name="openai-gpt-5.4-cli",
+            provider=None,
+            cli="codex",
+            model="gpt-5.4",
+            budget_usd=5.0,
+            timeout_seconds=900,
+            tier="mid",
+            api_fallback=api_fallback,
+        ),
+        AgentDef(
+            name="openai-gpt-5.4-cheap",
+            provider=None,
+            cli="codex",
+            model="gpt-5.4-mini",
+            budget_usd=1.0,
+            timeout_seconds=600,
+            tier="cheap",
+            api_fallback=api_fallback,
+        ),
+        AgentDef(
+            name="claude-opus-cli",
+            provider=None,
+            cli="claude",
+            model="opus",
+            budget_usd=8.0,
+            timeout_seconds=1200,
+            tier="strong",
+        ),
+    ]
+
+
+# ── Routed profiles carry the configured fallback (#2298) ─────────────
+
+
+def test_routed_dev_profile_carries_configured_transport_fallback():
+    """The reported symptom: dev is routed from the catalog, so it lost the fallback."""
+    decision = assign_models(
+        _catalog_agents(),
+        _assign_cfg(),
+        complexity="medium",
+        transport_fallbacks=_FALLBACKS,
+    )
+
+    assert decision.dev.cli == "codex"
+    assert decision.dev.api_fallback is not None
+    assert decision.dev.api_fallback.provider == "openai"
+    assert decision.dev.api_fallback.model == "gpt-5.4"
+
+
+def test_routed_dev_profile_without_configured_fallback_stays_none():
+    """No configuration means no fallback — the fix must not invent one."""
+    decision = assign_models(_catalog_agents(), _assign_cfg(), complexity="medium")
+
+    assert decision.dev.api_fallback is None
+
+
+def test_explicit_catalog_api_fallback_wins_over_configured_entry():
+    """A fallback the catalog entry states explicitly is preserved, not overwritten."""
+    explicit = TransportFallbackConfig(provider="openai", model="o4-mini", timeout_seconds=600)
+    decision = assign_models(
+        _catalog_agents(api_fallback=explicit),
+        _assign_cfg(),
+        complexity="medium",
+        transport_fallbacks=_FALLBACKS,
+    )
+
+    assert decision.dev.api_fallback is not None
+    assert decision.dev.api_fallback.model == "o4-mini"
+
+
+def test_routed_reviewer_and_planner_profiles_carry_configured_fallback():
+    """Every routed role, not just dev — the fallback is a provider-level decision."""
+    decision = assign_models(
+        _catalog_agents(),
+        _assign_cfg(min_reviewers=1, max_reviewers=1),
+        complexity="medium",
+        transport_fallbacks=_FALLBACKS,
+    )
+
+    routed = [decision.preflight, decision.planner, *decision.code_reviewers]
+    for profile in routed:
+        if profile.mode != "cli" or profile.provider_family != "openai":
+            continue
+        assert profile.api_fallback is not None, f"{profile.name} lost the configured fallback"
+
+
+def test_post_plan_demoted_dev_profile_carries_configured_fallback():
+    """The post-plan checkpoint rebuilds the dev profile — it must not drop the fallback."""
+    decision = assign_models(
+        _catalog_agents(),
+        _assign_cfg(),
+        complexity="medium",
+        transport_fallbacks=_FALLBACKS,
+    )
+    updated = apply_post_plan_checkpoint(
+        decision,
+        _catalog_agents(),
+        _assign_cfg(),
+        "medium",
+        plan_review_decision="APPROVE",
+        plan_review_cycles=1,
+        p1_count=0,
+        p2_count=0,
+        transport_fallbacks=_FALLBACKS,
+    )
+
+    assert updated.dev.api_fallback is not None
+    assert updated.dev.api_fallback.model == "gpt-5.4"
+
+
+def test_apply_transport_fallback_preserves_registry_identity():
+    """The helper must not silently reset fields it does not name.
+
+    Routed profiles carry registry provenance; rebuilding them field-by-field
+    (as this helper used to) dropped it, which is the same defect that once lost
+    ``phase``.
+    """
+    from theforge.config.profiles import _apply_transport_fallback
+
+    profile = ModelProfile(
+        name="openai-gpt-5.4-cli",
+        cli="codex",
+        model="gpt-5.4",
+        budget_usd=5.0,
+        timeout_seconds=900,
+        allowed_tools=("Read",),
+        phase="dev",
+        registry_id="openai/gpt-5.4/cli",
+        registry_source="forge.yaml",
+        sandbox_capability_profile="wide",
+    )
+
+    out = _apply_transport_fallback(profile, _FALLBACKS)
+
+    assert out.api_fallback is _OPENAI_FALLBACK
+    assert out.registry_id == "openai/gpt-5.4/cli"
+    assert out.registry_source == "forge.yaml"
+    assert out.sandbox_capability_profile == "wide"
+    assert out.phase == "dev"
+
+
+# ── Eligible-but-unavailable fallback is recorded (#2298) ─────────────
+
+
+def _codex_profile(**kwargs) -> ModelProfile:
+    defaults = dict(
+        name="openai-gpt-5.4-cli",
+        cli="codex",
+        model="gpt-5.4",
+        budget_usd=5.0,
+        timeout_seconds=900,
+        allowed_tools=("Read",),
+        phase="dev",
+    )
+    defaults.update(kwargs)
+    return ModelProfile(**defaults)
+
+
+def _quota_failure(profile: ModelProfile) -> AgentResult:
+    return AgentResult(
+        success=False,
+        output=_QUOTA_OUTPUT,
+        session_id=None,
+        cost_usd=0.0,
+        exit_code=1,
+        raw={},
+        profile_name=profile.name,
+    )
+
+
+def _run_codex_agent(profile: ModelProfile, tmp_path: Path) -> AgentResult:
+    from theforge.runners.cli import run_agent
+
+    with patch(
+        "theforge.runners.runner_codex._run_codex",
+        return_value=_quota_failure(profile),
+    ):
+        return run_agent(
+            prompt="do work",
+            profile=profile,
+            working_dir=tmp_path,
+            quiet=True,
+        )
+
+
+def test_quota_failure_without_fallback_records_why_it_was_not_applied(tmp_path: Path) -> None:
+    """Recording only the reason describes an intention; the outcome must be stated too."""
+    profile = _codex_profile()
+    result = _run_codex_agent(profile, tmp_path)
+
+    assert result.cli_quota_error_observed is True
+    assert result.transport_fallback_fired is False
+    assert result.transport_fallback_reason == "matched 'usage limit'"
+    assert result.transport_fallback_not_applied_reason is not None
+    assert "no transport fallback configured" in result.transport_fallback_not_applied_reason
+    assert "openai" in result.transport_fallback_not_applied_reason
+
+
+def test_quota_failure_records_the_reset_time_the_provider_stated(tmp_path: Path) -> None:
+    result = _run_codex_agent(_codex_profile(), tmp_path)
+
+    assert result.provider_quota_reset_at == "Aug 8th, 2026 7:59 AM"
+
+
+def test_quota_failure_without_a_stated_reset_time_records_none(tmp_path: Path) -> None:
+    """A limit that names no reset moment may clear on its own — do not claim certainty."""
+    profile = _codex_profile()
+    failure = replace(_quota_failure(profile), output="429 rate limit exceeded, try again later")
+    from theforge.runners.cli import run_agent
+
+    with patch("theforge.runners.runner_codex._run_codex", return_value=failure):
+        result = run_agent(prompt="do work", profile=profile, working_dir=tmp_path, quiet=True)
+
+    assert result.cli_quota_error_observed is True
+    assert result.transport_fallback_not_applied_reason is not None
+    assert result.provider_quota_reset_at is None
+
+
+def test_applied_fallback_records_no_not_applied_reason(tmp_path: Path) -> None:
+    """When the fallback does fire, there is no 'not applied' outcome to record."""
+    profile = _codex_profile(api_fallback=_OPENAI_FALLBACK)
+    api_success = AgentResult(
+        success=True,
+        output="done",
+        session_id=None,
+        cost_usd=0.02,
+        exit_code=0,
+        raw={},
+        profile_name=profile.name,
+    )
+    from theforge.runners.cli import run_agent
+
+    with (
+        patch("theforge.runners.runner_codex._run_codex", return_value=_quota_failure(profile)),
+        patch("theforge.runners.api.run_api_agent", return_value=api_success),
+    ):
+        result = run_agent(prompt="do work", profile=profile, working_dir=tmp_path, quiet=True)
+
+    assert result.transport_fallback_fired is True
+    assert result.transport_fallback_not_applied_reason is None
+    assert result.provider_quota_reset_at is None
+
+
+# ── The run stops rather than re-asking a provider that answered ──────
+
+
+def _unrecoverable_quota_result() -> AgentResult:
+    return AgentResult(
+        success=False,
+        output=_QUOTA_OUTPUT,
+        session_id=None,
+        cost_usd=0.0,
+        exit_code=1,
+        raw={},
+        profile_name="dev",
+        cli_quota_error_observed=True,
+        transport_fallback_fired=False,
+        transport_fallback_reason="matched 'usage limit'",
+        transport_fallback_not_applied_reason=(
+            "no transport fallback configured for provider 'openai'"
+        ),
+        provider_quota_reset_at="Aug 8th, 2026 7:59 AM",
+        transport_used="cli",
+    )
+
+
+def test_unrecoverable_quota_failure_is_not_transient() -> None:
+    from theforge.coordinator.dev_phase import _is_transient_dev_failure
+
+    assert _is_transient_dev_failure(_unrecoverable_quota_result()) is False
+
+
+def test_quota_failure_without_reset_time_stays_transient() -> None:
+    """Where the failure carries no certainty, repeating it is still reasonable."""
+    from theforge.coordinator.dev_phase import _is_transient_dev_failure
+
+    result = replace(
+        _unrecoverable_quota_result(),
+        output="429 rate limit exceeded",
+        provider_quota_reset_at=None,
+    )
+
+    assert _is_transient_dev_failure(result) is True
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "README.md").write_text("seed\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+            base_branch="main",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        preflight_fallback_profile=None,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=3, max_review_cycles=2),
+        log=LogConfig(enabled=False),
+    )
+
+
+def test_dev_phase_halts_instead_of_spending_remaining_iterations(tmp_path: Path) -> None:
+    """The reported run spent two further iterations against a dead provider.
+
+    With a stated reset time and no applicable fallback, the phase must end the
+    story now — as an infrastructure abort, since no model judged anything —
+    rather than return None and let the engine re-enter DEV.
+    """
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    spec = tmp_path / "specs" / "t.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# t\n", encoding="utf-8")
+    state = CoordinatorState()
+    state.adaptive_dev_max = 3
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+
+    agent_result = _unrecoverable_quota_result()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.run_agent", return_value=agent_result)
+        )
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock())
+        )
+        result = _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/x", notify=False, logger=None
+        )
+
+    # Not None → the engine loop ends the story instead of re-entering DEV with
+    # two iterations still on the budget.
+    assert result is not None
+    assert result.success is False
+    assert result.infrastructure_failure is True
+    assert state.phase == Phase.ESCALATE
+    # The audit says why, in the same terms a fired fallback would be reported.
+    assert "Aug 8th, 2026 7:59 AM" in (state.error or "")
+    assert "no transport fallback configured" in (state.error or "")
+    assert state.infrastructure_failure is not None
+    assert state.agent_invocation_failures
+    _recorded = state.agent_invocation_failures[-1]
+    assert _recorded["category"] == "transport"
+    # Budget was never spent down to the limit.
+    assert state.budget.remaining() > 0
+
+
+def test_dev_phase_retries_when_the_provider_stated_no_reset_time(tmp_path: Path) -> None:
+    """The halt is narrow: only a quota refusal certain to repeat ends the story."""
+    from theforge.coordinator.dev_phase import _run_dev_phase
+
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=tmp_path, check=True)
+    config = _make_config(tmp_path)
+    task = TaskStory(name="t", slug="t", story_path="specs/t.md")
+    spec = tmp_path / "specs" / "t.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# t\n", encoding="utf-8")
+    state = CoordinatorState()
+    state.adaptive_dev_max = 3
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+
+    agent_result = replace(
+        _unrecoverable_quota_result(),
+        output="TIMEOUT: Agent exceeded 900s limit",
+        failure_code="timeout",
+        cli_quota_error_observed=False,
+        transport_fallback_reason=None,
+        transport_fallback_not_applied_reason=None,
+        provider_quota_reset_at=None,
+    )
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.run_agent", return_value=agent_result)
+        )
+        stack.enter_context(
+            patch("theforge.coordinator.dev_phase.log_agent_result", new=MagicMock())
+        )
+        result = _run_dev_phase(
+            state, config, task, "# t\n", tmp_path, "feat/x", notify=False, logger=None
+        )
+
+    assert result is None
+    assert state.phase != Phase.ESCALATE


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change satisfies the configured fallback propagation, audit visibility, and quota-halt requirements; no blocking defects found. | [google-gemini-3.5-flash-api] The implementation is clean, robust, and correctly attaches transport fallbacks to adaptively routed profiles while halting gracefully upon unrecoverable quota errors.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-haiku-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, anthropic-opus-cli, openai-gpt-5.5-cli
- **Cost:** $8.31
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A configured transport fallback never reaches an adaptively-routed phase, so dev keeps spending iterations against a provider that has stopped answering (GitHub Issue #2298)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2298