### PR TITLE
A story waiting at the escalate gate is displayed as stalled, so the wait expires without the operator knowing it was asked

### DIFF
--- a/src/theforge/cli/status_watch.py
+++ b/src/theforge/cli/status_watch.py
@@ -43,6 +43,9 @@ def CURSOR_UP(n: int) -> str:
 
 GREEN = "\x1b[32m"
 RED = "\x1b[31m"
+# Reserved for the one row that is waiting on the operator: it must not read as
+# a healthy live row (green) nor as background inactivity (dim) (#2313).
+YELLOW = "\x1b[33m"
 DIM = "\x1b[2m"
 RESET = "\x1b[0m"
 
@@ -214,7 +217,11 @@ def render_frame(
     per-slug cost so the next frame can compute deltas.
     """
     from theforge.cli.sprint_status import _format_story_cell, display_sprint_status
-    from theforge.sprint.status_reader import COLLISION_GATE_STAGE, read_live_status
+    from theforge.sprint.status_reader import (
+        COLLISION_GATE_STAGE,
+        OPERATOR_DECISION_STAGE,
+        read_live_status,
+    )
 
     # Persist the GitHub title cache across frames so titles fetched on frame 1
     # are reused on every subsequent frame (zero re-fetch).
@@ -243,6 +250,7 @@ def render_frame(
     prev_costs = dict(state.get("costs", {}))
     new_costs: dict[str, float] = {}
     stalled_paths: list[str] = []
+    decision_lines: list[tuple[str, str]] = []
 
     overlay_lines: list[str] = []
     overlay_lines.append("")
@@ -283,7 +291,17 @@ def render_frame(
         # events, so its age crossing the stall threshold means nothing. Report
         # the wait, not a warning the operator cannot act on (#2235).
         gated = status == "running" and getattr(e, "stage", "") == COLLISION_GATE_STAGE
-        if gated:
+        # A gate waiting on a person is the one wait the operator can end, and
+        # the only one they will never look for if it renders as inactivity. Say
+        # a decision is pending, and carry the remaining time below (#2313).
+        awaiting_decision = (
+            status == "running" and getattr(e, "stage", "") == OPERATOR_DECISION_STAGE
+        )
+        if awaiting_decision:
+            label = f"{GATE_CHAR} decision"
+            act = _c(label, YELLOW, color)
+            decision_lines.append((path, getattr(e, "detail", "") or ""))
+        elif gated:
             label = f"{GATE_CHAR} gated"
             act = _c(label, DIM, color)
         elif status == "running":
@@ -318,6 +336,17 @@ def render_frame(
         path_disp = path if len(path) <= 30 else path[:29] + "…"
         act_padded = act + " " * max(0, _ACT_COL - len(label))
         overlay_lines.append(f"{path_disp:<30}  {act_padded}  {delta_str:>8}  {age_str:>9}")
+
+    if decision_lines:
+        overlay_lines.append("")
+        for path_name, detail in decision_lines:
+            text = f"Awaiting operator decision: {path_name}"
+            if detail:
+                text += f" — {detail}"
+            overlay_lines.append(_c(text, YELLOW, color))
+        overlay_lines.append(
+            _c("Resolve with: forge decide <run-id> <action>", DIM, color),
+        )
 
     if stalled_paths:
         stalled_preview = ", ".join(stalled_paths[:2])

--- a/src/theforge/pending.py
+++ b/src/theforge/pending.py
@@ -19,6 +19,10 @@ import yaml
 from .coordinator import util as _cu
 from .pid import _is_pid_alive
 
+#: Env var carrying the run id of the process that owns this run. Exported by
+#: ``detach.export_run_context`` on both the detached and foreground paths.
+_OWNER_RUN_ID_ENV = "FORGE_DETACHED_RUN_ID"
+
 
 def _pending_dir(project_root: Path | None = None) -> Path:
     """Return .forge/pending/ relative to project root or cwd."""
@@ -61,6 +65,13 @@ def write_pending(
         "timeout_at": timeout_at.isoformat(),
         "pid": os.getpid(),
     }
+    # Which run is holding this gate. A checkpoint is keyed by the *story* run
+    # id, which two concurrently live sprints can share for the same slug — so
+    # the owning sprint run is recorded here, and a status view can tell whose
+    # gate it is looking at rather than inferring it from the slug (#2313).
+    owner_run_id = os.environ.get(_OWNER_RUN_ID_ENV)
+    if owner_run_id:
+        data["owner_run_id"] = owner_run_id
     if extra:
         for key, value in extra.items():
             data.setdefault(key, value)

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -565,6 +565,125 @@ def _collision_gate_detail(detail_data: dict) -> str | None:
     return text
 
 
+#: Stage reported for a story the coordinator is deliberately holding at a gate
+#: that waits on a person (escalate, human review, plan review). The story emits
+#: no events while the gate polls, so without this the wait reads as a stall —
+#: and the one state that only an operator can clear is the one state the view
+#: gives them no reason to act on (#2313).
+OPERATOR_DECISION_STAGE = "operator decision"
+
+#: How many decision options to name before summarising the rest.
+_DECISION_OPTION_PREVIEW = 3
+
+
+def _fmt_remaining(seconds: float) -> str:
+    """Format a remaining-time span the same way the run log does."""
+    h, rem = divmod(int(seconds), 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h {m}m {s}s"
+    if m:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+
+def _pending_entry_is_live(entry: dict) -> bool:
+    """True when ``entry`` is an undecided checkpoint owned by a live process.
+
+    ``list_pending`` returns every file in ``.forge/pending`` verbatim, including
+    already-decided records and records left behind by a dead run. Rendering
+    either as "waiting on you" would send the operator to a gate that is not
+    open, so both are filtered out here.
+    """
+    if entry.get("decision"):
+        return False
+    pid = entry.get("pid")
+    try:
+        owner_pid = int(pid)
+    except (TypeError, ValueError):
+        return False
+    try:
+        from theforge.pid import _is_pid_alive  # noqa: PLC0415
+
+        return _is_pid_alive(owner_pid)
+    except Exception:
+        return False
+
+
+def _pending_remaining_text(entry: dict) -> str:
+    """Describe how long the pending wait has left, or that it has lapsed."""
+    timeout_at_str = entry.get("timeout_at")
+    if not isinstance(timeout_at_str, str) or not timeout_at_str:
+        return ""
+    try:
+        timeout_at = datetime.datetime.fromisoformat(timeout_at_str)
+    except Exception:
+        return ""
+    if timeout_at.tzinfo is None:
+        timeout_at = timeout_at.replace(tzinfo=datetime.timezone.utc)
+    remaining = (timeout_at - datetime.datetime.now(datetime.timezone.utc)).total_seconds()
+    if remaining > 0:
+        return f"{_fmt_remaining(remaining)} remaining"
+    # The escalate gate preserves an expired checkpoint and keeps awaiting a
+    # selection rather than auto-rejecting, so an elapsed window still needs the
+    # operator — say that instead of implying the decision is gone.
+    return "window elapsed — still awaiting decision"
+
+
+def _select_pending_for_story(pending: list[dict], slug: str) -> dict | None:
+    """Pick the live pending record a story row should display, if any."""
+    if not slug:
+        return None
+    candidates = [
+        entry
+        for entry in pending
+        if isinstance(entry, dict)
+        and _nonempty_str(entry.get("story")) == slug
+        and _pending_entry_is_live(entry)
+    ]
+    if not candidates:
+        return None
+
+    # An ESCALATE checkpoint is the gate that stalls longest and costs most to
+    # miss; prefer it, then the most recently created record.
+    def _rank(entry: dict) -> tuple[int, str]:
+        phase = _nonempty_str(entry.get("phase")) or ""
+        created = _nonempty_str(entry.get("created_at")) or ""
+        return (1 if phase.upper() == "ESCALATE" else 0, created)
+
+    return max(candidates, key=_rank)
+
+
+def _live_pending_records(project_root: Path) -> list[dict]:
+    """Load `.forge/pending` checkpoints, best-effort (never raises)."""
+    try:
+        from theforge.pending import list_pending  # noqa: PLC0415
+
+        return [entry for entry in list_pending(project_root) if isinstance(entry, dict)]
+    except Exception:
+        return []
+
+
+def _pending_decision_display(entry: dict) -> str:
+    """Render the DETAIL text for a story awaiting an operator decision."""
+    phase = _nonempty_str(entry.get("phase")) or "gate"
+    run_id = _nonempty_str(entry.get("run_id")) or "?"
+    parts = [f"{phase} decision pending {run_id}"]
+    remaining = _pending_remaining_text(entry)
+    if remaining:
+        parts.append(remaining)
+    options = entry.get("options")
+    opts = [o for o in options if isinstance(o, str) and o] if isinstance(options, list) else []
+    if opts:
+        shown = opts[:_DECISION_OPTION_PREVIEW]
+        extra = len(opts) - len(shown)
+        opts_str = "/".join(shown)
+        if extra > 0:
+            opts_str += f" +{extra} more"
+        parts.append(f"options: {opts_str}")
+    return "; ".join(parts)
+
+
 def _stage_and_detail_from_live_story(story: dict) -> tuple[str, str, str | None]:
     phase_val = story.get("phase")
     status_val = story.get("status", "waiting")
@@ -1073,6 +1192,15 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
         return None
 
     stories_data = data.get("stories", [])
+    # Read the pending checkpoints once per snapshot: a gate waiting on a person
+    # writes one, and it is the only live record of that wait (#2313).
+    pending_records = (
+        _live_pending_records(project_root)
+        if any(
+            isinstance(s, dict) and s.get("status") in _IN_FLIGHT_STATUSES for s in stories_data
+        )
+        else []
+    )
     entries = []
     seen_slugs: set[str] = set()
     for story in stories_data:
@@ -1090,6 +1218,14 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
             if last_phase_str:
                 phase_display = last_phase_str
         stage, detail, complexity = _stage_and_detail_from_live_story(story)
+        # A gate holding this story for a person outranks whatever the phase
+        # would otherwise render: the phase says what the story was doing, the
+        # checkpoint says what it is waiting for and who can clear it (#2313).
+        if status_val in _IN_FLIGHT_STATUSES and pending_records:
+            pending_entry = _select_pending_for_story(pending_records, slug)
+            if pending_entry is not None:
+                stage = OPERATOR_DECISION_STAGE
+                detail = _pending_decision_display(pending_entry)
         complexity_score = _normalize_complexity_score(story.get("complexity_score"))
 
         if status_val in {"skipped", "blocked", "operator-action"}:

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -630,7 +630,80 @@ def _pending_remaining_text(entry: dict) -> str:
     return "window elapsed — still awaiting decision"
 
 
-def _select_pending_for_story(pending: list[dict], slug: str) -> dict | None:
+def _run_identity(run_id: str, project_root: Path, state_path: Path) -> set[str]:
+    """Every run id that names the run whose live state is being displayed.
+
+    A sprint that re-execs keeps its work under a new run id while status may
+    still be queried under the old one, so both ends of the redirect chain — and
+    the stem of the state file actually resolved — identify the same run.
+    """
+    import json  # noqa: PLC0415
+
+    ids = {run_id, state_path.stem}
+    for candidate in (run_id, state_path.stem):
+        if candidate:
+            ids.add(_follow_redirect_chain(candidate, project_root))
+
+    # Walk the redirect chain backwards too: a re-exec'd sprint opened its gates
+    # under the run id it carried before the handoff, and that is still this run.
+    predecessors: dict[str, list[str]] = {}
+    try:
+        redirect_files = sorted((project_root / ".forge" / "runs").glob("*.redirect"))
+    except OSError:
+        redirect_files = []
+    for redirect_file in redirect_files:
+        try:
+            data = json.loads(redirect_file.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        new_id = data.get("new_run_id") if isinstance(data, dict) else None
+        if isinstance(new_id, str) and new_id:
+            predecessors.setdefault(new_id, []).append(redirect_file.stem)
+
+    frontier = list(ids)
+    while frontier:
+        current = frontier.pop()
+        for previous in predecessors.get(current, []):
+            if previous and previous not in ids:
+                ids.add(previous)
+                frontier.append(previous)
+
+    return {i for i in ids if i}
+
+
+def _pending_belongs_to_run(entry: dict, identity: set[str], project_root: Path) -> bool:
+    """True when ``entry`` is a checkpoint held by the run being displayed.
+
+    A checkpoint is named after the *story* run id, which two concurrently live
+    sprints working the same slug can share — so slug equality alone would show
+    one sprint's gate on the other's row, sending the operator to a decision
+    that is not theirs to make (#2313).
+    """
+    owner_run_id = _nonempty_str(entry.get("owner_run_id"))
+    if owner_run_id:
+        return owner_run_id in identity
+
+    # A checkpoint written before ``owner_run_id`` existed still identifies its
+    # process. If that PID is a different live run's, the gate is that run's.
+    try:
+        owner_pid = int(entry.get("pid"))
+    except (TypeError, ValueError):
+        return False
+    try:
+        from theforge.detach import find_run_id_for_pid  # noqa: PLC0415
+
+        other_run_id = find_run_id_for_pid(project_root, owner_pid)
+    except Exception:
+        return True
+    return not other_run_id or other_run_id in identity
+
+
+def _select_pending_for_story(
+    pending: list[dict],
+    slug: str,
+    identity: set[str],
+    project_root: Path,
+) -> dict | None:
     """Pick the live pending record a story row should display, if any."""
     if not slug:
         return None
@@ -640,6 +713,7 @@ def _select_pending_for_story(pending: list[dict], slug: str) -> dict | None:
         if isinstance(entry, dict)
         and _nonempty_str(entry.get("story")) == slug
         and _pending_entry_is_live(entry)
+        and _pending_belongs_to_run(entry, identity, project_root)
     ]
     if not candidates:
         return None
@@ -1194,13 +1268,11 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
     stories_data = data.get("stories", [])
     # Read the pending checkpoints once per snapshot: a gate waiting on a person
     # writes one, and it is the only live record of that wait (#2313).
-    pending_records = (
-        _live_pending_records(project_root)
-        if any(
-            isinstance(s, dict) and s.get("status") in _IN_FLIGHT_STATUSES for s in stories_data
-        )
-        else []
+    has_in_flight = any(
+        isinstance(s, dict) and s.get("status") in _IN_FLIGHT_STATUSES for s in stories_data
     )
+    pending_records = _live_pending_records(project_root) if has_in_flight else []
+    run_identity = _run_identity(run_id, project_root, state_path) if pending_records else set()
     entries = []
     seen_slugs: set[str] = set()
     for story in stories_data:
@@ -1222,7 +1294,9 @@ def read_live_status(run_id: str, project_root: Path) -> list[StoryStatusEntry] 
         # would otherwise render: the phase says what the story was doing, the
         # checkpoint says what it is waiting for and who can clear it (#2313).
         if status_val in _IN_FLIGHT_STATUSES and pending_records:
-            pending_entry = _select_pending_for_story(pending_records, slug)
+            pending_entry = _select_pending_for_story(
+                pending_records, slug, run_identity, project_root
+            )
             if pending_entry is not None:
                 stage = OPERATOR_DECISION_STAGE
                 detail = _pending_decision_display(pending_entry)

--- a/tests/test_sprint_escalate_gate_visibility.py
+++ b/tests/test_sprint_escalate_gate_visibility.py
@@ -1,0 +1,199 @@
+"""A story held at a gate that waits on a person must not read as a stall.
+
+Issue #2313: a story parked at the escalate gate emits no events while the
+coordinator polls its pending checkpoint, so the live view aged it out as
+``· stalled`` — the same signal as a hang. The information needed to say
+otherwise already exists on disk: ``.forge/pending/<run>.yaml`` carries the
+phase, the options and the deadline. These tests pin the seam that projects
+that record into live status and renders it as a deliberate wait.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from theforge import pending as pending_mod
+from theforge.cli import status_watch
+from theforge.sprint.state_writer import SprintStateWriter
+from theforge.sprint.status_reader import (
+    OPERATOR_DECISION_STAGE,
+    StoryStatusEntry,
+    read_live_status,
+)
+
+RUN_ID = "run-esc"
+STORY = "issue-2206"
+PENDING_RUN_ID = "b05817e579cd"
+OPTIONS = ["accept", "redirect", "defer"]
+
+
+def _live_state(tmp_path: Path, *, slugs: tuple[str, ...] = (STORY,)) -> SprintStateWriter:
+    """A live sprint state file with each slug running in REVIEW."""
+    (tmp_path / ".forge" / "runs").mkdir(parents=True, exist_ok=True)
+    writer = SprintStateWriter(RUN_ID, tmp_path, "sprint")
+    writer.init(
+        [{"slug": slug, "path": slug, "status": "running", "phase": "REVIEW"} for slug in slugs]
+    )
+    return writer
+
+
+def _write_pending(
+    tmp_path: Path,
+    *,
+    story: str = STORY,
+    run_id: str = PENDING_RUN_ID,
+    timeout_seconds: int = 900,
+    phase: str = "ESCALATE",
+) -> Path:
+    return pending_mod.write_pending(
+        run_id=run_id,
+        story=story,
+        phase=phase,
+        reason="ESCALATION — advisory report unavailable; select an action.",
+        options=OPTIONS,
+        timeout_seconds=timeout_seconds,
+        project_root=tmp_path,
+    )
+
+
+def _patch_pending_file(path: Path, **fields: object) -> None:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    data.update(fields)
+    path.write_text(yaml.safe_dump(data, default_flow_style=False), encoding="utf-8")
+
+
+def _frame(tmp_path: Path, entries: list[StoryStatusEntry], *, age_seconds: float) -> str:
+    state: dict = {"costs": {}, "interval": 2.0}
+    with (
+        patch("theforge.cli.sprint_status.display_sprint_status", return_value=0),
+        patch("theforge.sprint.status_reader.read_live_status", return_value=entries),
+        patch.object(status_watch, "_last_audit_mtime", return_value=1000.0),
+    ):
+        text, _ok, _err = status_watch.render_frame(
+            RUN_ID,
+            tmp_path,
+            state,
+            frame_idx=0,
+            color=False,
+            now_fn=lambda: 1000.0 + age_seconds,
+        )
+    return text
+
+
+class TestPendingDecisionInLiveStatus:
+    """`.forge/pending/*.yaml` → read_live_status stage/detail."""
+
+    def test_reports_an_operator_decision_stage_with_remaining_time(self, tmp_path: Path) -> None:
+        _live_state(tmp_path)
+        _write_pending(tmp_path)
+
+        entry = next(e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY)
+
+        # Still running: the wait is inside the story, not a separate outcome.
+        assert entry.status == "running"
+        assert entry.stage == OPERATOR_DECISION_STAGE
+        # Enough to act on without opening a log: which checkpoint, which gate,
+        # how long is left, and what may be chosen.
+        assert PENDING_RUN_ID in entry.detail
+        assert "ESCALATE" in entry.detail
+        assert "remaining" in entry.detail
+        assert "accept" in entry.detail
+
+    def test_expired_window_still_reads_as_awaiting_a_decision(self, tmp_path: Path) -> None:
+        # The escalate gate preserves a lapsed checkpoint rather than
+        # auto-rejecting, so an elapsed window still needs the operator.
+        _live_state(tmp_path)
+        _write_pending(tmp_path, timeout_seconds=-60)
+
+        entry = next(e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY)
+
+        assert entry.stage == OPERATOR_DECISION_STAGE
+        assert "awaiting decision" in entry.detail
+
+    def test_decided_checkpoint_is_not_shown_as_pending(self, tmp_path: Path) -> None:
+        _live_state(tmp_path)
+        path = _write_pending(tmp_path)
+        _patch_pending_file(path, decision="accept")
+
+        entry = next(e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY)
+
+        assert entry.stage != OPERATOR_DECISION_STAGE
+
+    def test_checkpoint_owned_by_a_dead_process_is_not_shown_as_pending(
+        self, tmp_path: Path
+    ) -> None:
+        _live_state(tmp_path)
+        path = _write_pending(tmp_path)
+        with patch("theforge.pid._is_pid_alive", return_value=False):
+            entry = next(e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY)
+        assert entry.stage != OPERATOR_DECISION_STAGE
+
+        # Same file, live owner — proves the filter is the PID and nothing else.
+        _patch_pending_file(path, pid=os.getpid())
+        entry = next(e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY)
+        assert entry.stage == OPERATOR_DECISION_STAGE
+
+    def test_a_checkpoint_never_leaks_onto_another_story(self, tmp_path: Path) -> None:
+        _live_state(tmp_path, slugs=(STORY, "issue-999"))
+        _write_pending(tmp_path)
+
+        entries = {e.slug: e for e in read_live_status(RUN_ID, tmp_path) or []}
+
+        assert entries[STORY].stage == OPERATOR_DECISION_STAGE
+        assert entries["issue-999"].stage != OPERATOR_DECISION_STAGE
+
+    def test_escalate_checkpoint_wins_over_another_gate_for_the_same_story(
+        self, tmp_path: Path
+    ) -> None:
+        _live_state(tmp_path)
+        _write_pending(tmp_path, run_id="older-plan", phase="PLAN_REVIEW")
+        _write_pending(tmp_path)
+
+        entry = next(e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY)
+
+        assert entry.stage == OPERATOR_DECISION_STAGE
+        assert PENDING_RUN_ID in entry.detail
+
+
+class TestWatchRendersPendingDecisions:
+    """read_live_status → status_watch.render_frame."""
+
+    def test_stale_story_awaiting_a_decision_is_not_rendered_as_stalled(
+        self, tmp_path: Path
+    ) -> None:
+        _live_state(tmp_path)
+        _write_pending(tmp_path)
+        entries = [e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY]
+
+        # 46 minutes past the last event — the age from the reported incident.
+        text = _frame(tmp_path, entries, age_seconds=46 * 60)
+
+        assert "stalled" not in text
+        assert "decision" in text
+        # The operator learns what is pending and how long is left without
+        # opening a log, plus how to resolve it.
+        assert "Awaiting operator decision" in text
+        assert "remaining" in text
+        assert PENDING_RUN_ID in text
+        assert "forge decide" in text
+        # The event age stays visible; only the warning framing is dropped.
+        assert "46m00s" in text
+
+    def test_ordinary_stale_running_story_still_reports_stalled(self, tmp_path: Path) -> None:
+        entry = StoryStatusEntry(
+            slug="story-c",
+            path="story-c",
+            status="running",
+            phase="DEV",
+            cost_usd=0.0,
+        )
+
+        text = _frame(tmp_path, [entry], age_seconds=46 * 60)
+
+        assert "stalled" in text
+        assert "Hint:" in text
+        assert "Awaiting operator decision" not in text

--- a/tests/test_sprint_escalate_gate_visibility.py
+++ b/tests/test_sprint_escalate_gate_visibility.py
@@ -31,10 +31,15 @@ PENDING_RUN_ID = "b05817e579cd"
 OPTIONS = ["accept", "redirect", "defer"]
 
 
-def _live_state(tmp_path: Path, *, slugs: tuple[str, ...] = (STORY,)) -> SprintStateWriter:
+def _live_state(
+    tmp_path: Path,
+    *,
+    slugs: tuple[str, ...] = (STORY,),
+    run_id: str = RUN_ID,
+) -> SprintStateWriter:
     """A live sprint state file with each slug running in REVIEW."""
     (tmp_path / ".forge" / "runs").mkdir(parents=True, exist_ok=True)
-    writer = SprintStateWriter(RUN_ID, tmp_path, "sprint")
+    writer = SprintStateWriter(run_id, tmp_path, "sprint")
     writer.init(
         [{"slug": slug, "path": slug, "status": "running", "phase": "REVIEW"} for slug in slugs]
     )
@@ -48,16 +53,34 @@ def _write_pending(
     run_id: str = PENDING_RUN_ID,
     timeout_seconds: int = 900,
     phase: str = "ESCALATE",
+    owner_run_id: str | None = RUN_ID,
 ) -> Path:
-    return pending_mod.write_pending(
-        run_id=run_id,
-        story=story,
-        phase=phase,
-        reason="ESCALATION — advisory report unavailable; select an action.",
-        options=OPTIONS,
-        timeout_seconds=timeout_seconds,
-        project_root=tmp_path,
-    )
+    """Write a checkpoint as the sprint process would.
+
+    ``owner_run_id`` is what ``detach.export_run_context`` publishes into the
+    environment of the run holding the gate; ``None`` writes the pre-#2313
+    record shape that carries no owning run at all.
+    """
+    env = {"FORGE_DETACHED_RUN_ID": owner_run_id} if owner_run_id else {}
+    with patch.dict(os.environ, env, clear=False):
+        if not owner_run_id:
+            os.environ.pop("FORGE_DETACHED_RUN_ID", None)
+        return pending_mod.write_pending(
+            run_id=run_id,
+            story=story,
+            phase=phase,
+            reason="ESCALATION — advisory report unavailable; select an action.",
+            options=OPTIONS,
+            timeout_seconds=timeout_seconds,
+            project_root=tmp_path,
+        )
+
+
+def _write_pid_file(tmp_path: Path, run_id: str, pid: int, slug: str = "sprint") -> None:
+    """Register ``run_id`` as the live run owned by ``pid``."""
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / f"{run_id}.pid").write_text(f"{pid}\n{slug}\n", encoding="utf-8")
 
 
 def _patch_pending_file(path: Path, **fields: object) -> None:
@@ -159,6 +182,71 @@ class TestPendingDecisionInLiveStatus:
         assert PENDING_RUN_ID in entry.detail
 
 
+class TestPendingDecisionIsScopedToItsRun:
+    """A checkpoint belongs to the run that opened it, not to a matching slug.
+
+    Two sprints can be live on the same story slug (a re-run alongside the
+    original, a second project checkout). Showing one run's gate on the other's
+    row points the operator at a decision that is not theirs and hands them
+    another run's id to resolve it with (#2313).
+    """
+
+    OTHER_RUN = "run-other"
+
+    def _two_live_runs(self, tmp_path: Path) -> None:
+        _live_state(tmp_path, run_id=RUN_ID)
+        _live_state(tmp_path, run_id=self.OTHER_RUN)
+
+    def test_only_the_owning_run_shows_the_pending_decision(self, tmp_path: Path) -> None:
+        self._two_live_runs(tmp_path)
+        _write_pending(tmp_path, owner_run_id=RUN_ID)
+
+        owner = next(e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY)
+        bystander = next(
+            e for e in read_live_status(self.OTHER_RUN, tmp_path) or [] if e.slug == STORY
+        )
+
+        assert owner.stage == OPERATOR_DECISION_STAGE
+        assert bystander.stage != OPERATOR_DECISION_STAGE
+        assert PENDING_RUN_ID not in bystander.detail
+
+    def test_a_legacy_record_owned_by_another_live_run_is_not_shown(self, tmp_path: Path) -> None:
+        # Written before owner_run_id existed: the owning PID is the only
+        # identity it carries, and that PID is the other run's sprint process.
+        self._two_live_runs(tmp_path)
+        _write_pending(tmp_path, owner_run_id=None)
+        _write_pid_file(tmp_path, self.OTHER_RUN, os.getpid())
+
+        entry = next(e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY)
+
+        assert entry.stage != OPERATOR_DECISION_STAGE
+
+    def test_a_legacy_record_owned_by_this_run_is_still_shown(self, tmp_path: Path) -> None:
+        self._two_live_runs(tmp_path)
+        _write_pending(tmp_path, owner_run_id=None)
+        _write_pid_file(tmp_path, RUN_ID, os.getpid())
+
+        entry = next(e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY)
+
+        assert entry.stage == OPERATOR_DECISION_STAGE
+
+    def test_a_reexeced_run_still_owns_the_checkpoint_it_opened(self, tmp_path: Path) -> None:
+        # The sprint opened the gate under its pre-re-exec run id; status is
+        # queried under the successor. Both name the same run.
+        _live_state(tmp_path, run_id="run-successor")
+        (tmp_path / ".forge" / "runs" / f"{RUN_ID}.redirect").write_text(
+            '{"new_run_id": "run-successor"}', encoding="utf-8"
+        )
+        _write_pending(tmp_path, owner_run_id=RUN_ID)
+
+        # The successor's rows still own the gate its predecessor opened.
+        entry = next(
+            e for e in read_live_status("run-successor", tmp_path) or [] if e.slug == STORY
+        )
+        assert entry.stage == OPERATOR_DECISION_STAGE
+        assert PENDING_RUN_ID in entry.detail
+
+
 class TestWatchRendersPendingDecisions:
     """read_live_status → status_watch.render_frame."""
 
@@ -182,6 +270,20 @@ class TestWatchRendersPendingDecisions:
         assert "forge decide" in text
         # The event age stays visible; only the warning framing is dropped.
         assert "46m00s" in text
+
+    def test_a_non_escalate_gate_renders_the_same_way(self, tmp_path: Path) -> None:
+        # The stage is about "a gate is waiting on a person", not about which
+        # gate — a human-review checkpoint must read the same in the view.
+        _live_state(tmp_path)
+        _write_pending(tmp_path, run_id="hr-checkpoint", phase="HUMAN_REVIEW")
+        entries = [e for e in read_live_status(RUN_ID, tmp_path) or [] if e.slug == STORY]
+
+        text = _frame(tmp_path, entries, age_seconds=46 * 60)
+
+        assert "stalled" not in text
+        assert "Awaiting operator decision" in text
+        assert "HUMAN_REVIEW" in text
+        assert "hr-checkpoint" in text
 
     def test_ordinary_stale_running_story_still_reports_stalled(self, tmp_path: Path) -> None:
         entry = StoryStatusEntry(


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The pending-decision status path satisfies the spec, the prior cross-run P1 is fixed, and targeted tests passed. | [deepseek-deepseek-reasoner-api] The escalate-gate wait is now surfaced as a distinct operator-decision state with remaining time, options and a resolve hint; the prior P1 cross-run mis-attribution is fixed via owner_run_id plus run-identity scoping, and all 13 targeted tests plus 257 neighbouring status/pending tests pass. | [google-gemini-3.5-flash-api] Approved: Pending decisions are properly scoped and rendered as waits rather than stalls, and the cross-run leakage P1 has been successfully resolved.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, openai-gpt-5.6-luna-api, anthropic-claude-haiku-4-5-cli, deepseek-deepseek-reasoner-api, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-api, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-api
- **Cost:** $13.49
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

A story waiting at the escalate gate is displayed as stalled, so the wait expires without the operator knowing it was asked (GitHub Issue #2313)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2313