### PR TITLE
A single unmeasured agent call makes a story permanently unrunnable with no path that clears or accepts it

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -558,6 +558,13 @@ derivable ceiling: it is refused with the reason logged and the guard stays
 closed, because accepting an unbounded unknown would defeat the measurement it
 stands in for.
 
+An acceptance covers the **occurrence** it was made for — one recorded call, at
+one recorded ceiling, in one recorded run — not the story. If the same story
+runs again and *again* finishes with cost unmeasured, that is a second unknown
+nobody has bounded, and the guard closes on it exactly as it did the first time.
+A story that keeps needing acceptance is telling you its transport or provider
+is not reporting cost; fix that rather than re-accepting.
+
 ---
 
 ### Large diffs degrade quality

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -561,9 +561,15 @@ stands in for.
 An acceptance covers the **occurrence** it was made for — one recorded call, at
 one recorded ceiling, in one recorded run — not the story. If the same story
 runs again and *again* finishes with cost unmeasured, that is a second unknown
-nobody has bounded, and the guard closes on it exactly as it did the first time.
-A story that keeps needing acceptance is telling you its transport or provider
-is not reporting cost; fix that rather than re-accepting.
+nobody has bounded, and the guard closes on it exactly as it did the first time,
+on that run and on every later resume. A story that keeps needing acceptance is
+telling you its transport or provider is not reporting cost; fix that rather
+than re-accepting.
+
+You never accept `carried:prior-generation`. That entry is derived — it says
+only that *some* source the previous generation named went unmeasured — so it
+has no origin and no ceiling of its own. Accept the named sources beside it and
+it goes away.
 
 ---
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -519,9 +519,44 @@ total it knows is understated (#1992). One unmeasured story is enough, which
 is why the failure hides: single-story runs don't aggregate against a sprint
 cap, so they pass (#2215).
 
-**Fix:** The halt message names the unmeasured source(s). Check their
-per-story audit records under `.forge/audits/runs/` to see why cost went
-unrecorded, then diagnose that story's run.
+**Fix:** The halt message names the unmeasured source(s) and, for each, the
+measured lower bound, the most it could still have cost, and the call it came
+from (`run_id`, phase, role, profile, failure code). Check the per-story audit
+under `.forge/audits/runs/` to see why cost went unrecorded, then diagnose that
+story's run.
+
+**When the condition is stuck:** an unmeasured source is carried into every
+later run of the same sprint, so a story whose reviewer died on (say) a provider
+quota error stays unrunnable — the refusal happens after its reuse gate has
+already passed. When the unknown is bounded, resolve it deliberately:
+
+```bash
+forge sprint sprint.yaml --resume --accept-unmeasured-spend issue-2206 \
+  --accept-unmeasured-reason "reviewer hit a provider quota"
+```
+
+The source id is the one printed in the refusal; `issue-2206` and
+`carried:issue-2206` name the same work. Acceptance charges the source's
+recorded ceiling (the story's allocation, less what was measured) to the budget
+comparison in place of the unknown — so it never buys headroom, and a sprint
+that is genuinely near its cap still stops. It also never relabels the cost as
+measured: `cost_complete` stays `false` and the sprint total stays a lower
+bound.
+
+Inspect the result in `.forge/audits/sprint-audit.yaml` under `sprint:`:
+
+- `unresolved_unmeasured_spend_sources` — what the guard is still refusing on
+- `accepted_unmeasured_spend` — each acceptance with its ceiling, origin
+  (`origin_run_id`, `origin_phase`, `origin_role`, `origin_profile`,
+  `origin_failure_code`), timestamp and reason
+- `budget_verification_spend_usd` — measured spend plus every accepted ceiling;
+  the figure the cap was actually verified against
+
+The resolution is persisted per sprint, so a later `--resume` reads it rather
+than needing the flag again. A source with no recorded allocation has no
+derivable ceiling: it is refused with the reason logged and the guard stays
+closed, because accepting an unbounded unknown would defeat the measurement it
+stands in for.
 
 ---
 

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -244,6 +244,8 @@ def _cmd_sprint(args: object) -> int:
     dry_run = getattr(args, "dry_run", False)
     max_parallel: int | None = getattr(args, "parallel", None)
     force = getattr(args, "force", False)
+    accept_unmeasured_spend = list(getattr(args, "accept_unmeasured_spend", None) or [])
+    accept_unmeasured_reason = getattr(args, "accept_unmeasured_reason", None)
 
     # ── Query mode: fetch issues and build ResolvedSprint ───────────────
     if query_mode:
@@ -263,6 +265,8 @@ def _cmd_sprint(args: object) -> int:
             reexec=reexec,
             no_pull=no_pull,
             force=force,
+            accept_unmeasured_spend=accept_unmeasured_spend,
+            accept_unmeasured_reason=accept_unmeasured_reason,
             _daemon=_daemon,
             _detach=_detach,
             _generate_run_id=_generate_run_id,
@@ -345,6 +349,8 @@ def _cmd_sprint(args: object) -> int:
             "config": str(config_path),
             "no_pull": no_pull,
             "force": force,
+            "accept_unmeasured_spend": accept_unmeasured_spend,
+            "accept_unmeasured_reason": accept_unmeasured_reason,
         }
         response = _daemon.submit_sprint(config.project_root, str(manifest_path), sprint_args)
         if response.get("ok"):
@@ -379,6 +385,8 @@ def _cmd_sprint(args: object) -> int:
             force=force,
             live_story_slugs=set(liveness.live_slugs),
             unresolved_live_slugs=set(liveness.unresolved_slugs),
+            accept_unmeasured_spend=accept_unmeasured_spend,
+            accept_unmeasured_reason=accept_unmeasured_reason,
         )
     except KeyboardInterrupt:
         # Ctrl-C is a deliberate termination, not a crash — record it as such
@@ -883,6 +891,8 @@ def _run_query_mode(
     no_pull: bool,
     force: bool = False,
     reexec: bool = False,
+    accept_unmeasured_spend: list[str] | None = None,
+    accept_unmeasured_reason: str | None = None,
     _daemon: object,
     _detach: object,
     _generate_run_id: object,
@@ -1279,6 +1289,8 @@ def _run_query_mode(
             force=force,
             live_story_slugs=set(liveness.live_slugs),
             unresolved_live_slugs=set(liveness.unresolved_slugs),
+            accept_unmeasured_spend=accept_unmeasured_spend or [],
+            accept_unmeasured_reason=accept_unmeasured_reason,
         )
     except KeyboardInterrupt:
         # Ctrl-C is a deliberate termination, not a crash — record it as such
@@ -1425,4 +1437,30 @@ def register_parser(subparsers: object) -> None:
             "of needs-grooming labels or local shape check results. Emits a "
             "prominent warning listing every skipped issue's reason codes."
         ),
+    )
+    sprint_parser.add_argument(
+        "--accept-unmeasured-spend",
+        metavar="SOURCE",
+        action="append",
+        default=None,
+        help=(
+            "Accept one unmeasured-spend source by id (repeatable). A story "
+            "whose agent call exited without reporting cost makes the sprint "
+            "total a lower bound, and the budget guard then refuses to certify "
+            "a cap it cannot evaluate. Naming the source here charges its "
+            "recorded ceiling to budget verification in place of the unknown, "
+            "so the story runs again. The source id is the one printed in the "
+            "'budget unverifiable' refusal (e.g. issue-2206 or "
+            "carried:issue-2206 — both name the same work). A source with no "
+            "derivable ceiling is refused and the guard stays closed. The "
+            "resolution is recorded in sprint-audit.yaml under "
+            "sprint.accepted_unmeasured_spend; the cost stays reported as "
+            "unmeasured."
+        ),
+    )
+    sprint_parser.add_argument(
+        "--accept-unmeasured-reason",
+        metavar="TEXT",
+        default=None,
+        help="Reason recorded alongside each --accept-unmeasured-spend acceptance",
     )

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -1452,10 +1452,12 @@ def register_parser(subparsers: object) -> None:
             "so the story runs again. The source id is the one printed in the "
             "'budget unverifiable' refusal (e.g. issue-2206 or "
             "carried:issue-2206 — both name the same work). A source with no "
-            "derivable ceiling is refused and the guard stays closed. The "
-            "resolution is recorded in sprint-audit.yaml under "
-            "sprint.accepted_unmeasured_spend; the cost stays reported as "
-            "unmeasured."
+            "derivable ceiling is refused and the guard stays closed. An "
+            "acceptance resolves the recorded occurrence, not the story: if "
+            "that story goes unmeasured again it is a new unknown and the guard "
+            "closes on it again. The resolution is recorded in "
+            "sprint-audit.yaml under sprint.accepted_unmeasured_spend; the cost "
+            "stays reported as unmeasured."
         ),
     )
     sprint_parser.add_argument(

--- a/src/theforge/daemon.py
+++ b/src/theforge/daemon.py
@@ -315,6 +315,11 @@ class DaemonServer:
                 state_update_fn=state_update_fn,
                 no_pull=args.get("no_pull", False),
                 force=args.get("force", False),
+                # Enumerated explicitly like every other kwarg here, so an
+                # operator acceptance submitted with --detach is not silently
+                # dropped on the way to the runner (#2310).
+                accept_unmeasured_spend=args.get("accept_unmeasured_spend") or [],
+                accept_unmeasured_reason=args.get("accept_unmeasured_reason"),
             )
         finally:
             release_story_locks(locked_fds)

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -112,6 +112,30 @@ def persist_accumulated_story_state(
         _save_accumulated_stories(sprint_id, sprint_name, project_root, stories)
 
 
+def persist_accepted_unmeasured_spend(
+    sprint_id: str | None,
+    sprint_name: str,
+    project_root: Path | None,
+    records: list[dict],
+) -> None:
+    """Persist operator acceptances of unmeasured spend, keeping stories intact.
+
+    Written on its own rather than through the story-state path so a resolution
+    an operator made once survives every later run of the sprint without the
+    flag being repeated (#2310) — and so the story writer, which knows nothing
+    about acceptances, cannot erase one by omission.
+    """
+    if not sprint_id or not project_root:
+        return
+    _save_accumulated_stories(
+        sprint_id,
+        sprint_name,
+        project_root,
+        _load_accumulated_stories(sprint_id, project_root),
+        accepted_unmeasured_spend=list(records),
+    )
+
+
 if TYPE_CHECKING:
     from ..config import ForgeConfig
     from ..coordinator.state import CoordinatorResult, CoordinatorState
@@ -307,18 +331,44 @@ def _load_accumulated_stories(sprint_id: str, project_root: Path) -> list[dict]:
         return []
 
 
+def _load_accepted_unmeasured_spend(sprint_id: str, project_root: Path) -> list[dict]:
+    """Load operator acceptances of unmeasured spend for a sprint.
+
+    Persisted alongside the accumulated stories because that is where the
+    carried unmeasured sources come from: one read gives both what is unpriced
+    and what has already been resolved about it (#2310).
+    """
+    state_path = project_root / ".forge" / "sprints" / sprint_id / "state.yaml"
+    if not state_path.exists():
+        return []
+    try:
+        with open(state_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        records = data.get("accepted_unmeasured_spend") or []
+        return [r for r in records if isinstance(r, dict)]
+    except Exception:
+        return []
+
+
 def _save_accumulated_stories(
     sprint_id: str,
     sprint_name: str,
     project_root: Path,
     stories: list[dict],
+    accepted_unmeasured_spend: list[dict] | None = None,
 ) -> None:
     """Save story entries to .forge/sprints/<sprint_id>/state.yaml.
 
     Each entry should have a ``canonical_ref`` field for cross-run matching.
     Writes atomically via a temp file.
+
+    ``accepted_unmeasured_spend`` of ``None`` carries the persisted acceptances
+    forward unchanged: a caller that has nothing to say about them must not
+    silently erase a resolution the operator made.
     """
     state_dir = project_root / ".forge" / "sprints" / sprint_id
+    if accepted_unmeasured_spend is None:
+        accepted_unmeasured_spend = _load_accepted_unmeasured_spend(sprint_id, project_root)
     try:
         state_dir.mkdir(parents=True, exist_ok=True)
         state_path = state_dir / "state.yaml"
@@ -327,6 +377,7 @@ def _save_accumulated_stories(
             "sprint_id": sprint_id,
             "sprint_name": sprint_name,
             "stories": stories,
+            "accepted_unmeasured_spend": list(accepted_unmeasured_spend),
         }
         with open(tmp_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
@@ -792,6 +843,20 @@ def _write_sprint_audit(
             "unmeasured_spend_sources": list(
                 getattr(result, "unmeasured_spend_sources", ()) or []
             ),
+            # Of those, the ones no operator has resolved — the list the budget
+            # guard actually refuses on — beside the acceptances standing in for
+            # the rest and the figure the cap was verified against (#2310).
+            # Kept distinct from ``unmeasured_spend_sources`` so an acceptance is
+            # never mistaken for a measurement.
+            "unresolved_unmeasured_spend_sources": list(
+                getattr(result, "unresolved_unmeasured_spend_sources", ()) or []
+            ),
+            "accepted_unmeasured_spend": [
+                dict(r) for r in (getattr(result, "accepted_unmeasured_spend", ()) or [])
+            ],
+            "budget_verification_spend_usd": round(
+                float(getattr(result, "budget_verification_spend_usd", 0.0) or 0.0), 4
+            ),
             "budget_note": "Costs reflect Claude invocations only; Codex/Gemini report $0.00",
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -1246,6 +1311,18 @@ def _write_sprint_summary(
             "total_cost_measured_usd": effective_cost_usd,
             "cost_complete": effective_cost_complete,
             "unmeasured_spend_sources": _unmeasured_sources,
+            # See the audit writer: which unmeasured sources are still
+            # unresolved, which were accepted with a recorded ceiling and
+            # origin, and the figure the cap was verified against (#2310).
+            "unresolved_unmeasured_spend_sources": list(
+                getattr(result, "unresolved_unmeasured_spend_sources", ()) or []
+            ),
+            "accepted_unmeasured_spend": [
+                dict(r) for r in (getattr(result, "accepted_unmeasured_spend", ()) or [])
+            ],
+            "budget_verification_spend_usd": round(
+                float(getattr(result, "budget_verification_spend_usd", 0.0) or 0.0), 4
+            ),
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "duration_seconds": round(duration, 1),

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -117,17 +117,22 @@ def persist_accepted_unmeasured_spend(
     sprint_name: str,
     project_root: Path | None,
     records: list[dict],
-) -> None:
+) -> bool:
     """Persist operator acceptances of unmeasured spend, keeping stories intact.
 
     Written on its own rather than through the story-state path so a resolution
     an operator made once survives every later run of the sprint without the
     flag being repeated (#2310) — and so the story writer, which knows nothing
     about acceptances, cannot erase one by omission.
+
+    Returns whether the resolution actually reached disk. An acceptance that
+    exists only in memory is a decision the operator will have to make again
+    without being told, so the caller must report a failure rather than log the
+    acceptance as recorded.
     """
     if not sprint_id or not project_root:
-        return
-    _save_accumulated_stories(
+        return False
+    return _save_accumulated_stories(
         sprint_id,
         sprint_name,
         project_root,
@@ -356,11 +361,13 @@ def _save_accumulated_stories(
     project_root: Path,
     stories: list[dict],
     accepted_unmeasured_spend: list[dict] | None = None,
-) -> None:
+) -> bool:
     """Save story entries to .forge/sprints/<sprint_id>/state.yaml.
 
     Each entry should have a ``canonical_ref`` field for cross-run matching.
-    Writes atomically via a temp file.
+    Writes atomically via a temp file. Returns whether the write landed —
+    failure stays non-fatal for the story path, which can rebuild its state, but
+    a caller persisting something that only exists here has to be able to tell.
 
     ``accepted_unmeasured_spend`` of ``None`` carries the persisted acceptances
     forward unchanged: a caller that has nothing to say about them must not
@@ -382,8 +389,9 @@ def _save_accumulated_stories(
         with open(tmp_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
         tmp_path.replace(state_path)
+        return True
     except Exception:
-        pass
+        return False
 
 
 def _load_story_summary_entry_from_audit(

--- a/src/theforge/sprint/budget.py
+++ b/src/theforge/sprint/budget.py
@@ -13,11 +13,18 @@ the understatement correlates with which transport served a story — so the
 error is systematic, not noise (#1992). When any spend is unmeasured the check
 therefore fails closed: it refuses to dispatch further work rather than
 dispatch it against a number it knows is a lower bound.
+
+Failing closed is not the same as failing forever. An unmeasured source whose
+origin and ceiling are both recorded can be accepted by an operator, and the
+accepted ceiling is then charged to the comparison in place of the unknown
+(#2310) — the cap is still verified against a number that means what it says,
+and the number says "at most this much". Only sources with no such resolution
+keep the check closed.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 #: How many unmeasured sources to name in an operator-facing message before
@@ -63,42 +70,100 @@ def describe_unmeasured_spend(sources: Sequence[str]) -> str:
     return rendered
 
 
+def budget_verification_spend(
+    *,
+    accumulated_cost: float,
+    prior_cost: float,
+    accepted_unmeasured_ceiling_usd: float = 0.0,
+) -> float:
+    """The figure the cap is actually verified against.
+
+    Measured spend plus every accepted ceiling. It is deliberately not called a
+    total: the ceilings in it stand in for spend nobody measured, so it is an
+    upper bound on this sprint, not a statement of what it cost.
+    """
+    return round(prior_cost + accumulated_cost + max(0.0, accepted_unmeasured_ceiling_usd), 6)
+
+
 def evaluate_budget(
     *,
     accumulated_cost: float,
     prior_cost: float,
     budget_usd: float,
     unmeasured_spend: Sequence[str],
+    accepted_unmeasured_ceiling_usd: float = 0.0,
+    source_details: Mapping[str, str] | None = None,
 ) -> BudgetBlock | None:
     """Return the reason to stop dispatching, or ``None`` to proceed.
 
     ``unmeasured_spend`` names every source whose spend this sprint could not
-    measure (completed stories, intake remediation passes). It being non-empty
-    means ``accumulated_cost`` is a lower bound.
+    measure AND that no operator has resolved (completed stories, intake
+    remediation passes). It being non-empty means ``accumulated_cost`` is a
+    lower bound with no ceiling standing in for the remainder.
 
-    Exhaustion is checked first: when the measured lower bound alone already
-    meets the cap, that is a definite answer and stays worded exactly as before,
-    whether or not other spend was unmeasured. Otherwise, unmeasured spend makes
-    the comparison unanswerable and the sprint stops rather than launching more
-    work against a total it knows is understated.
+    ``accepted_unmeasured_ceiling_usd`` is the sum of the ceilings an operator
+    deliberately accepted for sources that WERE resolvable. It is charged to the
+    comparison exactly as if it had been spent, so accepting never buys
+    headroom — it converts an unanswerable comparison into a conservative one.
+
+    ``source_details`` maps a source id to a one-line description of its origin
+    and bound, so a refusal names the amount and where it came from rather than
+    reporting an opaque condition.
+
+    Exhaustion is checked first: when the verification figure already meets the
+    cap, that is a definite answer, whether or not other spend is unresolved.
+    Its wording is unchanged when nothing was accepted. Otherwise, unresolved
+    unmeasured spend makes the comparison unanswerable and the sprint stops
+    rather than launching more work against a total it knows is understated.
     """
+    accepted = max(0.0, accepted_unmeasured_ceiling_usd)
     cumulative = prior_cost + accumulated_cost
-    if cumulative >= budget_usd:
-        return BudgetBlock(
-            kind="exhausted",
-            detail=(
-                f"sprint ${accumulated_cost:.2f} + carried ${prior_cost:.2f} = "
-                f"${cumulative:.2f} >= ${budget_usd:.2f}"
-            ),
+    verification = budget_verification_spend(
+        accumulated_cost=accumulated_cost,
+        prior_cost=prior_cost,
+        accepted_unmeasured_ceiling_usd=accepted,
+    )
+    if verification >= budget_usd:
+        base = (
+            f"sprint ${accumulated_cost:.2f} + carried ${prior_cost:.2f} = "
+            f"${cumulative:.2f} >= ${budget_usd:.2f}"
         )
+        if accepted > 0.0:
+            base = (
+                f"sprint ${accumulated_cost:.2f} + carried ${prior_cost:.2f} + "
+                f"accepted unmeasured ceiling ${accepted:.2f} = "
+                f"${verification:.2f} >= ${budget_usd:.2f}"
+            )
+        return BudgetBlock(kind="exhausted", detail=base)
     if unmeasured_spend:
-        return BudgetBlock(
-            kind="unverifiable",
-            detail=(
-                f"spend unmeasured for {len(unmeasured_spend)} source(s) "
-                f"[{describe_unmeasured_spend(unmeasured_spend)}]; "
-                f"measured ${cumulative:.2f} of ${budget_usd:.2f} cap is a lower bound, "
-                "so the cap cannot be verified"
-            ),
+        detail = (
+            f"spend unmeasured for {len(unmeasured_spend)} source(s) "
+            f"[{describe_unmeasured_spend(unmeasured_spend)}]; "
+            f"measured ${cumulative:.2f} of ${budget_usd:.2f} cap is a lower bound, "
+            "so the cap cannot be verified"
         )
+        rendered = describe_source_origins(unmeasured_spend, source_details)
+        if rendered:
+            detail = f"{detail}; {rendered}"
+        return BudgetBlock(kind="unverifiable", detail=detail)
     return None
+
+
+def describe_source_origins(
+    sources: Sequence[str],
+    source_details: Mapping[str, str] | None,
+) -> str:
+    """Render per-source origin/ceiling detail for a refusal message.
+
+    A decision about accepting an unknown is only possible if the unknown is
+    bounded and attributed, so the refusal carries both — for the same sources
+    it names, under the same elision rule.
+    """
+    if not source_details:
+        return ""
+    lines = [
+        source_details[src] for src in sources[:_MAX_NAMED_SOURCES] if source_details.get(src)
+    ]
+    if not lines:
+        return ""
+    return "unresolved: " + "; ".join(lines)

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -67,6 +67,17 @@ class SprintResult:
     # passes). Recorded so an operator can trace WHICH work is unpriced rather
     # than only that the total is incomplete.
     unmeasured_spend_sources: tuple[str, ...] = ()
+    # The subset of ``unmeasured_spend_sources`` no operator has resolved. These
+    # are what keeps the budget check closed; the rest are accounted for by an
+    # accepted ceiling below (#2310).
+    unresolved_unmeasured_spend_sources: tuple[str, ...] = ()
+    # Serialized ``AcceptedUnmeasuredSpend`` records in force for this run: the
+    # source, its origin, and the ceiling charged in place of the unknown.
+    # Acceptance never relabels cost as measured — ``cost_complete`` stays False.
+    accepted_unmeasured_spend: tuple[dict, ...] = ()
+    # Measured spend plus every accepted ceiling: the figure the cap was
+    # verified against. Not a total — part of it stands in for unmeasured spend.
+    budget_verification_spend_usd: float = 0.0
     results: list[tuple[str, CoordinatorResult]] = field(default_factory=list)
     stopped_reason: str | None = None  # why sprint stopped early, if it did
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -58,6 +58,7 @@ from ..intake import (
 )
 from ..log_util import _log_line
 from ..task import BatchMember, TaskStory
+from . import unmeasured as unmeasured_spend_policy
 from .abnormal import (
     ABNORMAL_LAUNCH_GUARD_DROP,
     ABNORMAL_SHARED_INFRASTRUCTURE,
@@ -69,15 +70,17 @@ from .abnormal import (
 )
 from .audit import (
     _get_or_create_sprint_id,
+    _load_accepted_unmeasured_spend,
     _write_sprint_audit,
     _write_sprint_summary,
     _write_story_audit,
     load_prior_generation_story_audit,
+    persist_accepted_unmeasured_spend,
     persist_accumulated_story_state,
     write_live_story_audit,
 )
 from .auth_gate import enforce_sprint_auth_readiness
-from .budget import evaluate_budget
+from .budget import budget_verification_spend, evaluate_budget
 from .ci_checks import PrCheckState, poll_required_checks, required_pr_check_state
 from .collision import (
     batch_group_id,
@@ -130,6 +133,7 @@ from .story_state import (
     coerce_outcome,
     landing_failure_outcome,
 )
+from .unmeasured import AcceptedUnmeasuredSpend, UnmeasuredSource
 
 # CLI transports whose spend forge cannot measure at all, warned about up front.
 # `codex` left this set in #2019: `codex exec --json` reports a real token split
@@ -898,30 +902,60 @@ def _read_prior_sprint_cost(project_root: Path, sprint_id: str | None) -> float:
         return 0.0
 
 
-def _prior_sprint_cost_incomplete(project_root: Path, sprint_id: str | None) -> bool:
+def _prior_sprint_block(project_root: Path, sprint_id: str | None) -> dict:
+    """Return this sprint's block from sprint-audit.yaml, or ``{}``."""
+    if not sprint_id:
+        return {}
+    audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
+    if not audit_path.exists():
+        return {}
+    try:
+        with open(audit_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        sprint_block = data.get("sprint", {})
+        if not isinstance(sprint_block, dict):
+            return {}
+        if sprint_block.get("sprint_id") != sprint_id:
+            return {}
+        return sprint_block
+    except (OSError, yaml.YAMLError, AttributeError):
+        return {}
+
+
+def _prior_unmeasured_spend_sources(project_root: Path, sprint_id: str | None) -> list[str]:
+    """The sources the prior generation recorded as unmeasured, if any."""
+    recorded = _prior_sprint_block(project_root, sprint_id).get("unmeasured_spend_sources") or []
+    return [str(s) for s in recorded if s] if isinstance(recorded, list) else []
+
+
+def _prior_sprint_cost_incomplete(
+    project_root: Path,
+    sprint_id: str | None,
+    accepted: Mapping[str, AcceptedUnmeasuredSpend] | None = None,
+) -> bool:
     """Return True when the prior generation recorded an incomplete sprint cost.
 
     A carried total from a generation that could not measure all of its spend is
     itself a lower bound; the budget check must know that before enforcing a cap
     against it (#1992). Absent/unreadable records report False — the pre-#1992
     shape simply carries no completeness claim.
+
+    ``accepted`` clears the flag only when the prior generation NAMED what it
+    could not measure and every one of those sources has been accepted with a
+    recorded ceiling (#2310). An incomplete generation that named nothing keeps
+    the flag: there is no source there for an operator to have resolved, so the
+    whole-generation carry remains the honest statement.
     """
-    if not sprint_id:
+    sprint_block = _prior_sprint_block(project_root, sprint_id)
+    if sprint_block.get("cost_complete") is not False:
         return False
-    audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
-    if not audit_path.exists():
-        return False
-    try:
-        with open(audit_path, encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
-        sprint_block = data.get("sprint", {})
-        if not isinstance(sprint_block, dict):
+    if accepted:
+        recorded = sprint_block.get("unmeasured_spend_sources") or []
+        if isinstance(recorded, list) and unmeasured_spend_policy.all_sources_accepted(
+            [str(s) for s in recorded if s], accepted
+        ):
             return False
-        if sprint_block.get("sprint_id") != sprint_id:
-            return False
-        return sprint_block.get("cost_complete") is False
-    except (OSError, yaml.YAMLError, AttributeError):
-        return False
+    return True
 
 
 def _parse_accumulated_story_timestamp(value: object) -> datetime.datetime | None:
@@ -3215,6 +3249,8 @@ def run_sprint(
     force: bool = False,
     live_story_slugs: "set[str] | None" = None,
     unresolved_live_slugs: "set[str] | None" = None,
+    accept_unmeasured_spend: Sequence[str] | None = None,
+    accept_unmeasured_reason: str | None = None,
 ) -> SprintResult:
     """Run all stories in a sprint with optional concurrency.
 
@@ -3257,6 +3293,16 @@ def run_sprint(
             like ``live_story_slugs`` everywhere protection or deferral matters —
             an unresolved lookup is not evidence that no agent is running — but
             reported honestly as unresolved rather than as observed live work.
+        accept_unmeasured_spend: Unmeasured-spend source ids the operator has
+            deliberately accepted (``issue-2206`` or ``carried:issue-2206`` —
+            both name the same work). Each is resolved against the records the
+            failing run already wrote; one with no derivable ceiling is REFUSED
+            with the reason logged, and the budget guard stays closed on it. An
+            accepted source's ceiling is charged to budget verification in place
+            of the unknown, and the resolution is persisted so a later resume
+            reads it rather than requiring the flag again (#2310).
+        accept_unmeasured_reason: Free-text reason recorded on each acceptance
+            made by this invocation.
 
     Returns:
         SprintResult with per-story outcomes and aggregate stats.
@@ -3794,6 +3840,89 @@ def run_sprint(
                 canonical_ref=_prior.get("canonical_ref"),
                 detail=_prior_detail,
             )
+    # ── Operator resolutions of unmeasured spend (#2310) ─────────────────────
+    # A fail-closed guard that no action can satisfy is not a safety property;
+    # it is an absorbing state whose only exit is to stop using the pipeline for
+    # the story — the very outcome the guard exists to prevent. These records
+    # are the deliberate exit: each names one source, the origin of the call
+    # that went unpriced, and the ceiling charged in its place. Nothing here
+    # relabels unmeasured spend as measured — ``cost_complete`` stays False for
+    # it, and the accepted ceiling is charged to budget verification only.
+    _unmeasured_source_cache: dict[str, UnmeasuredSource] = {}
+
+    def _describe_unmeasured_source(raw: str) -> UnmeasuredSource:
+        """Resolve one raw source id to its origin and derivable ceiling."""
+        key = unmeasured_spend_policy.normalize_source_id(raw)
+        cached = _unmeasured_source_cache.get(key)
+        if cached is None:
+            _slug = unmeasured_spend_policy.source_slug(raw)
+            _story_audit = (
+                unmeasured_spend_policy.read_story_audit(config.project_root, resolved.name, _slug)
+                if _slug
+                else None
+            )
+            cached = unmeasured_spend_policy.build_source(raw, _story_audit)
+            _unmeasured_source_cache[key] = cached
+        return cached
+
+    accepted_unmeasured: dict[str, AcceptedUnmeasuredSpend] = {}
+    if _sprint_id is not None:
+        for _persisted in _load_accepted_unmeasured_spend(_sprint_id, config.project_root):
+            _restored = AcceptedUnmeasuredSpend.from_dict(_persisted)
+            if _restored is not None:
+                accepted_unmeasured[_restored.source] = _restored
+    _newly_accepted = False
+    if accept_unmeasured_spend:
+        # The set an operator could possibly be talking about: what this run has
+        # already flagged, plus what the prior generation recorded. Accepting a
+        # name outside it would record a resolution of nothing.
+        _known_sources = {unmeasured_spend_policy.normalize_source_id(s) for s in unmeasured_spend}
+        _known_sources.update(
+            unmeasured_spend_policy.normalize_source_id(s)
+            for s in _prior_unmeasured_spend_sources(config.project_root, _sprint_id)
+        )
+        _accepted_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        for _raw_accept in accept_unmeasured_spend:
+            _normalized = unmeasured_spend_policy.normalize_source_id(_raw_accept)
+            if not _normalized:
+                continue
+            if _normalized not in _known_sources:
+                _log(
+                    f"REFUSED --accept-unmeasured-spend {_raw_accept}: this sprint has no "
+                    f"unmeasured source by that name "
+                    f"(known: {', '.join(sorted(_known_sources)) or 'none'})"
+                )
+                continue
+            _source = _describe_unmeasured_source(_raw_accept)
+            _accepted = unmeasured_spend_policy.accept(
+                _source,
+                accepted_at=_accepted_at,
+                reason=accept_unmeasured_reason,
+            )
+            if _accepted is None:
+                _log(
+                    f"REFUSED --accept-unmeasured-spend {_raw_accept}: {_source.ceiling_reason}. "
+                    "The guard stays closed — accepting an unbounded unknown would defeat "
+                    "the measurement it stands in for."
+                )
+                continue
+            accepted_unmeasured[_accepted.source] = _accepted
+            _newly_accepted = True
+            _log(
+                f"Accepted unmeasured spend {_accepted.source}: charging "
+                f"${_accepted.accepted_ceiling_usd:.2f} to budget verification "
+                f"({_source.describe()})"
+            )
+    if _newly_accepted:
+        # Written before any dispatch: the resolution is what makes this run
+        # legal, so it must be on disk even if the run dies mid-sprint.
+        persist_accepted_unmeasured_spend(
+            _sprint_id,
+            resolved.name,
+            config.project_root,
+            [r.as_dict() for r in accepted_unmeasured.values()],
+        )
+
     _state_writer: SprintStateWriter | None = None
     stopped_reason: str | None = None
     ci_halt_slug: str | None = None
@@ -3839,9 +3968,12 @@ def run_sprint(
         )
         if prior_cost > 0.0:
             _log(f"Resuming with prior cost: ${prior_cost:.2f}")
-        if _prior_sprint_cost_incomplete(config.project_root, _sprint_id):
+        if _prior_sprint_cost_incomplete(config.project_root, _sprint_id, accepted_unmeasured):
             # The carried total came from a generation that recorded incomplete
-            # cost, so it is a lower bound too (#1992).
+            # cost, so it is a lower bound too (#1992) — unless every source that
+            # generation named has an accepted ceiling standing in for it, in
+            # which case the whole-generation carry has nothing left to say that
+            # the per-source records do not already say (#2310).
             unmeasured_spend.append("carried:prior-generation")
         if recovered_prior_started_at is not None and recovered_prior_started_at < started_at:
             started_at = recovered_prior_started_at
@@ -5812,12 +5944,31 @@ def run_sprint(
                     break
 
                 with cost_lock:
-                    _budget_decision = evaluate_budget(
-                        accumulated_cost=accumulated_cost,
-                        prior_cost=prior_cost,
-                        budget_usd=resolved.budget_usd,
-                        unmeasured_spend=list(unmeasured_spend),
+                    _budget_accumulated = accumulated_cost
+                    _budget_prior = prior_cost
+                    _budget_unresolved, _budget_applied = unmeasured_spend_policy.partition(
+                        list(unmeasured_spend), accepted_unmeasured
                     )
+                # Origin/ceiling lookup reads per-story audits, so it runs
+                # outside ``cost_lock`` — it is reporting, not accounting.
+                _budget_details = (
+                    {
+                        raw: _describe_unmeasured_source(raw).describe()
+                        for raw in _budget_unresolved
+                    }
+                    if _budget_unresolved
+                    else None
+                )
+                _budget_decision = evaluate_budget(
+                    accumulated_cost=_budget_accumulated,
+                    prior_cost=_budget_prior,
+                    budget_usd=resolved.budget_usd,
+                    unmeasured_spend=_budget_unresolved,
+                    accepted_unmeasured_ceiling_usd=unmeasured_spend_policy.accepted_ceiling_total(
+                        _budget_applied
+                    ),
+                    source_details=_budget_details,
+                )
                 if _budget_decision is not None:
                     dag.mark_skipped(task.slug)
                     _budget_reason = _budget_decision.story_reason
@@ -6728,6 +6879,19 @@ def run_sprint(
     _cost_complete = not unmeasured_spend and all(
         e.cost_usd is not None for e in _story_state.stories()
     )
+    # An acceptance resolves the BUDGET question, never the measurement one:
+    # ``_cost_complete`` above still reads the raw source list, so an accepted
+    # source keeps the sprint total reported as a lower bound. What acceptance
+    # changes is which figure the cap was verified against (#2310).
+    _final_unresolved, _final_accepted = unmeasured_spend_policy.partition(
+        list(unmeasured_spend), accepted_unmeasured
+    )
+    _final_accepted_ceiling = unmeasured_spend_policy.accepted_ceiling_total(_final_accepted)
+    _budget_verification_usd = budget_verification_spend(
+        accumulated_cost=accumulated_cost,
+        prior_cost=prior_cost,
+        accepted_unmeasured_ceiling_usd=_final_accepted_ceiling,
+    )
     # Banner, summary, notifications, and SprintResult all project from the
     # same canonical structure — by construction they cannot disagree.
     _canonical_counts = _story_state.counts()
@@ -6748,6 +6912,9 @@ def run_sprint(
         budget_usd=resolved.budget_usd,
         cost_complete=_cost_complete,
         unmeasured_spend_sources=tuple(unmeasured_spend),
+        unresolved_unmeasured_spend_sources=tuple(_final_unresolved),
+        accepted_unmeasured_spend=tuple(r.as_dict() for r in _final_accepted),
+        budget_verification_spend_usd=_budget_verification_usd,
         results=results,
         stopped_reason=stopped_reason,
     )

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -3706,13 +3706,26 @@ def run_sprint(
     # evaluate rather than dispatch more work against an understated total
     # (#1992). Guarded by ``cost_lock`` alongside ``accumulated_cost``.
     unmeasured_spend: list[str] = []
+    # The subset of ``unmeasured_spend`` this generation produced itself, as
+    # opposed to inherited under a ``carried:`` prefix. An operator acceptance
+    # stands in for one recorded call at one recorded ceiling; spend that
+    # happened HERE is a new unknown nobody has bounded, so it must never be
+    # absorbed by an acceptance made for an earlier occurrence of the same story
+    # (#2310). Guarded by ``cost_lock`` alongside ``unmeasured_spend``.
+    current_generation_unmeasured: set[str] = set()
+
+    def _flag_unmeasured_here(source: str) -> None:
+        """Record a source whose unmeasured spend occurred in THIS run."""
+        unmeasured_spend.append(source)
+        current_generation_unmeasured.add(source)
+
     # Entry-level intake remediation runs in the CLI before run_sprint and
     # spends the same sprint-authorized budget; fold its agent cost into
     # the sprint total so operator-visible accounting matches actual spend.
     if entry_intake_outcomes:
         for _issue_num, _entry_outcome in entry_intake_outcomes.items():
             if _intake_outcome_cost_measured(_entry_outcome) is None:
-                unmeasured_spend.append(f"entry-intake:issue-{_issue_num}")
+                _flag_unmeasured_here(f"entry-intake:issue-{_issue_num}")
         _entry_intake_cost = sum(_intake_outcome_cost(o) for o in entry_intake_outcomes.values())
         if _entry_intake_cost > 0.0:
             accumulated_cost += _entry_intake_cost
@@ -3916,12 +3929,22 @@ def run_sprint(
     if _newly_accepted:
         # Written before any dispatch: the resolution is what makes this run
         # legal, so it must be on disk even if the run dies mid-sprint.
-        persist_accepted_unmeasured_spend(
+        if not persist_accepted_unmeasured_spend(
             _sprint_id,
             resolved.name,
             config.project_root,
             [r.as_dict() for r in accepted_unmeasured.values()],
-        )
+        ):
+            # Reporting the acceptance as recorded when it is not would leave an
+            # operator to rediscover the same refusal with no idea they had
+            # already answered it. It still applies to this run — nothing was
+            # lost yet — but say plainly that it will not survive.
+            _log(
+                "WARNING: could not persist the unmeasured-spend acceptance to "
+                f"{config.project_root / '.forge' / 'sprints' / (_sprint_id or '?')}"
+                "/state.yaml — it applies to THIS run only and must be passed "
+                "again on the next one."
+            )
 
     _state_writer: SprintStateWriter | None = None
     stopped_reason: str | None = None
@@ -3968,13 +3991,36 @@ def run_sprint(
         )
         if prior_cost > 0.0:
             _log(f"Resuming with prior cost: ${prior_cost:.2f}")
-        if _prior_sprint_cost_incomplete(config.project_root, _sprint_id, accepted_unmeasured):
+        if _prior_sprint_cost_incomplete(config.project_root, _sprint_id):
             # The carried total came from a generation that recorded incomplete
-            # cost, so it is a lower bound too (#1992) — unless every source that
-            # generation named has an accepted ceiling standing in for it, in
-            # which case the whole-generation carry has nothing left to say that
-            # the per-source records do not already say (#2310).
-            unmeasured_spend.append("carried:prior-generation")
+            # cost, so it is a lower bound too (#1992). An accepted ceiling can
+            # stand in for it — but only per source, and only if the ledger
+            # actually carries that source. Clearing the whole-generation marker
+            # without re-surfacing what it stood for would let the acceptance
+            # open the guard while its ceiling was charged to nothing, under a
+            # cap the ceiling might not even fit (#2310 review).
+            _cleared_by_acceptance = not _prior_sprint_cost_incomplete(
+                config.project_root, _sprint_id, accepted_unmeasured
+            )
+            if _cleared_by_acceptance:
+                _carried_already = {
+                    unmeasured_spend_policy.normalize_source_id(s) for s in unmeasured_spend
+                }
+                for _prior_source in _prior_unmeasured_spend_sources(
+                    config.project_root, _sprint_id
+                ):
+                    _prior_norm = unmeasured_spend_policy.normalize_source_id(_prior_source)
+                    if not _prior_norm or _prior_norm in _carried_already:
+                        continue
+                    # Accepted, and nothing else in this run's ledger names it —
+                    # typically because the accumulated story row was pruned.
+                    # It is still spend this sprint carries, so it goes in the
+                    # ledger by name: its ceiling gets charged, the audit records
+                    # it, and the total stays a lower bound.
+                    unmeasured_spend.append(f"carried:{_prior_norm}")
+                    _carried_already.add(_prior_norm)
+            else:
+                unmeasured_spend.append("carried:prior-generation")
         if recovered_prior_started_at is not None and recovered_prior_started_at < started_at:
             started_at = recovered_prior_started_at
         _log("Triaging specs...")
@@ -4485,7 +4531,7 @@ def run_sprint(
     # excludes every dollar spent on intake auto-fix attempts.
     for _intake_slug, _intake_outcome in intake_outcomes.items():
         if _intake_outcome_cost_measured(_intake_outcome) is None:
-            unmeasured_spend.append(f"intake:{_intake_slug}")
+            _flag_unmeasured_here(f"intake:{_intake_slug}")
     _intake_remediation_cost = sum(_intake_outcome_cost(o) for o in intake_outcomes.values())
     if _intake_remediation_cost > 0.0:
         accumulated_cost += _intake_remediation_cost
@@ -5084,7 +5130,7 @@ def run_sprint(
                 if _recovered_stranded is not None:
                     _stranded_cost = _recovered_stranded
             if _stranded_cost is None:
-                unmeasured_spend.append(f"stranded-unmeasured:{slug}")
+                _flag_unmeasured_here(f"stranded-unmeasured:{slug}")
             _set_outcome(
                 slug,
                 StoryOutcome.DROPPED,
@@ -5141,7 +5187,7 @@ def run_sprint(
             _carried_cost = _attribute_prior_generation_cost(slug)
             if work_detail:
                 if _carried_cost is None:
-                    unmeasured_spend.append(f"dropped-with-work:{slug}")
+                    _flag_unmeasured_here(f"dropped-with-work:{slug}")
                 _set_outcome(
                     slug,
                     StoryOutcome.DROPPED,
@@ -5947,7 +5993,9 @@ def run_sprint(
                     _budget_accumulated = accumulated_cost
                     _budget_prior = prior_cost
                     _budget_unresolved, _budget_applied = unmeasured_spend_policy.partition(
-                        list(unmeasured_spend), accepted_unmeasured
+                        list(unmeasured_spend),
+                        accepted_unmeasured,
+                        current_generation=set(current_generation_unmeasured),
                     )
                 # Origin/ceiling lookup reads per-story audits, so it runs
                 # outside ``cost_lock`` — it is reporting, not accounting.
@@ -6506,7 +6554,7 @@ def run_sprint(
                     # spend. Record the shortfall alongside it so the dispatch
                     # check knows the running total is a lower bound (#1992).
                     if result.state.total_cost_measured is None:
-                        unmeasured_spend.append(slug)
+                        _flag_unmeasured_here(slug)
                     accumulated_cost += result.state.total_cost
 
                 spec_str = slug_to_spec[slug]
@@ -6884,7 +6932,9 @@ def run_sprint(
     # source keeps the sprint total reported as a lower bound. What acceptance
     # changes is which figure the cap was verified against (#2310).
     _final_unresolved, _final_accepted = unmeasured_spend_policy.partition(
-        list(unmeasured_spend), accepted_unmeasured
+        list(unmeasured_spend),
+        accepted_unmeasured,
+        current_generation=set(current_generation_unmeasured),
     )
     _final_accepted_ceiling = unmeasured_spend_policy.accepted_ceiling_total(_final_accepted)
     _budget_verification_usd = budget_verification_spend(

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -4003,14 +4003,21 @@ def run_sprint(
                 config.project_root, _sprint_id, accepted_unmeasured
             )
             if _cleared_by_acceptance:
+                # The marker itself is never re-surfaced. It is a derived
+                # statement that SOME source that generation named was
+                # unmeasured, so once every one of those sources is accepted it
+                # asserts nothing the per-source records do not already assert —
+                # and it has no origin, no ceiling and no accept path, so
+                # carrying it forward would refuse the run on a condition no
+                # operator action can satisfy (#2310 review). Only the named,
+                # acceptable sources come across.
                 _carried_already = {
                     unmeasured_spend_policy.normalize_source_id(s) for s in unmeasured_spend
                 }
-                for _prior_source in _prior_unmeasured_spend_sources(
-                    config.project_root, _sprint_id
+                for _prior_norm in unmeasured_spend_policy.acceptable_prior_sources(
+                    _prior_unmeasured_spend_sources(config.project_root, _sprint_id)
                 ):
-                    _prior_norm = unmeasured_spend_policy.normalize_source_id(_prior_source)
-                    if not _prior_norm or _prior_norm in _carried_already:
+                    if _prior_norm in _carried_already:
                         continue
                     # Accepted, and nothing else in this run's ledger names it —
                     # typically because the accumulated story row was pruned.
@@ -4049,6 +4056,19 @@ def run_sprint(
             _log(
                 f"  {triage.slug:<20} {triage.action.upper().replace('_', ' ')} ({triage.reason})"
             )
+
+    # Pin which run each inherited unmeasured source belongs to, BEFORE any story
+    # can rewrite its per-story audit. That file is the only durable record of a
+    # source's occurrence identity, and a story re-running here overwrites it —
+    # so read once, up front, or a source carried from run A would later be
+    # measured against run B's record and an acceptance the operator legitimately
+    # made would be silently discarded (#2310 review).
+    carried_occurrence_ids: dict[str, str | None] = {}
+    for _carried_raw in unmeasured_spend:
+        if _carried_raw in current_generation_unmeasured:
+            continue
+        _carried_origin = _describe_unmeasured_source(_carried_raw).origin
+        carried_occurrence_ids[_carried_raw] = _carried_origin.get("run_id")
 
     def _recorded_prior_done(slug: str, canonical_ref: str | None = None) -> bool:
         """True when this sprint already recorded the story as run-to-DONE.
@@ -5996,6 +6016,7 @@ def run_sprint(
                         list(unmeasured_spend),
                         accepted_unmeasured,
                         current_generation=set(current_generation_unmeasured),
+                        occurrence_ids=carried_occurrence_ids,
                     )
                 # Origin/ceiling lookup reads per-story audits, so it runs
                 # outside ``cost_lock`` — it is reporting, not accounting.
@@ -6935,6 +6956,7 @@ def run_sprint(
         list(unmeasured_spend),
         accepted_unmeasured,
         current_generation=set(current_generation_unmeasured),
+        occurrence_ids=carried_occurrence_ids,
     )
     _final_accepted_ceiling = unmeasured_spend_policy.accepted_ceiling_total(_final_accepted)
     _budget_verification_usd = budget_verification_spend(

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -3861,11 +3861,32 @@ def run_sprint(
     # that went unpriced, and the ceiling charged in its place. Nothing here
     # relabels unmeasured spend as measured — ``cost_complete`` stays False for
     # it, and the accepted ceiling is charged to budget verification only.
-    _unmeasured_source_cache: dict[str, UnmeasuredSource] = {}
+    #
+    # The cache is keyed by (occurrence, source), never by source alone. A story
+    # has ONE per-story audit, and running it again overwrites that file — so the
+    # carried occurrence and a new one produced here are two different records
+    # read from the same path at two different times. Keyed by source alone, the
+    # carried read wins and the refusal on the NEW unknown would name the old
+    # run's id and ceiling: an operator would go looking at a call they had
+    # already accepted, and the amount they were being asked about would be the
+    # wrong one (#2310 review).
+    _OCCURRENCE_CARRIED = "carried"
+    _OCCURRENCE_CURRENT = "current"
+    _unmeasured_source_cache: dict[tuple[str, str], UnmeasuredSource] = {}
 
-    def _describe_unmeasured_source(raw: str) -> UnmeasuredSource:
-        """Resolve one raw source id to its origin and derivable ceiling."""
-        key = unmeasured_spend_policy.normalize_source_id(raw)
+    def _describe_unmeasured_source(
+        raw: str, *, occurrence: str | None = None
+    ) -> UnmeasuredSource:
+        """Resolve one raw source id to its origin and derivable ceiling.
+
+        ``occurrence`` defaults to whichever bucket the source is in: one this
+        run produced reads the audit as it stands now, an inherited one reads it
+        as it stood before any story here could rewrite it.
+        """
+        _occurrence = occurrence or (
+            _OCCURRENCE_CURRENT if raw in current_generation_unmeasured else _OCCURRENCE_CARRIED
+        )
+        key = (_occurrence, unmeasured_spend_policy.normalize_source_id(raw))
         cached = _unmeasured_source_cache.get(key)
         if cached is None:
             _slug = unmeasured_spend_policy.source_slug(raw)
@@ -3906,7 +3927,10 @@ def run_sprint(
                     f"(known: {', '.join(sorted(_known_sources)) or 'none'})"
                 )
                 continue
-            _source = _describe_unmeasured_source(_raw_accept)
+            # An operator is always accepting an occurrence that has already been
+            # recorded, so this reads the audit as it stands before dispatch —
+            # never a record some story in this run is about to overwrite.
+            _source = _describe_unmeasured_source(_raw_accept, occurrence=_OCCURRENCE_CARRIED)
             _accepted = unmeasured_spend_policy.accept(
                 _source,
                 accepted_at=_accepted_at,
@@ -4067,7 +4091,9 @@ def run_sprint(
     for _carried_raw in unmeasured_spend:
         if _carried_raw in current_generation_unmeasured:
             continue
-        _carried_origin = _describe_unmeasured_source(_carried_raw).origin
+        _carried_origin = _describe_unmeasured_source(
+            _carried_raw, occurrence=_OCCURRENCE_CARRIED
+        ).origin
         carried_occurrence_ids[_carried_raw] = _carried_origin.get("run_id")
 
     def _recorded_prior_done(slug: str, canonical_ref: str | None = None) -> bool:

--- a/src/theforge/sprint/unmeasured.py
+++ b/src/theforge/sprint/unmeasured.py
@@ -350,7 +350,11 @@ def build_source(raw: str, story_audit: Mapping | None) -> UnmeasuredSource:
     """Describe one unmeasured source from the records that named it.
 
     Pure over ``story_audit`` so the derivation is testable without a sprint
-    tree; :func:`resolve_sources` supplies the record.
+    tree; :func:`read_story_audit` supplies the record. Deliberately describes
+    ONE record rather than a whole list: a story has one audit path, and the
+    caller — which knows whether it is reading a carried occurrence or one this
+    run just produced — is the only thing that can say which reading of that path
+    a description belongs to.
     """
     normalized = normalize_source_id(raw)
     origin = origin_from_story_audit(story_audit)
@@ -379,28 +383,6 @@ def build_source(raw: str, story_audit: Mapping | None) -> UnmeasuredSource:
         ceiling_basis=basis,
         ceiling_reason=reason,
     )
-
-
-def resolve_sources(
-    raw_sources: Sequence[str],
-    *,
-    project_root: Path,
-    sprint_name: str,
-) -> list[UnmeasuredSource]:
-    """Describe every raw unmeasured-spend source, deduplicated by identity."""
-    seen: set[str] = set()
-    resolved: list[UnmeasuredSource] = []
-    for raw in raw_sources:
-        normalized = normalize_source_id(raw)
-        if not normalized or normalized in seen:
-            continue
-        seen.add(normalized)
-        slug = source_slug(raw)
-        story_audit = (
-            read_story_audit(project_root, sprint_name, slug) if slug is not None else None
-        )
-        resolved.append(build_source(str(raw), story_audit))
-    return resolved
 
 
 def accept(

--- a/src/theforge/sprint/unmeasured.py
+++ b/src/theforge/sprint/unmeasured.py
@@ -15,6 +15,11 @@ cost as measured — ``cost_complete`` stays false and the measured total stays 
 lower bound. What acceptance changes is only which number the cap is verified
 against: the accepted ceiling is charged in place of an unknown.
 
+An acceptance also resolves one OCCURRENCE, not a story. It stands in for a
+specific recorded call, at a specific recorded ceiling, in a specific recorded
+run. If the same story goes unmeasured again, that is a second unknown nobody
+has bounded, and the guard closes on it again — see :func:`partition`.
+
 Pure and stdlib-only apart from one narrow YAML read of a per-story audit, so
 the policy is testable without a live sprint.
 """
@@ -420,16 +425,31 @@ def accept(
 def partition(
     raw_sources: Sequence[str],
     accepted: Mapping[str, AcceptedUnmeasuredSpend],
+    *,
+    current_generation: Iterable[str] = (),
 ) -> tuple[list[str], list[AcceptedUnmeasuredSpend]]:
     """Split raw sources into the unresolved ones and the acceptances in force.
 
     Only acceptances whose source actually appears in ``raw_sources`` are
     returned: a ceiling is charged for spend this run is carrying, never for a
     stale record of work it is not.
+
+    ``current_generation`` names the raw sources THIS run produced itself — a
+    story that completed unmeasured here, an intake pass that ran here. An
+    acceptance resolves the occurrence it was made for, not the story: it stands
+    in for one recorded call, at one recorded ceiling, in one recorded run. A
+    second unmeasured call is a second unknown, of an amount nobody has bounded
+    and nobody has accepted, so the guard closes on it exactly as it did the
+    first time. Without this an operator's one-time acceptance would silently
+    become a standing licence for that story to spend unmeasured forever.
     """
+    fresh = {str(s) for s in current_generation}
     unresolved: list[str] = []
     applied: dict[str, AcceptedUnmeasuredSpend] = {}
     for raw in raw_sources:
+        if str(raw) in fresh:
+            unresolved.append(str(raw))
+            continue
         normalized = normalize_source_id(raw)
         record = accepted.get(normalized)
         if record is None:

--- a/src/theforge/sprint/unmeasured.py
+++ b/src/theforge/sprint/unmeasured.py
@@ -31,15 +31,20 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 #: Prefix the runner stamps on spend inherited from an earlier generation of the
-#: same sprint. ``carried:issue-2206`` and ``issue-2206`` name the same work —
+#: same sprint. ``carried:issue-2206`` and ``issue-2206`` name the same STORY —
 #: the first is how a resume sees it, the second is how the generation that ran
-#: it did — so acceptance keys on the normalized form or a re-run that again
-#: completes unmeasured would re-block despite the recorded acceptance.
+#: it did — so acceptance is looked up on the normalized form. Which of that
+#: story's unmeasured calls a given entry stands for is a separate question, and
+#: is settled by occurrence identity rather than by the prefix (see
+#: :func:`partition`).
 CARRIED_PREFIX = "carried:"
 
 #: The whole-generation marker the resume path adds when the prior sprint audit
-#: recorded an incomplete cost. It is not a story, so it has no allocation of
-#: its own; it clears when every source that generation named has been accepted.
+#: recorded an incomplete cost. It is derived, not observed: it says only that
+#: SOME source that generation named went unmeasured. So it has no story, no
+#: allocation, no origin and no accept path, and it is never carried forward once
+#: every source it stood for has been accepted — see
+#: :func:`acceptable_prior_sources`.
 PRIOR_GENERATION_SOURCE = "prior-generation"
 
 #: Where a ceiling came from. Only ``derived`` bounds may be accepted.
@@ -427,6 +432,7 @@ def partition(
     accepted: Mapping[str, AcceptedUnmeasuredSpend],
     *,
     current_generation: Iterable[str] = (),
+    occurrence_ids: Mapping[str, str | None] | None = None,
 ) -> tuple[list[str], list[AcceptedUnmeasuredSpend]]:
     """Split raw sources into the unresolved ones and the acceptances in force.
 
@@ -434,16 +440,31 @@ def partition(
     returned: a ceiling is charged for spend this run is carrying, never for a
     stale record of work it is not.
 
+    An acceptance resolves the OCCURRENCE it was made for, not the story: it
+    stands in for one recorded call, at one recorded ceiling, in one recorded
+    run. A second unmeasured call is a second unknown, of an amount nobody has
+    bounded and nobody has accepted, so the guard closes on it exactly as it did
+    the first time. Without this an operator's one-time acceptance would
+    silently become a standing licence for that story to spend unmeasured
+    forever. Two independent tests carry that, because the two occurrences look
+    different depending on when you ask:
+
     ``current_generation`` names the raw sources THIS run produced itself — a
-    story that completed unmeasured here, an intake pass that ran here. An
-    acceptance resolves the occurrence it was made for, not the story: it stands
-    in for one recorded call, at one recorded ceiling, in one recorded run. A
-    second unmeasured call is a second unknown, of an amount nobody has bounded
-    and nobody has accepted, so the guard closes on it exactly as it did the
-    first time. Without this an operator's one-time acceptance would silently
-    become a standing licence for that story to spend unmeasured forever.
+    story that completed unmeasured here, an intake pass that ran here. Nothing
+    accepted before this run began can stand in for them.
+
+    ``occurrence_ids`` maps a raw source to the run its unmeasured call happened
+    in. Once the stopped run is resumed, its two occurrences are no longer
+    distinguishable by *when* they were recorded — both are simply carried — so
+    identity has to come from the record instead. An acceptance whose
+    ``origin_run_id`` names a different run than the occurrence now in the ledger
+    is an acceptance of some earlier call, and does not resolve this one. Either
+    side being unrecorded falls back to matching on the source alone: an unknown
+    identity is not evidence of a mismatch, and refusing there would strand an
+    acceptance the operator legitimately made.
     """
     fresh = {str(s) for s in current_generation}
+    ids = occurrence_ids or {}
     unresolved: list[str] = []
     applied: dict[str, AcceptedUnmeasuredSpend] = {}
     for raw in raw_sources:
@@ -452,11 +473,18 @@ def partition(
             continue
         normalized = normalize_source_id(raw)
         record = accepted.get(normalized)
-        if record is None:
+        if record is None or not _same_occurrence(record, ids.get(str(raw))):
             unresolved.append(str(raw))
         else:
             applied.setdefault(normalized, record)
     return unresolved, list(applied.values())
+
+
+def _same_occurrence(record: AcceptedUnmeasuredSpend, occurrence_id: str | None) -> bool:
+    """Whether an acceptance was made for the occurrence now in the ledger."""
+    if not record.origin_run_id or not occurrence_id:
+        return True
+    return str(record.origin_run_id) == str(occurrence_id)
 
 
 def accepted_ceiling_total(records: Iterable[AcceptedUnmeasuredSpend]) -> float:
@@ -480,18 +508,43 @@ def accepted_by_source(
     return index
 
 
+def acceptable_prior_sources(recorded_sources: Sequence[str]) -> list[str]:
+    """Normalized sources from a prior generation's record an operator can accept.
+
+    The whole-generation marker is excluded, and this is the single place that
+    exclusion is decided so no caller can drift from it. The marker names no work
+    of its own: it is a DERIVED statement that some source in that generation was
+    unmeasured, so it has no origin, no ceiling and no accept path by
+    construction. Anything that treats it as a source — a completeness test, or a
+    ledger re-surfacing pass — makes the generation permanently unresolvable,
+    because the operator is then required to accept something nothing can bound.
+
+    Order is preserved and duplicates collapse, since a source named twice by one
+    record is one source as far as acceptance is concerned.
+    """
+    seen: set[str] = set()
+    usable: list[str] = []
+    for raw in recorded_sources:
+        normalized = normalize_source_id(raw)
+        if not normalized or normalized == PRIOR_GENERATION_SOURCE or normalized in seen:
+            continue
+        seen.add(normalized)
+        usable.append(normalized)
+    return usable
+
+
 def all_sources_accepted(
     recorded_sources: Sequence[str],
     accepted: Mapping[str, AcceptedUnmeasuredSpend],
 ) -> bool:
     """Whether every source a prior generation named has been accepted.
 
-    An empty ``recorded_sources`` is False, not vacuously True: a generation
-    that reported incomplete cost without naming what was unpriced carries a
-    claim nothing here can resolve, so the guard must stay closed on it.
+    A record with nothing acceptable in it is False, not vacuously True: a
+    generation that reported incomplete cost while naming only the derived
+    marker (or nothing at all) carries a claim nothing here can resolve, so the
+    guard must stay closed on it.
     """
-    normalized = [normalize_source_id(s) for s in recorded_sources]
-    usable = [s for s in normalized if s and s != PRIOR_GENERATION_SOURCE]
+    usable = acceptable_prior_sources(recorded_sources)
     if not usable:
         return False
     return all(s in accepted for s in usable)

--- a/src/theforge/sprint/unmeasured.py
+++ b/src/theforge/sprint/unmeasured.py
@@ -1,0 +1,477 @@
+"""Unmeasured sprint spend: what it was, where it came from, and accepting it.
+
+The budget check fails closed on spend it could not measure (#1992), and that
+is right: a ceiling that cannot be checked is not a ceiling. What does not
+follow is that the condition must be permanent. A single agent call that exits
+without reporting cost belongs to one completed run, whose allocation, phase,
+role and failure are all recorded — so the unknown is bounded and attributed,
+and an operator can accept that bound deliberately instead of abandoning the
+pipeline for the story (#2310).
+
+This module is the sprint-owned representation of that: it normalizes source
+ids, reads the origin and a derivable ceiling out of records the run already
+wrote, and serializes the resolution. Accepting a source does NOT relabel its
+cost as measured — ``cost_complete`` stays false and the measured total stays a
+lower bound. What acceptance changes is only which number the cap is verified
+against: the accepted ceiling is charged in place of an unknown.
+
+Pure and stdlib-only apart from one narrow YAML read of a per-story audit, so
+the policy is testable without a live sprint.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: Prefix the runner stamps on spend inherited from an earlier generation of the
+#: same sprint. ``carried:issue-2206`` and ``issue-2206`` name the same work —
+#: the first is how a resume sees it, the second is how the generation that ran
+#: it did — so acceptance keys on the normalized form or a re-run that again
+#: completes unmeasured would re-block despite the recorded acceptance.
+CARRIED_PREFIX = "carried:"
+
+#: The whole-generation marker the resume path adds when the prior sprint audit
+#: recorded an incomplete cost. It is not a story, so it has no allocation of
+#: its own; it clears when every source that generation named has been accepted.
+PRIOR_GENERATION_SOURCE = "prior-generation"
+
+#: Where a ceiling came from. Only ``derived`` bounds may be accepted.
+CEILING_BASIS_ALLOCATION = "story_allocation"
+CEILING_BASIS_CONFIGURED = "story_allocation_configured_fallback"
+CEILING_BASIS_NONE = "no_recorded_bound"
+
+
+def normalize_source_id(raw: object) -> str:
+    """Return the canonical identity of an unmeasured-spend source."""
+    text = str(raw or "").strip()
+    while text.startswith(CARRIED_PREFIX):
+        text = text[len(CARRIED_PREFIX) :].strip()
+    return text
+
+
+def source_slug(raw: object) -> str | None:
+    """The story slug a source names, or ``None`` when it names no story.
+
+    Story sources are recorded bare (``issue-2206``) or carried
+    (``carried:issue-2206``). Every other source carries a kind prefix
+    (``intake:``, ``entry-intake:``, ``dropped-with-work:``, …) naming work that
+    is not a story run, and the whole-generation marker names no work at all.
+    """
+    normalized = normalize_source_id(raw)
+    if not normalized or normalized == PRIOR_GENERATION_SOURCE:
+        return None
+    if ":" in normalized:
+        return None
+    return normalized
+
+
+@dataclass(frozen=True)
+class UnmeasuredSource:
+    """One source of spend a sprint could not measure, with its origin.
+
+    ``ceiling_usd`` is ``None`` when the recorded audit cannot support a bound.
+    Such a source is never acceptable: fabricating a number to get past the
+    check is exactly what measuring exists to prevent.
+    """
+
+    raw: str
+    source: str
+    origin: dict = field(default_factory=dict)
+    measured_lower_bound_usd: float = 0.0
+    ceiling_usd: float | None = None
+    ceiling_basis: str = CEILING_BASIS_NONE
+    ceiling_reason: str = "no per-story audit recorded a bound for this source"
+
+    @property
+    def acceptable(self) -> bool:
+        """Whether an operator has a bounded number available to accept."""
+        return self.ceiling_usd is not None
+
+    def describe(self) -> str:
+        """Operator-facing one-liner: what is unknown, how much, and from where."""
+        origin_bits = [
+            f"{key}={self.origin[key]}"
+            for key in ("run_id", "phase", "role", "profile", "failure_code")
+            if self.origin.get(key)
+        ]
+        origin_text = ", ".join(origin_bits) if origin_bits else "origin not recorded"
+        if self.ceiling_usd is None:
+            return f"{self.raw}: unbounded ({self.ceiling_reason}; {origin_text})"
+        return (
+            f"{self.raw}: measured ${self.measured_lower_bound_usd:.2f}, "
+            f"at most ${self.ceiling_usd:.2f} more ({self.ceiling_basis}; {origin_text})"
+        )
+
+    def as_dict(self) -> dict:
+        return {
+            "source": self.source,
+            "recorded_as": self.raw,
+            "origin": dict(self.origin),
+            "measured_lower_bound_usd": round(self.measured_lower_bound_usd, 4),
+            "ceiling_usd": None if self.ceiling_usd is None else round(self.ceiling_usd, 4),
+            "ceiling_basis": self.ceiling_basis,
+            "ceiling_reason": self.ceiling_reason,
+            "acceptable": self.acceptable,
+        }
+
+
+@dataclass(frozen=True)
+class AcceptedUnmeasuredSpend:
+    """An operator's deliberate acceptance of one bounded unmeasured source.
+
+    The record is the whole point: the cap is afterwards verified against
+    ``accepted_ceiling_usd`` rather than against an unknown, so a reader must be
+    able to see which source that number stands in for, where it came from, and
+    who decided it was acceptable.
+    """
+
+    source: str
+    accepted_ceiling_usd: float
+    measured_lower_bound_usd: float = 0.0
+    ceiling_basis: str = CEILING_BASIS_NONE
+    origin_run_id: str | None = None
+    origin_phase: str | None = None
+    origin_role: str | None = None
+    origin_profile: str | None = None
+    origin_failure_code: str | None = None
+    accepted_at: str | None = None
+    reason: str | None = None
+
+    def as_dict(self) -> dict:
+        return {
+            "source": self.source,
+            "accepted_ceiling_usd": round(self.accepted_ceiling_usd, 4),
+            "measured_lower_bound_usd": round(self.measured_lower_bound_usd, 4),
+            "ceiling_basis": self.ceiling_basis,
+            "origin_run_id": self.origin_run_id,
+            "origin_phase": self.origin_phase,
+            "origin_role": self.origin_role,
+            "origin_profile": self.origin_profile,
+            "origin_failure_code": self.origin_failure_code,
+            "accepted_at": self.accepted_at,
+            "reason": self.reason,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping) -> "AcceptedUnmeasuredSpend | None":
+        """Rebuild a persisted record, or ``None`` when it is unusable.
+
+        A record without a source or without a numeric ceiling resolves nothing
+        — it is dropped rather than treated as an acceptance of an unknown.
+        """
+        if not isinstance(data, Mapping):
+            return None
+        source = normalize_source_id(data.get("source"))
+        if not source:
+            return None
+        try:
+            ceiling = float(data.get("accepted_ceiling_usd"))
+        except (TypeError, ValueError):
+            return None
+        try:
+            lower_bound = float(data.get("measured_lower_bound_usd") or 0.0)
+        except (TypeError, ValueError):
+            lower_bound = 0.0
+        return cls(
+            source=source,
+            accepted_ceiling_usd=ceiling,
+            measured_lower_bound_usd=lower_bound,
+            ceiling_basis=str(data.get("ceiling_basis") or CEILING_BASIS_NONE),
+            origin_run_id=_opt_str(data.get("origin_run_id")),
+            origin_phase=_opt_str(data.get("origin_phase")),
+            origin_role=_opt_str(data.get("origin_role")),
+            origin_profile=_opt_str(data.get("origin_profile")),
+            origin_failure_code=_opt_str(data.get("origin_failure_code")),
+            accepted_at=_opt_str(data.get("accepted_at")),
+            reason=_opt_str(data.get("reason")),
+        )
+
+
+def _opt_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _phase_for_role(role: str | None) -> str | None:
+    """Map an audit agent role onto the coordinator phase that invoked it."""
+    if not role:
+        return None
+    lowered = str(role).lower()
+    if lowered.startswith("review") or lowered == "synthesis":
+        return "REVIEW"
+    if lowered.startswith("dev"):
+        return "DEV"
+    if lowered.startswith("plan"):
+        return "PLAN"
+    if lowered.startswith("preflight"):
+        return "PREFLIGHT"
+    return lowered.upper()
+
+
+def origin_from_story_audit(audit_data: Mapping | None) -> dict:
+    """Extract the origin of a story's unmeasured spend from its audit record.
+
+    The first agent invocation that reported no cost is the origin: that is the
+    call whose spend is unknown. Everything reported here is read off the
+    record, never inferred — an absent field stays absent.
+    """
+    origin: dict = {}
+    if not isinstance(audit_data, Mapping):
+        return origin
+    run_id = _opt_str(audit_data.get("run_id"))
+    if run_id:
+        origin["run_id"] = run_id
+    outcome = audit_data.get("outcome")
+    if isinstance(outcome, Mapping):
+        final_phase = _opt_str(outcome.get("final_phase"))
+        if final_phase:
+            origin["final_phase"] = final_phase
+    failure_code = _opt_str(audit_data.get("error_type"))
+    cost = audit_data.get("cost")
+    agents = cost.get("agents") if isinstance(cost, Mapping) else None
+    if isinstance(agents, list):
+        for agent in agents:
+            if not isinstance(agent, Mapping) or agent.get("cost_usd") is not None:
+                continue
+            role = _opt_str(agent.get("role"))
+            if role:
+                origin["role"] = role
+                phase = _phase_for_role(role)
+                if phase:
+                    origin["phase"] = phase
+            profile = _opt_str(agent.get("profile"))
+            if profile:
+                origin["profile"] = profile
+            agent_failure = _opt_str(agent.get("failure_code"))
+            if agent_failure:
+                failure_code = agent_failure
+            break
+    if failure_code:
+        origin["failure_code"] = failure_code
+    if "phase" not in origin and origin.get("final_phase"):
+        origin["phase"] = origin["final_phase"]
+    return origin
+
+
+def _measured_lower_bound(audit_data: Mapping | None) -> float:
+    """Sum the agent invocations of a story that DID report a cost."""
+    if not isinstance(audit_data, Mapping):
+        return 0.0
+    cost = audit_data.get("cost")
+    if not isinstance(cost, Mapping):
+        return 0.0
+    total = cost.get("total_usd")
+    if isinstance(total, (int, float)) and not isinstance(total, bool):
+        return max(0.0, float(total))
+    agents = cost.get("agents")
+    if not isinstance(agents, list):
+        return 0.0
+    measured = 0.0
+    for agent in agents:
+        if not isinstance(agent, Mapping):
+            continue
+        value = agent.get("cost_usd")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            measured += float(value)
+    return max(0.0, measured)
+
+
+def _allocation_ceiling(audit_data: Mapping | None) -> tuple[float | None, str, str]:
+    """Return ``(allocation_usd, basis, reason)`` for a story's recorded ceiling.
+
+    The per-story allocation is the amount the run was permitted to spend on
+    this story, so it bounds what the unmeasured call inside it could have cost.
+    When no allocation was recorded there is no bound to offer, and the source
+    stays unresolved rather than being given a guessed one.
+    """
+    if not isinstance(audit_data, Mapping):
+        return None, CEILING_BASIS_NONE, "no per-story audit found for this source"
+    cost = audit_data.get("cost")
+    allocation = cost.get("story_allocation") if isinstance(cost, Mapping) else None
+    if not isinstance(allocation, Mapping):
+        return (
+            None,
+            CEILING_BASIS_NONE,
+            "the per-story audit records no allocation to bound the unmeasured call",
+        )
+    for key, basis in (
+        ("allocation_usd", CEILING_BASIS_ALLOCATION),
+        ("fallback_configured_usd", CEILING_BASIS_CONFIGURED),
+    ):
+        value = allocation.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and float(value) > 0.0:
+            return (
+                float(value),
+                basis,
+                f"bounded by the story's recorded {key} (${float(value):.2f})",
+            )
+    return (
+        None,
+        CEILING_BASIS_NONE,
+        "the recorded allocation carries no usable dollar figure",
+    )
+
+
+def read_story_audit(project_root: Path, sprint_name: str, slug: str) -> dict | None:
+    """Load ``.forge/logs/<sprint>/<slug>/audit.yaml``, or ``None``.
+
+    The one I/O boundary in this module. An unreadable record is not an error
+    here — it means the source has no derivable bound, which the caller reports
+    as unresolvable rather than papering over.
+    """
+    import yaml  # noqa: PLC0415
+
+    audit_path = Path(project_root) / ".forge" / "logs" / sprint_name / slug / "audit.yaml"
+    if not audit_path.exists():
+        return None
+    try:
+        with open(audit_path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def build_source(raw: str, story_audit: Mapping | None) -> UnmeasuredSource:
+    """Describe one unmeasured source from the records that named it.
+
+    Pure over ``story_audit`` so the derivation is testable without a sprint
+    tree; :func:`resolve_sources` supplies the record.
+    """
+    normalized = normalize_source_id(raw)
+    origin = origin_from_story_audit(story_audit)
+    lower_bound = _measured_lower_bound(story_audit)
+    allocation, basis, reason = _allocation_ceiling(story_audit)
+    if allocation is None:
+        return UnmeasuredSource(
+            raw=str(raw),
+            source=normalized,
+            origin=origin,
+            measured_lower_bound_usd=lower_bound,
+            ceiling_usd=None,
+            ceiling_basis=basis,
+            ceiling_reason=reason,
+        )
+    # The bound on what is UNKNOWN, not on the story: the measured part is
+    # already in the sprint's accumulated total, and charging the whole
+    # allocation on top of it would bill the same dollars twice.
+    remainder = max(0.0, float(allocation) - lower_bound)
+    return UnmeasuredSource(
+        raw=str(raw),
+        source=normalized,
+        origin={**origin, "allocation_usd": round(float(allocation), 4)},
+        measured_lower_bound_usd=lower_bound,
+        ceiling_usd=round(remainder, 4),
+        ceiling_basis=basis,
+        ceiling_reason=reason,
+    )
+
+
+def resolve_sources(
+    raw_sources: Sequence[str],
+    *,
+    project_root: Path,
+    sprint_name: str,
+) -> list[UnmeasuredSource]:
+    """Describe every raw unmeasured-spend source, deduplicated by identity."""
+    seen: set[str] = set()
+    resolved: list[UnmeasuredSource] = []
+    for raw in raw_sources:
+        normalized = normalize_source_id(raw)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        slug = source_slug(raw)
+        story_audit = (
+            read_story_audit(project_root, sprint_name, slug) if slug is not None else None
+        )
+        resolved.append(build_source(str(raw), story_audit))
+    return resolved
+
+
+def accept(
+    source: UnmeasuredSource,
+    *,
+    accepted_at: str,
+    reason: str | None = None,
+) -> AcceptedUnmeasuredSpend | None:
+    """Turn a bounded source into an acceptance record, or ``None`` if unbounded."""
+    if source.ceiling_usd is None:
+        return None
+    return AcceptedUnmeasuredSpend(
+        source=source.source,
+        accepted_ceiling_usd=float(source.ceiling_usd),
+        measured_lower_bound_usd=source.measured_lower_bound_usd,
+        ceiling_basis=source.ceiling_basis,
+        origin_run_id=source.origin.get("run_id"),
+        origin_phase=source.origin.get("phase"),
+        origin_role=source.origin.get("role"),
+        origin_profile=source.origin.get("profile"),
+        origin_failure_code=source.origin.get("failure_code"),
+        accepted_at=accepted_at,
+        reason=reason,
+    )
+
+
+def partition(
+    raw_sources: Sequence[str],
+    accepted: Mapping[str, AcceptedUnmeasuredSpend],
+) -> tuple[list[str], list[AcceptedUnmeasuredSpend]]:
+    """Split raw sources into the unresolved ones and the acceptances in force.
+
+    Only acceptances whose source actually appears in ``raw_sources`` are
+    returned: a ceiling is charged for spend this run is carrying, never for a
+    stale record of work it is not.
+    """
+    unresolved: list[str] = []
+    applied: dict[str, AcceptedUnmeasuredSpend] = {}
+    for raw in raw_sources:
+        normalized = normalize_source_id(raw)
+        record = accepted.get(normalized)
+        if record is None:
+            unresolved.append(str(raw))
+        else:
+            applied.setdefault(normalized, record)
+    return unresolved, list(applied.values())
+
+
+def accepted_ceiling_total(records: Iterable[AcceptedUnmeasuredSpend]) -> float:
+    """Sum of the ceilings a set of acceptances charges to budget verification."""
+    return round(sum(max(0.0, float(r.accepted_ceiling_usd)) for r in records), 4)
+
+
+def accepted_by_source(
+    records: Iterable[Mapping | AcceptedUnmeasuredSpend],
+) -> dict[str, AcceptedUnmeasuredSpend]:
+    """Index acceptance records (persisted dicts or typed) by normalized source."""
+    index: dict[str, AcceptedUnmeasuredSpend] = {}
+    for record in records:
+        typed = (
+            record
+            if isinstance(record, AcceptedUnmeasuredSpend)
+            else AcceptedUnmeasuredSpend.from_dict(record)
+        )
+        if typed is not None:
+            index[typed.source] = typed
+    return index
+
+
+def all_sources_accepted(
+    recorded_sources: Sequence[str],
+    accepted: Mapping[str, AcceptedUnmeasuredSpend],
+) -> bool:
+    """Whether every source a prior generation named has been accepted.
+
+    An empty ``recorded_sources`` is False, not vacuously True: a generation
+    that reported incomplete cost without naming what was unpriced carries a
+    claim nothing here can resolve, so the guard must stay closed on it.
+    """
+    normalized = [normalize_source_id(s) for s in recorded_sources]
+    usable = [s for s in normalized if s and s != PRIOR_GENERATION_SOURCE]
+    if not usable:
+        return False
+    return all(s in accepted for s in usable)

--- a/tests/test_unmeasured_cost_reporting.py
+++ b/tests/test_unmeasured_cost_reporting.py
@@ -1380,3 +1380,282 @@ class TestAcceptanceReachesTheRunner:
         kwargs = mock_run_sprint.call_args.kwargs
         assert kwargs["accept_unmeasured_spend"] == ["issue-2206"]
         assert kwargs["accept_unmeasured_reason"] == "quota failure"
+
+
+class TestAcceptanceCoversOneOccurrence:
+    """An acceptance stands in for one recorded call, not for the story.
+
+    Keying it to the story would turn a one-time operator decision into a
+    standing licence to spend unmeasured — the guard would never close on that
+    story again, however many further calls went unpriced.
+    """
+
+    def test_a_fresh_unmeasured_call_is_not_absorbed_by_an_older_acceptance(self) -> None:
+        from theforge.sprint.unmeasured import (
+            accept,
+            accepted_by_source,
+            accepted_ceiling_total,
+            build_source,
+            partition,
+        )
+
+        index = accepted_by_source(
+            [
+                accept(
+                    build_source("carried:feature-a", _bounded_story_audit()),
+                    accepted_at="2026-08-08T00:00:00+00:00",
+                )
+            ]
+        )
+        # The carried occurrence is resolved; the one this run produced is not.
+        unresolved, applied = partition(
+            ["carried:feature-a", "feature-a"],
+            index,
+            current_generation={"feature-a"},
+        )
+        assert unresolved == ["feature-a"]
+        # The accepted occurrence is still charged — both unknowns are accounted
+        # for, one by a ceiling and one by refusing to certify the cap.
+        assert accepted_ceiling_total(applied) == 4.5
+
+    def test_the_accepted_occurrence_alone_still_resolves(self) -> None:
+        from theforge.sprint.unmeasured import (
+            accept,
+            accepted_by_source,
+            build_source,
+            partition,
+        )
+
+        index = accepted_by_source(
+            [
+                accept(
+                    build_source("carried:feature-a", _bounded_story_audit()),
+                    accepted_at="2026-08-08T00:00:00+00:00",
+                )
+            ]
+        )
+        unresolved, applied = partition(
+            ["carried:feature-a"], index, current_generation={"feature-b"}
+        )
+        assert unresolved == []
+        assert [r.source for r in applied] == ["feature-a"]
+
+    def test_accepted_story_that_goes_unmeasured_again_stops_the_next_story(
+        self, tmp_path: Path
+    ) -> None:
+        """Seam: the guard closes again on the second unknown, unprompted."""
+        from unittest.mock import patch
+
+        from test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+
+        from theforge.sprint import run_sprint
+        from theforge.sprint.audit import persist_accumulated_story_state
+        from theforge.sprint.dag import StoryTriage
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=100.0)
+        config = _make_config(tmp_path)
+
+        sprint_dir = tmp_path / ".forge" / "logs" / "Test Sprint"
+        sprint_dir.mkdir(parents=True, exist_ok=True)
+        (sprint_dir / ".sprint_id").write_text("sprint-2310", encoding="utf-8")
+        _write_story_audit(tmp_path, "Test Sprint", "feature-a", _bounded_story_audit())
+        persist_accumulated_story_state(
+            "sprint-2310",
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                }
+            ],
+        )
+
+        def _triage(spec_path, *args, **kwargs):
+            return StoryTriage(
+                story_path=str(spec_path),
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+            )
+
+        # feature-a runs again on the operator's acceptance — and goes unmeasured
+        # a second time. That is new unknown spend, not the accepted one.
+        with patch("theforge.sprint.runner._triage_spec", side_effect=_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                return_value=TestBudgetEnforcementSeam._unmeasured_dev_result(),
+            ) as mock_run:
+                result = run_sprint(
+                    config,
+                    manifest_path,
+                    accept_unmeasured_spend=["feature-a"],
+                )
+
+        # The accepted story ran; the independent next story did not.
+        assert mock_run.call_count == 1
+        assert result.stopped_reason is not None
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        assert "feature-a" in result.unresolved_unmeasured_spend_sources
+        # The earlier occurrence stays resolved and charged — the refusal is
+        # about the new call, not a retraction of the operator's decision.
+        assert [r["source"] for r in result.accepted_unmeasured_spend] == ["feature-a"]
+        assert result.budget_verification_spend_usd >= 4.5
+
+
+class TestAcceptedPriorAuditSourceIsCharged:
+    """An acceptance that clears the generation carry must still cost something.
+
+    The prior generation's own record can be the only place a source appears —
+    the accumulated story row is gone, pruned or never written. Clearing the
+    whole-generation marker on an acceptance whose ceiling was then charged to
+    nothing would open the guard for free, under a cap the accepted amount might
+    not even fit inside.
+    """
+
+    @staticmethod
+    def _arrange(tmp_path: Path, *, budget: float):
+        from test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+
+        from theforge.sprint.audit import persist_accumulated_story_state
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=budget)
+        config = _make_config(tmp_path)
+
+        sprint_dir = tmp_path / ".forge" / "logs" / "Test Sprint"
+        sprint_dir.mkdir(parents=True, exist_ok=True)
+        (sprint_dir / ".sprint_id").write_text("sprint-2310", encoding="utf-8")
+        _write_story_audit(tmp_path, "Test Sprint", "feature-a", _bounded_story_audit())
+
+        # The prior generation named the unmeasured source...
+        audits = tmp_path / ".forge" / "audits"
+        audits.mkdir(parents=True, exist_ok=True)
+        (audits / "sprint-audit.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "sprint": {
+                        "sprint_id": "sprint-2310",
+                        "total_cost_usd": None,
+                        "total_cost_measured_usd": 0.0,
+                        "cost_complete": False,
+                        "unmeasured_spend_sources": ["feature-a"],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        # ...but no accumulated story row carries it.
+        persist_accumulated_story_state("sprint-2310", "Test Sprint", tmp_path, [])
+        return config, manifest_path
+
+    @staticmethod
+    def _run(config, manifest_path, **kwargs):
+        from unittest.mock import patch
+
+        from test_sprint_resume import _make_coordinator_result
+
+        from theforge.sprint import run_sprint
+        from theforge.sprint.dag import StoryTriage
+
+        def _triage(spec_path, *args, **kw):
+            return StoryTriage(
+                story_path=str(spec_path),
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+            )
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                side_effect=lambda *a, **k: _make_coordinator_result(success=True, cost=1.0),
+            ) as mock_run:
+                result = run_sprint(config, manifest_path, resume=True, **kwargs)
+        return result, mock_run
+
+    def test_the_ceiling_is_charged_and_can_exhaust_the_cap(self, tmp_path: Path) -> None:
+        config, manifest_path = self._arrange(tmp_path, budget=4.0)
+        result, mock_run = self._run(config, manifest_path, accept_unmeasured_spend=["feature-a"])
+
+        # $4.50 accepted against a $4.00 cap: this is not headroom.
+        assert mock_run.call_count == 0
+        assert result.stopped_reason is not None
+        assert result.stopped_reason.startswith("Budget exhausted")
+        assert "accepted unmeasured ceiling $4.50" in result.stopped_reason
+        assert result.budget_verification_spend_usd >= 4.5
+        assert [r["source"] for r in result.accepted_unmeasured_spend] == ["feature-a"]
+
+    def test_the_source_stays_named_in_the_ledger(self, tmp_path: Path) -> None:
+        """Convention 6: the spend must not vanish just because its row did."""
+        config, manifest_path = self._arrange(tmp_path, budget=100.0)
+        result, mock_run = self._run(config, manifest_path, accept_unmeasured_spend=["feature-a"])
+
+        assert mock_run.call_count == 1
+        assert result.stopped_reason is None
+        assert "carried:feature-a" in result.unmeasured_spend_sources
+        # Still unmeasured spend, so the total is still a lower bound.
+        assert result.cost_complete is False
+        assert result.budget_verification_spend_usd >= 4.5
+
+        audit = yaml.safe_load(
+            (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text(encoding="utf-8")
+        )["sprint"]
+        assert "carried:feature-a" in audit["unmeasured_spend_sources"]
+        assert audit["unresolved_unmeasured_spend_sources"] == []
+        assert audit["accepted_unmeasured_spend"][0]["source"] == "feature-a"
+
+    def test_without_the_acceptance_the_generation_carry_still_closes_the_guard(
+        self, tmp_path: Path
+    ) -> None:
+        config, manifest_path = self._arrange(tmp_path, budget=100.0)
+        result, mock_run = self._run(config, manifest_path)
+
+        assert mock_run.call_count == 0
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        assert "carried:prior-generation" in result.unresolved_unmeasured_spend_sources
+
+
+class TestAcceptancePersistenceIsReportedHonestly:
+    """A resolution that did not reach disk must not be logged as recorded."""
+
+    def test_the_writer_reports_whether_the_write_landed(self, tmp_path: Path) -> None:
+        from theforge.sprint.audit import persist_accepted_unmeasured_spend
+
+        assert (
+            persist_accepted_unmeasured_spend("sprint-2310", "Test Sprint", tmp_path, []) is True
+        )
+        # A project root that cannot hold the state directory fails the write.
+        blocked = tmp_path / "not-a-dir"
+        blocked.write_text("", encoding="utf-8")
+        assert (
+            persist_accepted_unmeasured_spend("sprint-2310", "Test Sprint", blocked, []) is False
+        )
+        # No sprint identity means there is nowhere to record it either.
+        assert persist_accepted_unmeasured_spend(None, "Test Sprint", tmp_path, []) is False
+
+    def test_a_failed_write_warns_that_the_acceptance_is_run_scoped(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        from unittest.mock import patch
+
+        config, manifest_path = TestUnmeasuredResolutionSeam._arrange(tmp_path)
+        with patch(
+            "theforge.sprint.runner.persist_accepted_unmeasured_spend",
+            return_value=False,
+        ):
+            result, mock_run = TestUnmeasuredResolutionSeam._run(
+                config, manifest_path, accept_unmeasured_spend=["feature-a"]
+            )
+
+        # The acceptance still governs this run — nothing was lost yet.
+        assert mock_run.call_count == 1
+        assert result.accepted_unmeasured_spend
+        err = capsys.readouterr().err
+        assert "could not persist the unmeasured-spend acceptance" in err
+        assert "THIS run only" in err

--- a/tests/test_unmeasured_cost_reporting.py
+++ b/tests/test_unmeasured_cost_reporting.py
@@ -796,3 +796,587 @@ class TestBudgetEnforcementSeam:
             encoding="utf-8",
         )
         assert _prior_sprint_cost_incomplete(tmp_path, "sid") is False
+
+
+# ── Resolving unmeasured spend deliberately (#2310) ───────────────────────────
+#
+# Refusing to spend against a cap that cannot be verified is right. A guard that
+# no action can satisfy is not: its only exit is to abandon the pipeline for the
+# story, which is the outcome the guard exists to prevent. These tests pin the
+# deliberate exit — the unknown is bounded, attributed, accepted by name, and the
+# resolution is recorded WITHOUT the cost ever being relabelled as measured.
+
+_ALLOCATION_USD = 5.0
+_MEASURED_BEFORE_FAILURE = 0.5
+
+
+def _bounded_story_audit(*, run_id: str = "194febaf01fd") -> dict:
+    """A per-story audit for a run whose reviewer exited without a cost."""
+    return {
+        "run_id": run_id,
+        "outcome": {"final_phase": "FAILED"},
+        "error_type": "provider_quota",
+        "cost": {
+            "total_usd": None,
+            "agents": [
+                {
+                    "role": "dev",
+                    "profile": "claude-dev",
+                    "cost_usd": _MEASURED_BEFORE_FAILURE,
+                    "success": True,
+                },
+                {
+                    "role": "review",
+                    "profile": "gpt-reviewer",
+                    "cost_usd": None,
+                    "success": False,
+                    "failure_code": "quota_exhausted",
+                },
+            ],
+            "story_allocation": {
+                "allocation_usd": _ALLOCATION_USD,
+                "basis": "substrate_band",
+                "complexity_score": 4,
+                "fallback_configured_usd": 8.0,
+            },
+        },
+    }
+
+
+def _write_story_audit(tmp_path: Path, sprint_name: str, slug: str, data: dict) -> None:
+    story_dir = tmp_path / ".forge" / "logs" / sprint_name / slug
+    story_dir.mkdir(parents=True, exist_ok=True)
+    (story_dir / "audit.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+class TestUnmeasuredSourceIdentity:
+    """A carried source and a fresh one name the same work."""
+
+    def test_carried_and_bare_ids_normalize_together(self) -> None:
+        from theforge.sprint.unmeasured import normalize_source_id
+
+        assert normalize_source_id("carried:issue-2206") == "issue-2206"
+        assert normalize_source_id("issue-2206") == "issue-2206"
+        assert normalize_source_id("  carried:carried:issue-2206 ") == "issue-2206"
+        assert normalize_source_id(None) == ""
+
+    def test_only_story_sources_resolve_to_a_slug(self) -> None:
+        from theforge.sprint.unmeasured import source_slug
+
+        assert source_slug("carried:issue-2206") == "issue-2206"
+        assert source_slug("issue-2206") == "issue-2206"
+        # Kind-prefixed sources are not story runs, and the whole-generation
+        # marker is not work at all — neither has a per-story audit to read.
+        assert source_slug("intake:issue-2206") is None
+        assert source_slug("carried:prior-generation") is None
+
+
+class TestUnmeasuredSourceDerivation:
+    """The bound and the origin are read off records, never invented."""
+
+    def test_recorded_allocation_bounds_the_unmeasured_remainder(self) -> None:
+        from theforge.sprint.unmeasured import build_source
+
+        source = build_source("carried:issue-2206", _bounded_story_audit())
+        assert source.source == "issue-2206"
+        assert source.acceptable is True
+        # The measured part is already in the sprint's accumulated total; only
+        # the remainder of the allocation stands in for what is unknown.
+        assert source.measured_lower_bound_usd == _MEASURED_BEFORE_FAILURE
+        assert source.ceiling_usd == round(_ALLOCATION_USD - _MEASURED_BEFORE_FAILURE, 4)
+        assert source.origin["run_id"] == "194febaf01fd"
+        assert source.origin["role"] == "review"
+        assert source.origin["phase"] == "REVIEW"
+        assert source.origin["profile"] == "gpt-reviewer"
+        assert source.origin["failure_code"] == "quota_exhausted"
+
+    def test_a_source_with_no_recorded_allocation_stays_unbounded(self) -> None:
+        """No fabricated bound: an unreadable origin keeps the guard closed."""
+        from theforge.sprint.unmeasured import accept, build_source
+
+        assert build_source("issue-2206", None).acceptable is False
+        no_allocation = build_source(
+            "issue-2206", {"run_id": "r1", "cost": {"total_usd": None, "agents": []}}
+        )
+        assert no_allocation.acceptable is False
+        assert accept(no_allocation, accepted_at="2026-08-08T00:00:00+00:00") is None
+
+    def test_acceptance_record_round_trips_through_persistence(self) -> None:
+        from theforge.sprint.unmeasured import (
+            AcceptedUnmeasuredSpend,
+            accept,
+            build_source,
+        )
+
+        record = accept(
+            build_source("carried:issue-2206", _bounded_story_audit()),
+            accepted_at="2026-08-08T00:00:00+00:00",
+            reason="reviewer hit a provider quota; landed by hand",
+        )
+        assert record is not None
+        restored = AcceptedUnmeasuredSpend.from_dict(record.as_dict())
+        assert restored == record
+        # A record without a numeric ceiling resolves nothing and is dropped.
+        assert AcceptedUnmeasuredSpend.from_dict({"source": "issue-2206"}) is None
+
+    def test_only_sources_this_run_carries_are_charged(self) -> None:
+        from theforge.sprint.unmeasured import (
+            accept,
+            accepted_by_source,
+            accepted_ceiling_total,
+            build_source,
+            partition,
+        )
+
+        record = accept(
+            build_source("issue-2206", _bounded_story_audit()),
+            accepted_at="2026-08-08T00:00:00+00:00",
+        )
+        index = accepted_by_source([record])
+        # Matches the carried spelling of the same source...
+        unresolved, applied = partition(["carried:issue-2206", "carried:prior-generation"], index)
+        assert unresolved == ["carried:prior-generation"]
+        assert accepted_ceiling_total(applied) == 4.5
+        # ...and charges nothing when this run carries no such spend.
+        unresolved, applied = partition(["issue-9999"], index)
+        assert unresolved == ["issue-9999"]
+        assert accepted_ceiling_total(applied) == 0.0
+
+
+class TestBudgetWithAcceptedCeilings:
+    def test_accepted_ceiling_replaces_the_unknown_and_dispatch_resumes(self) -> None:
+        from theforge.sprint.budget import evaluate_budget
+
+        assert (
+            evaluate_budget(
+                accumulated_cost=0.5,
+                prior_cost=0.0,
+                budget_usd=100.0,
+                unmeasured_spend=[],
+                accepted_unmeasured_ceiling_usd=4.5,
+            )
+            is None
+        )
+
+    def test_accepted_ceiling_is_charged_not_forgiven(self) -> None:
+        """Accepting never buys headroom — the ceiling counts against the cap."""
+        from theforge.sprint.budget import evaluate_budget
+
+        block = evaluate_budget(
+            accumulated_cost=1.0,
+            prior_cost=0.0,
+            budget_usd=5.0,
+            unmeasured_spend=[],
+            accepted_unmeasured_ceiling_usd=4.5,
+        )
+        assert block is not None
+        assert block.kind == "exhausted"
+        assert "accepted unmeasured ceiling $4.50" in block.detail
+
+    def test_exhaustion_wording_is_unchanged_when_nothing_was_accepted(self) -> None:
+        from theforge.sprint.budget import evaluate_budget
+
+        block = evaluate_budget(
+            accumulated_cost=0.0,
+            prior_cost=6.0,
+            budget_usd=5.0,
+            unmeasured_spend=[],
+        )
+        assert block is not None
+        assert block.stopped_reason == (
+            "Budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
+        )
+
+    def test_refusal_names_the_amount_and_the_origin(self) -> None:
+        """An unknown can only be accepted if it is bounded and attributed."""
+        from theforge.sprint.budget import evaluate_budget
+        from theforge.sprint.unmeasured import build_source
+
+        source = build_source("carried:issue-2206", _bounded_story_audit())
+        block = evaluate_budget(
+            accumulated_cost=0.0,
+            prior_cost=0.0,
+            budget_usd=100.0,
+            unmeasured_spend=["carried:issue-2206"],
+            source_details={"carried:issue-2206": source.describe()},
+        )
+        assert block is not None
+        assert block.kind == "unverifiable"
+        assert "at most $4.50 more" in block.detail
+        assert "run_id=194febaf01fd" in block.detail
+        assert "role=review" in block.detail
+
+    def test_budget_verification_spend_sums_measured_and_accepted(self) -> None:
+        from theforge.sprint.budget import budget_verification_spend
+
+        assert (
+            budget_verification_spend(
+                accumulated_cost=1.0,
+                prior_cost=0.5,
+                accepted_unmeasured_ceiling_usd=4.5,
+            )
+            == 6.0
+        )
+
+
+class TestPriorGenerationCarryIsSourceAware:
+    @staticmethod
+    def _write_incomplete_audit(tmp_path: Path, sources: list[str] | None) -> None:
+        audits = tmp_path / ".forge" / "audits"
+        audits.mkdir(parents=True, exist_ok=True)
+        block = {
+            "sprint_id": "sid",
+            "total_cost_usd": None,
+            "total_cost_measured_usd": 0.0,
+            "cost_complete": False,
+        }
+        if sources is not None:
+            block["unmeasured_spend_sources"] = sources
+        (audits / "sprint-audit.yaml").write_text(
+            yaml.safe_dump({"sprint": block}), encoding="utf-8"
+        )
+
+    def test_accepting_every_named_source_clears_the_generation_carry(
+        self, tmp_path: Path
+    ) -> None:
+        from theforge.sprint.runner import _prior_sprint_cost_incomplete
+        from theforge.sprint.unmeasured import accept, accepted_by_source, build_source
+
+        self._write_incomplete_audit(tmp_path, ["issue-2206"])
+        assert _prior_sprint_cost_incomplete(tmp_path, "sid") is True
+        accepted = accepted_by_source(
+            [
+                accept(
+                    build_source("issue-2206", _bounded_story_audit()),
+                    accepted_at="2026-08-08T00:00:00+00:00",
+                )
+            ]
+        )
+        assert _prior_sprint_cost_incomplete(tmp_path, "sid", accepted) is False
+
+    def test_a_partially_accepted_generation_still_carries(self, tmp_path: Path) -> None:
+        from theforge.sprint.runner import _prior_sprint_cost_incomplete
+        from theforge.sprint.unmeasured import accept, accepted_by_source, build_source
+
+        self._write_incomplete_audit(tmp_path, ["issue-2206", "intake:issue-2207"])
+        accepted = accepted_by_source(
+            [
+                accept(
+                    build_source("issue-2206", _bounded_story_audit()),
+                    accepted_at="2026-08-08T00:00:00+00:00",
+                )
+            ]
+        )
+        assert _prior_sprint_cost_incomplete(tmp_path, "sid", accepted) is True
+
+    def test_an_incomplete_generation_that_named_nothing_still_carries(
+        self, tmp_path: Path
+    ) -> None:
+        """Nothing there for an operator to have resolved — stay closed."""
+        from theforge.sprint.runner import _prior_sprint_cost_incomplete
+        from theforge.sprint.unmeasured import accept, accepted_by_source, build_source
+
+        self._write_incomplete_audit(tmp_path, None)
+        accepted = accepted_by_source(
+            [
+                accept(
+                    build_source("issue-2206", _bounded_story_audit()),
+                    accepted_at="2026-08-08T00:00:00+00:00",
+                )
+            ]
+        )
+        assert _prior_sprint_cost_incomplete(tmp_path, "sid", accepted) is True
+
+
+class TestUnmeasuredResolutionSeam:
+    """The reported failure end to end: refuse, accept, run, record."""
+
+    @staticmethod
+    def _arrange(tmp_path: Path):
+        from test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+
+        from theforge.sprint.audit import persist_accumulated_story_state
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=100.0)
+        config = _make_config(tmp_path)
+
+        sprint_dir = tmp_path / ".forge" / "logs" / "Test Sprint"
+        sprint_dir.mkdir(parents=True, exist_ok=True)
+        (sprint_dir / ".sprint_id").write_text("sprint-2310", encoding="utf-8")
+        _write_story_audit(tmp_path, "Test Sprint", "feature-a", _bounded_story_audit())
+        persist_accumulated_story_state(
+            "sprint-2310",
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                }
+            ],
+        )
+        return config, manifest_path
+
+    @staticmethod
+    def _run(config, manifest_path, **kwargs):
+        from unittest.mock import patch
+
+        from test_sprint_resume import _make_coordinator_result
+
+        from theforge.sprint import run_sprint
+        from theforge.sprint.dag import StoryTriage
+
+        def _triage(spec_path, *args, **kw):
+            return StoryTriage(
+                story_path=str(spec_path),
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+            )
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                side_effect=lambda *a, **k: _make_coordinator_result(success=True, cost=1.0),
+            ) as mock_run:
+                result = run_sprint(config, manifest_path, **kwargs)
+        return result, mock_run
+
+    def test_carried_unmeasured_story_is_refused_with_its_amount_and_origin(
+        self, tmp_path: Path
+    ) -> None:
+        config, manifest_path = self._arrange(tmp_path)
+        result, mock_run = self._run(config, manifest_path)
+
+        assert mock_run.call_count == 0
+        assert result.stopped_reason is not None
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        # The refusal is no longer opaque: it names the bound and the call.
+        assert "at most $4.50 more" in result.stopped_reason
+        assert "role=review" in result.stopped_reason
+        assert result.unresolved_unmeasured_spend_sources
+        assert result.accepted_unmeasured_spend == ()
+
+    def test_accepting_the_source_lets_the_same_story_run(self, tmp_path: Path) -> None:
+        config, manifest_path = self._arrange(tmp_path)
+        result, mock_run = self._run(
+            config,
+            manifest_path,
+            accept_unmeasured_spend=["carried:feature-a"],
+            accept_unmeasured_reason="reviewer hit a provider quota",
+        )
+
+        assert mock_run.call_count == 1
+        assert result.stopped_reason is None
+        assert result.unresolved_unmeasured_spend_sources == ()
+        # The spend is still unmeasured — acceptance resolved the budget
+        # question, not the measurement one.
+        assert result.cost_complete is False
+        assert "carried:feature-a" in result.unmeasured_spend_sources
+        [accepted] = result.accepted_unmeasured_spend
+        assert accepted["source"] == "feature-a"
+        assert accepted["accepted_ceiling_usd"] == 4.5
+        assert accepted["origin_run_id"] == "194febaf01fd"
+        assert accepted["origin_role"] == "review"
+        assert accepted["origin_failure_code"] == "quota_exhausted"
+        assert accepted["reason"] == "reviewer hit a provider quota"
+        # Budget verification charged the ceiling on top of measured spend.
+        assert result.budget_verification_spend_usd >= 4.5
+
+    def test_an_unbounded_source_cannot_be_accepted(self, tmp_path: Path) -> None:
+        """Without a recorded bound there is nothing to accept — stay closed."""
+        config, manifest_path = self._arrange(tmp_path)
+        # Strip the allocation that made the source bounded.
+        _write_story_audit(
+            tmp_path,
+            "Test Sprint",
+            "feature-a",
+            {"run_id": "r1", "cost": {"total_usd": None, "agents": []}},
+        )
+        result, mock_run = self._run(config, manifest_path, accept_unmeasured_spend=["feature-a"])
+
+        assert mock_run.call_count == 0
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        assert result.accepted_unmeasured_spend == ()
+
+    def test_a_source_this_sprint_never_flagged_is_refused(self, tmp_path: Path) -> None:
+        config, manifest_path = self._arrange(tmp_path)
+        result, mock_run = self._run(config, manifest_path, accept_unmeasured_spend=["issue-9999"])
+
+        assert mock_run.call_count == 0
+        assert result.accepted_unmeasured_spend == ()
+
+    def test_audit_and_summary_record_the_resolution(self, tmp_path: Path) -> None:
+        config, manifest_path = self._arrange(tmp_path)
+        self._run(config, manifest_path, accept_unmeasured_spend=["feature-a"])
+
+        audit = yaml.safe_load(
+            (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text(encoding="utf-8")
+        )["sprint"]
+        # Still incomplete: an acceptance is not a measurement.
+        assert audit["cost_complete"] is False
+        assert audit["total_cost_usd"] is None
+        assert audit["unresolved_unmeasured_spend_sources"] == []
+        assert audit["unmeasured_spend_sources"]
+        [accepted] = audit["accepted_unmeasured_spend"]
+        assert accepted["source"] == "feature-a"
+        assert accepted["accepted_ceiling_usd"] == 4.5
+        assert accepted["origin_run_id"] == "194febaf01fd"
+        assert audit["budget_verification_spend_usd"] >= 4.5
+
+        summary = yaml.safe_load(
+            (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text(
+                encoding="utf-8"
+            )
+        )["sprint"]
+        assert summary["cost_complete"] is False
+        assert summary["unresolved_unmeasured_spend_sources"] == []
+        assert summary["accepted_unmeasured_spend"][0]["source"] == "feature-a"
+        assert summary["budget_verification_spend_usd"] >= 4.5
+
+    def test_the_resolution_survives_into_the_next_run(self, tmp_path: Path) -> None:
+        """The operator resolves it once; a later run reads the record."""
+        config, manifest_path = self._arrange(tmp_path)
+        self._run(config, manifest_path, accept_unmeasured_spend=["feature-a"])
+
+        persisted = yaml.safe_load(
+            (tmp_path / ".forge" / "sprints" / "sprint-2310" / "state.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert persisted["accepted_unmeasured_spend"][0]["source"] == "feature-a"
+
+        # The story goes unmeasured again on a later attempt: the recorded
+        # resolution still stands, with no flag on this invocation at all. The
+        # current generation flags it bare (``feature-a``) rather than carried,
+        # so acceptance has to key on the normalized id or it would re-block.
+        state_path = tmp_path / ".forge" / "sprints" / "sprint-2310" / "state.yaml"
+        state = yaml.safe_load(state_path.read_text(encoding="utf-8"))
+        for story in state["stories"]:
+            story["cost_usd"] = None
+        state_path.write_text(yaml.safe_dump(state), encoding="utf-8")
+
+        result, mock_run = self._run(config, manifest_path)
+        assert mock_run.call_count == 1
+        assert result.stopped_reason is None
+        assert result.unresolved_unmeasured_spend_sources == ()
+        assert result.accepted_unmeasured_spend[0]["source"] == "feature-a"
+
+
+class TestAcceptanceReachesTheRunner:
+    """CLI plumbing: the option is parsed and threaded through every path."""
+
+    def test_option_is_repeatable_and_parsed(self) -> None:
+        import argparse
+
+        from theforge.cli.sprint import register_parser
+
+        parser = argparse.ArgumentParser()
+        register_parser(parser.add_subparsers(dest="command"))
+        args = parser.parse_args(
+            [
+                "sprint",
+                "sprint.yaml",
+                "--accept-unmeasured-spend",
+                "issue-2206",
+                "--accept-unmeasured-spend",
+                "carried:prior-generation",
+                "--accept-unmeasured-reason",
+                "quota failure, landed by hand",
+            ]
+        )
+        assert args.accept_unmeasured_spend == ["issue-2206", "carried:prior-generation"]
+        assert args.accept_unmeasured_reason == "quota failure, landed by hand"
+        # Absent by default, so nothing is accepted unless asked for.
+        assert parser.parse_args(["sprint", "sprint.yaml"]).accept_unmeasured_spend is None
+
+    def test_cmd_sprint_passes_the_acceptance_to_run_sprint(self, tmp_path: Path) -> None:
+        import argparse
+        from unittest.mock import MagicMock, patch
+
+        from test_sprint_resume import _make_manifest, _make_spec_file
+
+        from theforge.cli import sprint as sprint_cli
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
+        config_path = tmp_path / "forge.yaml"
+        config_path.write_text("project: test\n", encoding="utf-8")
+
+        fake_config = MagicMock()
+        fake_config.project_root = tmp_path
+        fake_config.project = "test"
+        fake_result = MagicMock()
+        fake_result.specs_failed = 0
+
+        args = argparse.Namespace(
+            manifest=str(manifest_path),
+            milestone=None,
+            label=None,
+            issues=None,
+            config=str(config_path),
+            base_branch=None,
+            name=None,
+            fg=True,
+            detach=False,
+            dry_run=False,
+            verbose=False,
+            auto_merge=False,
+            interactive=False,
+            resume=False,
+            no_pull=False,
+            parallel=None,
+            force=False,
+            no_notify=True,
+            accept_unmeasured_spend=["carried:issue-2206"],
+            accept_unmeasured_reason="quota failure",
+        )
+
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=fake_config),
+            patch("theforge.cli.sprint.apply_base_branch_override", return_value=fake_config),
+            patch("theforge.cli.sprint._find_config", return_value=config_path),
+            patch("theforge.cli.sprint.parse_manifest_slugs", return_value=["feature-a"]),
+            patch("theforge.cli.sprint._acquire_launch_locks", return_value=([], None, {})),
+            patch("theforge.cli.sprint.release_story_locks"),
+            patch("theforge.cli.sprint.run_sprint", return_value=fake_result) as mock_run_sprint,
+        ):
+            sprint_cli.cmd_sprint(args)
+
+        kwargs = mock_run_sprint.call_args.kwargs
+        assert kwargs["accept_unmeasured_spend"] == ["carried:issue-2206"]
+        assert kwargs["accept_unmeasured_reason"] == "quota failure"
+
+    def test_daemon_submission_forwards_the_acceptance(self, tmp_path: Path) -> None:
+        """--detach enumerates run_sprint kwargs by hand; the flag must be there."""
+        from unittest.mock import MagicMock, patch
+
+        from theforge.daemon import DaemonServer
+
+        daemon = DaemonServer.__new__(DaemonServer)
+        daemon.forge_root = tmp_path
+        (tmp_path / "forge.yaml").write_text("project: test\n", encoding="utf-8")
+
+        with (
+            patch("theforge.config.load_config", return_value=MagicMock()),
+            patch("theforge.sprint.runner.parse_manifest_slugs", return_value=["feature-a"]),
+            patch("theforge.sprint.lock.acquire_story_locks", return_value=([], [])),
+            patch("theforge.sprint.lock.release_story_locks"),
+            patch("theforge.sprint.run_sprint") as mock_run_sprint,
+        ):
+            daemon._execute_sprint(
+                str(tmp_path / "sprint.yaml"),
+                {
+                    "accept_unmeasured_spend": ["issue-2206"],
+                    "accept_unmeasured_reason": "quota failure",
+                },
+                lambda _state: None,
+            )
+
+        kwargs = mock_run_sprint.call_args.kwargs
+        assert kwargs["accept_unmeasured_spend"] == ["issue-2206"]
+        assert kwargs["accept_unmeasured_reason"] == "quota failure"

--- a/tests/test_unmeasured_cost_reporting.py
+++ b/tests/test_unmeasured_cost_reporting.py
@@ -1931,3 +1931,100 @@ class TestOccurrenceIdentitySurvivesAResume:
 
         assert mock_run.call_count == 2
         assert result.stopped_reason is None
+
+
+class TestSecondOccurrenceIsReportedAsItself:
+    """The refusal must describe the unknown it is refusing on.
+
+    A story has one per-story audit path, and running it again overwrites that
+    file. Describing sources by story alone lets the carried reading win, so the
+    refusal on a NEW unmeasured call would name the run id and ceiling of the
+    call the operator had already accepted — sending them to look at settled
+    work, and asking them about the wrong amount.
+    """
+
+    @staticmethod
+    def _second_occurrence_audit() -> dict:
+        """What the coordinator records when the story goes unmeasured again."""
+        audit = _bounded_story_audit(run_id="run-2")
+        audit["cost"]["agents"][0]["cost_usd"] = 1.0
+        audit["cost"]["story_allocation"]["allocation_usd"] = 9.0
+        return audit
+
+    def test_the_refusal_names_the_new_occurrence_not_the_accepted_one(
+        self, tmp_path: Path
+    ) -> None:
+        from unittest.mock import patch
+
+        from test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+
+        from theforge.sprint import run_sprint
+        from theforge.sprint.audit import persist_accumulated_story_state
+        from theforge.sprint.dag import StoryTriage
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=100.0)
+        config = _make_config(tmp_path)
+
+        sprint_dir = tmp_path / ".forge" / "logs" / "Test Sprint"
+        sprint_dir.mkdir(parents=True, exist_ok=True)
+        (sprint_dir / ".sprint_id").write_text("sprint-2310", encoding="utf-8")
+        # The occurrence the operator accepts: run-1, $4.50 still unknown.
+        _write_story_audit(
+            tmp_path, "Test Sprint", "feature-a", _bounded_story_audit(run_id="run-1")
+        )
+        persist_accumulated_story_state(
+            "sprint-2310",
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                }
+            ],
+        )
+
+        def _triage(spec_path, *args, **kwargs):
+            return StoryTriage(
+                story_path=str(spec_path),
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+            )
+
+        def _rewrite_audit(*_args, **_kwargs):
+            """Stand in for the coordinator's audit write after the story ran."""
+            _write_story_audit(
+                tmp_path, "Test Sprint", "feature-a", self._second_occurrence_audit()
+            )
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=_triage):
+            with patch("theforge.sprint.runner._write_story_audit", side_effect=_rewrite_audit):
+                with patch(
+                    "theforge.sprint.runner.run_task",
+                    return_value=TestBudgetEnforcementSeam._unmeasured_dev_result(),
+                ) as mock_run:
+                    result = run_sprint(
+                        config,
+                        manifest_path,
+                        accept_unmeasured_spend=["feature-a"],
+                    )
+
+        assert mock_run.call_count == 1
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        # The unresolved unknown is the second occurrence: run-2, and the $8.00
+        # its own allocation leaves unaccounted.
+        assert "run_id=run-2" in result.stopped_reason
+        assert "at most $8.00 more" in result.stopped_reason
+        # ...not the occurrence that was already accepted and already charged.
+        assert "run_id=run-1" not in result.stopped_reason
+        assert "at most $4.50 more" not in result.stopped_reason
+        # The acceptance itself still describes the occurrence it was made for.
+        [accepted] = result.accepted_unmeasured_spend
+        assert accepted["origin_run_id"] == "run-1"
+        assert accepted["accepted_ceiling_usd"] == 4.5

--- a/tests/test_unmeasured_cost_reporting.py
+++ b/tests/test_unmeasured_cost_reporting.py
@@ -1659,3 +1659,275 @@ class TestAcceptancePersistenceIsReportedHonestly:
         err = capsys.readouterr().err
         assert "could not persist the unmeasured-spend acceptance" in err
         assert "THIS run only" in err
+
+
+class TestAcceptablePriorSources:
+    """The whole-generation marker is not a source anyone can accept."""
+
+    def test_the_marker_is_never_offered_as_acceptable(self) -> None:
+        from theforge.sprint.unmeasured import acceptable_prior_sources
+
+        # The exact list run 6796605f9982 left behind.
+        assert acceptable_prior_sources(["carried:issue-2206", "carried:prior-generation"]) == [
+            "issue-2206"
+        ]
+        # A record naming only the marker leaves nothing to resolve.
+        assert acceptable_prior_sources(["carried:prior-generation"]) == []
+        # One source named twice is one source.
+        assert acceptable_prior_sources(["issue-2206", "carried:issue-2206", ""]) == ["issue-2206"]
+
+    def test_a_record_with_nothing_acceptable_never_reads_as_resolved(self) -> None:
+        from theforge.sprint.unmeasured import all_sources_accepted
+
+        assert (
+            all_sources_accepted(["carried:prior-generation"], {"issue-2206": object()}) is False
+        )
+        assert all_sources_accepted([], {}) is False
+
+
+class TestReportedShapeIsResolvable:
+    """The exact record run 6796605f9982 left must not be an absorbing state.
+
+    Its prior audit named both the carried story source and the derived
+    whole-generation marker. The marker has no origin, no ceiling and no accept
+    path, so re-surfacing it after the story source was accepted refuses the run
+    on a condition no operator action can satisfy — the story never dispatches,
+    on that resume or any later one.
+    """
+
+    @staticmethod
+    def _arrange(tmp_path: Path, *, extra_specs: list[str] | None = None):
+        from test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+
+        from theforge.sprint.audit import persist_accumulated_story_state
+
+        _make_spec_file(tmp_path, "Issue 2206", "issue-2206")
+        specs = ["issue-2206.md", *(extra_specs or [])]
+        manifest_path = _make_manifest(tmp_path, specs, budget=100.0)
+        config = _make_config(tmp_path)
+
+        sprint_dir = tmp_path / ".forge" / "logs" / "Test Sprint"
+        sprint_dir.mkdir(parents=True, exist_ok=True)
+        (sprint_dir / ".sprint_id").write_text("sprint-2310", encoding="utf-8")
+        _write_story_audit(tmp_path, "Test Sprint", "issue-2206", _bounded_story_audit())
+
+        audits = tmp_path / ".forge" / "audits"
+        audits.mkdir(parents=True, exist_ok=True)
+        (audits / "sprint-audit.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "sprint": {
+                        "sprint_id": "sprint-2310",
+                        "total_cost_usd": None,
+                        "total_cost_measured_usd": 0.0,
+                        "cost_complete": False,
+                        "unmeasured_spend_sources": [
+                            "carried:issue-2206",
+                            "carried:prior-generation",
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        persist_accumulated_story_state(
+            "sprint-2310",
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue-2206.md",
+                    "slug": "issue-2206",
+                    "path": "issue-2206.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                }
+            ],
+        )
+        return config, manifest_path
+
+    @staticmethod
+    def _run(config, manifest_path, **kwargs):
+        from unittest.mock import patch
+
+        from test_sprint_resume import _make_coordinator_result
+
+        from theforge.sprint import run_sprint
+        from theforge.sprint.dag import StoryTriage
+
+        def _triage(spec_path, *args, **kw):
+            return StoryTriage(
+                story_path=str(spec_path),
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+            )
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                side_effect=lambda *a, **k: _make_coordinator_result(success=True, cost=1.0),
+            ) as mock_run:
+                result = run_sprint(config, manifest_path, resume=True, **kwargs)
+        return result, mock_run
+
+    def test_resume_without_acceptance_is_still_refused(self, tmp_path: Path) -> None:
+        config, manifest_path = self._arrange(tmp_path)
+        result, mock_run = self._run(config, manifest_path)
+
+        assert mock_run.call_count == 0
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        assert "carried:prior-generation" in result.unresolved_unmeasured_spend_sources
+
+    def test_accepting_the_story_source_clears_the_derived_marker(self, tmp_path: Path) -> None:
+        config, manifest_path = self._arrange(tmp_path)
+        result, mock_run = self._run(config, manifest_path, accept_unmeasured_spend=["issue-2206"])
+
+        assert mock_run.call_count == 1
+        assert result.stopped_reason is None
+        # The marker is gone entirely — not re-surfaced under any spelling.
+        assert result.unresolved_unmeasured_spend_sources == ()
+        assert not any("prior-generation" in s for s in result.unmeasured_spend_sources), (
+            result.unmeasured_spend_sources
+        )
+        # The accepted source is still charged and still reported as unmeasured.
+        assert [r["source"] for r in result.accepted_unmeasured_spend] == ["issue-2206"]
+        assert result.budget_verification_spend_usd >= 4.5
+        assert result.cost_complete is False
+
+    def test_a_later_resume_reads_the_recorded_resolution(self, tmp_path: Path) -> None:
+        """The story must not become unrunnable again on the next resume."""
+        config, manifest_path = self._arrange(tmp_path)
+        self._run(config, manifest_path, accept_unmeasured_spend=["issue-2206"])
+
+        # Re-arm the reported shape exactly as a stopped generation would, and
+        # resume with no flag: the recorded resolution still stands.
+        self._arrange(tmp_path)
+        result, mock_run = self._run(config, manifest_path)
+
+        assert mock_run.call_count == 1
+        assert result.stopped_reason is None
+        assert [r["source"] for r in result.accepted_unmeasured_spend] == ["issue-2206"]
+
+
+class TestOccurrenceIdentitySurvivesAResume:
+    """A stale acceptance must not clear an occurrence recorded after it.
+
+    Within one process the two occurrences are told apart by when they were
+    recorded. Once the run is resumed that distinction is gone — both are simply
+    carried — so identity has to come from the record: which run the unmeasured
+    call actually happened in.
+    """
+
+    @staticmethod
+    def _arrange(tmp_path: Path, *, audit_run_id: str, accepted_run_id: str):
+        from test_sprint_resume import _make_config, _make_manifest, _make_spec_file
+
+        from theforge.sprint.audit import (
+            persist_accepted_unmeasured_spend,
+            persist_accumulated_story_state,
+        )
+
+        _make_spec_file(tmp_path, "Issue 2206", "issue-2206")
+        _make_spec_file(tmp_path, "Feature B", "feature-b")
+        manifest_path = _make_manifest(tmp_path, ["issue-2206.md", "feature-b.md"], budget=100.0)
+        config = _make_config(tmp_path)
+
+        sprint_dir = tmp_path / ".forge" / "logs" / "Test Sprint"
+        sprint_dir.mkdir(parents=True, exist_ok=True)
+        (sprint_dir / ".sprint_id").write_text("sprint-2310", encoding="utf-8")
+        # The per-story audit records the occurrence CURRENTLY carried.
+        _write_story_audit(
+            tmp_path, "Test Sprint", "issue-2206", _bounded_story_audit(run_id=audit_run_id)
+        )
+        persist_accumulated_story_state(
+            "sprint-2310",
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue-2206.md",
+                    "slug": "issue-2206",
+                    "path": "issue-2206.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                }
+            ],
+        )
+        # The acceptance on record was made for the run named here.
+        persist_accepted_unmeasured_spend(
+            "sprint-2310",
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "source": "issue-2206",
+                    "accepted_ceiling_usd": 4.5,
+                    "measured_lower_bound_usd": _MEASURED_BEFORE_FAILURE,
+                    "ceiling_basis": "story_allocation",
+                    "origin_run_id": accepted_run_id,
+                    "accepted_at": "2026-08-08T00:00:00+00:00",
+                    "reason": "reviewer hit a provider quota",
+                }
+            ],
+        )
+        return config, manifest_path
+
+    @staticmethod
+    def _run(config, manifest_path):
+        from unittest.mock import patch
+
+        from test_sprint_resume import _make_coordinator_result
+
+        from theforge.sprint import run_sprint
+        from theforge.sprint.dag import StoryTriage
+
+        def _triage(spec_path, *args, **kw):
+            return StoryTriage(
+                story_path=str(spec_path),
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+            )
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=_triage):
+            with patch(
+                "theforge.sprint.runner.run_task",
+                side_effect=lambda *a, **k: _make_coordinator_result(success=True, cost=1.0),
+            ) as mock_run:
+                result = run_sprint(config, manifest_path, resume=True)
+        return result, mock_run
+
+    def test_a_second_occurrence_is_not_cleared_by_the_first_acceptance(
+        self, tmp_path: Path
+    ) -> None:
+        # Accepted for run-1; the ledger now carries the run-2 occurrence.
+        config, manifest_path = self._arrange(
+            tmp_path, audit_run_id="run-2", accepted_run_id="run-1"
+        )
+        result, mock_run = self._run(config, manifest_path)
+
+        assert mock_run.call_count == 0
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        assert "carried:issue-2206" in result.unresolved_unmeasured_spend_sources
+        # Nothing is charged either — an acceptance of some earlier call is not
+        # a ceiling on this one.
+        assert result.accepted_unmeasured_spend == ()
+
+    def test_the_occurrence_that_was_accepted_still_resolves(self, tmp_path: Path) -> None:
+        config, manifest_path = self._arrange(
+            tmp_path, audit_run_id="run-1", accepted_run_id="run-1"
+        )
+        result, mock_run = self._run(config, manifest_path)
+
+        assert mock_run.call_count == 2
+        assert result.stopped_reason is None
+        assert [r["source"] for r in result.accepted_unmeasured_spend] == ["issue-2206"]
+
+    def test_an_acceptance_with_no_recorded_origin_still_applies(self, tmp_path: Path) -> None:
+        """Unknown identity is not evidence of a mismatch."""
+        config, manifest_path = self._arrange(tmp_path, audit_run_id="run-2", accepted_run_id="")
+        result, mock_run = self._run(config, manifest_path)
+
+        assert mock_run.call_count == 2
+        assert result.stopped_reason is None


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior P1 is resolved; no new P1 regressions found, and the focused unmeasured-spend suite passes. | [deepseek-deepseek-reasoner-api] Cycle 2: the prior P1 (refusal on a new unmeasured occurrence naming the previously-accepted run id/ceiling) is fixed via (occurrence, source)-keyed description cache with per-occurrence derivation, and no regressions were found across the budget, resume-carry, persistence, audit, or CLI/daemon paths. | [google-gemini-3.5-flash-api] Successfully resolved the unmeasured spend issue by introducing a robust operator-acceptance and caching path keyed by occurrence id.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, deepseek-deepseek-reasoner-api, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-api, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-api
- **Cost:** $19.53
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A single unmeasured agent call makes a story permanently unrunnable with no path that clears or accepts it (GitHub Issue #2310)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2310