### PR TITLE
A failed phase attempt overwrites the resumption record left by a successful one, so resuming replays the failure and carries its unfounded derived values forward

### DIFF
--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -140,6 +140,42 @@ clarification; if you rewrote the diagnosis, remove the worktree
 re-running so the dev starts clean. `unknown` just means the tree predates the
 record — it is not a defect.
 
+### Which attempt a resume proceeds from (issue #2351)
+
+The per-story resume record (`.forge/resume_state/<slug>.json`) keeps the
+**best-founded** block for each phase, not the most recent one. A preflight
+attempt that was killed by signal — `degraded: true`, `criteria_checked: []` —
+no longer displaces a stored block from an attempt that exited cleanly, so
+resuming continues from the clean result instead of deterministically replaying
+the failure and the higher complexity score it derived while observing nothing.
+
+Two signals decide it, in order: whether the attempt was marked degraded, then
+how much it examined (`criteria_checked` for preflight). `routing_decision` and
+`complexity_routing_audit` inherit the founding preflight's standing via the
+`complexity_source` / `preflight_degraded` provenance already stamped on the
+audit. Blocks that record a *decision* rather than an observation
+(`plan_review`, `escalation`, `timeout_escalation`, `review_progress`) carry no
+foundedness signal and still merge latest-wins.
+
+Every selection is recorded, so this never has to be reconstructed by diffing
+run directories:
+
+- `resume_selection` on the record itself — a bounded list of
+  `{phase, action, reason, prior_foundation, incoming_foundation, prior_run_id,
+  incoming_run_id}`, where `action` is `kept_existing` (a less-founded save was
+  refused) or `replaced_existing` (a better-founded save displaced what was
+  there).
+- `phase_recovery.block_selection` in the run audit and in the `phase_recovery`
+  log event — the same list, at the moment a resume reads it.
+
+Where a degraded attempt's derived values are the **only** ones available, they
+are still carried forward — a resumed story needs a number — but marked:
+`state.complexity_routing_audit` and `story_allocation` carry `unfounded: true`,
+`unfounded_reason` (the degraded reason), and `unfounded_source`. Those markers
+survive preflight's re-scale and the allocation evaluation, so an allocation or
+worker ceiling resting on a phase that observed nothing reads as such on the
+story row rather than as a derived figure.
+
 ## 2. Branch & forward-port model
 
 - Fixes land on the **base branch**. `forward-port.yml` then auto-carries every

--- a/src/theforge/coordinator/resume_persistence.py
+++ b/src/theforge/coordinator/resume_persistence.py
@@ -26,6 +26,14 @@ run is least healthy:
 * **Merge, never replace.** Each phase writes its own block as it produces it.
   A later save must not erase an earlier phase's block just because the state it
   was called with no longer carries that phase's fields.
+* **Best-founded wins, not latest.** Where two saves both carry a block for the
+  same phase, the one that examined more of the story is kept, and a degraded
+  attempt never displaces a non-degraded one.  The record exists so later work
+  can proceed, and a failed attempt carries strictly less of what later work
+  needs — keeping it because it happened to be written last is how a resumed
+  story deterministically replays the failure it was resumed to get past
+  (#2351).  Every such selection is recorded in :data:`RESUME_SELECTION_KEY` so
+  what the story resumes from is readable without diffing run directories.
 * **Never overwrite a real value with a null.** Both when merging on save and
   when applying on load.
 * **Best-effort.** A sidecar that cannot be written or read must never take down
@@ -74,6 +82,21 @@ PHASE_BLOCKS: tuple[str, ...] = (
 #: lacks it, and classification then reports the obligation as *unknown* rather
 #: than inventing a completed review.
 REVIEW_PROGRESS_KEY = "review_progress"
+
+#: Sibling key carrying the complexity/routing audit — and, nested inside it,
+#: the story allocation.  Not a phase block (nothing reports it as a recovered
+#: phase) but merged and restored alongside them.
+ROUTING_AUDIT_KEY = "complexity_routing_audit"
+
+#: Non-phase key holding the merge's block-selection decisions (#2351).  A
+#: bounded list, oldest first, so an operator reading the record can see that a
+#: less-founded save was refused — or that a better-founded one displaced what
+#: was there — without comparing files across run directories.
+RESUME_SELECTION_KEY = "resume_selection"
+
+#: Cap on retained selection entries.  The record is a recovery aid read when
+#: the run is least healthy; an unbounded audit trail inside it is a liability.
+_MAX_SELECTION_ENTRIES = 20
 
 #: Verdicts that end the review loop.  Anything else recorded as the latest
 #: verdict means the loop was still owed another cycle when the attempt stopped.
@@ -282,7 +305,147 @@ def capture_phase_blocks(state: "CoordinatorState") -> dict[str, Any]:
 # ── Persistence ──────────────────────────────────────────────────────────
 
 
-_METADATA_KEYS = frozenset({"version", "slug", "run_id", "story_content_hash"})
+_METADATA_KEYS = frozenset(
+    {"version", "slug", "run_id", "story_content_hash", RESUME_SELECTION_KEY}
+)
+
+
+# ── Foundedness ──────────────────────────────────────────────────────────
+#
+# What makes one save's block more authoritative than another's for the same
+# phase.  Two signals, in that order of weight:
+#
+# 1. *degraded* — an attempt the coordinator marked degraded produced its block
+#    from a failure, not from an observation.
+# 2. *examined* — how much of the story the phase actually inspected.  Preflight
+#    records this directly as ``criteria_checked``; an attempt that checked
+#    nothing cannot supersede one that checked something, whatever their order.
+#
+# Blocks carrying neither signal (``plan_review``, ``escalation``,
+# ``timeout_escalation``, ``review_progress``) have no foundation to compare and
+# are treated as equally founded, so ordinary incoming-wins merging applies.  A
+# signal must not be invented for them: their content is a decision, not an
+# observation, and the latest one is the one the coordinator acted on.
+
+#: Mirror of ``preflight.COMPLEXITY_SOURCE_DEGRADED``.  Duplicated rather than
+#: imported to keep this module stdlib-only (convention 4).
+_DEGRADED_COMPLEXITY_SOURCE = "preflight_degraded_conservative"
+
+#: Foundation ranks, low to high.  A tuple compares lexicographically, so a
+#: non-degraded block outranks a degraded one whatever either examined.
+_DEGRADED_RANK = 0
+_FOUNDED_RANK = 1
+
+
+def _preflight_foundation(block: Any) -> tuple[int, int] | None:
+    """Return ``(degraded_rank, examined)`` for a preflight block, or None.
+
+    None means the block carries no foundedness signal at all (a record written
+    before either field existed), which the merge treats as "no opinion".
+    """
+    if not isinstance(block, dict) or not block:
+        return None
+    degraded = block.get("degraded")
+    criteria = block.get("criteria_checked")
+    examined = len(criteria) if isinstance(criteria, list) else None
+    if degraded is None and examined is None:
+        return None
+    return (_DEGRADED_RANK if bool(degraded) else _FOUNDED_RANK, examined or 0)
+
+
+def _derived_foundation(block: Any, preflight_block: Any) -> tuple[int, int] | None:
+    """Foundation of a value *derived from* preflight rather than observed.
+
+    ``complexity_routing_audit`` carries its own provenance (``complexity_source``
+    / ``preflight_degraded``, stamped by ``preflight.stamp_complexity_provenance``);
+    ``routing_decision`` carries none and inherits the foundation of the
+    preflight block written in the same save.
+    """
+    inherited = _preflight_foundation(preflight_block)
+    degraded: bool | None = None
+    if isinstance(block, dict):
+        provenance = block.get("preflight_degraded")
+        if isinstance(provenance, dict) and "degraded" in provenance:
+            degraded = bool(provenance.get("degraded"))
+        else:
+            source = block.get("complexity_source")
+            if isinstance(source, str) and source:
+                degraded = source == _DEGRADED_COMPLEXITY_SOURCE
+    if degraded is None:
+        return inherited
+    return (
+        _DEGRADED_RANK if degraded else _FOUNDED_RANK,
+        inherited[1] if inherited is not None else 0,
+    )
+
+
+def block_foundation(
+    name: str, block: Any, sibling_blocks: dict[str, Any] | None = None
+) -> tuple[int, int] | None:
+    """Return how well-founded ``block`` is, or None when it carries no signal.
+
+    ``sibling_blocks`` are the other blocks written by the same save (or already
+    on the record), which is where a derived block's provenance lives.
+    """
+    if name == "preflight":
+        return _preflight_foundation(block)
+    if name in ("routing_decision", ROUTING_AUDIT_KEY):
+        return _derived_foundation(block, (sibling_blocks or {}).get("preflight"))
+    return None
+
+
+def _foundation_report(foundation: tuple[int, int] | None) -> dict[str, Any] | None:
+    """Operator-readable form of a foundation tuple."""
+    if foundation is None:
+        return None
+    return {"degraded": foundation[0] == _DEGRADED_RANK, "examined": foundation[1]}
+
+
+def _merge_phase_blocks(
+    base: dict[str, Any],
+    blocks: dict[str, Any],
+    *,
+    prior_run_id: str | None,
+    run_id: str | None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Fold ``blocks`` into ``base`` block by block, best-founded winning.
+
+    Returns the merged blocks and the selection decisions worth disclosing.
+    Equal foundation — including two blocks that both carry no signal — keeps
+    the incoming block, so ordinary additive saves behave exactly as before.
+    """
+    merged = dict(base)
+    decisions: list[dict[str, Any]] = []
+    for name, value in blocks.items():
+        if not value:
+            continue
+        existing_block = base.get(name)
+        if not existing_block:
+            merged[name] = value
+            continue
+        prior = block_foundation(name, existing_block, base)
+        incoming = block_foundation(name, value, blocks)
+        if prior is not None and incoming is not None and incoming != prior:
+            keep_existing = incoming < prior
+            decisions.append(
+                {
+                    "phase": name,
+                    "action": "kept_existing" if keep_existing else "replaced_existing",
+                    "reason": (
+                        "incoming_block_less_founded"
+                        if keep_existing
+                        else "incoming_block_more_founded"
+                    ),
+                    "prior_foundation": _foundation_report(prior),
+                    "incoming_foundation": _foundation_report(incoming),
+                    "prior_run_id": prior_run_id,
+                    "incoming_run_id": run_id,
+                }
+            )
+            if keep_existing:
+                continue
+        merged[name] = value
+    return merged, decisions
 
 
 def merge_resume_record(
@@ -300,20 +463,43 @@ def merge_resume_record(
     holds an earlier phase's fields must not erase them.  When the recorded
     story hash disagrees with the current one the prior blocks describe a
     different story and are discarded rather than merged.
+
+    Each block is decided on its own foundation rather than by save order (see
+    the foundedness section above), so a degraded attempt that examined nothing
+    does not displace a stored block from an attempt that succeeded.  Selections
+    that changed or preserved what the story resumes from are recorded under
+    :data:`RESUME_SELECTION_KEY`, which is metadata and never re-enters the
+    block merge.
     """
     base: dict[str, Any] = {}
+    prior_selection: list[dict[str, Any]] = []
+    prior_run_id: str | None = None
     if isinstance(existing, dict) and existing.get("version") == RECORD_VERSION:
         recorded_hash = existing.get("story_content_hash")
         if not (story_hash and recorded_hash and recorded_hash != story_hash):
             base = {k: v for k, v in existing.items() if k not in _METADATA_KEYS}
-    merged = {**base, **{k: v for k, v in blocks.items() if v}}
-    return {
+            recorded_selection = existing.get(RESUME_SELECTION_KEY)
+            if isinstance(recorded_selection, list):
+                prior_selection = [e for e in recorded_selection if isinstance(e, dict)]
+            recorded_run_id = existing.get("run_id")
+            prior_run_id = recorded_run_id if isinstance(recorded_run_id, str) else None
+    merged, decisions = _merge_phase_blocks(
+        base,
+        {k: v for k, v in blocks.items() if v},
+        prior_run_id=prior_run_id,
+        run_id=run_id,
+    )
+    record: dict[str, Any] = {
         "version": RECORD_VERSION,
         "slug": slug,
         "run_id": run_id or (existing or {}).get("run_id"),
         "story_content_hash": story_hash or (existing or {}).get("story_content_hash"),
         **merged,
     }
+    selection = [*prior_selection, *decisions][-_MAX_SELECTION_ENTRIES:]
+    if selection:
+        record[RESUME_SELECTION_KEY] = selection
+    return record
 
 
 def save_resume_record(
@@ -574,6 +760,51 @@ def _set_if_unset(state: "CoordinatorState", attr: str, value: Any) -> bool:
     return True
 
 
+#: Marker keys stamped on a value carried forward from a degraded attempt.
+#: A degraded preflight still yields a conservative complexity score so routing,
+#: timeouts, and allocation have a number — but nothing observed founded it, and
+#: a resumed attempt that consumes it must be able to say so (#2351).
+UNFOUNDED_KEY = "unfounded"
+UNFOUNDED_REASON_KEY = "unfounded_reason"
+UNFOUNDED_SOURCE_KEY = "unfounded_source"
+
+
+def _degraded_provenance(record: dict[str, Any]) -> dict[str, str] | None:
+    """Why this record's derived values are unfounded, or None when they are not.
+
+    The preflight block is the direct signal; the routing audit's own
+    provenance stamp is the fallback for a record whose preflight block was
+    never written or predates the ``degraded`` field.
+    """
+    preflight = record.get("preflight")
+    if isinstance(preflight, dict) and preflight.get("degraded"):
+        return {
+            "reason": str(preflight.get("degraded_reason") or "preflight_degraded"),
+            "source": "preflight",
+        }
+    audit = record.get(ROUTING_AUDIT_KEY)
+    if isinstance(audit, dict):
+        stamped = audit.get("preflight_degraded")
+        if isinstance(stamped, dict) and stamped.get("degraded"):
+            return {
+                "reason": str(stamped.get("degraded_reason") or "preflight_degraded"),
+                "source": ROUTING_AUDIT_KEY,
+            }
+        if audit.get("complexity_source") == _DEGRADED_COMPLEXITY_SOURCE:
+            return {"reason": _DEGRADED_COMPLEXITY_SOURCE, "source": ROUTING_AUDIT_KEY}
+    return None
+
+
+def _mark_unfounded(block: dict[str, Any], provenance: dict[str, str]) -> dict[str, Any]:
+    """Return ``block`` copied with the unfounded markers stamped on it."""
+    return {
+        **block,
+        UNFOUNDED_KEY: True,
+        UNFOUNDED_REASON_KEY: provenance["reason"],
+        UNFOUNDED_SOURCE_KEY: provenance["source"],
+    }
+
+
 def _apply_preflight(state: "CoordinatorState", block: dict[str, Any]) -> bool:
     """Restore preflight fields onto ``state``; return whether anything landed.
 
@@ -703,14 +934,25 @@ def apply_resume_record_to_state(state: "CoordinatorState", record: dict[str, An
         state.routing_decision = routing
         recovered.append("routing_decision")
 
-    routing_audit = record.get("complexity_routing_audit")
+    routing_audit = record.get(ROUTING_AUDIT_KEY)
     if isinstance(routing_audit, dict) and routing_audit and not state.complexity_routing_audit:
+        # A value this attempt has already derived is never overwritten (the
+        # guard above); what lands here is the record's copy being the *only*
+        # available one. When the attempt that derived it was degraded, it is
+        # carried forward marked as unfounded rather than silently taken as
+        # founded, so every later consumer of the figure sees what it rests on.
+        provenance = _degraded_provenance(record)
+        if provenance is not None:
+            routing_audit = _mark_unfounded(routing_audit, provenance)
         state.complexity_routing_audit = routing_audit
         # The story allocation rides inside the routing audit (#2169) so a
         # resumed attempt reports spend against the same basis the first
         # attempt derived, instead of re-deriving against a moved distribution.
         allocation = routing_audit.get("story_allocation")
         if isinstance(allocation, dict) and allocation and not state.story_allocation:
+            if provenance is not None:
+                allocation = _mark_unfounded(allocation, provenance)
+                routing_audit["story_allocation"] = allocation
             state.story_allocation = allocation
 
     plan_review = record.get("plan_review")
@@ -753,6 +995,12 @@ def recover_phase_state(
     ``reentry_impact`` carries the re-entry analysis when the recovery changes
     which phases run — today, when a recovered escalate-gate decision means the
     outstanding review cycle will not be run.  None otherwise.
+
+    ``block_selection`` carries the record's merge decisions, so the audit and
+    the ``phase_recovery`` log event state which attempt's phase output the
+    story is resuming from — a save that refused a degraded block, or one that
+    was displaced by a better-founded one, is visible there rather than only by
+    diffing run directories (#2351).
     """
     record = load_resume_record(project_root, slug)
     if record is None:
@@ -762,6 +1010,7 @@ def recover_phase_state(
             "recovered_phases": [],
             "source_run_id": None,
             "reentry_impact": None,
+            "block_selection": [],
         }
 
     usable, reason = validate_resume_record(record, story_content=story_content)
@@ -772,6 +1021,7 @@ def recover_phase_state(
             "recovered_phases": [],
             "source_run_id": record.get("run_id"),
             "reentry_impact": None,
+            "block_selection": [],
         }
 
     recovered = apply_resume_record_to_state(state, record)
@@ -782,4 +1032,20 @@ def recover_phase_state(
         "source_run_id": record.get("run_id"),
         "recorded_phases": [name for name in PHASE_BLOCKS if record.get(name)],
         "reentry_impact": _reentry_impact(record, recovered),
+        "block_selection": block_selection(record),
     }
+
+
+def block_selection(record: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Return the merge's block-selection decisions for ``record``.
+
+    One derivation, read by ``recover_phase_state`` and available to any status
+    surface that wants to report what a resume would proceed from without
+    starting a run.
+    """
+    if not isinstance(record, dict):
+        return []
+    entries = record.get(RESUME_SELECTION_KEY)
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]

--- a/tests/test_coord_resume_phase_recovery.py
+++ b/tests/test_coord_resume_phase_recovery.py
@@ -101,6 +101,307 @@ def _escalation_state() -> CoordinatorState:
     return state
 
 
+#: Routing decision a degraded attempt produced — distinguishable from the one
+#: the founded attempts produced, so adopting the wrong one is visible.
+DEGRADED_ROUTING_BLOCK = {
+    "origin": "degraded_fallback",
+    "code_review": {"final": {"models": ["opus"]}},
+}
+
+
+def _founded_preflight_state(*, criteria: int = 2, score: int = 8) -> CoordinatorState:
+    """A preflight attempt that exited cleanly having checked ``criteria`` criteria."""
+    state = _preflight_state()
+    state.preflight_complexity_score = score
+    state.preflight_criteria_checked = [
+        {"criterion": f"criterion {index}", "satisfied": True} for index in range(criteria)
+    ]
+    state.preflight_degraded = False
+    state.complexity_routing_audit = {
+        "complexity": "large",
+        "complexity_source": "preflight",
+        "preflight_degraded": {"degraded": False, "complexity_source": "preflight"},
+        "story_allocation": {"allocation_usd": 12.0, "complexity_score": score},
+    }
+    return state
+
+
+def _degraded_preflight_state() -> CoordinatorState:
+    """A preflight attempt killed by signal: nothing checked, scored conservatively."""
+    state = _preflight_state()
+    state.preflight_complexity_score = 9
+    state.preflight_criteria_checked = []
+    state.preflight_degraded = True
+    state.preflight_degraded_reason = "agent_failed_with_risk_signals"
+    state.preflight_failure_action = "escalate"
+    state.preflight_risk_signals = ["killed_by_signal"]
+    state.routing_decision = dict(DEGRADED_ROUTING_BLOCK)
+    state.complexity_routing_audit = {
+        "complexity": "large",
+        "complexity_source": "preflight_degraded_conservative",
+        "preflight_degraded": {
+            "degraded": True,
+            "degraded_reason": "agent_failed_with_risk_signals",
+            "complexity_source": "preflight_degraded_conservative",
+        },
+        "story_allocation": {"allocation_usd": 50.8, "complexity_score": 9},
+    }
+    return state
+
+
+class TestFoundedBlockSelection:
+    """A failed attempt never displaces a stored result of the same phase (#2351).
+
+    The record is written so later work can proceed; an attempt that examined
+    nothing carries strictly less of what later work needs, whatever its order.
+    """
+
+    def test_degraded_save_does_not_displace_a_founded_one(self, tmp_path: Path) -> None:
+        save_resume_record(
+            tmp_path,
+            _founded_preflight_state(),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-clean",
+        )
+        save_resume_record(
+            tmp_path,
+            _degraded_preflight_state(),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-killed",
+        )
+
+        loaded = load_resume_record(tmp_path, "test-story")
+        assert loaded is not None
+        assert loaded["preflight"]["degraded"] is False
+        assert loaded["preflight"]["complexity_score"] == 8
+        assert len(loaded["preflight"]["criteria_checked"]) == 2
+        assert loaded["routing_decision"] == ROUTING_BLOCK
+        assert loaded["complexity_routing_audit"]["complexity_source"] == "preflight"
+        assert loaded["complexity_routing_audit"]["story_allocation"]["allocation_usd"] == 12.0
+
+    def test_resume_proceeds_from_the_founded_attempt(self, tmp_path: Path) -> None:
+        """The fix-success criterion: resuming continues from the clean result."""
+        save_resume_record(
+            tmp_path,
+            _founded_preflight_state(),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-clean",
+        )
+        save_resume_record(
+            tmp_path,
+            _degraded_preflight_state(),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-killed",
+        )
+
+        resumed = CoordinatorState()
+        recovery = recover_phase_state(
+            tmp_path, resumed, slug="test-story", story_content=STORY_CONTENT
+        )
+
+        assert recovery["status"] == "recovered"
+        assert resumed.preflight_degraded is False
+        assert resumed.preflight_complexity_score == 8
+        assert resumed.preflight_failure_action is None
+        assert resumed.routing_decision == ROUTING_BLOCK
+        # The founded figure is founded: nothing is marked carried-unfounded.
+        assert "unfounded" not in resumed.complexity_routing_audit
+        assert "unfounded" not in resumed.story_allocation
+
+    def test_a_zero_criteria_save_cannot_supersede_a_checked_one(self, tmp_path: Path) -> None:
+        """Foundedness, not degraded-ness alone, decides between two clean saves."""
+        checked = _founded_preflight_state(criteria=2, score=8)
+        nothing_checked = _founded_preflight_state(criteria=0, score=9)
+
+        save_resume_record(
+            tmp_path, checked, slug="test-story", story_content=STORY_CONTENT, run_id="run-a"
+        )
+        save_resume_record(
+            tmp_path,
+            nothing_checked,
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-b",
+        )
+
+        loaded = load_resume_record(tmp_path, "test-story")
+        assert loaded is not None
+        assert loaded["preflight"]["complexity_score"] == 8
+
+    def test_a_better_founded_later_save_replaces_the_stored_one(self, tmp_path: Path) -> None:
+        save_resume_record(
+            tmp_path,
+            _founded_preflight_state(criteria=1, score=8),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-thin",
+        )
+        thorough = _founded_preflight_state(criteria=3, score=6)
+        save_resume_record(
+            tmp_path,
+            thorough,
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-thorough",
+        )
+
+        loaded = load_resume_record(tmp_path, "test-story")
+        assert loaded is not None
+        assert loaded["preflight"]["complexity_score"] == 6
+        assert len(loaded["preflight"]["criteria_checked"]) == 3
+
+        entries = loaded["resume_selection"]
+        replaced = [e for e in entries if e["phase"] == "preflight"]
+        assert [e["action"] for e in replaced] == ["replaced_existing"]
+        assert replaced[0]["reason"] == "incoming_block_more_founded"
+        assert replaced[0]["prior_foundation"] == {"degraded": False, "examined": 1}
+        assert replaced[0]["incoming_foundation"] == {"degraded": False, "examined": 3}
+        assert replaced[0]["prior_run_id"] == "run-thin"
+        assert replaced[0]["incoming_run_id"] == "run-thorough"
+
+    def test_selection_is_disclosed_to_the_operator_on_recovery(self, tmp_path: Path) -> None:
+        """What the story resumes from is readable without diffing run dirs."""
+        save_resume_record(
+            tmp_path,
+            _founded_preflight_state(),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-clean",
+        )
+        save_resume_record(
+            tmp_path,
+            _degraded_preflight_state(),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-killed",
+        )
+
+        recovery = recover_phase_state(
+            tmp_path, CoordinatorState(), slug="test-story", story_content=STORY_CONTENT
+        )
+
+        by_phase = {entry["phase"]: entry for entry in recovery["block_selection"]}
+        assert by_phase["preflight"]["action"] == "kept_existing"
+        assert by_phase["preflight"]["reason"] == "incoming_block_less_founded"
+        assert by_phase["preflight"]["prior_foundation"] == {"degraded": False, "examined": 2}
+        assert by_phase["preflight"]["incoming_foundation"] == {"degraded": True, "examined": 0}
+        assert by_phase["preflight"]["incoming_run_id"] == "run-killed"
+        assert by_phase["complexity_routing_audit"]["action"] == "kept_existing"
+        assert by_phase["routing_decision"]["action"] == "kept_existing"
+
+    def test_selection_metadata_does_not_re_enter_the_block_merge(self, tmp_path: Path) -> None:
+        """The disclosure is metadata: it never becomes a phase block itself."""
+        for state, run_id in (
+            (_founded_preflight_state(), "run-clean"),
+            (_degraded_preflight_state(), "run-killed"),
+            (_plan_review_state(), "run-later"),
+        ):
+            save_resume_record(
+                tmp_path, state, slug="test-story", story_content=STORY_CONTENT, run_id=run_id
+            )
+
+        loaded = load_resume_record(tmp_path, "test-story")
+        assert loaded is not None
+        # Survives the save that carried no selection decision of its own.
+        assert [e["phase"] for e in loaded["resume_selection"]] == [
+            "preflight",
+            "routing_decision",
+            "complexity_routing_audit",
+        ]
+        recovery = recover_phase_state(
+            tmp_path, CoordinatorState(), slug="test-story", story_content=STORY_CONTENT
+        )
+        assert "resume_selection" not in recovery["recorded_phases"]
+        assert "resume_selection" not in recovery["recovered_phases"]
+
+    def test_blocks_with_no_foundedness_signal_keep_incoming_wins(self) -> None:
+        """A decision is not an observation: the latest one is what the
+        coordinator acted on, so escalation and plan review still merge by order."""
+        existing = {
+            "version": RECORD_VERSION,
+            "slug": "test-story",
+            "escalation": {"decision": "advisory_pending"},
+            "plan_review": {"decision": "reject"},
+        }
+        merged = merge_resume_record(
+            existing,
+            {
+                "escalation": {"decision": "operator_approved"},
+                "plan_review": {"decision": "approve"},
+            },
+            slug="test-story",
+            story_hash=None,
+            run_id="run-2",
+        )
+        assert merged["escalation"]["decision"] == "operator_approved"
+        assert merged["plan_review"]["decision"] == "approve"
+        assert "resume_selection" not in merged
+
+
+class TestDegradedValuesCarryForwardAsUnfounded:
+    """A figure derived while degraded is marked wherever later stages read it."""
+
+    def test_degraded_only_record_marks_the_routing_audit_and_allocation(
+        self, tmp_path: Path
+    ) -> None:
+        save_resume_record(
+            tmp_path,
+            _degraded_preflight_state(),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-killed",
+        )
+
+        resumed = CoordinatorState()
+        recover_phase_state(tmp_path, resumed, slug="test-story", story_content=STORY_CONTENT)
+
+        assert resumed.complexity_routing_audit["unfounded"] is True
+        assert resumed.complexity_routing_audit["unfounded_reason"] == (
+            "agent_failed_with_risk_signals"
+        )
+        assert resumed.story_allocation["unfounded"] is True
+        assert resumed.story_allocation["unfounded_source"] == "preflight"
+        assert resumed.complexity_routing_audit["story_allocation"]["unfounded"] is True
+
+    def test_a_value_this_attempt_derived_is_not_overwritten(self, tmp_path: Path) -> None:
+        save_resume_record(
+            tmp_path,
+            _degraded_preflight_state(),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-killed",
+        )
+
+        live = CoordinatorState()
+        live.complexity_routing_audit = {"complexity": "medium", "complexity_source": "preflight"}
+        live.story_allocation = {"allocation_usd": 3.0, "complexity_score": 5}
+
+        recover_phase_state(tmp_path, live, slug="test-story", story_content=STORY_CONTENT)
+
+        assert live.complexity_routing_audit["complexity"] == "medium"
+        assert "unfounded" not in live.complexity_routing_audit
+        assert live.story_allocation["allocation_usd"] == 3.0
+
+    def test_founded_record_carries_no_unfounded_marker(self, tmp_path: Path) -> None:
+        save_resume_record(
+            tmp_path,
+            _founded_preflight_state(),
+            slug="test-story",
+            story_content=STORY_CONTENT,
+            run_id="run-clean",
+        )
+
+        resumed = CoordinatorState()
+        recover_phase_state(tmp_path, resumed, slug="test-story", story_content=STORY_CONTENT)
+
+        assert "unfounded" not in resumed.complexity_routing_audit
+        assert "unfounded" not in resumed.story_allocation
+
+
 class TestRecordPersistence:
     """The record round-trips, merges across phases, and refuses bad input."""
 

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -477,6 +477,50 @@ class TestResumeCarriesTheAllocation:
 
         assert state.story_allocation == allocation
 
+    def test_a_degraded_only_allocation_carries_forward_marked_unfounded(
+        self, tmp_path: Path
+    ) -> None:
+        """A figure derived while degraded stays labelled through the seam (#2351).
+
+        The degraded attempt's allocation is the only one on the record, so it
+        is what the resumed story is judged against — but nothing observed
+        founded it, and preflight's rescale and the audit evaluation must both
+        carry that fact rather than presenting it as a derived number.
+        """
+        from theforge.coordinator.resume_persistence import apply_resume_record_to_state
+
+        allocation = sb.allocation_from_samples(9, _SCORE_9_COSTS, configured_usd=50.0).as_dict()
+        record = {
+            "preflight": {
+                "complexity": "large",
+                "complexity_score": 9,
+                "verdict": "PROCEED",
+                "degraded": True,
+                "degraded_reason": "agent_failed_with_risk_signals",
+                "criteria_checked": [],
+            },
+            "complexity_routing_audit": {
+                "complexity_source": "preflight_degraded_conservative",
+                "story_allocation": allocation,
+            },
+        }
+        state = CoordinatorState()
+        apply_resume_record_to_state(state, record)
+
+        assert state.story_allocation["unfounded"] is True
+        assert state.story_allocation["unfounded_reason"] == "agent_failed_with_risk_signals"
+
+        _apply_preflight_config(_config(tmp_path), state)
+
+        # The rescale reuses the carried allocation and keeps its provenance.
+        assert state.story_allocation["carried"] is True
+        assert state.story_allocation["unfounded"] is True
+        assert state.complexity_routing_audit["story_allocation"]["unfounded"] is True
+
+        block = sb.evaluate_allocation_dict(state.story_allocation, 4.0)
+        assert block["unfounded"] is True
+        assert block["unfounded_reason"] == "agent_failed_with_risk_signals"
+
     def test_resumed_preflight_reuses_the_restored_allocation(self, tmp_path: Path) -> None:
         """The restored allocation survives the resumed run's preflight re-run.
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The implementation keeps founded resume blocks over degraded later attempts, discloses selections on recovery, and preserves unfounded provenance through allocation consumption. | [google-gemini-3.5-flash-api] Durable phase record selection logic is now determined by foundedness instead of save order, with unfounded markers and operator-visible selection metadata implemented elegantly.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-api, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-api
- **Cost:** unknown (>= $8.96 measured)
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A failed phase attempt overwrites the resumption record left by a successful one, so resuming replays the failure and carries its unfounded derived values forward (GitHub Issue #2351)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2351