### PR TITLE
A story allocation reserves for review cycles it never runs, so dev is funded for one attempt

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -327,6 +327,9 @@ def _refuse_dev_without_nonreview_funds(
     by dev. Once everything the allocation left for non-review work is gone,
     another dev attempt would draw down the reserved review cycles and leave the
     work unreviewed — precisely the failure the reservation exists to prevent.
+    What is protected is review spend that is still POSSIBLE (#2340): cycles
+    already run, and cycles a terminal approve put out of reach, are not withheld
+    from dev, so a refusal here means the allocation is genuinely gone.
     Returns ``None`` when the attempt is funded, when no reservation was seated,
     or when spend is unmeasured; otherwise records the refusal on ``state`` and
     returns the escalation result the caller must return.
@@ -356,6 +359,11 @@ def _refuse_dev_without_nonreview_funds(
                     "nonreview_allocation_usd",
                     "reserved_review_usd",
                     "reserved_review_cycles",
+                    # The gross seated reserve above is not what the refusal was
+                    # computed against once review has spent or terminally
+                    # approved; emit the effective protected balance too (#2340).
+                    "reserved_review_remaining_usd",
+                    "reserved_review_released",
                     "observed_usd",
                 )
             },

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -37,6 +37,7 @@ from theforge.review import (
 from theforge.symptom_test_classifier import escalate_symptom_test_findings
 from theforge.task import ContextAssembler, TaskStory, build_review_prompt
 
+from . import story_budget as _story_budget
 from .commit_guard import _has_commits_ahead_of_base
 from .completion import _append_cycle_history, _finalize_approve
 from .escalate_actions import (
@@ -760,6 +761,44 @@ def _carry_handoff(findings: list[ReviewFinding]) -> str:
         if f.suggestion:
             lines.append(f"**Fix:** {f.suggestion}")
     return "\n".join(lines)
+
+
+def _release_review_reservation(
+    state: CoordinatorState,
+    *,
+    retained_cycles: int,
+    reason: str,
+) -> None:
+    """Release the unspent review reserve once review has terminally approved (#2340).
+
+    The reservation is priced at seating against the *maximum* review cycles the
+    story was granted. When review reaches an approve-equivalent terminal path
+    those cycles cannot all occur, so continuing to withhold their money turns a
+    safety margin into a phantom debit — a story gets refused a funded P2-cleanup
+    dev attempt against dollars that provably will not be spent.
+
+    ``retained_cycles`` is how many review cycles remain reachable: one for a P2
+    cleanup pass (its dev iteration loops back through REVIEW), zero once the
+    approval is being finalized. The release is mirrored into
+    ``adaptive_limits_audit`` so the run audit keeps showing the real dispatch
+    inputs without a new audit schema path.
+    """
+    reservation = state.review_funding_reservation
+    if not isinstance(reservation, dict) or reservation.get("released"):
+        return
+    released = _story_budget.release_review_reservation(
+        reservation,
+        review_observed_usd=state.total_review_cost_measured,
+        retained_cycles=retained_cycles,
+        review_cycle=state.review_cycle,
+        reason=reason,
+    )
+    if released is reservation:
+        # Nothing to release (no reserve seated, or review spend unmeasured).
+        return
+    state.review_funding_reservation = released
+    if isinstance(state.adaptive_limits_audit, dict):
+        state.adaptive_limits_audit["review_funding_reservation"] = released
 
 
 def _clear_p2_cleanup_state(state: CoordinatorState) -> None:
@@ -1947,6 +1986,12 @@ def _run_review_phase(
         # remaining carried P2s, an iteration cap, or p2_cleanup_enabled=
         # false all fall through to the existing approve handler.
         if _maybe_enter_p2_cleanup(state, config, parsed_review):
+            # Review has approved: of the cycles the reserve was priced against,
+            # only the re-review of this cleanup pass is still reachable. Release
+            # the rest BEFORE the dev dispatch this returns to is checked for
+            # funding, so cleanup is funded from money that provably cannot be
+            # spent on review (#2340).
+            _release_review_reservation(state, retained_cycles=1, reason="approve_p2_cleanup")
             _entry = state.p2_cleanup_audit[-1]
             _log(
                 f"  ↻ P2 CLEANUP  entering dev iteration "
@@ -1973,6 +2018,9 @@ def _run_review_phase(
                 )
             return _ReviewOutcome.RETRY_DEV, None, config
         # Cleanup was either skipped or terminated.
+        # No further review cycle is reachable on this path, so nothing of the
+        # reserve is still review's — release all of it before finalization.
+        _release_review_reservation(state, retained_cycles=0, reason="approve_final")
         if interactive:
             return _handle_interactive_review_decision(
                 state,

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -437,6 +437,9 @@ def _run_escalate_gate_inner(
                 state.escalate_reason = escalate_reason
                 state.escalate_decision_source = ESCALATE_SOURCE_POLICY_AUTO_APPROVE
                 _append_cycle_history(state, state.review_results[-1])
+                _release_review_reservation(
+                    state, retained_cycles=0, reason="approve_escalate_gate"
+                )
                 return _finalize_approve(
                     state,
                     config,
@@ -574,6 +577,7 @@ def _run_escalate_gate_inner(
             )
         state.escalate_decision = norm if norm in ACTION_TAXONOMY else "approve"
         _append_cycle_history(state, approvable)
+        _release_review_reservation(state, retained_cycles=0, reason="approve_escalate_gate")
         return _finalize_approve(
             state,
             config,
@@ -781,7 +785,11 @@ def _release_review_reservation(
     cleanup pass (its dev iteration loops back through REVIEW), zero once the
     approval is being finalized. Callers must sit where the branch PROVES that
     count — an approve alone does not, since an interactive session can still
-    reject or extend back into REVIEW. The release is mirrored into
+    reject or extend back into REVIEW. Every route that finalizes an approval
+    settles here (normal, interactive, escalate-gate, hygiene replay, early
+    termination), each naming itself in ``reason``, so no DONE story lands with
+    an audit record still claiming the gross seated reserve is withheld. The
+    release is mirrored into
     ``adaptive_limits_audit`` so the run audit keeps showing the real dispatch
     inputs without a new audit schema path.
 
@@ -1276,6 +1284,7 @@ def _maybe_replay_hygiene_consensus(
     state.escalate_kind = None
     state.hygiene_escalation_prior_review = None
     _append_cycle_history(state, prior_review)
+    _release_review_reservation(state, retained_cycles=0, reason="approve_hygiene_replay")
     return (
         _ReviewOutcome.DONE,
         _finalize_approve(
@@ -1893,6 +1902,9 @@ def _run_review_phase(
             if not _blocking_p1:
                 # No blocking P1 — treat as APPROVE path.
                 _append_cycle_history(state, parsed_review)
+                _release_review_reservation(
+                    state, retained_cycles=0, reason="approve_early_termination"
+                )
                 return (
                     _ReviewOutcome.DONE,
                     _finalize_approve(

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -782,9 +782,14 @@ def _release_review_reservation(
     approval is being finalized. The release is mirrored into
     ``adaptive_limits_audit`` so the run audit keeps showing the real dispatch
     inputs without a new audit schema path.
+
+    A reservation released by an earlier cleanup pass is released again when a
+    later cycle approves: the retained cycle it held may by then have run, and
+    the recomputation starts from what is still protected, so a re-release only
+    ever shrinks the retained balance.
     """
     reservation = state.review_funding_reservation
-    if not isinstance(reservation, dict) or reservation.get("released"):
+    if not isinstance(reservation, dict):
         return
     released = _story_budget.release_review_reservation(
         reservation,

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -779,7 +779,9 @@ def _release_review_reservation(
 
     ``retained_cycles`` is how many review cycles remain reachable: one for a P2
     cleanup pass (its dev iteration loops back through REVIEW), zero once the
-    approval is being finalized. The release is mirrored into
+    approval is being finalized. Callers must sit where the branch PROVES that
+    count — an approve alone does not, since an interactive session can still
+    reject or extend back into REVIEW. The release is mirrored into
     ``adaptive_limits_audit`` so the run audit keeps showing the real dispatch
     inputs without a new audit schema path.
 
@@ -1022,6 +1024,11 @@ def _handle_interactive_review_decision(
     if decision == "approve":
         if not history_already_appended:
             _append_cycle_history(state, parsed_review)
+        # The operator ended the run, so the seated review cycles cannot run.
+        # This is the only interactive outcome that proves that: extend and
+        # reject both loop back through REVIEW, and a release before the
+        # decision would strip their cycles of the reservation (#2258/#2340).
+        _release_review_reservation(state, retained_cycles=0, reason="approve_final")
         if exhausted_cycles:
             _approve_msg = (
                 f"Task '{task.name}' completed. "
@@ -2023,9 +2030,11 @@ def _run_review_phase(
                 )
             return _ReviewOutcome.RETRY_DEV, None, config
         # Cleanup was either skipped or terminated.
-        # No further review cycle is reachable on this path, so nothing of the
-        # reserve is still review's — release all of it before finalization.
-        _release_review_reservation(state, retained_cycles=0, reason="approve_final")
+        # The reservation is released where the branch PROVES the cycles it was
+        # priced against cannot run — not merely where review approved. An
+        # interactive session may still send this back through REVIEW on a
+        # reject or an extend, so the release for that path happens inside the
+        # decision handler, on its approve branch only.
         if interactive:
             return _handle_interactive_review_decision(
                 state,
@@ -2044,6 +2053,9 @@ def _run_review_phase(
                 history_already_appended=True,
             )
         else:
+            # The run finalizes here: no review cycle is reachable any more, so
+            # nothing of the reserve is still review's.
+            _release_review_reservation(state, retained_cycles=0, reason="approve_final")
             return (
                 _ReviewOutcome.DONE,
                 _finalize_approve(

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -1013,6 +1013,12 @@ class CoordinatorState:
     # further attempts once the rest of the allocation is spent, so the seating
     # decision binds when it is exceeded rather than only when it is computed.
     # None/empty on runs where the reconciliation reserved nothing.
+    # The record can be terminally RELEASED (#2340): once review reaches an
+    # approve-equivalent path the seated cycles can no longer all occur, so the
+    # release adds released=True plus retained_review_cycles/retained_review_usd,
+    # released_review_usd, review_observed_usd, release_review_cycle and
+    # release_reason. From then on only the retained amount is protected — a
+    # released reserve stops being withheld from dev.
     review_funding_reservation: dict | None = None
     adaptive_limits_audit: dict = field(default_factory=dict)
     # One entry per development invocation whose timeout was shortened to fit

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -968,7 +968,12 @@ def nonreview_funding_exhausted(
     # back into the dev pool, funding attempts past the whole allocation: with a
     # reserve fully consumed by a cycle that ran, `allocation - protected` is the
     # entire allocation again, and dev would be admitted having spent it twice.
-    ceiling = _balance(allocation_usd - float(review_observed_usd) - protected)
+    # Floored at zero: review spend can exceed the whole allocation, and a pool
+    # reported as holding less than nothing is not a number an operator can act
+    # on. Clamping keeps the reported figures consistent — remaining_usd stays
+    # `ceiling - observed`, so the two still agree — and cannot change the
+    # decision, since a ceiling below zero refuses either way.
+    ceiling = _balance(max(0.0, allocation_usd - float(review_observed_usd) - protected))
     remaining = _balance(ceiling - nonreview_observed)
     # Strictly greater: a non-review pool spent to the cent has nothing left to
     # fund another attempt with, and admitting one would spend the reserved

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -734,13 +734,101 @@ def phase_funding_shortfall(
 
 
 def _reserved_review_usd(reservation: dict | None) -> float:
-    """The reserved review balance on a reservation record, or 0.0."""
+    """The gross reserved review balance seated on a reservation record, or 0.0."""
     if not isinstance(reservation, dict):
         return 0.0
     try:
         return max(0.0, float(reservation.get("reserved_review_usd") or 0.0))
     except (TypeError, ValueError):
         return 0.0
+
+
+def remaining_reserved_review_usd(
+    reservation: dict | None,
+    review_observed_usd: float | None,
+) -> float | None:
+    """Reserved review money that can still be spent, or ``None`` when unknowable.
+
+    The seated figure prices the *maximum* number of review cycles a story was
+    granted, and holding that gross number for the life of the story withholds
+    money from cycles that have already run — and, once review reaches a terminal
+    verdict, from cycles that can no longer run at all (#2340). What a
+    reservation actually protects is the unspent balance:
+
+    * a reservation released after terminal review protects only the amount the
+      release explicitly retained (``retained_review_usd``) — for a P2-cleanup
+      pass, one further cycle; for a finalized approval, nothing;
+    * otherwise the seated reserve less measured review spend.
+
+    ``None`` is returned when review spend is unmeasured and the balance is
+    therefore a guess — callers must not refuse work on it.
+    """
+    if not isinstance(reservation, dict):
+        return 0.0
+    if reservation.get("released"):
+        try:
+            return _balance(max(0.0, float(reservation.get("retained_review_usd") or 0.0)))
+        except (TypeError, ValueError):
+            return 0.0
+    reserved = _reserved_review_usd(reservation)
+    if reserved <= 0.0:
+        return 0.0
+    if review_observed_usd is None:
+        return None
+    try:
+        return _balance(reserved - float(review_observed_usd))
+    except (TypeError, ValueError):
+        return None
+
+
+def release_review_reservation(
+    reservation: dict | None,
+    *,
+    review_observed_usd: float | None,
+    retained_cycles: int,
+    review_cycle: int | None,
+    reason: str,
+) -> dict | None:
+    """Return ``reservation`` marked released, retaining ``retained_cycles`` cycles.
+
+    Called when review reaches an approve-equivalent terminal path: the cycles
+    the reserve was priced against cannot all happen any more, so the unspent
+    remainder stops being review's and becomes spendable by a P2-cleanup dev
+    attempt. ``retained_cycles`` is how many review cycles are still reachable —
+    one for a P2-cleanup pass (whose dev iteration loops back through REVIEW),
+    zero for a finalized approval. Cycles beyond the retained one, should the
+    cleanup pass regress into REQUEST_CHANGES, draw the general allocation
+    through the pre-existing whole-allocation check.
+
+    Returns the same record when there is nothing to release, so the caller can
+    assign unconditionally.
+    """
+    if not isinstance(reservation, dict):
+        return reservation
+    reserved = _reserved_review_usd(reservation)
+    if reserved <= 0.0:
+        return reservation
+    try:
+        cycle_cost = max(0.0, float(reservation.get("review_cycle_cost_usd") or 0.0))
+    except (TypeError, ValueError):
+        cycle_cost = 0.0
+    remaining = remaining_reserved_review_usd(reservation, review_observed_usd)
+    if remaining is None:
+        # Review spend is unmeasured: the unspent balance is a guess, so hold the
+        # reservation as seated rather than release a number the run does not have.
+        return reservation
+    retained = _balance(min(remaining, max(0, int(retained_cycles)) * cycle_cost))
+    released = dict(reservation)
+    released["released"] = True
+    released["release_reason"] = reason
+    released["release_review_cycle"] = review_cycle
+    released["review_observed_usd"] = (
+        None if review_observed_usd is None else round(float(review_observed_usd), 4)
+    )
+    released["retained_review_cycles"] = max(0, int(retained_cycles))
+    released["retained_review_usd"] = retained
+    released["released_review_usd"] = _balance(remaining - retained)
+    return released
 
 
 def reserved_review_shortfall(
@@ -775,9 +863,9 @@ def reserved_review_shortfall(
             participants=participants,
             planned_usd=planned_usd,
         )
-    if review_observed_usd is None:
+    reserved_remaining = remaining_reserved_review_usd(reservation, review_observed_usd)
+    if reserved_remaining is None:
         return None
-    reserved_remaining = _balance(reserved - float(review_observed_usd))
     if reserved_remaining >= _balance(planned_usd):
         return None
     shortfall = phase_funding_shortfall(
@@ -792,6 +880,7 @@ def reserved_review_shortfall(
     shortfall["reserved_review_usd"] = _balance(reserved)
     shortfall["reserved_review_cycles"] = (reservation or {}).get("reserved_review_cycles")
     shortfall["reserved_review_remaining_usd"] = reserved_remaining
+    shortfall["reserved_review_released"] = bool((reservation or {}).get("released"))
     return shortfall
 
 
@@ -808,9 +897,14 @@ def nonreview_funding_exhausted(
 
     The other half of holding a reservation: money committed to review must not
     be spendable by an earlier phase, so once non-review spend has reached
-    ``allocation - reserved``, no further attempt at ``phase`` is funded. The
-    reserved balance is deliberately excluded — it is still there, and it is
-    still review's.
+    ``allocation - reserved``, no further attempt at ``phase`` is funded.
+
+    What is protected is the reserve that can *still be spent*, not the gross
+    figure seating priced against the maximum permitted cycle count (#2340).
+    Review spend already made comes out of the reserve, and once review reaches a
+    terminal verdict the reservation is released down to the cycles that remain
+    reachable. Withholding money from cycles that have run, or that can no longer
+    run, refuses dev funded work against a phantom debit.
 
     Returns ``None`` — funded — whenever there is no reservation to protect or
     spend is unmeasured. The payload reuses the :func:`phase_funding_shortfall`
@@ -824,8 +918,11 @@ def nonreview_funding_exhausted(
         allocation_usd = float((allocation or {}).get("allocation_usd"))
     except (TypeError, ValueError, AttributeError):
         return None
+    protected = remaining_reserved_review_usd(reservation, review_observed_usd)
+    if protected is None:
+        return None
     nonreview_observed = _balance(max(0.0, float(observed_usd) - float(review_observed_usd)))
-    ceiling = _balance(allocation_usd - reserved)
+    ceiling = _balance(allocation_usd - protected)
     remaining = _balance(ceiling - nonreview_observed)
     # Strictly greater: a non-review pool spent to the cent has nothing left to
     # fund another attempt with, and admitting one would spend the reserved
@@ -843,6 +940,11 @@ def nonreview_funding_exhausted(
         "nonreview_allocation_usd": ceiling,
         "reserved_review_usd": _balance(reserved),
         "reserved_review_cycles": (reservation or {}).get("reserved_review_cycles"),
+        # The figure that actually drove the refusal, alongside the gross seated
+        # reserve it was derived from, so an allocation_exhausted record shows
+        # whether review money was still reachable when dev was refused (#2340).
+        "reserved_review_remaining_usd": protected,
+        "reserved_review_released": bool((reservation or {}).get("released")),
         "total_observed_usd": round(float(observed_usd), 4),
         "basis": (allocation or {}).get("basis"),
         "complexity_score": (allocation or {}).get("complexity_score"),
@@ -1306,16 +1408,22 @@ def format_shortfall(shortfall: dict, *, story: str | None = None) -> str:
     story_label = f"story {story}" if story else "story"
     if shortfall.get("nonreview_exhausted"):
         cycles = shortfall.get("reserved_review_cycles")
+        # The protected figure, not the gross seated one: review spend already
+        # made, and cycles a terminal verdict put out of reach, are no longer
+        # withheld, and the operator line must name the money actually held (#2340).
+        protected = shortfall.get("reserved_review_remaining_usd")
+        if protected is None:
+            protected = shortfall.get("reserved_review_usd")
         return (
             f"Story allocation exhausted: {story_label} has spent "
             f"${float(shortfall['observed_usd']):.2f} of the "
             f"${float(shortfall['nonreview_allocation_usd']):.2f} its "
             f"${float(shortfall['allocation_usd']):.2f} allocation leaves for non-review "
-            f"work, so no further {shortfall['phase']} attempt is funded. The remaining "
-            f"${float(shortfall['reserved_review_usd']):.2f} is reserved for the "
-            f"{cycles} review cycle(s) this story was seated with and is not "
-            "available to spend here. Sprint headroom is reported alongside this "
-            "story in the sprint summary."
+            f"work, so no further {shortfall['phase']} attempt is funded. "
+            f"${float(protected):.2f} is reserved for the review cycles that can yet "
+            f"run — of the ${float(shortfall['reserved_review_usd']):.2f} seated for "
+            f"{cycles} review cycle(s) — and is not available to spend here. Sprint "
+            "headroom is reported alongside this story in the sprint summary."
         )
     expected = "no band history"
     if shortfall.get("median_usd") is not None:

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -836,14 +836,18 @@ def release_review_reservation(
     reserved = _reserved_review_usd(reservation)
     if reserved <= 0.0:
         return reservation
+    if review_observed_usd is None:
+        # Review spend is unmeasured: the unspent balance is a guess, so hold the
+        # record as it stands rather than release a number the run does not have.
+        # A re-release must bail here too — writing a zero baseline over the one
+        # an earlier release recorded would silently un-net the retained cycle.
+        return reservation
     try:
         cycle_cost = max(0.0, float(reservation.get("review_cycle_cost_usd") or 0.0))
     except (TypeError, ValueError):
         cycle_cost = 0.0
     remaining = remaining_reserved_review_usd(reservation, review_observed_usd)
     if remaining is None:
-        # Review spend is unmeasured: the unspent balance is a guess, so hold the
-        # reservation as seated rather than release a number the run does not have.
         return reservation
     retained = _balance(min(remaining, max(0, int(retained_cycles)) * cycle_cost))
     released = dict(reservation)
@@ -853,7 +857,7 @@ def release_review_reservation(
     # The baseline every later netting of the retained balance is measured from:
     # review spend recorded AT this release. Without it a retained cycle that
     # then runs would go on being withheld from dev after it was paid for.
-    released["review_observed_at_release_usd"] = round(float(review_observed_usd or 0.0), 4)
+    released["review_observed_at_release_usd"] = round(float(review_observed_usd), 4)
     released["retained_review_cycles"] = max(0, int(retained_cycles))
     released["retained_review_usd"] = retained
     # What THIS release let go — a re-release records its own delta, and
@@ -928,15 +932,19 @@ def nonreview_funding_exhausted(
     """Return a shortfall when the non-reserved part of the allocation is gone.
 
     The other half of holding a reservation: money committed to review must not
-    be spendable by an earlier phase, so once non-review spend has reached
-    ``allocation - reserved``, no further attempt at ``phase`` is funded.
+    be spendable by an earlier phase, so once non-review spend has reached what
+    the allocation leaves after review, no further attempt at ``phase`` is
+    funded. Equivalently — and this is the invariant the arithmetic keeps — an
+    attempt is funded only while ``total spend + review spend still possible``
+    is under the allocation.
 
     What is protected is the reserve that can *still be spent*, not the gross
     figure seating priced against the maximum permitted cycle count (#2340).
     Review spend already made comes out of the reserve, and once review reaches a
     terminal verdict the reservation is released down to the cycles that remain
     reachable. Withholding money from cycles that have run, or that can no longer
-    run, refuses dev funded work against a phantom debit.
+    run, refuses dev funded work against a phantom debit — but the money those
+    cycles DID spend is spent, and stays out of the dev pool.
 
     Returns ``None`` — funded — whenever there is no reservation to protect or
     spend is unmeasured. The payload reuses the :func:`phase_funding_shortfall`
@@ -954,7 +962,13 @@ def nonreview_funding_exhausted(
     if protected is None:
         return None
     nonreview_observed = _balance(max(0.0, float(observed_usd) - float(review_observed_usd)))
-    ceiling = _balance(allocation_usd - protected)
+    # What is left for non-review work is the allocation less the review money
+    # ALREADY SPENT and the review money that can still be spent. Netting only
+    # the protected balance would credit every dollar review has already drawn
+    # back into the dev pool, funding attempts past the whole allocation: with a
+    # reserve fully consumed by a cycle that ran, `allocation - protected` is the
+    # entire allocation again, and dev would be admitted having spent it twice.
+    ceiling = _balance(allocation_usd - float(review_observed_usd) - protected)
     remaining = _balance(ceiling - nonreview_observed)
     # Strictly greater: a non-review pool spent to the cent has nothing left to
     # fund another attempt with, and admitting one would spend the reserved

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -733,6 +733,16 @@ def phase_funding_shortfall(
 # number the run does not have would be a guess.
 
 
+def _nonneg_float(value: object, *, default: float | None = 0.0) -> float | None:
+    """``value`` as a non-negative float, or ``default`` when it is not one."""
+    if value is None:
+        return default
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return default
+
+
 def _reserved_review_usd(reservation: dict | None) -> float:
     """The gross reserved review balance seated on a reservation record, or 0.0."""
     if not isinstance(reservation, dict):
@@ -755,10 +765,16 @@ def remaining_reserved_review_usd(
     verdict, from cycles that can no longer run at all (#2340). What a
     reservation actually protects is the unspent balance:
 
-    * a reservation released after terminal review protects only the amount the
+    * a reservation released after terminal review protects the amount the
       release explicitly retained (``retained_review_usd``) — for a P2-cleanup
-      pass, one further cycle; for a finalized approval, nothing;
+      pass, one further cycle; for a finalized approval, nothing — less whatever
+      review has spent SINCE the release, so once the retained cycle has
+      actually run its cost stops being withheld too;
     * otherwise the seated reserve less measured review spend.
+
+    Either way the balance floors at zero: a review phase that overran its
+    reserve has nothing left to protect, and letting the figure go negative
+    would hand dev a ceiling ABOVE the story's whole allocation.
 
     ``None`` is returned when review spend is unmeasured and the balance is
     therefore a guess — callers must not refuse work on it.
@@ -766,17 +782,24 @@ def remaining_reserved_review_usd(
     if not isinstance(reservation, dict):
         return 0.0
     if reservation.get("released"):
+        retained = _nonneg_float(reservation.get("retained_review_usd")) or 0.0
+        baseline = _nonneg_float(reservation.get("review_observed_at_release_usd"), default=None)
+        if retained <= 0.0 or review_observed_usd is None or baseline is None:
+            # Nothing retained, or nothing to net it against: the retained
+            # amount stands as recorded at release.
+            return _balance(retained)
         try:
-            return _balance(max(0.0, float(reservation.get("retained_review_usd") or 0.0)))
+            spent_since_release = max(0.0, float(review_observed_usd) - baseline)
         except (TypeError, ValueError):
-            return 0.0
+            return _balance(retained)
+        return _balance(max(0.0, retained - spent_since_release))
     reserved = _reserved_review_usd(reservation)
     if reserved <= 0.0:
         return 0.0
     if review_observed_usd is None:
         return None
     try:
-        return _balance(reserved - float(review_observed_usd))
+        return _balance(max(0.0, reserved - float(review_observed_usd)))
     except (TypeError, ValueError):
         return None
 
@@ -800,6 +823,11 @@ def release_review_reservation(
     cleanup pass regress into REQUEST_CHANGES, draw the general allocation
     through the pre-existing whole-allocation check.
 
+    An already-released reservation may be released AGAIN when a later cycle
+    approves: the recomputation starts from what is still protected now, so a
+    re-release can only ever shrink the retained balance — it never hands review
+    back money a previous release already gave to dev.
+
     Returns the same record when there is nothing to release, so the caller can
     assign unconditionally.
     """
@@ -822,12 +850,16 @@ def release_review_reservation(
     released["released"] = True
     released["release_reason"] = reason
     released["release_review_cycle"] = review_cycle
-    released["review_observed_usd"] = (
-        None if review_observed_usd is None else round(float(review_observed_usd), 4)
-    )
+    # The baseline every later netting of the retained balance is measured from:
+    # review spend recorded AT this release. Without it a retained cycle that
+    # then runs would go on being withheld from dev after it was paid for.
+    released["review_observed_at_release_usd"] = round(float(review_observed_usd or 0.0), 4)
     released["retained_review_cycles"] = max(0, int(retained_cycles))
     released["retained_review_usd"] = retained
+    # What THIS release let go — a re-release records its own delta, and
+    # release_count says how many there have been.
     released["released_review_usd"] = _balance(remaining - retained)
+    released["release_count"] = int(reservation.get("release_count") or 0) + 1
     return released
 
 

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -446,7 +446,8 @@ def _nonreview_shortfall() -> dict:
     """The shortfall payload the coordinator records, built by the real function.
 
     Reproduces the figures reported for issue-2226: $33.82 spent of the $29.48 a
-    $48.02 allocation leaves for non-review work, $18.54 reserved for 5 cycles.
+    $48.02 allocation leaves for non-review work, $18.54 reserved for 5 cycles —
+    none of which had run yet, so the whole reservation is still review's (#2340).
     """
     from theforge.coordinator import story_budget as _story_budget
 
@@ -461,8 +462,8 @@ def _nonreview_shortfall() -> dict:
             "max_usd": 38.4,
             "sample_count": 11,
         },
-        observed_usd=40.0,
-        review_observed_usd=6.18,
+        observed_usd=33.82,
+        review_observed_usd=0.0,
         participants=["reviewer-a"],
     )
     assert shortfall is not None

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -1584,6 +1584,22 @@ class TestReviewFundingReservation:
             is not None
         )
 
+    def test_a_pool_the_review_overrun_swallowed_reports_zero_not_less(self) -> None:
+        """A non-review pool cannot hold less than nothing, and does not say it does."""
+        shortfall = sb.nonreview_funding_exhausted(
+            self._reservation(reserved_usd=1.01, cycles=1),
+            self._allocation(),  # $4.12
+            observed_usd=5.62,  # $1.00 dev + $4.62 review: review ate it all
+            review_observed_usd=4.62,
+            participants=["dev"],
+        )
+
+        assert shortfall is not None
+        assert shortfall["nonreview_allocation_usd"] == 0.0
+        # The reported figures still agree: remaining is ceiling less spend.
+        assert shortfall["observed_usd"] == 1.00
+        assert shortfall["remaining_usd"] == -1.00
+
     def test_re_releasing_only_ever_shrinks_the_retained_balance(self) -> None:
         """A second terminal approve must not hand review back dev's money."""
         first = sb.release_review_reservation(

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -1309,7 +1309,7 @@ class TestReviewFundingReservation:
         message = sb.format_shortfall(shortfall, story="issue-2252")
         assert "issue-2252" in message
         assert "$3.11" in message
-        assert "reserved for the 1 review cycle(s)" in message
+        assert "seated for 1 review cycle(s)" in message
 
     def test_a_non_review_pool_spent_to_the_cent_refuses_the_next_attempt(self) -> None:
         """The boundary binds where the operator sees it: $3.11 of $3.11 is gone.
@@ -1386,6 +1386,163 @@ class TestReviewFundingReservation:
                 observed_usd=3.01,  # $2.00 dev + $1.01 review
                 review_observed_usd=1.01,
                 participants=["dev"],
+            )
+            is None
+        )
+
+    # ── Only review spend that is still POSSIBLE is protected (#2340) ────────
+
+    def test_review_spend_already_made_stops_being_withheld_from_dev(self) -> None:
+        """A reserve of 3 cycles with 2 run protects one cycle, not three.
+
+        The seated figure prices the maximum; holding it gross withholds money
+        from cycles that have already been paid for out of it.
+        """
+        reservation = self._reservation(reserved_usd=3.03, cycles=3)
+        allocation = self._allocation(usd=6.12)
+
+        # $2.02 of review has run: $1.01 of reserve is still reachable, so the
+        # non-review pool is $6.12 - $1.01 = $5.11, and $3.00 of dev fits.
+        assert (
+            sb.nonreview_funding_exhausted(
+                reservation,
+                allocation,
+                observed_usd=5.02,  # $3.00 dev + $2.02 review
+                review_observed_usd=2.02,
+                participants=["dev"],
+            )
+            is None
+        )
+
+    def test_dev_is_still_refused_when_possible_review_spend_exhausts_it(self) -> None:
+        """Netting spent cycles out is not the same as dropping the reservation."""
+        reservation = self._reservation(reserved_usd=3.03, cycles=3)
+        shortfall = sb.nonreview_funding_exhausted(
+            reservation,
+            self._allocation(usd=6.12),
+            observed_usd=7.13,  # $5.11 dev + $2.02 review
+            review_observed_usd=2.02,
+            participants=["dev"],
+        )
+
+        assert shortfall is not None
+        assert shortfall["nonreview_exhausted"] is True
+        assert shortfall["reserved_review_usd"] == 3.03
+        assert shortfall["reserved_review_remaining_usd"] == 1.01
+        assert shortfall["reserved_review_released"] is False
+        assert shortfall["nonreview_allocation_usd"] == 5.11
+        assert shortfall["observed_usd"] == 5.11
+
+    def test_a_released_reservation_frees_the_remainder_for_dev(self) -> None:
+        """The #2340 symptom: dev refused against cycles that can no longer run."""
+        reservation = self._reservation(reserved_usd=3.03, cycles=3)
+        allocation = self._allocation(usd=4.12)
+        # One cycle ran; $2.02 of reserve is held for two cycles that will not
+        # happen, and dev has spent everything outside the reserve.
+        assert (
+            sb.nonreview_funding_exhausted(
+                reservation,
+                allocation,
+                observed_usd=3.11,  # $2.10 dev + $1.01 review
+                review_observed_usd=1.01,
+                participants=["dev"],
+            )
+            is not None
+        )
+
+        released = sb.release_review_reservation(
+            reservation,
+            review_observed_usd=1.01,
+            retained_cycles=1,
+            review_cycle=1,
+            reason="approve_p2_cleanup",
+        )
+
+        assert released["released"] is True
+        assert released["retained_review_usd"] == 1.01
+        assert released["released_review_usd"] == 1.01
+        assert released["release_reason"] == "approve_p2_cleanup"
+        assert released["release_review_cycle"] == 1
+        # The retained cycle is still protected; everything past it is dev's.
+        assert (
+            sb.nonreview_funding_exhausted(
+                released,
+                allocation,
+                observed_usd=3.11,
+                review_observed_usd=1.01,
+                participants=["dev"],
+            )
+            is None
+        )
+
+    def test_a_fully_released_reservation_retains_nothing(self) -> None:
+        released = sb.release_review_reservation(
+            self._reservation(reserved_usd=3.03, cycles=3),
+            review_observed_usd=1.01,
+            retained_cycles=0,
+            review_cycle=1,
+            reason="approve_final",
+        )
+
+        assert released["retained_review_usd"] == 0.0
+        assert released["released_review_usd"] == 2.02
+        assert sb.remaining_reserved_review_usd(released, 1.01) == 0.0
+        # And the whole-allocation check is what governs from here.
+        shortfall = sb.nonreview_funding_exhausted(
+            released,
+            self._allocation(),
+            observed_usd=5.13,  # $4.12 dev + $1.01 review
+            review_observed_usd=1.01,
+            participants=["dev"],
+        )
+        assert shortfall is not None
+        assert shortfall["nonreview_allocation_usd"] == 4.12
+        assert shortfall["reserved_review_released"] is True
+
+    def test_releasing_on_unmeasured_review_spend_holds_the_reservation(self) -> None:
+        """An unspent balance nobody measured is a guess, not a release."""
+        reservation = self._reservation(reserved_usd=3.03, cycles=3)
+        assert (
+            sb.release_review_reservation(
+                reservation,
+                review_observed_usd=None,
+                retained_cycles=0,
+                review_cycle=1,
+                reason="approve_final",
+            )
+            is reservation
+        )
+        assert sb.remaining_reserved_review_usd(reservation, None) is None
+        for empty in (None, {}, {"reserved_review_usd": 0.0}):
+            assert (
+                sb.release_review_reservation(
+                    empty,
+                    review_observed_usd=1.0,
+                    retained_cycles=0,
+                    review_cycle=1,
+                    reason="approve_final",
+                )
+                is empty
+            )
+
+    def test_a_released_reserve_still_funds_the_retained_review_cycle(self) -> None:
+        """Release must not defund the re-review a P2-cleanup pass loops back to."""
+        released = sb.release_review_reservation(
+            self._reservation(reserved_usd=3.03, cycles=3),
+            review_observed_usd=1.01,
+            retained_cycles=1,
+            review_cycle=1,
+            reason="approve_p2_cleanup",
+        )
+
+        assert (
+            sb.reserved_review_shortfall(
+                released,
+                self._allocation(),
+                observed_usd=4.12,  # nothing left in the general pool
+                review_observed_usd=1.01,
+                participants=["a"],
+                planned_usd=1.01,
             )
             is None
         )

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -1401,8 +1401,8 @@ class TestReviewFundingReservation:
         reservation = self._reservation(reserved_usd=3.03, cycles=3)
         allocation = self._allocation(usd=6.12)
 
-        # $2.02 of review has run: $1.01 of reserve is still reachable, so the
-        # non-review pool is $6.12 - $1.01 = $5.11, and $3.00 of dev fits.
+        # $2.02 of review has run and $1.01 of reserve is still reachable, so the
+        # non-review pool is $6.12 - $2.02 - $1.01 = $3.09, and $3.00 of dev fits.
         assert (
             sb.nonreview_funding_exhausted(
                 reservation,
@@ -1430,7 +1430,9 @@ class TestReviewFundingReservation:
         assert shortfall["reserved_review_usd"] == 3.03
         assert shortfall["reserved_review_remaining_usd"] == 1.01
         assert shortfall["reserved_review_released"] is False
-        assert shortfall["nonreview_allocation_usd"] == 5.11
+        # $6.12 less the $2.02 review has already spent and the $1.01 it may
+        # still spend — dev's $5.11 is well past it.
+        assert shortfall["nonreview_allocation_usd"] == 3.09
         assert shortfall["observed_usd"] == 5.11
 
     def test_a_released_reservation_frees_the_remainder_for_dev(self) -> None:
@@ -1443,7 +1445,7 @@ class TestReviewFundingReservation:
             sb.nonreview_funding_exhausted(
                 reservation,
                 allocation,
-                observed_usd=3.11,  # $2.10 dev + $1.01 review
+                observed_usd=2.61,  # $1.60 dev + $1.01 review
                 review_observed_usd=1.01,
                 participants=["dev"],
             )
@@ -1468,7 +1470,7 @@ class TestReviewFundingReservation:
             sb.nonreview_funding_exhausted(
                 released,
                 allocation,
-                observed_usd=3.11,
+                observed_usd=2.61,
                 review_observed_usd=1.01,
                 participants=["dev"],
             )
@@ -1497,9 +1499,10 @@ class TestReviewFundingReservation:
         )
 
         assert shortfall is not None
-        assert shortfall["nonreview_allocation_usd"] == 4.12
+        # $4.12 less the $2.50 review spent and the $0.00 it may still spend.
+        assert shortfall["nonreview_allocation_usd"] == 1.62
         assert shortfall["reserved_review_remaining_usd"] == 0.0
-        assert shortfall["remaining_usd"] == 0.0
+        assert shortfall["remaining_usd"] == -2.50
 
     def test_a_retained_cycle_that_runs_stops_being_withheld_from_dev(self) -> None:
         """Release nets from the spend AT release, so the retained cycle frees up."""
@@ -1522,16 +1525,63 @@ class TestReviewFundingReservation:
         # And an overrunning retained cycle still floors at zero.
         assert sb.remaining_reserved_review_usd(released, 3.50) == 0.0
 
-        # The dev attempt after the retained cycle draws the whole allocation.
+        # The dev attempt after the retained cycle draws what is left of the
+        # allocation with nothing withheld: $4.12 - $2.02 spent - $0.00 possible.
         assert (
             sb.nonreview_funding_exhausted(
                 released,
                 self._allocation(),  # $4.12
-                observed_usd=6.02,  # $4.00 dev + $2.02 review
+                observed_usd=3.50,  # $1.48 dev + $2.02 review
                 review_observed_usd=2.02,
                 participants=["dev"],
             )
             is None
+        )
+        # Holding the retained cycle flat would have refused that attempt:
+        # $4.12 - $2.02 - $1.01 = $1.09, against $1.48 of dev spend.
+
+    def test_total_spend_never_passes_the_allocation_once_review_has_run(self) -> None:
+        """Review money already spent stays out of the dev pool.
+
+        Netting only the *protected* balance out of the allocation would credit
+        every dollar review already drew back to dev: a reserve fully consumed by
+        a cycle that ran leaves ``allocation - protected`` equal to the whole
+        allocation again, and dev is admitted having spent it twice. The check
+        binds on total spend plus review spend still possible.
+        """
+        allocation = self._allocation()  # $4.12
+        reservation = self._reservation(reserved_usd=1.01, cycles=1)
+
+        # The reserved cycle ran, so nothing is protected — but $1.01 is gone.
+        for dev_usd in (3.11, 3.50, 4.12, 5.00):
+            shortfall = sb.nonreview_funding_exhausted(
+                reservation,
+                allocation,
+                observed_usd=round(dev_usd + 1.01, 4),
+                review_observed_usd=1.01,
+                participants=["dev"],
+            )
+            funded = shortfall is None
+            # Funded only while total spend is under the allocation.
+            assert funded is (round(dev_usd + 1.01, 4) < 4.12), dev_usd
+
+        # And the same holds for a released reservation with nothing retained.
+        released = sb.release_review_reservation(
+            reservation,
+            review_observed_usd=1.01,
+            retained_cycles=0,
+            review_cycle=1,
+            reason="approve_final",
+        )
+        assert (
+            sb.nonreview_funding_exhausted(
+                released,
+                allocation,
+                observed_usd=4.12,  # $3.11 dev + $1.01 review: exactly spent
+                review_observed_usd=1.01,
+                participants=["dev"],
+            )
+            is not None
         )
 
     def test_re_releasing_only_ever_shrinks_the_retained_balance(self) -> None:
@@ -1581,7 +1631,9 @@ class TestReviewFundingReservation:
             participants=["dev"],
         )
         assert shortfall is not None
-        assert shortfall["nonreview_allocation_usd"] == 4.12
+        # Nothing is withheld any more, but the $1.01 review spent is still gone:
+        # $4.12 - $1.01 - $0.00.
+        assert shortfall["nonreview_allocation_usd"] == 3.11
         assert shortfall["reserved_review_released"] is True
 
     def test_releasing_on_unmeasured_review_spend_holds_the_reservation(self) -> None:
@@ -1598,6 +1650,30 @@ class TestReviewFundingReservation:
             is reservation
         )
         assert sb.remaining_reserved_review_usd(reservation, None) is None
+
+        # A RE-release on unmeasured spend must hold too: writing a zero
+        # baseline over the one the first release recorded would silently
+        # un-net the retained cycle and withhold it all over again.
+        released = sb.release_review_reservation(
+            reservation,
+            review_observed_usd=1.01,
+            retained_cycles=1,
+            review_cycle=1,
+            reason="approve_p2_cleanup",
+        )
+        assert (
+            sb.release_review_reservation(
+                released,
+                review_observed_usd=None,
+                retained_cycles=0,
+                review_cycle=2,
+                reason="approve_final",
+            )
+            is released
+        )
+        assert released["review_observed_at_release_usd"] == 1.01
+        assert sb.remaining_reserved_review_usd(released, 2.02) == 0.0
+
         for empty in (None, {}, {"reserved_review_usd": 0.0}):
             assert (
                 sb.release_review_reservation(

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -1475,6 +1475,91 @@ class TestReviewFundingReservation:
             is None
         )
 
+    def test_a_review_overrun_protects_nothing_rather_than_a_negative_balance(
+        self,
+    ) -> None:
+        """A reserve spent past its face value has nothing left to withhold.
+
+        Netting a larger review spend out of a smaller reserve reads as a
+        negative balance, and subtracting that from the allocation hands dev a
+        ceiling ABOVE the whole allocation — funding attempts on money the story
+        does not have.
+        """
+        reservation = self._reservation(reserved_usd=1.01, cycles=1)
+        assert sb.remaining_reserved_review_usd(reservation, 2.50) == 0.0
+
+        shortfall = sb.nonreview_funding_exhausted(
+            reservation,
+            self._allocation(),  # $4.12
+            observed_usd=6.62,  # $4.12 dev + $2.50 review
+            review_observed_usd=2.50,
+            participants=["dev"],
+        )
+
+        assert shortfall is not None
+        assert shortfall["nonreview_allocation_usd"] == 4.12
+        assert shortfall["reserved_review_remaining_usd"] == 0.0
+        assert shortfall["remaining_usd"] == 0.0
+
+    def test_a_retained_cycle_that_runs_stops_being_withheld_from_dev(self) -> None:
+        """Release nets from the spend AT release, so the retained cycle frees up."""
+        released = sb.release_review_reservation(
+            self._reservation(reserved_usd=3.03, cycles=3),
+            review_observed_usd=1.01,
+            retained_cycles=1,
+            review_cycle=1,
+            reason="approve_p2_cleanup",
+        )
+
+        assert released["review_observed_at_release_usd"] == 1.01
+        assert released["release_count"] == 1
+        # Before the retained cycle runs, its cost is protected.
+        assert sb.remaining_reserved_review_usd(released, 1.01) == 1.01
+        # Half-spent, half-protected.
+        assert sb.remaining_reserved_review_usd(released, 1.51) == 0.51
+        # Once it has run, nothing of it is withheld any more.
+        assert sb.remaining_reserved_review_usd(released, 2.02) == 0.0
+        # And an overrunning retained cycle still floors at zero.
+        assert sb.remaining_reserved_review_usd(released, 3.50) == 0.0
+
+        # The dev attempt after the retained cycle draws the whole allocation.
+        assert (
+            sb.nonreview_funding_exhausted(
+                released,
+                self._allocation(),  # $4.12
+                observed_usd=6.02,  # $4.00 dev + $2.02 review
+                review_observed_usd=2.02,
+                participants=["dev"],
+            )
+            is None
+        )
+
+    def test_re_releasing_only_ever_shrinks_the_retained_balance(self) -> None:
+        """A second terminal approve must not hand review back dev's money."""
+        first = sb.release_review_reservation(
+            self._reservation(reserved_usd=3.03, cycles=3),
+            review_observed_usd=1.01,
+            retained_cycles=1,
+            review_cycle=1,
+            reason="approve_p2_cleanup",
+        )
+        # The retained cycle ran; the next approve releases again.
+        second = sb.release_review_reservation(
+            first,
+            review_observed_usd=2.02,
+            retained_cycles=1,
+            review_cycle=2,
+            reason="approve_p2_cleanup",
+        )
+
+        assert second["release_count"] == 2
+        assert second["retained_review_usd"] == 0.0
+        assert second["review_observed_at_release_usd"] == 2.02
+        assert sb.remaining_reserved_review_usd(second, 2.02) == 0.0
+        # The gross seated figures are still on the record for the audit.
+        assert second["reserved_review_usd"] == 3.03
+        assert second["reserved_review_cycles"] == 3
+
     def test_a_fully_released_reservation_retains_nothing(self) -> None:
         released = sb.release_review_reservation(
             self._reservation(reserved_usd=3.03, cycles=3),

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -1482,11 +1482,18 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         return state
 
     def _run_to_p2_cleanup(self, tmp_path: Path, *, dev_cost_usd: float):
-        """Drive DEV → VALIDATE → REVIEW(APPROVE + P2s) → the next DEV dispatch.
+        """One dev iteration, then REVIEW(APPROVE + P2s) → the next DEV dispatch."""
+        return self._run_loop(tmp_path, dev_costs=[dev_cost_usd])
 
-        Returns ``(state, result, dev_calls)`` where ``dev_calls`` records the
-        measured spend at the entry of every dev dispatch — its length is how
-        many dev attempts the funding checks admitted.
+    def _run_loop(self, tmp_path: Path, *, dev_costs: list[float]):
+        """Drive DEV → VALIDATE → REVIEW(APPROVE + P2s) round the cleanup loop.
+
+        Each dev dispatch spends the next figure in ``dev_costs``; the dispatch
+        after the list is exhausted stops the loop, so the run gets exactly as
+        many review cycles as there are cleanup passes. Returns
+        ``(state, result, dev_calls)`` where ``dev_calls`` records the measured
+        spend at the entry of every dev dispatch — its length is how many dev
+        attempts the funding checks admitted.
         """
         from coord_test_helpers import _make_agent_result, _make_task
         from test_coord_review_p2_cleanup import APPROVE_WITH_P2
@@ -1504,11 +1511,11 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
 
         def _dev(_state, *_args, **_kwargs):
             dev_calls.append(_state.total_cost_measured)
-            if len(dev_calls) > 1:
+            if len(dev_calls) > len(dev_costs):
                 # The cleanup attempt was funded — that is the whole question.
                 raise _StopAtCleanupDev()
             _state.dev_results.append(
-                _make_agent_result(cost_usd=dev_cost_usd, profile_name="dev")
+                _make_agent_result(cost_usd=dev_costs[len(dev_calls) - 1], profile_name="dev")
             )
             return None
 
@@ -1562,7 +1569,7 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         assert reservation["release_reason"] == "approve_p2_cleanup"
         assert reservation["retained_review_cycles"] == 1
         assert reservation["retained_review_usd"] == 1.01
-        assert reservation["review_observed_usd"] == 1.01
+        assert reservation["review_observed_at_release_usd"] == 1.01
         assert reservation["released_review_usd"] == round(
             float(reservation["reserved_review_usd"]) - 1.01 - 1.01, 4
         )
@@ -1629,3 +1636,34 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         # The refusal names the balance that actually drove it.
         assert state.allocation_exhausted["reserved_review_remaining_usd"] == 1.01
         assert state.allocation_exhausted["reserved_review_released"] is True
+
+    def test_a_retained_cycle_that_runs_funds_the_next_cleanup_attempt(
+        self, tmp_path: Path
+    ) -> None:
+        """The retained cycle is protected until it runs — and not one dollar longer.
+
+        Two cleanup passes: the first release retains one $1.01 cycle, that cycle
+        then actually runs, and the dev attempt after it must be funded from the
+        allocation the retained cycle no longer needs. Holding the retained
+        figure flat refuses this attempt against money already spent.
+        """
+        state, result, dev_calls = self._run_loop(tmp_path, dev_costs=[6.95, 4.10])
+
+        # Three dev dispatches: the seated one and two cleanup passes.
+        assert len(dev_calls) == 3
+        assert result is None
+        assert state.allocation_exhausted is None
+        assert state.review_cycle == 2
+        assert state.total_review_cost_measured == 2.02
+        # Non-review spend ($11.05) is past what the first release left free
+        # ($12.00 - $1.01 = $10.99); only netting the spent retained cycle out
+        # of the reserve funds this attempt.
+        assert round(dev_calls[2] - state.total_review_cost_measured, 4) == 11.05
+
+        reservation = state.review_funding_reservation
+        assert reservation["release_count"] == 2
+        assert reservation["retained_review_usd"] == 0.0
+        assert reservation["review_observed_at_release_usd"] == 2.02
+        assert sb.remaining_reserved_review_usd(reservation, 2.02) == 0.0
+        # The audit shows the re-release, not the first one.
+        assert state.adaptive_limits_audit["review_funding_reservation"]["release_count"] == 2

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -1647,7 +1647,7 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         allocation the retained cycle no longer needs. Holding the retained
         figure flat refuses this attempt against money already spent.
         """
-        state, result, dev_calls = self._run_loop(tmp_path, dev_costs=[6.95, 4.10])
+        state, result, dev_calls = self._run_loop(tmp_path, dev_costs=[6.95, 2.53])
 
         # Three dev dispatches: the seated one and two cleanup passes.
         assert len(dev_calls) == 3
@@ -1655,10 +1655,12 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         assert state.allocation_exhausted is None
         assert state.review_cycle == 2
         assert state.total_review_cost_measured == 2.02
-        # Non-review spend ($11.05) is past what the first release left free
-        # ($12.00 - $1.01 = $10.99); only netting the spent retained cycle out
-        # of the reserve funds this attempt.
-        assert round(dev_calls[2] - state.total_review_cost_measured, 4) == 11.05
+        # Total spend at this dispatch is $11.50 of a $12.00 allocation, so the
+        # story genuinely has money left — but only once the retained cycle's
+        # $1.01 stops being withheld: holding it flat leaves $12.00 - $11.50 -
+        # $1.01 = -$0.51 and refuses the attempt.
+        assert dev_calls[2] == 11.50
+        assert dev_calls[2] < 12.00
 
         reservation = state.review_funding_reservation
         assert reservation["release_count"] == 2

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -1492,13 +1492,15 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         dev_costs: list[float],
         review_output: str | None = None,
         human_decision: tuple[str, str | None] | None = None,
+        zero_findings_stop: int = 0,
     ):
         """Drive DEV → VALIDATE → REVIEW round the loop the review verdict picks.
 
         ``review_output`` defaults to an APPROVE carrying P2s, which routes into
         the cleanup loop; a clean APPROVE finalizes instead. Passing
         ``human_decision`` runs the loop interactively and answers the operator
-        prompt with it. Each dev dispatch spends the next figure in
+        prompt with it; ``zero_findings_stop`` arms the convergence
+        early-termination route. Each dev dispatch spends the next figure in
         ``dev_costs``; the dispatch after the list is exhausted stops the loop.
         Returns ``(state, result, dev_calls)`` where ``dev_calls`` records the
         measured spend at the entry of every dev dispatch — its length is how
@@ -1514,6 +1516,13 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
 
         review_output = APPROVE_WITH_P2 if review_output is None else review_output
         config = self._config(tmp_path)
+        if zero_findings_stop:
+            config = dataclasses.replace(
+                config,
+                retry=dataclasses.replace(
+                    config.retry, review_zero_findings_stop=zero_findings_stop
+                ),
+            )
         task = _make_task(tmp_path)
         state = self._seated_state(tmp_path)
         dev_calls: list[float | None] = []
@@ -1769,3 +1778,36 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         assert sb.remaining_reserved_review_usd(
             reservation, state.total_review_cost_measured
         ) == round(float(reservation["reserved_review_usd"]) - 1.01, 4)
+
+    def test_every_terminal_approve_route_settles_the_reservation(self, tmp_path: Path) -> None:
+        """Early termination lands DONE too, and must not leave the reserve withheld.
+
+        The normal approve is not the only route to DONE: convergence
+        early-termination, the escalate gate and the hygiene replay all finalize
+        an approval. A story landing through one of them with the record still
+        claiming five withheld cycles misreports where the money went.
+        """
+        # Identical APPROVE+P2 cycles: cycles 2 and 3 bring zero new findings,
+        # so the run converges and finalizes through early termination.
+        state, result, dev_calls = self._run_loop(
+            tmp_path, dev_costs=[1.00, 0.50, 0.50], zero_findings_stop=2
+        )
+
+        assert result is not None
+        assert result.phase == Phase.DONE
+        assert state.review_early_terminated is True
+        assert len(dev_calls) == 3
+
+        reservation = state.review_funding_reservation
+        assert reservation["released"] is True
+        assert reservation["release_reason"] == "approve_early_termination"
+        # Two cleanup passes released before it; this one settles the record.
+        assert reservation["release_count"] == 3
+        assert reservation["retained_review_usd"] == 0.0
+        assert (
+            sb.remaining_reserved_review_usd(reservation, state.total_review_cost_measured) == 0.0
+        )
+        assert (
+            state.adaptive_limits_audit["review_funding_reservation"]["release_reason"]
+            == "approve_early_termination"
+        )

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -1424,3 +1424,208 @@ class TestTheSeatedReviewReservationIsHeldAcrossPhases:
 
         assert state.review_funding_reservation["reserved_review_usd"] == 0.0
         assert state.allocation_exhausted is None
+
+
+class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
+    """A story is not refused work against cycles that cannot happen (#2340).
+
+    The reservation is priced at seating against the MAXIMUM review cycles the
+    story was granted, and nothing revised it afterwards — run
+    ``d55c953fe273`` / story ``issue-2309`` reserved $32.98 for five cycles,
+    ran one for $14.08, and was then refused a P2-cleanup dev attempt in the
+    same second the APPROVE landed, with $18.90 of its allocation withheld for
+    four cycles that could no longer occur. These tests pin the release at the
+    seam: after an approve-equivalent verdict only the cycles still reachable
+    stay protected, and the run audit shows what was let go.
+    """
+
+    def _config(self, tmp_path: Path):
+        from coord_test_helpers import _make_config, _make_review_profile
+
+        from theforge.config.types import AssignmentConfig, RetryPolicy
+
+        config = _make_config(tmp_path)
+        return dataclasses.replace(
+            config,
+            dev_profile=dataclasses.replace(config.dev_profile, budget_usd=2.38),
+            review_pool=[_make_review_profile("openai-gpt-5.5-cli", budget_usd=1.01)],
+            synthesis_profile=None,
+            retry=RetryPolicy(
+                max_dev_iterations=3,
+                max_review_cycles=5,
+                max_dev_iterations_cap=6,
+                max_review_cycles_cap=5,
+                adaptive_iterations=True,
+            ),
+            assignment=AssignmentConfig(enabled=True, adaptive_enabled=True),
+        )
+
+    def _seated_state(self, tmp_path: Path):
+        """A $12.00 allocation: enough for the dev estimate and five cycles."""
+        _seed_dev_profile_history(
+            tmp_path, avg_cost_usd=1.904, avg_iterations=2.0, complexity_score=3
+        )
+        state = CoordinatorState(log_dir=tmp_path / "logs")
+        state.preflight_complexity = "medium"
+        state.preflight_complexity_score = 3
+        state.workspace_path = tmp_path
+        state.branch_name = "feat/issue-2340"
+        state.story_allocation = {
+            "allocation_usd": 12.00,
+            "basis": sb.BASIS_SUBSTRATE_BAND,
+            "complexity_score": 3,
+            "median_usd": 0.94,
+            "p90_usd": 2.38,
+            "max_usd": 3.30,
+            "sample_count": 20,
+        }
+        return state
+
+    def _run_to_p2_cleanup(self, tmp_path: Path, *, dev_cost_usd: float):
+        """Drive DEV → VALIDATE → REVIEW(APPROVE + P2s) → the next DEV dispatch.
+
+        Returns ``(state, result, dev_calls)`` where ``dev_calls`` records the
+        measured spend at the entry of every dev dispatch — its length is how
+        many dev attempts the funding checks admitted.
+        """
+        from coord_test_helpers import _make_agent_result, _make_task
+        from test_coord_review_p2_cleanup import APPROVE_WITH_P2
+
+        from theforge.coordinator.engine import _coordinator_loop
+        from theforge.coordinator.validate_phase import _ValidateOutcome
+
+        config = self._config(tmp_path)
+        task = _make_task(tmp_path)
+        state = self._seated_state(tmp_path)
+        dev_calls: list[float | None] = []
+
+        class _StopAtCleanupDev(Exception):
+            pass
+
+        def _dev(_state, *_args, **_kwargs):
+            dev_calls.append(_state.total_cost_measured)
+            if len(dev_calls) > 1:
+                # The cleanup attempt was funded — that is the whole question.
+                raise _StopAtCleanupDev()
+            _state.dev_results.append(
+                _make_agent_result(cost_usd=dev_cost_usd, profile_name="dev")
+            )
+            return None
+
+        def _pool(**_kwargs):
+            return [
+                _make_agent_result(
+                    success=True,
+                    output=APPROVE_WITH_P2,
+                    profile_name="openai-gpt-5.5-cli",
+                    cost_usd=1.01,
+                )
+            ]
+
+        result: object | None = None
+        with (
+            patch("theforge.coordinator.engine._run_dev_phase", _dev),
+            patch(
+                "theforge.coordinator.engine._run_validate_phase",
+                return_value=(_ValidateOutcome.PASS, None),
+            ),
+            patch("theforge.coordinator.review_pool.run_agent_pool", side_effect=_pool),
+            patch("theforge.coordinator.review_pool.log_agent_result"),
+            patch(
+                "theforge.coordinator.review_phase._has_commits_ahead_of_base",
+                return_value=True,
+            ),
+        ):
+            try:
+                result = _coordinator_loop(state, config, task, "story", task_start=0.0)
+            except _StopAtCleanupDev:
+                result = None
+        return state, result, dev_calls
+
+    def test_p2_cleanup_is_funded_from_the_cycles_that_cannot_run(self, tmp_path: Path) -> None:
+        """The issue's exact shape: dev refused in the same second as APPROVE."""
+        state, result, dev_calls = self._run_to_p2_cleanup(tmp_path, dev_cost_usd=6.95)
+
+        reservation = state.review_funding_reservation
+        assert reservation["reserved_review_cycles"] >= 2
+        # Dev spent the whole non-review pool, so the gross reserve would refuse
+        # the cleanup attempt outright.
+        assert dev_calls[0] == 0.0
+        assert 6.95 >= float(reservation["nonreview_allocation_usd"])
+        # The cleanup dev attempt ran instead of escalating.
+        assert len(dev_calls) == 2
+        assert result is None
+        assert state.allocation_exhausted is None
+        assert state.p2_cleanup_active is True
+        # Only the re-review this cleanup pass loops back to is still held.
+        assert reservation["released"] is True
+        assert reservation["release_reason"] == "approve_p2_cleanup"
+        assert reservation["retained_review_cycles"] == 1
+        assert reservation["retained_review_usd"] == 1.01
+        assert reservation["review_observed_usd"] == 1.01
+        assert reservation["released_review_usd"] == round(
+            float(reservation["reserved_review_usd"]) - 1.01 - 1.01, 4
+        )
+        # And the audit carries the released record, not the seated one.
+        assert (
+            state.adaptive_limits_audit["review_funding_reservation"]["released_review_usd"]
+            == reservation["released_review_usd"]
+        )
+
+    def test_the_release_reaches_the_run_audit(self, tmp_path: Path) -> None:
+        """An operator can see which withheld dollars were let go, and why."""
+        from coord_test_helpers import _make_task
+
+        from theforge.coordinator.audit import generate_audit_log
+        from theforge.coordinator.state import CoordinatorResult
+
+        state, _result, _calls = self._run_to_p2_cleanup(tmp_path, dev_cost_usd=6.95)
+
+        audit = generate_audit_log(
+            self._config(tmp_path),
+            _make_task(tmp_path),
+            CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message="x"),
+        )
+        block = audit["iterations"]["adaptive_limits"]["review_funding_reservation"]
+        assert block["released"] is True
+        assert block["release_reason"] == "approve_p2_cleanup"
+        assert block["release_review_cycle"] == state.review_cycle
+        assert block["retained_review_usd"] == 1.01
+        # The seated figures survive alongside the release.
+        assert block["allocation_usd"] == 12.00
+        assert block["review_cycle_cost_usd"] == 1.01
+
+    def test_a_release_does_not_defund_the_re_review_it_loops_back_to(
+        self, tmp_path: Path
+    ) -> None:
+        """One cycle stays protected: cleanup dev is followed by another review."""
+        state, _result, _calls = self._run_to_p2_cleanup(tmp_path, dev_cost_usd=6.95)
+
+        # Even with the general pool spent to the allocation, the retained cycle
+        # funds the re-review.
+        assert (
+            sb.reserved_review_shortfall(
+                state.review_funding_reservation,
+                state.story_allocation,
+                observed_usd=12.00,
+                review_observed_usd=state.total_review_cost_measured,
+                participants=["openai-gpt-5.5-cli"],
+                planned_usd=1.01,
+            )
+            is None
+        )
+
+    def test_a_story_whose_allocation_is_genuinely_gone_is_still_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """Releasing the impossible cycles is not the same as removing the check."""
+        state, result, dev_calls = self._run_to_p2_cleanup(tmp_path, dev_cost_usd=11.00)
+
+        assert len(dev_calls) == 1
+        assert result is not None
+        assert result.phase == Phase.ESCALATE
+        assert state.error_type == "allocation_exhausted"
+        assert state.allocation_exhausted["nonreview_exhausted"] is True
+        # The refusal names the balance that actually drove it.
+        assert state.allocation_exhausted["reserved_review_remaining_usd"] == 1.01
+        assert state.allocation_exhausted["reserved_review_released"] is True

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -1485,22 +1485,34 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         """One dev iteration, then REVIEW(APPROVE + P2s) → the next DEV dispatch."""
         return self._run_loop(tmp_path, dev_costs=[dev_cost_usd])
 
-    def _run_loop(self, tmp_path: Path, *, dev_costs: list[float]):
-        """Drive DEV → VALIDATE → REVIEW(APPROVE + P2s) round the cleanup loop.
+    def _run_loop(
+        self,
+        tmp_path: Path,
+        *,
+        dev_costs: list[float],
+        review_output: str | None = None,
+        human_decision: tuple[str, str | None] | None = None,
+    ):
+        """Drive DEV → VALIDATE → REVIEW round the loop the review verdict picks.
 
-        Each dev dispatch spends the next figure in ``dev_costs``; the dispatch
-        after the list is exhausted stops the loop, so the run gets exactly as
-        many review cycles as there are cleanup passes. Returns
-        ``(state, result, dev_calls)`` where ``dev_calls`` records the measured
-        spend at the entry of every dev dispatch — its length is how many dev
-        attempts the funding checks admitted.
+        ``review_output`` defaults to an APPROVE carrying P2s, which routes into
+        the cleanup loop; a clean APPROVE finalizes instead. Passing
+        ``human_decision`` runs the loop interactively and answers the operator
+        prompt with it. Each dev dispatch spends the next figure in
+        ``dev_costs``; the dispatch after the list is exhausted stops the loop.
+        Returns ``(state, result, dev_calls)`` where ``dev_calls`` records the
+        measured spend at the entry of every dev dispatch — its length is how
+        many dev attempts the funding checks admitted.
         """
+        import contextlib
+
         from coord_test_helpers import _make_agent_result, _make_task
         from test_coord_review_p2_cleanup import APPROVE_WITH_P2
 
         from theforge.coordinator.engine import _coordinator_loop
         from theforge.coordinator.validate_phase import _ValidateOutcome
 
+        review_output = APPROVE_WITH_P2 if review_output is None else review_output
         config = self._config(tmp_path)
         task = _make_task(tmp_path)
         state = self._seated_state(tmp_path)
@@ -1523,7 +1535,7 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
             return [
                 _make_agent_result(
                     success=True,
-                    output=APPROVE_WITH_P2,
+                    output=review_output,
                     profile_name="openai-gpt-5.5-cli",
                     cost_usd=1.01,
                 )
@@ -1542,9 +1554,24 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
                 "theforge.coordinator.review_phase._has_commits_ahead_of_base",
                 return_value=True,
             ),
+            (
+                patch(
+                    "theforge.coordinator.review_phase._human_review",
+                    return_value=human_decision,
+                )
+                if human_decision is not None
+                else contextlib.nullcontext()
+            ),
         ):
             try:
-                result = _coordinator_loop(state, config, task, "story", task_start=0.0)
+                result = _coordinator_loop(
+                    state,
+                    config,
+                    task,
+                    "story",
+                    task_start=0.0,
+                    interactive=human_decision is not None,
+                )
             except _StopAtCleanupDev:
                 result = None
         return state, result, dev_calls
@@ -1669,3 +1696,76 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         assert sb.remaining_reserved_review_usd(reservation, 2.02) == 0.0
         # The audit shows the re-release, not the first one.
         assert state.adaptive_limits_audit["review_funding_reservation"]["release_count"] == 2
+
+    def test_a_finalized_approval_releases_the_whole_reserve(self, tmp_path: Path) -> None:
+        """The approve_final path, end to end: nothing is reachable, nothing is held.
+
+        A clean APPROVE skips cleanup and finalizes, so every seated cycle the
+        story did not run is unreachable. The release must land on that branch —
+        the story's landing record and the audit both read the reservation, and a
+        record still claiming five withheld cycles misreports where the money went.
+        """
+        from coord_test_helpers import APPROVE_REVIEW, _make_task
+
+        from theforge.coordinator.audit import generate_audit_log
+        from theforge.coordinator.state import CoordinatorResult
+
+        state, result, dev_calls = self._run_loop(
+            tmp_path, dev_costs=[1.00], review_output=APPROVE_REVIEW
+        )
+
+        assert dev_calls == [0.0]
+        assert result is not None
+        assert result.phase == Phase.DONE
+        assert state.p2_cleanup_active is False
+
+        reservation = state.review_funding_reservation
+        assert reservation["released"] is True
+        assert reservation["release_reason"] == "approve_final"
+        assert reservation["release_count"] == 1
+        assert reservation["retained_review_cycles"] == 0
+        assert reservation["retained_review_usd"] == 0.0
+        # One $1.01 cycle ran of the five seated: the other four are let go.
+        assert reservation["released_review_usd"] == round(
+            float(reservation["reserved_review_usd"]) - 1.01, 4
+        )
+        assert sb.remaining_reserved_review_usd(reservation, 1.01) == 0.0
+
+        audit = generate_audit_log(
+            self._config(tmp_path),
+            _make_task(tmp_path),
+            CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="x"),
+        )
+        block = audit["iterations"]["adaptive_limits"]["review_funding_reservation"]
+        assert block["release_reason"] == "approve_final"
+        assert block["retained_review_usd"] == 0.0
+        assert block["reserved_review_cycles"] == reservation["reserved_review_cycles"]
+
+    def test_an_interactive_reject_keeps_the_reservation_seated(self, tmp_path: Path) -> None:
+        """An approve the operator can undo does not prove the cycles are unreachable.
+
+        Reject and extend both loop back through REVIEW, so releasing on the
+        strength of the reviewer's APPROVE alone would strip those cycles of the
+        #2258 protection. The release belongs on the operator's approve.
+        """
+        from coord_test_helpers import APPROVE_REVIEW
+
+        state, result, dev_calls = self._run_loop(
+            tmp_path,
+            dev_costs=[1.00],
+            review_output=APPROVE_REVIEW,
+            human_decision=("reject", "not yet"),
+        )
+
+        # The reject looped back to DEV, and that attempt was funded.
+        assert len(dev_calls) == 2
+        assert result is None
+        assert state.human_review_decision == "reject"
+
+        reservation = state.review_funding_reservation
+        assert reservation.get("released") is not True
+        assert "retained_review_usd" not in reservation
+        # The reserve still covers the cycles the reject made reachable again.
+        assert sb.remaining_reserved_review_usd(
+            reservation, state.total_review_cost_measured
+        ) == round(float(reservation["reserved_review_usd"]) - 1.01, 4)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior cycle P1s are resolved; the current code releases only unreachable review reserve, keeps spent review cost out of dev funding, and covers both terminal release branches at the coordinator seam. | [deepseek-deepseek-reasoner-api] All four prior P1 findings are resolved: the protected reserve floors at zero and nets the retained cycle against spend since release, spent review money stays out of the dev pool, and the approve_final branch is now pinned end-to-end by a coordinator-loop seam test; the full suite passes (7923 passed).

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, deepseek-deepseek-reasoner-api, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-api, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-api
- **Cost:** $33.41
- **Dev iterations:** 5
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/review_phase.py:1896`** The early-termination DONE path (and the escalate-gate auto-approve and hygiene-replay finalize paths) return _finalize_approve without calling _release_review_reservation, so a story that finalizes through those routes leaves the released-false reservation record with the gross seated reserve still shown as withheld in the audit and landing state.
- **[P2] `src/theforge/coordinator/story_budget.py:971`** When total spend already exceeds the allocation, nonreview_funding_exhausted still returns a shortfall payload computed with _balance flooring the ceiling at zero, so remaining_usd reports a negative figure rather than signalling the ceiling was already crossed.

## Story

A story allocation reserves for review cycles it never runs, so dev is funded for one attempt (GitHub Issue #2340)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2340