### PR TITLE
A catalog entry names an upstream identifier the provider has retired, so a superseded model is selected and priced from a rate card that no longer applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `extra_body`, since it is DeepSeek's own body extension), on the single-shot,
   tool-loop and finalizer paths alike. A retired identity is reserved against
   project redeclaration, so `models.custom` and inline `models.enabled` mappings
-  cannot put a retired name back into the selectable set. Cost provenance gains a
+  cannot put a retired name back into the selectable set. A provider-reported
+  `reasoning_content` now round-trips onto the assistant turn it belongs to,
+  which DeepSeek requires once tool calls are in play — without it the first tool
+  call succeeds and every continuation is rejected with a 400. Cost provenance
+  gains a
   fourth value, `estimated_unconfirmed`: an estimate derived from a rate card
   whose model identity is not currently confirmed is now distinguishable from one
   that is, per component and for the invocation as a whole.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   estimator prices from the catalog entry rather than a separate table — the
   DeepSeek rows are gone from `PRICING_TABLE`. `invocation.reasoning_mode` plus a
   real reasoning-effort knob for the DeepSeek transport mean a model banded as a
-  reasoning model is invoked with `thinking` actually requested, on the
-  single-shot, tool-loop and finalizer paths alike.
+  reasoning model is invoked with `thinking` actually requested (via the SDK's
+  `extra_body`, since it is DeepSeek's own body extension), on the single-shot,
+  tool-loop and finalizer paths alike. A retired identity is reserved against
+  project redeclaration, so `models.custom` and inline `models.enabled` mappings
+  cannot put a retired name back into the selectable set. Cost provenance gains a
+  fourth value, `estimated_unconfirmed`: an estimate derived from a rate card
+  whose model identity is not currently confirmed is now distinguishable from one
+  that is, per component and for the invocation as a whole.
 
   **Operator action:** if your `forge.yaml` names `deepseek/deepseek-chat` or
   `deepseek/deepseek-reasoner` under `models.enabled` or `models.custom`, replace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A retired upstream identifier can no longer be routed to, or priced from a
+  replaced rate card (#2352):** model definitions gain an `identity` block
+  (`status: served|retired`, `verified_against`, `verified_on`,
+  `retired_reason`). A retired entry is excluded from routing but kept
+  resolvable, so a configuration still naming it fails at load with the
+  retirement and its replacement named rather than with "unknown model"; an
+  identifier whose recorded check has aged out is reported by `forge
+  check-config` under `upstream identifier not confirmed`. DeepSeek's
+  `deepseek-chat`/`deepseek-reasoner` are declared retired and replaced by
+  `deepseek-v4-flash`/`deepseek-v4-pro` at the published rates. `cost` gains
+  `cached_input_per_mtok` for providers that bill prompt-cache hits at their own
+  rate, the OpenAI-compatible adapters now read the cache and reasoning token
+  counts the provider reports (instead of recording zero for both), and the cost
+  estimator prices from the catalog entry rather than a separate table — the
+  DeepSeek rows are gone from `PRICING_TABLE`. `invocation.reasoning_mode` plus a
+  real reasoning-effort knob for the DeepSeek transport mean a model banded as a
+  reasoning model is invoked with `thinking` actually requested, on the
+  single-shot, tool-loop and finalizer paths alike.
+
+  **Operator action:** if your `forge.yaml` names `deepseek/deepseek-chat` or
+  `deepseek/deepseek-reasoner` under `models.enabled` or `models.custom`, replace
+  it with `deepseek/deepseek-v4-flash` or `deepseek/deepseek-v4-pro`. Config load
+  fails until you do.
+
 - **Patient gates run under the project's pinned Python, not the orchestrator's
   (#1934):** `{forge_python}` now expands to a new required
   `workspace.python_interpreter` setting instead of TheForge's own

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -460,7 +460,15 @@ models:
       cost:
         input_per_mtok: 2.00
         output_per_mtok: 12.00
+        cached_input_per_mtok: 0.20     # only if the provider bills its cache
+                                        # tier at its own published rate
         pricing_provenance: gemini-4-pro-2026-08
+      identity:
+        status: served                  # served | retired
+        verified_against: provider model list
+        verified_on: 2026-08-10
+      invocation:
+        reasoning_mode: enabled         # enabled | disabled
 ```
 
 **Adding a model needs no code and no release** as long as it runs on an adapter
@@ -476,6 +484,32 @@ carried for reference, ignored by cost banding and price tie-breaks. Write
 record but cannot vouch for. `cost_rank_basis` states why the band holds when it
 is not simply this entry's own attributable price band; a band that is neither
 price-attributable nor explained is a load error rather than a silent guess.
+
+`cached_input_per_mtok` is for providers that publish an independent rate for a
+prompt-cache hit rather than expressing it as a fraction of the uncached rate.
+Omit it and forge applies its generic 10%-of-input discount, which is what
+OpenAI and Anthropic actually bill.
+
+**Upstream identifiers.** `identity` is what the entry claims about the name the
+*provider* serves, and when that claim was last checked. It matters because a
+retired identifier often keeps resolving: the call succeeds and returns real
+token counts while the capability, tier and price recorded here describe a model
+that is no longer behind the name.
+
+- `status: retired` makes the entry unroutable. It is not deleted, so a
+  configuration still naming the identifier is told what the provider did with
+  it — `retired_reason` is required and should name the replacement.
+- `verified_on` / `verified_against` record a check. They expire: past the window
+  in `config/model_identity.py` the entry reverts to *unconfirmed*, the same
+  state an entry that never declared a check is in. Unconfirmed is not an error —
+  `forge check-config` reports it under `upstream identifier not confirmed` so
+  you see it before a run spends against it.
+
+**Request-level modes.** `invocation.reasoning_mode` states a behavioural mode
+the provider expresses as a *request parameter* rather than as a distinct model
+name (DeepSeek's `thinking` block, for one). Where a provider works that way, an
+entry banded as a reasoning model has to declare it — otherwise the band
+describes a mode no invocation ever asks for.
 
 **Aliases and versions are both valid model strings.** A `model:` may name a
 vendor *family alias* (`opus`, `sonnet`, `haiku` — the Claude CLI shorthands) or

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -504,6 +504,12 @@ that is no longer behind the name.
   state an entry that never declared a check is in. Unconfirmed is not an error —
   `forge check-config` reports it under `upstream identifier not confirmed` so
   you see it before a run spends against it.
+- A retired identity is **reserved**. `models.custom` and inline `models.enabled`
+  mappings cannot redeclare one with their own routing and cost: the retirement
+  is a property of the identifier, not of the file it was declared in.
+- An API cost derived from a rate card whose identity is unconfirmed is recorded
+  as `cost_provenance: estimated_unconfirmed` rather than `estimated`, so a
+  decision made on price can tell how much the price is worth.
 
 **Request-level modes.** `invocation.reasoning_mode` states a behavioural mode
 the provider expresses as a *request parameter* rather than as a distinct model

--- a/docs/guides/model-reference.md
+++ b/docs/guides/model-reference.md
@@ -132,6 +132,11 @@ Per Google's April 2026 recommendation:
   reasoning_effort}`), not a model-name distinction. The catalog entries declare
   `invocation.reasoning_mode: enabled`, and forge's score-driven reasoning-effort
   axis maps `low`/`medium`/`high` onto DeepSeek's `low`/`high`/`max`.
+- In thinking mode **with tool calls**, DeepSeek requires the assistant turn's
+  `reasoning_content` to be passed back on every subsequent request, and returns
+  400 if it is not. Forge records it on the loop's assistant turn and replays it;
+  without that the first tool call succeeds and every continuation is rejected,
+  which reads as a reviewer that starts and then dies mid-review.
 - DeepSeek bills prompt-cache hits at roughly 2% of the uncached rate. That tier
   is declared as `cost.cached_input_per_mtok` and applied from the counts the
   provider reports, rather than through forge's generic 10% cache discount.

--- a/docs/guides/model-reference.md
+++ b/docs/guides/model-reference.md
@@ -114,15 +114,27 @@ Per Google's April 2026 recommendation:
 
 | Phase | Small | Medium | Large |
 |---|---|---|---|
-| Preflight | `deepseek-reasoner` | `deepseek-reasoner` | `deepseek-reasoner` |
+| Preflight | `deepseek-v4-pro` | `deepseek-v4-pro` | `deepseek-v4-pro` |
 | Planning | not recommended | not recommended | not recommended |
 | Dev | not recommended | not recommended | not recommended |
 | Review | not recommended | not recommended | not recommended |
 
 **Notes:**
-- DeepSeek Reasoner is used for preflight classification — the reasoning
+- `deepseek-v4-pro` is used for preflight classification — the reasoning
   overhead is justified because preflight drives $20-50 of downstream spend
 - Not recommended for dev or review due to tool-use limitations
+- **`deepseek-chat` and `deepseek-reasoner` are retired upstream** (#2352) and
+  are no longer routable. Both still resolve at DeepSeek's API, which is why the
+  catalog declares the retirement explicitly rather than deleting the entries:
+  naming one in `models.enabled` now fails at config load with the replacement
+  named, instead of running and recording spend off a replaced rate card.
+- Reasoning is a request parameter on this provider (`thinking: {type,
+  reasoning_effort}`), not a model-name distinction. The catalog entries declare
+  `invocation.reasoning_mode: enabled`, and forge's score-driven reasoning-effort
+  axis maps `low`/`medium`/`high` onto DeepSeek's `low`/`high`/`max`.
+- DeepSeek bills prompt-cache hits at roughly 2% of the uncached rate. That tier
+  is declared as `cost.cached_input_per_mtok` and applied from the counts the
+  provider reports, rather than through forge's generic 10% cache discount.
 - Cost: ~$0.30 per preflight call
 
 ---

--- a/src/theforge/agent_types.py
+++ b/src/theforge/agent_types.py
@@ -18,12 +18,33 @@ COST_PROVIDER_REPORTED = "provider_reported"
 """The provider returned this cost; forge did not compute it."""
 
 COST_ESTIMATED = "estimated"
-"""Derived by forge from observed token counts and a pricing table."""
+"""Derived by forge from observed token counts and a rate card whose model
+identity is currently confirmed against the provider."""
+
+COST_ESTIMATED_UNCONFIRMED = "estimated_unconfirmed"
+"""Derived by forge, but from a rate card that may no longer apply (#2352).
+
+The rate is real and the arithmetic is right; what is missing is any current
+evidence that the identifier it was recorded for still designates the model that
+was invoked. That is the state every DeepSeek estimate was in while the retired
+identifiers were still routable — indistinguishable, at the time, from an
+estimate off a rate card in force. A consumer deciding on price can tell how much
+the price is worth; see ``config/model_identity.IdentityVerification``.
+"""
 
 COST_UNKNOWN = "unknown"
 """No cost was observed. Always paired with ``cost_usd is None``."""
 
-COST_PROVENANCE_VALUES = (COST_PROVIDER_REPORTED, COST_ESTIMATED, COST_UNKNOWN)
+COST_PROVENANCE_VALUES = (
+    COST_PROVIDER_REPORTED,
+    COST_ESTIMATED,
+    COST_ESTIMATED_UNCONFIRMED,
+    COST_UNKNOWN,
+)
+
+# Every provenance that means "forge computed this", for consumers that care
+# about computed-vs-billed rather than about the confidence within computed.
+COST_ESTIMATED_VALUES = (COST_ESTIMATED, COST_ESTIMATED_UNCONFIRMED)
 
 
 @dataclass(frozen=True)

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -2209,15 +2209,17 @@ def _thinking_spend_captured(profile: ModelProfile, knob: EffortKnob) -> bool:
 
     Two independent facts, both required: the transport's accounting path must
     fold thinking tokens into the priced total (``knob.captures_thinking_spend``),
-    *and* the selected model must have a pricing entry — a model absent from
-    ``PRICING_TABLE`` records cost-unknown, which is precisely "spend not
-    captured". Imported lazily so this module stays import-time pure.
+    *and* the selected model must have a rate card — a model with none records
+    cost-unknown, which is precisely "spend not captured". Asked through
+    ``pricing_for`` rather than by indexing ``PRICING_TABLE``, so a model priced
+    from its catalog entry counts exactly like one priced from the table (#2352).
+    Imported lazily so this module stays import-time pure.
     """
     if not knob.captures_thinking_spend:
         return False
-    from .runners.schema_utils import PRICING_TABLE  # noqa: PLC0415
+    from .runners.schema_utils import pricing_for  # noqa: PLC0415
 
-    return (profile.provider_family, profile.model) in PRICING_TABLE
+    return pricing_for(profile.provider_family or "", profile.model) is not None
 
 
 def _apply_effort_to_profile(

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import date
 from pathlib import Path
 
 from theforge.cli.hooks import post_run_hook_upgrade_warnings
@@ -271,6 +272,33 @@ def _unattributed_pricing_models(
     return flagged
 
 
+def _unconfirmed_identity_models(
+    model_keys: list[str],
+    registry: dict | None = None,
+) -> list[tuple[str, str]]:
+    """Return ``(model_key, explanation)`` for enabled models with an unchecked identifier.
+
+    A model identifier is a claim about something outside this repository, and it
+    can stop being true without anything here changing — providers retire and
+    re-point names, and a retired name that keeps resolving upstream produces
+    successful runs whose declarations describe a different model. That is only
+    catchable before spend if it is reported where configuration is read (#2352).
+
+    Reported, never fatal: an unchecked identifier is usually fine. What it must
+    not be is invisible.
+    """
+    today = date.today()
+    rows: list[tuple[str, str]] = []
+    for model_key in model_keys:
+        try:
+            spec = resolve_agent_spec(model_key, registry=registry)
+        except ValueError:
+            continue  # unresolvable keys (including retired ones) report elsewhere
+        if not spec.identity.confirmed_on(today):
+            rows.append((model_key, spec.identity.describe(today)))
+    return rows
+
+
 def _cost_band_bases(
     model_keys: list[str],
     registry: dict | None = None,
@@ -487,6 +515,17 @@ def _format_config(
             # The cost band is the other price-shaped routing input, so show what
             # each enabled model's band is derived from — an operator diagnosing a
             # selection can otherwise only see the number, not its source (#2203).
+            # An identifier nothing has checked against the provider recently is
+            # the state that produced #2352: the declaration kept describing a
+            # model the name had stopped designating, and the only symptom was a
+            # cost figure that looked plausible.
+            unconfirmed = _unconfirmed_identity_models(
+                config.models, registry=config.model_registry
+            )
+            if unconfirmed:
+                lines.append("  upstream identifier not confirmed:")
+                for model_key, explanation in unconfirmed:
+                    lines.append(f"    {model_key:<32}{explanation}")
             bands = _cost_band_bases(config.models, registry=config.model_registry)
             if bands:
                 lines.append("  cost band basis:")

--- a/src/theforge/cli/eval_cmd.py
+++ b/src/theforge/cli/eval_cmd.py
@@ -143,8 +143,8 @@ def cmd_eval_preflight(args: object) -> int:
     if models_arg:
         model_names = [m.strip() for m in models_arg.split(",") if m.strip()]
     else:
-        # Default candidate shortlist per spec AC: GPT-5.4, Claude Sonnet, DeepSeek-reasoner
-        model_names = ["gpt-5.4", "claude-sonnet-4-5", "deepseek-reasoner"]
+        # Default candidate shortlist per spec AC: GPT-5.4, Claude Sonnet, DeepSeek V4 Pro
+        model_names = ["gpt-5.4", "claude-sonnet-4-5", "deepseek-v4-pro"]
 
     profiles = [_infer_profile(m, default_budget, default_timeout) for m in model_names]
     print(f"[eval-preflight] Evaluating {len(profiles)} model(s): {', '.join(model_names)}")
@@ -190,7 +190,7 @@ def register_parser(subparsers: object) -> None:
         metavar="MODEL[,MODEL...]",
         help=(
             "Comma-separated model identifiers to evaluate. "
-            "Default: gpt-5.4,claude-sonnet-4-5,deepseek-reasoner"
+            "Default: gpt-5.4,claude-sonnet-4-5,deepseek-v4-pro"
         ),
     )
     p.add_argument(

--- a/src/theforge/config/data/models.yaml
+++ b/src/theforge/config/data/models.yaml
@@ -20,7 +20,28 @@
 #   routing:    tier, capability, cost_rank, dev_capable, phase_eligibility,
 #               cost_rank_basis
 #   base_url:   endpoint metadata (locally served OpenAI-compatible servers)
-#   cost:       input_per_mtok, output_per_mtok, pricing_provenance
+#   cost:       input_per_mtok, output_per_mtok, cached_input_per_mtok,
+#               pricing_provenance
+#   identity:   status (served|retired), verified_against, verified_on,
+#               retired_reason
+#   invocation: reasoning_mode (enabled|disabled)
+#
+# `identity` is what the entry claims about its *upstream* identifier, and when
+# that claim was last checked. A `status: retired` entry is not routable at all:
+# it exists so a configuration still naming the identifier is told what the
+# provider did with it, instead of being told the name was never known. A served
+# entry whose `verified_on` is absent or older than the window in
+# config/model_identity.py is *unconfirmed* — still routable, but reported by
+# `forge check-config` so an operator sees it before a run does (#2352).
+#
+# `cost.cached_input_per_mtok` is for providers that bill a prompt-cache hit at
+# their own published rate rather than as a fixed fraction of the uncached rate.
+# Omitting it keeps the generic discount in runners/schema_utils.
+#
+# `invocation.reasoning_mode` states a behavioural mode the provider expresses as
+# a *request parameter* rather than as a distinct model name. An entry banded for
+# reasoning on a provider that works that way has to declare it, or the band
+# describes a mode no invocation ever asks for.
 #
 # `cost.pricing_provenance` names the concrete billed identity the figures were
 # recorded for. Omitting it marks them *unattributed*: routing ignores them.
@@ -281,9 +302,34 @@ models:
       pricing_provenance: gpt-5.4-pro
 
   # ── DeepSeek (API) ───────────────────────────────────────────────────
+  #
+  # #2352. `deepseek-chat` and `deepseek-reasoner` were retired upstream and are
+  # declared as such below rather than deleted. Deleting them would have made a
+  # configuration that still names one fail with "unknown model", which reads as
+  # a typo; the retirement is the thing the operator needs told.
+  #
+  # These two entries are checked against DeepSeek's published model list and
+  # pricing page, and carry the date that check was made — see `identity:`. That
+  # is what the previous entries could not say: they resolved upstream, returned
+  # token counts and exited 0 long after the names they used stopped designating
+  # the models their capability, tier and price were recorded against.
+  #
+  # DeepSeek bills a prompt-cache hit at its own published rate (~2% of the
+  # uncached rate), not at the flat 10%-of-input discount other providers use, so
+  # the rate is stated explicitly via `cached_input_per_mtok` rather than derived.
+  #
+  # Reasoning is now a *request* parameter (`thinking: {type, reasoning_effort}`),
+  # not a distinct model name. `invocation.reasoning_mode` is what makes the
+  # reasoning band below a claim about an invocation forge actually makes.
   - provider: deepseek
-    model: deepseek-reasoner
+    model: deepseek-v4-pro
     transport: {kind: api}
+    identity:
+      status: served
+      verified_against: api-docs.deepseek.com model list + pricing page
+      verified_on: 2026-08-10
+    invocation:
+      reasoning_mode: enabled
     routing:
       tier: strong
       capability: 9
@@ -293,21 +339,59 @@ models:
       # understates what filling a role with it costs.
       cost_rank_basis: declared-policy
     cost:
-      input_per_mtok: 0.55
-      output_per_mtok: 2.19
-      pricing_provenance: deepseek-reasoner
+      input_per_mtok: 0.435
+      output_per_mtok: 0.87
+      cached_input_per_mtok: 0.003625
+      pricing_provenance: deepseek-v4-pro
 
   - provider: deepseek
-    model: deepseek-chat
+    model: deepseek-v4-flash
     transport: {kind: api}
+    identity:
+      status: served
+      verified_against: api-docs.deepseek.com model list + pricing page
+      verified_on: 2026-08-10
+    invocation:
+      reasoning_mode: enabled
     routing:
       tier: fast
       capability: 7
       cost_rank: 1
     cost:
-      input_per_mtok: 0.27
-      output_per_mtok: 1.10
-      pricing_provenance: deepseek-chat
+      input_per_mtok: 0.14
+      output_per_mtok: 0.28
+      cached_input_per_mtok: 0.0028
+      pricing_provenance: deepseek-v4-flash
+
+  # Retired upstream. Not routable, carries no price: an identifier that no
+  # longer designates what was recorded about it must not be able to price
+  # anything, and the rates these entries used to carry were from a rate card
+  # DeepSeek has replaced.
+  - provider: deepseek
+    model: deepseek-reasoner
+    transport: {kind: api}
+    identity:
+      status: retired
+      verified_against: api-docs.deepseek.com model list
+      verified_on: 2026-08-10
+      retired_reason: >-
+        Removed from DeepSeek's published model list; superseded by
+        deepseek-v4-pro. The name still resolves upstream, so calls through it
+        succeed while designating a different model than the one whose
+        capability, tier and price were recorded here (#2352).
+
+  - provider: deepseek
+    model: deepseek-chat
+    transport: {kind: api}
+    identity:
+      status: retired
+      verified_against: api-docs.deepseek.com model list
+      verified_on: 2026-08-10
+      retired_reason: >-
+        Removed from DeepSeek's published model list; superseded by
+        deepseek-v4-flash. The name still resolves upstream, so calls through it
+        succeed while designating a different model than the one whose
+        capability, tier and price were recorded here (#2352).
 
   # ── Google (API) ─────────────────────────────────────────────────────
   - provider: google

--- a/src/theforge/config/model_catalog.py
+++ b/src/theforge/config/model_catalog.py
@@ -568,7 +568,27 @@ def resolve_project(
     Precedence per field: what the declaration states, then the built-in entry
     with the same canonical identity, then a value derived from ``tier`` and the
     transport. Every resolved field records which of the two sources supplied it.
+
+    A canonical identity the shipped catalog has declared **retired** is reserved
+    and cannot be resolved here at all. Without that, the retirement is only a
+    property of the *shipped* entry: a project could redeclare the same
+    identifier under ``models.custom`` or as an inline ``models.enabled``
+    mapping, supply its own routing and cost, and put the retired name straight
+    back into the selectable set — with a rate card the operator invented for a
+    model the provider no longer serves, which is the defect one layer down.
+    Both project surfaces resolve through this function, so the guard sits here
+    rather than at either call site.
     """
+    retired = packaged_retired_identities().get(defn.canonical_id)
+    if retired is not None:
+        raise ValueError(
+            f"forge.yaml '{where}' declares {defn.canonical_id!r}, an upstream identifier "
+            f"the provider has retired: {retired.identity.retired_reason or 'no reason recorded'} "
+            "A project declaration cannot un-retire an identifier — declaring routing or cost "
+            "for it would describe a model the provider no longer serves. Name a served "
+            "identifier instead."
+        )
+
     sources: dict[str, str] = {}
 
     def _pick(
@@ -759,6 +779,27 @@ def _read_catalog_document() -> Any:
     return yaml.safe_load(resource.read_text(encoding="utf-8"))
 
 
+_RETIRED_IDENTITIES_CACHE: dict[str, AgentSpec] | None = None
+
+
+def packaged_retired_identities() -> dict[str, AgentSpec]:
+    """Canonical identities the shipped catalog declares retired.
+
+    Read by :func:`resolve_project` to reserve those identities against project
+    redeclaration. Kept here rather than imported from
+    :mod:`theforge.config.models` because that module builds its registry *by
+    calling this one* — reaching back for it would be the import cycle the
+    identity/catalog/registry layering exists to prevent.
+
+    Populated as a side effect of :func:`load_packaged_catalog_split`, which
+    ``models.py`` calls at import, so the ordinary path costs no second parse.
+    """
+    global _RETIRED_IDENTITIES_CACHE
+    if _RETIRED_IDENTITIES_CACHE is None:
+        load_packaged_catalog_split()
+    return _RETIRED_IDENTITIES_CACHE or {}
+
+
 def load_packaged_catalog_split() -> tuple[dict[str, AgentSpec], dict[str, AgentSpec]]:
     """Load the shipped model set, partitioned into served and retired entries.
 
@@ -791,6 +832,8 @@ def load_packaged_catalog_split() -> tuple[dict[str, AgentSpec], dict[str, Agent
             )
         target = retired if resolved.spec.identity.retired else registry
         target[resolved.canonical_id] = resolved.spec
+    global _RETIRED_IDENTITIES_CACHE
+    _RETIRED_IDENTITIES_CACHE = retired
     return registry, retired
 
 

--- a/src/theforge/config/model_catalog.py
+++ b/src/theforge/config/model_catalog.py
@@ -53,6 +53,7 @@ without the two modules importing each other.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 from importlib import resources
 from typing import Any, Callable
 
@@ -62,10 +63,15 @@ from .model_identity import (
     _DEFAULT_PHASE_ELIGIBILITY,
     CAPABILITY_RANGE,
     COST_RANK_RANGE,
+    IDENTITY_STATUS_RETIRED,
+    IDENTITY_STATUSES,
     KNOWN_PHASES,
     MODEL_TIERS,
+    REASONING_MODES,
     TRANSPORT_KINDS,
+    UNCONFIRMED_IDENTITY,
     AgentSpec,
+    IdentityVerification,
     RoutingPolicy,
     TransportSpec,
     canonical_model_id,
@@ -88,7 +94,7 @@ SOURCE_BUILTIN = "builtin"
 SOURCE_PROJECT = "forge.yaml"
 
 DEFINITION_KEYS: frozenset[str] = frozenset(
-    {"provider", "model", "transport", "routing", "base_url", "cost"}
+    {"provider", "model", "transport", "routing", "base_url", "cost", "identity", "invocation"}
 )
 ROUTING_KEYS: frozenset[str] = frozenset(
     {
@@ -100,7 +106,18 @@ ROUTING_KEYS: frozenset[str] = frozenset(
         "cost_rank_basis",
     }
 )
-COST_KEYS: frozenset[str] = frozenset({"input_per_mtok", "output_per_mtok", "pricing_provenance"})
+COST_KEYS: frozenset[str] = frozenset(
+    {
+        "input_per_mtok",
+        "output_per_mtok",
+        "cached_input_per_mtok",
+        "pricing_provenance",
+    }
+)
+IDENTITY_KEYS: frozenset[str] = frozenset(
+    {"status", "verified_against", "verified_on", "retired_reason"}
+)
+INVOCATION_KEYS: frozenset[str] = frozenset({"reasoning_mode"})
 
 # The resolved fields provenance is reported for. Identity (provider, model,
 # transport) is deliberately absent: it is what the two sources *agree* on when
@@ -115,7 +132,10 @@ PROVENANCE_FIELDS: tuple[str, ...] = (
     "base_url",
     "input_cost_per_mtok",
     "output_cost_per_mtok",
+    "cached_input_cost_per_mtok",
     "pricing_provenance",
+    "identity",
+    "reasoning_mode",
 )
 
 _CATALOG_PACKAGE = "theforge.config"
@@ -139,6 +159,8 @@ class ParsedDefinition:
     cost: dict[str, Any]
     base_url: str | None
     declared: frozenset[str]
+    identity: IdentityVerification = UNCONFIRMED_IDENTITY
+    reasoning_mode: str | None = None
 
 
 @dataclass(frozen=True)
@@ -229,6 +251,95 @@ def parse_transport_block(raw: Any, where: str) -> tuple[str, str | None]:
     return str(kind), runner
 
 
+def parse_identity_block(raw: Any, where: str) -> IdentityVerification:
+    """Read the bounded ``identity: {status, verified_against, verified_on, …}`` object.
+
+    Two rules are enforced here rather than left to the reader, because both
+    describe the failure this block exists to stop:
+
+    - a ``retired`` entry must state ``retired_reason``. A withdrawn name with no
+      stated reason gives an operator nothing to act on, which is the state the
+      catalog was already in before the block existed;
+    - ``verified_on`` must be a real date. A free-text "recently" cannot age out,
+      and a verification that cannot expire is a permanent claim about something
+      that is not permanent.
+    """
+    if raw is None:
+        return UNCONFIRMED_IDENTITY
+    if not isinstance(raw, dict):
+        raise ValueError(f"forge.yaml '{where}.identity' must be a mapping")
+    unknown = set(raw) - IDENTITY_KEYS
+    if unknown:
+        raise ValueError(
+            f"forge.yaml '{where}.identity' only supports {sorted(IDENTITY_KEYS)}; "
+            f"unknown key(s): {sorted(unknown)}"
+        )
+    status = raw.get("status", "served")
+    if status not in IDENTITY_STATUSES:
+        raise ValueError(
+            f"forge.yaml '{where}.identity.status' must be one of {sorted(IDENTITY_STATUSES)}, "
+            f"got {status!r}"
+        )
+    verified_against = raw.get("verified_against")
+    if verified_against is not None:
+        verified_against = _require_str(
+            verified_against, where=f"{where}.identity.verified_against"
+        )
+    verified_on_raw = raw.get("verified_on")
+    verified_on: date | None
+    if verified_on_raw is None:
+        verified_on = None
+    elif isinstance(verified_on_raw, date):
+        # PyYAML parses an unquoted ISO date into a `datetime.date` already.
+        verified_on = verified_on_raw
+    else:
+        try:
+            verified_on = date.fromisoformat(str(verified_on_raw))
+        except ValueError:
+            raise ValueError(
+                f"forge.yaml '{where}.identity.verified_on' must be an ISO date "
+                f"(YYYY-MM-DD), got {verified_on_raw!r}"
+            ) from None
+    retired_reason = raw.get("retired_reason")
+    if retired_reason is not None:
+        retired_reason = _require_str(retired_reason, where=f"{where}.identity.retired_reason")
+    if status == IDENTITY_STATUS_RETIRED and not retired_reason:
+        raise ValueError(
+            f"forge.yaml '{where}.identity' declares status 'retired' but no "
+            "'retired_reason'. State what the provider did with the identifier and "
+            "what replaces it, so an operator reading this can act on it."
+        )
+    return IdentityVerification(
+        status=str(status),
+        verified_against=verified_against,
+        verified_on=verified_on,
+        retired_reason=retired_reason,
+    )
+
+
+def parse_invocation_block(raw: Any, where: str) -> str | None:
+    """Read the bounded ``invocation: {reasoning_mode: …}`` object."""
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(f"forge.yaml '{where}.invocation' must be a mapping")
+    unknown = set(raw) - INVOCATION_KEYS
+    if unknown:
+        raise ValueError(
+            f"forge.yaml '{where}.invocation' only supports {sorted(INVOCATION_KEYS)}; "
+            f"unknown key(s): {sorted(unknown)}"
+        )
+    mode = raw.get("reasoning_mode")
+    if mode is None:
+        return None
+    if mode not in REASONING_MODES:
+        raise ValueError(
+            f"forge.yaml '{where}.invocation.reasoning_mode' must be one of "
+            f"{sorted(REASONING_MODES)}, got {mode!r}"
+        )
+    return str(mode)
+
+
 def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
     """Validate one canonical model definition's syntax.
 
@@ -276,6 +387,9 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
     if base_url is not None:
         base_url = _require_str(base_url, where=f"{where}.base_url")
 
+    identity = parse_identity_block(entry.get("identity"), where)
+    reasoning_mode = parse_invocation_block(entry.get("invocation"), where)
+
     routing: dict[str, Any] = {}
     if "tier" in routing_raw:
         routing["tier"] = _require_tier(routing_raw["tier"], where=f"{where}.routing.tier")
@@ -321,6 +435,10 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
         cost["output_cost_per_mtok"] = _require_price(
             cost_raw["output_per_mtok"], where=f"{where}.cost.output_per_mtok"
         )
+    if "cached_input_per_mtok" in cost_raw:
+        cost["cached_input_cost_per_mtok"] = _require_price(
+            cost_raw["cached_input_per_mtok"], where=f"{where}.cost.cached_input_per_mtok"
+        )
     if "pricing_provenance" in cost_raw:
         provenance = cost_raw["pricing_provenance"]
         # An explicit null is meaningful: it says "these figures are not
@@ -330,7 +448,13 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
             provenance = _require_str(provenance, where=f"{where}.cost.pricing_provenance")
         cost["pricing_provenance"] = provenance
 
-    declared = frozenset(routing) | frozenset(cost) | ({"base_url"} if base_url else set())
+    declared = (
+        frozenset(routing)
+        | frozenset(cost)
+        | ({"base_url"} if base_url else set())
+        | ({"identity"} if entry.get("identity") is not None else set())
+        | ({"reasoning_mode"} if reasoning_mode is not None else set())
+    )
     return ParsedDefinition(
         canonical_id=canonical_model_id(provider, model, transport.kind),
         provider=provider,
@@ -340,6 +464,8 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
         cost=cost,
         base_url=base_url,
         declared=declared,
+        identity=identity,
+        reasoning_mode=reasoning_mode,
     )
 
 
@@ -353,15 +479,49 @@ def resolve_packaged(defn: ParsedDefinition, *, where: str) -> ResolvedModel:
     and the cost band is held to the attribution rule in
     :func:`config.pricing.resolve_cost_band_basis`: a band that is not this
     entry's own attributable price band has to name its non-price basis.
+
+    A **retired** entry is exempt from both. It is not a routing candidate — it
+    exists only so that a reference to the identifier resolves to an explanation
+    instead of to "unknown model" — so demanding a capability score and a
+    defensible cost band for it would be asking the operator to keep declaring
+    properties of a model the provider no longer serves.
     """
+    input_cost = defn.cost.get("input_cost_per_mtok")
+    output_cost = defn.cost.get("output_cost_per_mtok")
+    cached_input_cost = defn.cost.get("cached_input_cost_per_mtok")
+    provenance = defn.cost.get("pricing_provenance")
+    if defn.identity.retired:
+        routing_policy = RoutingPolicy(
+            tier=defn.routing.get("tier", "cheap"),
+            capability=defn.routing.get("capability", CAPABILITY_RANGE[0]),
+            cost_rank=defn.routing.get("cost_rank", UNPRICED_COST_RANK),
+            dev_capable=False,
+            phase_eligibility=frozenset(),
+            cost_rank_basis=COST_BAND_BASIS_UNPRICED_DEFAULT,
+        )
+        # A retired identifier's recorded price describes a rate card the
+        # provider has replaced, so it is dropped rather than carried: leaving
+        # it attached would let it keep pricing anything that reached it.
+        spec = AgentSpec(
+            provider=defn.provider,
+            model=defn.model,
+            transport=defn.transport,
+            routing=routing_policy,
+            base_url=defn.base_url,
+            registry_source=SOURCE_BUILTIN,
+            identity=defn.identity,
+        )
+        return ResolvedModel(
+            canonical_id=defn.canonical_id,
+            spec=spec,
+            field_sources={field: SOURCE_BUILTIN for field in PROVENANCE_FIELDS},
+        )
+
     for required in ("tier", "capability", "cost_rank"):
         if required not in defn.routing:
             raise ValueError(
                 f"forge.yaml '{where}.routing' is missing required field {required!r}"
             )
-    input_cost = defn.cost.get("input_cost_per_mtok")
-    output_cost = defn.cost.get("output_cost_per_mtok")
-    provenance = defn.cost.get("pricing_provenance")
     basis = resolve_cost_band_basis(
         defn.routing["cost_rank"],
         input_cost_per_mtok=input_cost,
@@ -385,7 +545,10 @@ def resolve_packaged(defn: ParsedDefinition, *, where: str) -> ResolvedModel:
         registry_source=SOURCE_BUILTIN,
         input_cost_per_mtok=input_cost,
         output_cost_per_mtok=output_cost,
+        cached_input_cost_per_mtok=cached_input_cost,
         pricing_provenance=provenance,
+        identity=defn.identity,
+        reasoning_mode=defn.reasoning_mode,
     )
     return ResolvedModel(
         canonical_id=defn.canonical_id,
@@ -446,6 +609,26 @@ def resolve_project(
         "output_cost_per_mtok",
         defn.cost.get("output_cost_per_mtok"),
         builtin.output_cost_per_mtok if builtin is not None else None,
+    )
+    cached_input_cost = _pick(
+        "cached_input_cost_per_mtok",
+        defn.cost.get("cached_input_cost_per_mtok"),
+        builtin.cached_input_cost_per_mtok if builtin is not None else None,
+    )
+    # An overlay that says nothing about the identifier inherits what the
+    # built-in entry established about it. It may not *upgrade* that: a project
+    # declaration is not a check against the provider, so an entry with no
+    # built-in behind it stays unconfirmed until someone records a check.
+    identity = _pick(
+        "identity",
+        defn.identity,
+        builtin.identity if builtin is not None else None,
+        lambda: UNCONFIRMED_IDENTITY,
+    )
+    reasoning_mode = _pick(
+        "reasoning_mode",
+        defn.reasoning_mode,
+        builtin.reasoning_mode if builtin is not None else None,
     )
     # Declaring a `cost:` figure without saying what it is attributed to
     # attributes it to this identity — the operator asserted it here. An
@@ -556,7 +739,10 @@ def resolve_project(
         registry_source=SOURCE_PROJECT,
         input_cost_per_mtok=input_cost,
         output_cost_per_mtok=output_cost,
+        cached_input_cost_per_mtok=cached_input_cost,
         pricing_provenance=provenance,
+        identity=identity or UNCONFIRMED_IDENTITY,
+        reasoning_mode=reasoning_mode,
     )
     return ResolvedModel(
         canonical_id=defn.canonical_id,
@@ -573,11 +759,18 @@ def _read_catalog_document() -> Any:
     return yaml.safe_load(resource.read_text(encoding="utf-8"))
 
 
-def load_packaged_catalog() -> dict[str, AgentSpec]:
-    """Load the shipped default model set from ``config/data/models.yaml``.
+def load_packaged_catalog_split() -> tuple[dict[str, AgentSpec], dict[str, AgentSpec]]:
+    """Load the shipped model set, partitioned into served and retired entries.
 
-    Read through the same parser project declarations use, so both sources
-    produce identical structures and one schema governs them.
+    Retired entries are kept out of the routable registry entirely — nothing that
+    selects a model can reach one — but they are not discarded, because the whole
+    point of declaring a retirement is that a configuration still naming the
+    identifier gets told what happened to it rather than being told the name was
+    never known (see :func:`config.models.resolve_agent_spec`).
+
+    Uniqueness is checked across *both* partitions: an entry cannot be both
+    served and retired, and the retired half is where an identifier's replacement
+    is named, so a collision there is the same declaration error it is anywhere.
     """
     document = _read_catalog_document()
     if not isinstance(document, dict) or not isinstance(document.get("models"), list):
@@ -586,14 +779,46 @@ def load_packaged_catalog() -> dict[str, AgentSpec]:
             "'models' list"
         )
     registry: dict[str, AgentSpec] = {}
+    retired: dict[str, AgentSpec] = {}
     for index, entry in enumerate(document["models"]):
         where = f"models[{index}]"
         defn = parse_definition(entry, where=where)
         resolved = resolve_packaged(defn, where=where)
-        if resolved.canonical_id in registry:
+        if resolved.canonical_id in registry or resolved.canonical_id in retired:
             raise ValueError(
                 f"packaged model catalog declares {resolved.canonical_id!r} twice "
                 f"({where}); canonical identities must be unique"
             )
-        registry[resolved.canonical_id] = resolved.spec
-    return registry
+        target = retired if resolved.spec.identity.retired else registry
+        target[resolved.canonical_id] = resolved.spec
+    return registry, retired
+
+
+def load_packaged_catalog() -> dict[str, AgentSpec]:
+    """Load the routable half of the shipped default model set.
+
+    Read through the same parser project declarations use, so both sources
+    produce identical structures and one schema governs them.
+    """
+    return load_packaged_catalog_split()[0]
+
+
+def unconfirmed_identities(
+    registry: dict[str, AgentSpec],
+    *,
+    today: date,
+) -> list[tuple[str, AgentSpec]]:
+    """Return routable entries whose upstream identifier is not currently confirmed.
+
+    "Not confirmed" covers both never-checked and checked-too-long-ago; the two
+    are the same state as far as trusting the entry's declarations goes. This is
+    reported, never raised: an unconfirmed identifier is usually fine, and making
+    it a load error would mean the catalog stops loading on a date rather than on
+    a defect. What it must not do is stay invisible until a run's output looks
+    wrong — see ``forge check-config`` (#2352).
+    """
+    return [
+        (key, spec)
+        for key, spec in sorted(registry.items())
+        if not spec.identity.confirmed_on(today)
+    ]

--- a/src/theforge/config/model_identity.py
+++ b/src/theforge/config/model_identity.py
@@ -19,10 +19,98 @@ library, so it stays importable from anywhere in the config package.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date, timedelta
 
 from .pricing import AttributablePricing
 
 TRANSPORT_KINDS: frozenset[str] = frozenset({"cli", "api"})
+
+
+# ── Upstream identifier status ───────────────────────────────────────────
+#
+# A model identifier is a claim about something outside this repository: that
+# the provider still serves that name, and that it still designates the model
+# whose capability, tier and price were recorded against it. Providers retire
+# and re-point identifiers, and — the dangerous case — a retired identifier
+# often keeps *resolving*, so a run against it completes with exit 0 and real
+# token counts while the declaration describes a model that is no longer there.
+#
+# So the claim is written down rather than assumed. Every catalog entry may
+# state when its identifier was last checked against the provider's published
+# model list, and an entry the provider has retired says so explicitly instead
+# of quietly staying selectable (#2352).
+
+IDENTITY_STATUS_SERVED = "served"
+IDENTITY_STATUS_RETIRED = "retired"
+IDENTITY_STATUSES: frozenset[str] = frozenset({IDENTITY_STATUS_SERVED, IDENTITY_STATUS_RETIRED})
+
+# How long a recorded verification stays load-bearing. A check made against the
+# provider's model list is evidence about the day it was made, not a permanent
+# property: past this window the entry reverts to *unconfirmed*, which is the
+# same state an entry that never declared a check is in. Deliberately not a
+# load error — an expired check is not bad configuration, it is configuration
+# whose supporting evidence has aged out, and the operator is the one who can
+# refresh it.
+IDENTITY_VERIFICATION_MAX_AGE_DAYS = 180
+
+
+@dataclass(frozen=True)
+class IdentityVerification:
+    """What is known about an entry's upstream identifier, and when.
+
+    ``status`` is what the provider is understood to do with the name today.
+    ``verified_against`` names the source the check was made against (a
+    published model list, a live probe) and ``verified_on`` the day it was made;
+    together they are what makes :meth:`confirmed_on` answerable rather than a
+    matter of belief. ``retired_reason`` is required of a retired entry — a name
+    withdrawn without a stated reason tells an operator nothing they can act on.
+    """
+
+    status: str = IDENTITY_STATUS_SERVED
+    verified_against: str | None = None
+    verified_on: date | None = None
+    retired_reason: str | None = None
+
+    @property
+    def retired(self) -> bool:
+        return self.status == IDENTITY_STATUS_RETIRED
+
+    def confirmed_on(self, today: date) -> bool:
+        """True when a check exists for this identifier and has not aged out."""
+        if self.retired or self.verified_on is None or not self.verified_against:
+            return False
+        return today - self.verified_on <= timedelta(days=IDENTITY_VERIFICATION_MAX_AGE_DAYS)
+
+    def describe(self, today: date) -> str:
+        """One-line statement of what is known, for operator-facing reports."""
+        if self.retired:
+            return f"retired upstream — {self.retired_reason or 'no reason recorded'}"
+        if self.verified_on is None or not self.verified_against:
+            return "never checked against the provider's published model list"
+        age = (today - self.verified_on).days
+        if age > IDENTITY_VERIFICATION_MAX_AGE_DAYS:
+            return (
+                f"last checked {self.verified_on.isoformat()} against {self.verified_against} "
+                f"({age}d ago, over the {IDENTITY_VERIFICATION_MAX_AGE_DAYS}d window)"
+            )
+        return f"checked {self.verified_on.isoformat()} against {self.verified_against}"
+
+
+# The state of an entry that says nothing about its identifier: the provider may
+# well still serve it, but nothing here establishes that.
+UNCONFIRMED_IDENTITY = IdentityVerification()
+
+
+# ── Provider invocation controls ─────────────────────────────────────────
+#
+# Where a provider expresses a behavioural mode as a *request parameter* rather
+# than as a distinct model name, banding an entry for that behaviour is only
+# meaningful if the request actually asks for it. ``reasoning_mode`` is that
+# declaration: it says what the entry's routing band was recorded about, in a
+# form the adapter can forward.
+REASONING_MODE_ENABLED = "enabled"
+REASONING_MODE_DISABLED = "disabled"
+REASONING_MODES: frozenset[str] = frozenset({REASONING_MODE_ENABLED, REASONING_MODE_DISABLED})
 
 
 @dataclass(frozen=True)
@@ -181,7 +269,7 @@ class AgentSpec(AttributablePricing):
     """
 
     provider: str  # "anthropic" | "openai" | "google" | "deepseek"
-    model: str  # model identifier (e.g. "sonnet", "gpt-5.4", "deepseek-reasoner")
+    model: str  # model identifier (e.g. "sonnet", "gpt-5.4", "deepseek-v4-pro")
     transport: TransportSpec
     routing: RoutingPolicy
     base_url: str | None = None  # endpoint metadata (local/OpenAI-compatible servers)
@@ -193,6 +281,16 @@ class AgentSpec(AttributablePricing):
     # PRICING_PROVENANCE_* marker). None = unattributed: routing treats the
     # figures as unknown. See _AttributablePricing.
     pricing_provenance: str | None = None
+    # A provider that bills prompt-cache hits at its own published rate rather
+    # than as a fixed fraction of the uncached rate states that rate here. None
+    # means "no separately-billed tier declared" and the generic cache discount
+    # in runners/schema_utils applies.
+    cached_input_cost_per_mtok: float | None = None
+    # What is known about the upstream identifier this entry names (#2352).
+    identity: IdentityVerification = UNCONFIRMED_IDENTITY
+    # Request-level behavioural mode to ask for at invocation, where the provider
+    # expresses one. None = send nothing and take the provider's default.
+    reasoning_mode: str | None = None
 
     @property
     def tier(self) -> str:

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -34,10 +34,11 @@ from __future__ import annotations
 from dataclasses import dataclass, fields, replace
 from typing import Any, TypeVar, overload
 
-from .model_catalog import load_packaged_catalog
+from .model_catalog import load_packaged_catalog_split
 from .model_identity import (
     _DEFAULT_PHASE_ELIGIBILITY,
     _LEGACY_CLI_TO_PROVIDER,
+    UNCONFIRMED_IDENTITY,
 )
 
 # Re-exported: the canonical identity types and the raw-input alias boundary
@@ -45,6 +46,7 @@ from .model_identity import (
 # without importing this module back. Every caller still imports them here.
 from .model_identity import TRANSPORT_KINDS as TRANSPORT_KINDS
 from .model_identity import AgentSpec as AgentSpec
+from .model_identity import IdentityVerification as IdentityVerification  # noqa: PLC0414
 from .model_identity import RoutingPolicy as RoutingPolicy
 from .model_identity import TransportSpec as TransportSpec
 from .model_identity import canonical_id_for_spec as canonical_id_for_spec
@@ -115,6 +117,12 @@ class ModelInfo(AttributablePricing):
     # identity half of the (provider, model, transport.kind) tuple.
     provider_family: str | None = None
     base_url: str | None = None  # endpoint metadata carried from the registry entry
+    # Provider's own separately-billed prompt-cache rate, when it publishes one.
+    cached_input_cost_per_mtok: float | None = None
+    # Request-level behavioural mode the entry was banded for, forwarded to the
+    # adapter so the band describes an invocation forge actually makes (#2352).
+    reasoning_mode: str | None = None
+    identity: IdentityVerification = UNCONFIRMED_IDENTITY
 
 
 _CLI_TO_PROVIDER: dict[str, str] = dict(_LEGACY_CLI_TO_PROVIDER)
@@ -147,6 +155,10 @@ class AgentDef(AttributablePricing):
     input_cost_per_mtok: float | None = None
     output_cost_per_mtok: float | None = None
     pricing_provenance: str | None = None
+    cached_input_cost_per_mtok: float | None = None
+    # Carried so ``to_model_profile`` can hand the adapter the mode the entry was
+    # banded for — the pool is the only path a routed profile takes to a runner.
+    reasoning_mode: str | None = None
 
     @property
     def effective_provider(self) -> str | None:
@@ -180,6 +192,7 @@ class AgentDef(AttributablePricing):
             api_fallback=self.api_fallback,
             registry_id=self.registry_id,
             registry_source=self.registry_source,
+            reasoning_mode=self.reasoning_mode,
         )
 
 
@@ -196,7 +209,23 @@ class AgentDef(AttributablePricing):
 # release, and no role-derivation, profile, or runner-dispatch edits. Adding a
 # *provider* still requires code, because a provider needs a runner module (see
 # :func:`transport_for`).
-AGENT_REGISTRY: dict[str, AgentSpec] = load_packaged_catalog()
+#
+# The catalog is loaded in two halves. ``AGENT_REGISTRY`` is the routable one —
+# nothing that selects a model can see anything else. ``RETIRED_MODEL_REGISTRY``
+# holds identities the provider has withdrawn; they are unreachable by routing
+# but still *resolvable*, so a configuration naming one is told what happened to
+# it rather than being told the name was never known (#2352).
+AGENT_REGISTRY, RETIRED_MODEL_REGISTRY = load_packaged_catalog_split()
+
+
+def retired_identity_message(canonical_id: str, spec: AgentSpec) -> str:
+    """Render the operator-facing explanation for a retired identifier."""
+    reason = spec.identity.retired_reason or "no reason recorded"
+    return (
+        f"Model {canonical_id!r} names an upstream identifier the provider has "
+        f"retired: {reason} Remove it from your configuration and pick a served "
+        f"identifier — see config/data/models.yaml."
+    )
 
 
 # Raw-input aliases for the pre-transport key spellings. These are accepted only
@@ -213,8 +242,16 @@ _LEGACY_MODEL_KEY_ALIASES: dict[str, str] = {
     "openai-api/gpt-5.4": "openai/gpt-5.4/api",
     "openai-api/gpt-5.4-mini": "openai/gpt-5.4-mini/api",
     "openai-api/gpt-5.4-pro": "openai/gpt-5.4-pro/api",
+    # `deepseek/deepseek-reasoner` and `deepseek/deepseek-chat` are deliberately
+    # still listed: both name identifiers DeepSeek has retired, and the canonical
+    # ids they translate to now live in RETIRED_MODEL_REGISTRY, so resolving them
+    # produces the retirement message instead of silently routing to a name that
+    # designates a different model than the one recorded here (#2352). Dropping
+    # the aliases would have degraded that into "unknown model".
     "deepseek/deepseek-reasoner": "deepseek/deepseek-reasoner/api",
     "deepseek/deepseek-chat": "deepseek/deepseek-chat/api",
+    "deepseek/deepseek-v4-pro": "deepseek/deepseek-v4-pro/api",
+    "deepseek/deepseek-v4-flash": "deepseek/deepseek-v4-flash/api",
     "google/gemini-3-flash-preview": "google/gemini-3-flash-preview/api",
     "google/gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview/api",
     "google/gemini-2.5-pro": "google/gemini-2.5-pro/api",
@@ -286,7 +323,10 @@ def _spec_to_model_info(
         registry_source=spec.registry_source,
         input_cost_per_mtok=spec.input_cost_per_mtok,
         output_cost_per_mtok=spec.output_cost_per_mtok,
+        cached_input_cost_per_mtok=spec.cached_input_cost_per_mtok,
         pricing_provenance=spec.pricing_provenance,
+        reasoning_mode=spec.reasoning_mode,
+        identity=spec.identity,
         transport=spec.transport,
     )
 
@@ -354,6 +394,11 @@ def apply_model_info(profile: _ProfileT, info: ModelInfo) -> _ProfileT:
         updates["transport"] = info.transport
     if "base_url" in profile_fields:
         updates["base_url"] = info.base_url
+    if "reasoning_mode" in profile_fields:
+        # Travels with the identity for the same reason transport does: the mode
+        # is a property of the model being swapped *to*, so leaving the old one
+        # behind would request a behaviour the new entry never declared.
+        updates["reasoning_mode"] = info.reasoning_mode
     return replace(profile, **updates)
 
 
@@ -378,6 +423,13 @@ def resolve_agent_spec(
     effective_registry = AGENT_REGISTRY if registry is None else registry
     lookup = model_key if model_key in effective_registry else normalize_model_key(model_key)
     if lookup not in effective_registry:
+        # A retired identity resolves to an *explanation*, not to a model. This
+        # is the whole reason retirements are declared rather than deleted: the
+        # dangerous case is a name that still resolves upstream, and the only
+        # place that can be caught before spend is here, at configuration load.
+        retired = RETIRED_MODEL_REGISTRY.get(lookup)
+        if retired is not None:
+            raise ValueError(retired_identity_message(lookup, retired))
         known = sorted(effective_registry)
         raise ValueError(
             f"Unknown model {model_key!r}: not in AGENT_REGISTRY. "

--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -123,7 +123,9 @@ def _agents_from_models(
                 registry_source=info.registry_source,
                 input_cost_per_mtok=info.input_cost_per_mtok,
                 output_cost_per_mtok=info.output_cost_per_mtok,
+                cached_input_cost_per_mtok=info.cached_input_cost_per_mtok,
                 pricing_provenance=info.pricing_provenance,
+                reasoning_mode=info.reasoning_mode,
             )
         )
     return agents

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -352,8 +352,14 @@ class ModelProfile:
     # Optional
     timeout_medium_seconds: int | None = None  # override for medium complexity
     timeout_large_seconds: int | None = None  # override for large complexity
-    reasoning_effort: str | None = None  # "low" | "medium" | "high"; Codex only
+    reasoning_effort: str | None = None  # "low" | "medium" | "high"; Codex/DeepSeek
     thinking_budget: int | None = None  # Google Gemini ThinkingConfig token budget
+    # Whether to ask the provider for reasoning at all, where it expresses that
+    # as a request parameter rather than as a distinct model name. Carried from
+    # the registry entry (``invocation.reasoning_mode``) so a model banded as a
+    # reasoning model is invoked in a way that actually requests reasoning
+    # (#2352). None = send nothing and take the provider's default.
+    reasoning_mode: str | None = None  # "enabled" | "disabled"
     review_role: str | None = None  # "correctness" | "patterns" | "edge-cases"
     phase: str | None = None  # "dev" | "preflight" | "review" | "plan_review" — set by coordinator
     base_url: str | None = None  # overrides provider's default API endpoint (Ollama etc.)

--- a/src/theforge/model_profiles.py
+++ b/src/theforge/model_profiles.py
@@ -2783,7 +2783,7 @@ def canonical_id_for_legacy_key(model_key: str, entry: dict | None = None) -> st
       4. ``-cli``/``-api`` suffix-aware unique-spec lookup
          (e.g. ``sonnet-cli`` → unique anthropic/sonnet CLI spec).
       5. Bare-name unique-spec lookup with constructable transport
-         (e.g. ``deepseek-deepseek-reasoner`` → unique deepseek/deepseek-reasoner
+         (e.g. ``deepseek-deepseek-v4-pro`` → unique deepseek/deepseek-v4-pro
          API spec), narrowed by a transport hint recorded on ``entry`` when the
          bare name alone is ambiguous (``gpt-5.4`` + ``transport_used: cli`` →
          ``openai/gpt-5.4/cli``).
@@ -2907,8 +2907,8 @@ def _resolve_canonical_key(key: str, entry_transport: str | None) -> str | None:
 
     if transport_hint is None:
         # Try `<provider>-<model>` style: split at the first dash where the
-        # prefix matches a known provider, e.g. ``deepseek-deepseek-reasoner``
-        # → provider=deepseek, model=deepseek-reasoner.
+        # prefix matches a known provider, e.g. ``deepseek-deepseek-v4-pro``
+        # → provider=deepseek, model=deepseek-v4-pro.
         try:
             from theforge.config.models import AGENT_REGISTRY  # noqa: PLC0415
         except Exception:  # noqa: BLE001

--- a/src/theforge/routing.py
+++ b/src/theforge/routing.py
@@ -149,13 +149,18 @@ REASONING_EFFORT_TRANSPORT_SUPPORT: dict[str, EffortKnob] = {
     # Google API adapter builds a ThinkingConfig from ``thinking_budget`` and
     # bills ``thoughts_token_count`` through _estimate_cost (adapters/google.py).
     "google": EffortKnob(KNOB_BUDGET, True),
+    # DeepSeek expresses reasoning as a request parameter — ``thinking:
+    # {type, reasoning_effort}`` — rather than as a distinct model name, and
+    # reports the spend back as ``completion_tokens_details.reasoning_tokens``,
+    # which adapters/openai.py folds into ``thinking_tokens`` and _estimate_cost
+    # bills at the output rate (#2352).
+    "deepseek": EffortKnob(KNOB_EFFORT, True),
     # No passthrough today.
     "claude": EffortKnob(KNOB_NONE, False),
     "gemini": EffortKnob(KNOB_NONE, False),  # CLI has no mechanism; ignores it
     "ghaw": EffortKnob(KNOB_NONE, False),
     "anthropic": EffortKnob(KNOB_NONE, False),
     "openai": EffortKnob(KNOB_NONE, False),
-    "deepseek": EffortKnob(KNOB_NONE, False),
 }
 
 _UNKNOWN_TRANSPORT_KNOB = EffortKnob(KNOB_NONE, False)

--- a/src/theforge/runners/adapters/deepseek.py
+++ b/src/theforge/runners/adapters/deepseek.py
@@ -56,6 +56,19 @@ def deepseek_request_kwargs(profile: "ModelProfile") -> dict[str, Any]:
     rather than having a mode invented for it. Every DeepSeek request — single
     shot, tool loop and finalizer — is built through here so the three cannot
     drift apart.
+
+    The control travels under ``extra_body``, not as a top-level keyword.
+    ``thinking`` is DeepSeek's own extension to the Chat Completions body; the
+    OpenAI SDK's ``create()`` declares an explicit parameter list with no
+    ``**kwargs``, so passing it directly raises ``TypeError`` in the client
+    before a request is ever sent — a mode that is never requested and an
+    invocation that never happens. ``extra_body`` is the SDK's supported channel
+    for exactly this: merged into the JSON body verbatim.
+
+    ``reasoning_effort`` deliberately goes inside the ``thinking`` object rather
+    than into the SDK's own top-level ``reasoning_effort`` parameter. They are
+    different fields with different vocabularies — DeepSeek nests its own and
+    accepts ``max``, which OpenAI's does not define.
     """
     thinking: dict[str, Any] = {}
     if profile.reasoning_mode is not None:
@@ -65,7 +78,7 @@ def deepseek_request_kwargs(profile: "ModelProfile") -> dict[str, Any]:
         thinking["reasoning_effort"] = effort
     if not thinking:
         return {}
-    return {"thinking": thinking}
+    return {"extra_body": {"thinking": thinking}}
 
 
 def _run_deepseek(

--- a/src/theforge/runners/adapters/deepseek.py
+++ b/src/theforge/runners/adapters/deepseek.py
@@ -29,6 +29,45 @@ def _deepseek_client(profile: "ModelProfile", secrets: dict[str, str] | None = N
     return openai.OpenAI(**kwargs)
 
 
+# DeepSeek expresses reasoning effort on three levels where forge's routing axis
+# has three of its own. The mapping is stated rather than passed through because
+# the two vocabularies only *look* alike: DeepSeek has no "medium", and sending a
+# level it does not define would either 400 or be silently remapped by the
+# provider — in which case the effort forge recorded is not the effort that ran.
+_REASONING_EFFORT_TO_DEEPSEEK: dict[str, str] = {
+    "low": "low",
+    "medium": "high",
+    "high": "max",
+}
+
+
+def deepseek_request_kwargs(profile: "ModelProfile") -> dict[str, Any]:
+    """Build the request-level controls for one DeepSeek invocation.
+
+    DeepSeek moved reasoning from a model-name distinction to a request
+    parameter, so an entry banded as a reasoning model is only *actually* a
+    reasoning model if the request says so. ``profile.reasoning_mode`` carries
+    that declaration from the catalog entry (``invocation.reasoning_mode``) and
+    ``profile.reasoning_effort`` carries the score-driven level the router
+    resolved for this phase.
+
+    Returns an empty mapping when the profile declares neither, so a profile
+    constructed outside the registry path keeps the provider's own defaults
+    rather than having a mode invented for it. Every DeepSeek request — single
+    shot, tool loop and finalizer — is built through here so the three cannot
+    drift apart.
+    """
+    thinking: dict[str, Any] = {}
+    if profile.reasoning_mode is not None:
+        thinking["type"] = profile.reasoning_mode
+    effort = _REASONING_EFFORT_TO_DEEPSEEK.get(profile.reasoning_effort or "")
+    if effort is not None:
+        thinking["reasoning_effort"] = effort
+    if not thinking:
+        return {}
+    return {"thinking": thinking}
+
+
 def _run_deepseek(
     prompt: str, profile: "ModelProfile", secrets: dict[str, str] | None = None
 ) -> AgentResult:
@@ -44,12 +83,14 @@ def _run_deepseek(
         client=client,
         provider="deepseek",
         response_format={"type": "json_object"},
+        extra_kwargs=deepseek_request_kwargs(profile),
     )
 
 
 def _make_deepseek_adapter(
     profile: "ModelProfile",
     secrets: dict[str, str] | None,
+    client: Any = None,
 ) -> Any:
     """Build DeepSeek adapter (reuses OpenAI Chat Completions adapter).
 
@@ -57,10 +98,12 @@ def _make_deepseek_adapter(
     are always valid JSON — prevents the APPROVE+P1 YAML contradiction bug
     that causes schema validation failures in both plan review and code review.
     """
-    client = _deepseek_client(profile, secrets)
+    if client is None:
+        client = _deepseek_client(profile, secrets)
     return _make_openai_chat_adapter(
         profile,
         secrets,
         client=client,
         response_format={"type": "json_object"},
+        extra_kwargs=deepseek_request_kwargs(profile),
     )

--- a/src/theforge/runners/adapters/openai.py
+++ b/src/theforge/runners/adapters/openai.py
@@ -279,7 +279,15 @@ def _make_openai_usage(usage: Any, model: str) -> ModelUsage | None:
 
 
 def _translate_messages_openai_chat(messages: list[dict]) -> list[dict]:
-    """Translate loop-internal messages to OpenAI Chat Completions format."""
+    """Translate loop-internal messages to OpenAI Chat Completions format.
+
+    Each outgoing message is built from named keys rather than by copying the
+    loop-internal dict, which is what keeps ``reasoning_content`` — recorded on
+    the assistant turn for the audit trail — out of the request body. DeepSeek
+    accepts that field on an input assistant message only as part of Chat Prefix
+    Completion, which requires ``prefix: true``; emitting it here would opt every
+    thinking-mode tool loop into a beta feature it never asked for.
+    """
     result = []
     for msg in messages:
         role = msg["role"]
@@ -360,11 +368,18 @@ def _make_openai_chat_adapter(
                 )
 
         text = msg.content or None
+        # DeepSeek returns the chain of thought as its own field beside
+        # ``content``. Reading it here is what stops a reasoning model's
+        # reasoning from being invisible to everything downstream — the loop
+        # previously kept only ``content``, so a thinking-mode turn that made a
+        # tool call left no trace of the thinking at all.
+        reasoning = getattr(msg, "reasoning_content", None)
         return LoopTurn(
             tool_calls=tool_calls,
             text_output=text,
             structured_data=None,
             usage=usage,
+            reasoning_content=reasoning if isinstance(reasoning, str) and reasoning else None,
         )
 
     return adapter

--- a/src/theforge/runners/adapters/openai.py
+++ b/src/theforge/runners/adapters/openai.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from theforge.agent_types import AgentResult, ModelUsage
@@ -48,6 +49,66 @@ def _openai_client(profile: "ModelProfile", secrets: dict[str, str] | None = Non
     return openai.OpenAI(**kwargs)
 
 
+@dataclass(frozen=True)
+class _ChatUsage:
+    """Token counts read off an OpenAI-compatible ``usage`` object.
+
+    Normalized to forge's convention, which differs from the wire format in one
+    place that matters for billing: ``output_tokens`` here EXCLUDES reasoning,
+    because ``_estimate_cost`` bills ``output_tokens + thinking_tokens``. On the
+    wire ``completion_tokens`` already *includes* ``reasoning_tokens``, so
+    carrying both through unchanged would bill the reasoning twice.
+
+    ``cache_read_tokens`` needs no such adjustment: it is a subset of
+    ``input_tokens`` on this wire format, which is exactly what
+    ``_estimate_cost`` expects of ``cached_input_tokens``.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    thinking_tokens: int = 0
+
+
+def _read_chat_usage(usage: Any) -> _ChatUsage:
+    """Read a Chat Completions ``usage`` object, including its detail fields.
+
+    Two spellings have to be read for the cache tier because neither is
+    universal: ``prompt_cache_hit_tokens`` (DeepSeek) and
+    ``prompt_tokens_details.cached_tokens`` (OpenAI). Reasoning output arrives as
+    ``completion_tokens_details.reasoning_tokens`` on both.
+
+    Reading these is what makes a separately-billed cache tier and reasoning
+    spend accountable at all: discarding them, as this path did before #2352,
+    priced every input token at the uncached rate and reported thinking spend as
+    zero on a model routed *for* its reasoning.
+    """
+    if usage is None:
+        return _ChatUsage()
+
+    def _int(value: Any) -> int:
+        return int(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else 0
+
+    input_tokens = _int(getattr(usage, "prompt_tokens", None)) or _int(
+        getattr(usage, "input_tokens", None)
+    )
+    completion_tokens = _int(getattr(usage, "completion_tokens", None)) or _int(
+        getattr(usage, "output_tokens", None)
+    )
+    cache_read = _int(getattr(usage, "prompt_cache_hit_tokens", None))
+    if not cache_read:
+        details = getattr(usage, "prompt_tokens_details", None)
+        cache_read = _int(getattr(details, "cached_tokens", None)) if details else 0
+    completion_details = getattr(usage, "completion_tokens_details", None)
+    reasoning = _int(getattr(completion_details, "reasoning_tokens", None))
+    return _ChatUsage(
+        input_tokens=input_tokens,
+        output_tokens=max(0, completion_tokens - reasoning),
+        cache_read_tokens=min(cache_read, input_tokens) if input_tokens else 0,
+        thinking_tokens=reasoning,
+    )
+
+
 def _openai_result(
     profile: "ModelProfile",
     output_text: str,
@@ -55,18 +116,29 @@ def _openai_result(
     output_tokens: int,
     raw: dict,
     provider: str = "openai",
+    *,
+    cache_read_tokens: int = 0,
+    thinking_tokens: int = 0,
 ) -> AgentResult:
     """Build AgentResult from parsed OpenAI-compatible response fields."""
-    cost = _estimate_cost(provider, profile.model, input_tokens, output_tokens)
+    cost = _estimate_cost(
+        provider,
+        profile.model,
+        input_tokens,
+        output_tokens,
+        thinking_tokens=thinking_tokens,
+        cached_input_tokens=cache_read_tokens,
+    )
     if _is_local_endpoint(profile.base_url):
         cost = 0.0
     model_usage = ModelUsage(
         model=profile.model,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
-        cache_read_tokens=0,
+        cache_read_tokens=cache_read_tokens,
         cache_creation_tokens=0,
         cost_usd=cost,
+        thinking_tokens=thinking_tokens,
     )
     return AgentResult(
         success=True,
@@ -88,8 +160,15 @@ def _run_openai_chat(
     client: Any = None,
     provider: str = "openai",
     response_format: dict[str, Any] | None = None,
+    extra_kwargs: dict[str, Any] | None = None,
 ) -> AgentResult:
-    """Run via OpenAI Chat Completions (/v1/chat/completions)."""
+    """Run via OpenAI Chat Completions (/v1/chat/completions).
+
+    ``extra_kwargs`` carries provider-specific request controls the caller has
+    already resolved (DeepSeek's ``thinking`` block, for one). It is merged last
+    so a provider wrapper can state a control this generic path knows nothing of,
+    without that knowledge leaking back into the shared adapter.
+    """
     from theforge.schemas import review_json_schema
 
     if client is None:
@@ -106,17 +185,20 @@ def _run_openai_chat(
             "messages": [{"role": "user", "content": prompt}],
             "response_format": response_format,
             **sampling_control_kwargs(),
+            **(extra_kwargs or {}),
         }
         response = client.chat.completions.create(**create_kwargs)
         output_text = response.choices[0].message.content or ""
-        usage = response.usage
+        chat_usage = _read_chat_usage(response.usage)
         return _openai_result(
             profile,
             output_text,
-            usage.prompt_tokens if usage else 0,
-            usage.completion_tokens if usage else 0,
+            chat_usage.input_tokens,
+            chat_usage.output_tokens,
             response.model_dump(),
             provider=provider,
+            cache_read_tokens=chat_usage.cache_read_tokens,
+            thinking_tokens=chat_usage.thinking_tokens,
         )
     except Exception as e:
         return AgentResult(
@@ -184,13 +266,15 @@ def _run_openai(
 def _make_openai_usage(usage: Any, model: str) -> ModelUsage | None:
     if usage is None:
         return None
+    chat_usage = _read_chat_usage(usage)
     return ModelUsage(
         model=model,
-        input_tokens=getattr(usage, "prompt_tokens", getattr(usage, "input_tokens", 0)),
-        output_tokens=getattr(usage, "completion_tokens", getattr(usage, "output_tokens", 0)),
-        cache_read_tokens=0,
+        input_tokens=chat_usage.input_tokens,
+        output_tokens=chat_usage.output_tokens,
+        cache_read_tokens=chat_usage.cache_read_tokens,
         cache_creation_tokens=0,
         cost_usd=None,
+        thinking_tokens=chat_usage.thinking_tokens,
     )
 
 
@@ -231,8 +315,13 @@ def _make_openai_chat_adapter(
     secrets: dict[str, str] | None,
     client: Any = None,
     response_format: dict[str, Any] | None = None,
+    extra_kwargs: dict[str, Any] | None = None,
 ) -> ProviderAdapter:
-    """Build OpenAI Chat Completions adapter for AgentLoopManager."""
+    """Build OpenAI Chat Completions adapter for AgentLoopManager.
+
+    ``extra_kwargs`` carries provider-specific request controls resolved by the
+    caller — see :func:`_run_openai_chat` for why they arrive that way.
+    """
     if client is None:
         client = _openai_client(profile, secrets)
 
@@ -242,6 +331,7 @@ def _make_openai_chat_adapter(
             "model": profile.model,
             "messages": oai_messages,
             **sampling_control_kwargs(),
+            **(extra_kwargs or {}),
         }
         if tools:
             kwargs["tools"] = tools

--- a/src/theforge/runners/adapters/openai.py
+++ b/src/theforge/runners/adapters/openai.py
@@ -281,12 +281,27 @@ def _make_openai_usage(usage: Any, model: str) -> ModelUsage | None:
 def _translate_messages_openai_chat(messages: list[dict]) -> list[dict]:
     """Translate loop-internal messages to OpenAI Chat Completions format.
 
-    Each outgoing message is built from named keys rather than by copying the
-    loop-internal dict, which is what keeps ``reasoning_content`` — recorded on
-    the assistant turn for the audit trail — out of the request body. DeepSeek
-    accepts that field on an input assistant message only as part of Chat Prefix
-    Completion, which requires ``prefix: true``; emitting it here would opt every
-    thinking-mode tool loop into a beta feature it never asked for.
+    ``reasoning_content`` round-trips: an assistant turn is replayed carrying
+    whatever chain of thought the provider reported for it. DeepSeek's thinking
+    mode *requires* this once tools are in play — "the intermediate assistant's
+    ``reasoning_content`` must participate in the context concatenation and must
+    be passed back to the API in all subsequent user interaction turns… if your
+    code does not correctly pass back ``reasoning_content``, the API will return
+    a 400 error" (api-docs.deepseek.com, thinking-mode guide, retrieved
+    2026-08-10). Without it the first tool call succeeds and every continuation
+    after it is rejected, which makes a routed reviewer unable to finish a review.
+
+    The rule is *narrower* than "always send" and *wider* than "never send", and
+    that is why this is data-driven rather than a provider flag: the field is
+    replayed exactly when the provider produced one. OpenAI's Chat Completions
+    never returns ``reasoning_content``, so an OpenAI history never carries the
+    key and its request bodies are unchanged; DeepSeek returns it on every
+    thinking-mode turn, so its histories round-trip it. No branch on provider is
+    needed, and no shared code has to hold an opinion about either.
+
+    (For a DeepSeek conversation with no tool calls the same guide says a
+    replayed ``reasoning_content`` "will be ignored", so replaying it there is
+    harmless. The failing case is only the tool-call one.)
     """
     result = []
     for msg in messages:
@@ -296,6 +311,9 @@ def _translate_messages_openai_chat(messages: list[dict]) -> list[dict]:
         elif role == "assistant":
             calls = msg.get("tool_calls", [])
             m: dict[str, Any] = {"role": "assistant", "content": msg.get("content")}
+            reasoning = msg.get("reasoning_content")
+            if reasoning:
+                m["reasoning_content"] = reasoning
             if calls:
                 m["tool_calls"] = [
                     {

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -632,14 +632,16 @@ class AgentLoopManager:
         says what it is about to do and then calls a tool had that sentence
         erased from its own history on the next turn.
 
-        ``reasoning_content`` is recorded on the turn but deliberately NOT
-        replayed to the provider. DeepSeek's API reference defines the input
-        ``reasoning_content`` field as belonging to Chat Prefix Completion —
-        "when using this feature, the ``prefix`` parameter must be set to true" —
-        so sending it on an ordinary tool-loop turn is not the documented
-        contract for this field and would enable a different (beta) feature as a
-        side effect. It is kept on the message so the audit trail carries what
-        the model actually reasoned, which is the part that was missing.
+        ``reasoning_content`` is the chain of thought the provider reported for
+        this turn. It is recorded here because a tool-calling thinking-mode
+        conversation is only continuable if it can be replayed: DeepSeek rejects
+        a follow-up request whose assistant tool-call turn omits it. Storing it
+        on the loop-internal message — rather than in a provider-specific side
+        channel — is what lets the translators put it back on the wire without
+        the loop knowing which providers care.
+
+        A turn the provider reported no reasoning for stores nothing, so a
+        non-reasoning provider's history is byte-identical to what it was.
         """
         new_messages = list(messages)
         assistant: dict[str, Any] = {

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -10,10 +10,11 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from theforge.agent_types import (
     COST_ESTIMATED,
+    COST_ESTIMATED_UNCONFIRMED,
     COST_UNKNOWN,
     AgentResult,
     ModelUsage,
@@ -60,6 +61,7 @@ from theforge.runners.schema_utils import (
     _estimate_cost,
     cache_reads_are_subset_of_input,
     noop_finalizer,
+    rate_card_confirmed,
     uses_openai_responses_api,
 )
 from theforge.runners.stuck_detection import StuckTracker, build_observation
@@ -472,7 +474,13 @@ class AgentLoopManager:
                 consecutive_malformed = 0
 
             # Append assistant turn + all tool results in a single history entry
-            messages = self._append_tool_results(messages, turn.tool_calls, turn_results)
+            messages = self._append_tool_results(
+                messages,
+                turn.tool_calls,
+                turn_results,
+                content=turn.text_output,
+                reasoning_content=turn.reasoning_content,
+            )
 
             # Progress-aware stuck detection: observe this iteration's calls/results.
             # On detection, inject a nudge; if the pattern persists after the nudge,
@@ -613,16 +621,35 @@ class AgentLoopManager:
         messages: list[dict],
         calls: list[ToolCallRequest],
         results: list[dict],
+        *,
+        content: str | None = None,
+        reasoning_content: str | None = None,
     ) -> list[dict]:
-        """Add assistant tool-call turn + tool result turn to messages."""
+        """Add assistant tool-call turn + tool result turn to messages.
+
+        ``content`` is the text the model emitted *alongside* its tool calls. It
+        was previously hardcoded to None, which silently dropped it: a model that
+        says what it is about to do and then calls a tool had that sentence
+        erased from its own history on the next turn.
+
+        ``reasoning_content`` is recorded on the turn but deliberately NOT
+        replayed to the provider. DeepSeek's API reference defines the input
+        ``reasoning_content`` field as belonging to Chat Prefix Completion —
+        "when using this feature, the ``prefix`` parameter must be set to true" —
+        so sending it on an ordinary tool-loop turn is not the documented
+        contract for this field and would enable a different (beta) feature as a
+        side effect. It is kept on the message so the audit trail carries what
+        the model actually reasoned, which is the part that was missing.
+        """
         new_messages = list(messages)
-        new_messages.append(
-            {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": calls,
-            }
-        )
+        assistant: dict[str, Any] = {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": calls,
+        }
+        if reasoning_content:
+            assistant["reasoning_content"] = reasoning_content
+        new_messages.append(assistant)
         new_messages.append(
             {
                 "role": "tool_results",
@@ -967,16 +994,35 @@ def _run_single_api_model(
         return runner_fn(prompt, profile, secrets)
 
 
-def _stamp_api_cost_provenance(result: AgentResult) -> AgentResult:
+def _estimated_provenance(provider: str | None, model: str | None) -> str:
+    """Which flavour of "forge computed this" applies to ``(provider, model)``.
+
+    A derived cost is only as good as the rate card behind it, and a rate card is
+    only as good as the evidence that the identifier it was recorded for still
+    designates the model that ran. Where that evidence is current the cost is
+    :data:`COST_ESTIMATED`; where it is absent or aged out the cost is
+    :data:`COST_ESTIMATED_UNCONFIRMED` — the same number, carrying an honest
+    statement of what it rests on (#2352).
+    """
+    if not provider or not model:
+        return COST_ESTIMATED_UNCONFIRMED
+    return COST_ESTIMATED if rate_card_confirmed(provider, model) else COST_ESTIMATED_UNCONFIRMED
+
+
+def _stamp_api_cost_provenance(result: AgentResult, provider: str | None = None) -> AgentResult:
     """Mark an API result's costs as forge-derived estimates (#2205).
 
     No API transport forge speaks returns a price: every provider reports token
-    counts and forge multiplies them by :data:`schema_utils.PRICING_TABLE`. So a
-    cost that reached here was computed, not billed, and a consumer attributing
-    spend has to be able to see that. Stamped at this one seam rather than at
-    each adapter's ``_estimate_cost`` call because the statement is a property of
-    the transport, not of any one provider — a new adapter is covered the day it
-    is added.
+    counts and forge multiplies them by a rate card. So a cost that reached here
+    was computed, not billed, and a consumer attributing spend has to be able to
+    see that. Stamped at this one seam rather than at each adapter's
+    ``_estimate_cost`` call because the statement is a property of the transport,
+    not of any one provider — a new adapter is covered the day it is added.
+
+    *Which* estimate it is depends on the rate card, so each component is
+    classified against its own model name (#2352): a result can span models, and
+    "this figure rests on a card nothing has confirmed" is true of one component
+    at a time, not of the invocation.
 
     A ``None`` cost stays :data:`COST_UNKNOWN`: nothing was observed, so there is
     nothing to characterize. An already-stated provenance is never overwritten —
@@ -987,20 +1033,26 @@ def _stamp_api_cost_provenance(result: AgentResult) -> AgentResult:
     usage = tuple(
         u
         if u.cost_usd is None or u.cost_provenance != COST_UNKNOWN
-        else dataclasses.replace(u, cost_provenance=COST_ESTIMATED)
+        else dataclasses.replace(u, cost_provenance=_estimated_provenance(provider, u.model))
         for u in (result.model_usage or ())
     )
     provenance = result.cost_provenance
     if result.cost_usd is None:
         provenance = COST_UNKNOWN
     elif provenance == COST_UNKNOWN:
-        provenance = COST_ESTIMATED
+        # The invocation-level statement is the weakest of its components': if any
+        # part of this cost rests on an unconfirmed card, the total does too.
+        provenance = (
+            COST_ESTIMATED_UNCONFIRMED
+            if any(u.cost_provenance == COST_ESTIMATED_UNCONFIRMED for u in usage)
+            else _estimated_provenance(provider, result.model_used)
+        )
     if provenance == result.cost_provenance and usage == result.model_usage:
         return result
     return dataclasses.replace(result, cost_provenance=provenance, model_usage=usage)
 
 
-def _stamp_api_transport(result: AgentResult) -> AgentResult:
+def _stamp_api_transport(result: AgentResult, provider: str | None = None) -> AgentResult:
     """Record that this result came over the API transport.
 
     The transport is a *hint the identity projection needs*: a bare model name
@@ -1018,7 +1070,7 @@ def _stamp_api_transport(result: AgentResult) -> AgentResult:
     """
     if not isinstance(result, AgentResult):
         return result
-    result = _stamp_api_cost_provenance(result)
+    result = _stamp_api_cost_provenance(result, provider)
     if result.transport_used:
         return result
     return dataclasses.replace(result, transport_used="api")
@@ -1099,9 +1151,10 @@ def run_api_agent(
             # callers that return non-dataclass objects (e.g., mocks in tests).
             if model_config:
                 return _stamp_api_transport(
-                    dataclasses.replace(result, model_config=model_config, model_used=model)
+                    dataclasses.replace(result, model_config=model_config, model_used=model),
+                    profile.provider,
                 )
-            return _stamp_api_transport(result)
+            return _stamp_api_transport(result, profile.provider)
 
         last_result = result
 
@@ -1127,6 +1180,7 @@ def run_api_agent(
         _log_verbose(f"  ... {label} done | {status} | cost={cost_str}")
     if model_config:
         return _stamp_api_transport(
-            dataclasses.replace(last_result, model_config=model_config, model_used=model)
+            dataclasses.replace(last_result, model_config=model_config, model_used=model),
+            profile.provider,
         )
-    return _stamp_api_transport(last_result)
+    return _stamp_api_transport(last_result, profile.provider)

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -25,6 +25,7 @@ from theforge.runners.adapters.anthropic import (
 from theforge.runners.adapters.deepseek import (
     _deepseek_client,
     _run_deepseek,
+    deepseek_request_kwargs,
 )
 from theforge.runners.adapters.google import (
     _make_google_adapter,
@@ -57,6 +58,7 @@ from theforge.runners.schema_utils import (
     _build_submit_tools_google,
     _build_submit_tools_openai,
     _estimate_cost,
+    cache_reads_are_subset_of_input,
     noop_finalizer,
     uses_openai_responses_api,
 )
@@ -157,12 +159,23 @@ class _UsageAccumulator:
         self.cache_creation_tokens += usage.cache_creation_tokens
 
     def to_model_usage(self, model: str, provider: str) -> ModelUsage:
+        # The accumulated cache-read count is passed through, not just recorded:
+        # a provider that bills prompt-cache hits at a distinct rate only gets
+        # that rate applied if the estimator is told how many hits there were.
+        # Withholding it priced every cached token at the uncached rate (#2352).
+        # Only for providers whose input count *contains* the cache reads —
+        # ``_estimate_cost`` subtracts them, which would delete real uncached
+        # input for a provider that reports the two side by side.
+        cached_input_tokens = (
+            self.cache_read_tokens if cache_reads_are_subset_of_input(provider) else 0
+        )
         cost = _estimate_cost(
             provider,
             model,
             self.input_tokens,
             self.output_tokens,
             thinking_tokens=self.thinking_tokens,
+            cached_input_tokens=cached_input_tokens,
         )
         return ModelUsage(
             model=model,
@@ -860,7 +873,16 @@ def _run_loop_deepseek(
     tool_schemas = [t.to_openai_function() for t in tools] + (
         _build_submit_tools_openai(responses_api=False) if is_review else []
     )
-    adapter = _make_openai_chat_adapter(profile, secrets, client=client)
+    # The loop's request-level controls are built by the same helper the
+    # single-shot and finalizer paths use, so the reasoning mode a DeepSeek entry
+    # is banded for is requested on every call the run makes rather than on
+    # whichever entry point happened to be wired for it (#2352).
+    adapter = _make_openai_chat_adapter(
+        profile,
+        secrets,
+        client=client,
+        extra_kwargs=deepseek_request_kwargs(profile),
+    )
     finalizer = (
         _make_deepseek_finalizer(profile, secrets, client=client) if is_review else noop_finalizer
     )

--- a/src/theforge/runners/finalizers.py
+++ b/src/theforge/runners/finalizers.py
@@ -84,7 +84,7 @@ def _make_deepseek_finalizer(
     DeepSeek's Chat Completions API supports JSON mode (json_object) but not
     structured output (json_schema).  Using json_schema returns HTTP 400.
     """
-    from theforge.runners.adapters.deepseek import _deepseek_client
+    from theforge.runners.adapters.deepseek import _deepseek_client, deepseek_request_kwargs
     from theforge.runners.adapters.openai import (
         _make_openai_usage,
         _translate_messages_openai_chat,
@@ -92,6 +92,10 @@ def _make_deepseek_finalizer(
 
     if client is None:
         client = _deepseek_client(profile, secrets)
+    # Same request controls as the loop and single-shot paths. A finalization
+    # call is still an invocation of the model the role was filled with, so it
+    # asks for the same mode rather than falling back to the provider default.
+    request_kwargs = deepseek_request_kwargs(profile)
 
     # DeepSeek has no json_schema mode, so the phase's contract reaches the model
     # through the instruction text alone — it still must be the right one.
@@ -108,6 +112,7 @@ def _make_deepseek_finalizer(
             "messages": oai_messages,
             "response_format": {"type": "json_object"},
             **sampling_control_kwargs(),
+            **request_kwargs,
         }
 
         response = client.chat.completions.create(**kwargs)

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import date
 from typing import TYPE_CHECKING, Any, Protocol
 
 from theforge.agent_types import ModelUsage
@@ -318,6 +319,31 @@ def pricing_for(provider: str, model: str) -> ModelRates | None:
     return ModelRates(input_per_mtok=price[0], output_per_mtok=price[1])
 
 
+def rate_card_confirmed(provider: str, model: str, *, today: date | None = None) -> bool:
+    """Is the rate card used for ``(provider, model)`` attached to a checked identity?
+
+    True only when the figures came from a catalog entry whose upstream
+    identifier has been checked against the provider inside the verification
+    window. A rate read from :data:`PRICING_TABLE` is never confirmed: that table
+    records no identity and no date, which is exactly how it carried DeepSeek's
+    superseded rates across two revisions of the provider's pricing without
+    anything noticing.
+
+    Consumed by the API cost-provenance stamp so an estimate off a rate card that
+    may no longer apply is distinguishable from one that is current (#2352).
+    """
+    from theforge.config.models import AGENT_REGISTRY  # noqa: PLC0415
+
+    if catalog_rates().get((provider, model)) is None:
+        return False
+    reference = today or date.today()
+    return any(
+        spec.identity.confirmed_on(reference)
+        for spec in AGENT_REGISTRY.values()
+        if (spec.provider, spec.model) == (provider, model)
+    )
+
+
 def _estimate_cost(
     provider: str,
     model: str,
@@ -388,6 +414,12 @@ class LoopTurn:
     text_output: str | None  # final text when no tool calls
     structured_data: dict | None  # final structured output when available
     usage: ModelUsage | None  # token usage for this turn
+    # Provider-reported chain of thought, where the provider returns one as a
+    # field separate from ``text_output`` (DeepSeek's ``reasoning_content``).
+    # Captured rather than discarded so a reasoning model's actual reasoning is
+    # observable; see ``AgentLoopManager._append_tool_results`` for why it is not
+    # replayed into the next request.
+    reasoning_content: str | None = None
 
 
 class ProviderAdapter(Protocol):

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -84,10 +84,12 @@ PRICING_TABLE: dict[tuple[str, str], tuple[float, float]] = {
     ("google", "gemini-2.5-flash-lite"): (0.10, 0.40),
     ("google", "gemini-2.0-flash"): (0.10, 0.40),
     ("google", "gemini-2.0-flash-lite"): (0.075, 0.30),
-    ("deepseek", "deepseek-chat"): (0.27, 1.10),  # V3 alias
-    ("deepseek", "deepseek-r1"): (0.55, 2.19),
-    ("deepseek", "deepseek-v3"): (0.27, 1.10),
-    ("deepseek", "deepseek-reasoner"): (0.55, 2.19),  # R1 alias
+    # DeepSeek is deliberately absent. Its rates — including the cache-hit tier
+    # it bills separately, which this table has no column for — are declared on
+    # the catalog entries in config/data/models.yaml and read through
+    # :func:`pricing_for`. The rows that used to sit here were the third
+    # hand-maintained copy of a rate card and outlived two of its revisions
+    # (#2352); the retired identifiers they priced now record no price at all.
 }
 
 # Models we intentionally route to the Responses API (/v1/responses).
@@ -202,10 +204,118 @@ _DEFAULT_MAX_ITERATIONS = 75
 
 _MISSING_PRICING_WARNED: set[tuple[str, str]] = set()
 
-# Fraction of the uncached input rate charged for a cache HIT. OpenAI and
-# Anthropic both bill cached input at 10% of the normal input rate; callers that
-# need a different discount pass ``cached_input_rate_mult`` explicitly.
+# Fraction of the uncached input rate charged for a cache HIT, for providers that
+# express their cache tier that way. OpenAI and Anthropic both bill cached input
+# at 10% of the normal input rate. A provider that publishes an independent
+# cache-hit rate instead (DeepSeek bills roughly 2%, which no fixed fraction of
+# the uncached rate approximates) states it on its catalog entry and is priced
+# from that figure rather than from this multiplier — see :class:`ModelRates`.
 CACHED_INPUT_RATE_MULT = 0.1
+
+
+# Providers whose reported prompt-token count INCLUDES the tokens served from
+# cache. ``_estimate_cost`` documents ``cached_input_tokens`` as a subset of
+# ``input_tokens`` and subtracts it, which is right for these and wrong for the
+# others: Anthropic reports ``cache_read_input_tokens`` *alongside* an
+# ``input_tokens`` that already excludes them, so handing its cache count to the
+# estimator would delete real uncached input from the bill.
+_CACHE_READS_INSIDE_INPUT: frozenset[str] = frozenset({"openai", "deepseek"})
+
+
+def cache_reads_are_subset_of_input(provider: str) -> bool:
+    """Is this provider's cache-read count part of its reported input count?"""
+    return provider in _CACHE_READS_INSIDE_INPUT
+
+
+@dataclass(frozen=True)
+class ModelRates:
+    """The rate card in force for one ``(provider, model)``.
+
+    ``cached_input_per_mtok`` is ``None`` for a provider that has no separately
+    published cache tier; the generic :data:`CACHED_INPUT_RATE_MULT` discount
+    applies in that case. Zero is a real rate and is honoured as one.
+    """
+
+    input_per_mtok: float
+    output_per_mtok: float
+    cached_input_per_mtok: float | None = None
+
+
+def _catalog_rates() -> dict[tuple[str, str], ModelRates]:
+    """Rate cards carried by the shipped model catalog, keyed like PRICING_TABLE.
+
+    The catalog is where a model's price is *declared alongside the identity it
+    was recorded for* — a price with no ``pricing_provenance`` is a literal
+    nothing can vouch for (see config/pricing.py), so those entries are skipped
+    and fall through to the table below. Where two catalog entries share a
+    ``(provider, model)`` and disagree on price (the same model offered over both
+    CLI and API), the pair is dropped rather than arbitrated: an ambiguous rate
+    is not a better answer than the explicit table.
+
+    Imported lazily so this module keeps its light import graph, and recomputed
+    per call is avoided by the module-level cache below.
+    """
+    from theforge.config.models import AGENT_REGISTRY  # noqa: PLC0415
+    from theforge.config.pricing import PRICING_PROVENANCE_LOCAL_ENDPOINT  # noqa: PLC0415
+
+    rates: dict[tuple[str, str], ModelRates] = {}
+    ambiguous: set[tuple[str, str]] = set()
+    for spec in AGENT_REGISTRY.values():
+        if spec.input_cost_per_mtok is None or spec.output_cost_per_mtok is None:
+            continue
+        if not spec.pricing_attributable:
+            continue
+        if spec.pricing_provenance == PRICING_PROVENANCE_LOCAL_ENDPOINT:
+            # A local endpoint's 0.00 is true of the *endpoint*, not of the model
+            # name — the same name reached over a vendor's API is billed. The
+            # runners already zero a genuinely local invocation by base_url, so
+            # importing the figure here would only mis-price the other case.
+            continue
+        key = (spec.provider, spec.model)
+        entry = ModelRates(
+            input_per_mtok=spec.input_cost_per_mtok,
+            output_per_mtok=spec.output_cost_per_mtok,
+            cached_input_per_mtok=spec.cached_input_cost_per_mtok,
+        )
+        existing = rates.get(key)
+        if existing is not None and existing != entry:
+            ambiguous.add(key)
+            continue
+        rates[key] = entry
+    for key in ambiguous:
+        rates.pop(key, None)
+    return rates
+
+
+_CATALOG_RATES_CACHE: dict[tuple[str, str], ModelRates] | None = None
+
+
+def catalog_rates() -> dict[tuple[str, str], ModelRates]:
+    """Memoized :func:`_catalog_rates`. ``AGENT_REGISTRY`` is built once at import."""
+    global _CATALOG_RATES_CACHE
+    if _CATALOG_RATES_CACHE is None:
+        _CATALOG_RATES_CACHE = _catalog_rates()
+    return _CATALOG_RATES_CACHE
+
+
+def pricing_for(provider: str, model: str) -> ModelRates | None:
+    """Return the rate card for ``(provider, model)``, or None if none is known.
+
+    Catalog first, :data:`PRICING_TABLE` second. The catalog is the surface where
+    a rate is declared next to the identity it was recorded for and the date that
+    identity was last checked against the provider, so it is the one that gets to
+    answer when both do. The table remains for identities the catalog does not
+    describe — vendor CLI shorthands resolve to concrete billed names that are
+    never catalog entries in their own right (``claude-sonnet-4-6``), and stream
+    events report those names directly.
+    """
+    catalog = catalog_rates().get((provider, model))
+    if catalog is not None:
+        return catalog
+    price = PRICING_TABLE.get((provider, model))
+    if price is None:
+        return None
+    return ModelRates(input_per_mtok=price[0], output_per_mtok=price[1])
 
 
 def _estimate_cost(
@@ -218,20 +328,22 @@ def _estimate_cost(
     cached_input_tokens: int = 0,
     cached_input_rate_mult: float = CACHED_INPUT_RATE_MULT,
 ) -> float | None:
-    """Estimate cost from pricing table; returns None if model unknown.
+    """Estimate cost from the rate card in force; returns None if model unknown.
 
     ``cached_input_tokens`` is the SUBSET of ``input_tokens`` that was served from
-    the provider's prompt cache, and is discounted to ``cached_input_rate_mult`` of
-    the input rate rather than double-counted. Callers that cannot distinguish the
-    cache tier leave it at 0 and get the previous flat-rate behaviour unchanged.
+    the provider's prompt cache. It is billed at the provider's own published
+    cache rate when the catalog entry declares one, and otherwise at
+    ``cached_input_rate_mult`` of the input rate. Callers that cannot distinguish
+    the cache tier leave it at 0 and get the flat-rate behaviour unchanged.
     """
-    price = PRICING_TABLE.get((provider, model))
-    if price is None:
+    rates = pricing_for(provider, model)
+    if rates is None:
         key = (provider, model)
         if key not in _MISSING_PRICING_WARNED:
             logger.warning(
                 "Missing pricing entry for provider=%s model=%s; cost cannot be estimated. "
-                "Add this model to PRICING_TABLE so audit and budget totals stay accurate.",
+                "Declare a cost block on the model's catalog entry (or add it to "
+                "PRICING_TABLE) so audit and budget totals stay accurate.",
                 provider,
                 model,
             )
@@ -242,10 +354,15 @@ def _estimate_cost(
     cached = max(0, min(cached_input_tokens, input_tokens))
     uncached_input_tokens = input_tokens - cached
     billable_output_tokens = output_tokens + thinking_tokens
+    cached_rate = (
+        rates.cached_input_per_mtok
+        if rates.cached_input_per_mtok is not None
+        else rates.input_per_mtok * cached_input_rate_mult
+    )
     return (
-        ((uncached_input_tokens / 1_000_000) * price[0])
-        + ((cached / 1_000_000) * price[0] * cached_input_rate_mult)
-        + ((billable_output_tokens / 1_000_000) * price[1])
+        ((uncached_input_tokens / 1_000_000) * rates.input_per_mtok)
+        + ((cached / 1_000_000) * cached_rate)
+        + ((billable_output_tokens / 1_000_000) * rates.output_per_mtok)
     )
 
 

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -416,9 +416,9 @@ class LoopTurn:
     usage: ModelUsage | None  # token usage for this turn
     # Provider-reported chain of thought, where the provider returns one as a
     # field separate from ``text_output`` (DeepSeek's ``reasoning_content``).
-    # Captured rather than discarded so a reasoning model's actual reasoning is
-    # observable; see ``AgentLoopManager._append_tool_results`` for why it is not
-    # replayed into the next request.
+    # Load-bearing, not merely observability: a provider that reports one may
+    # require it back on the next request to continue a tool-calling
+    # conversation, so the loop records it and the translators replay it.
     reasoning_content: str | None = None
 
 

--- a/tests/test_agent_spec.py
+++ b/tests/test_agent_spec.py
@@ -66,7 +66,7 @@ class TestAgentRegistry:
             assert AGENT_REGISTRY[key].transport.kind == "cli"
 
     def test_api_backed_models_resolve_to_api_transport(self):
-        for key in ("deepseek/deepseek-reasoner/api", "deepseek/deepseek-chat/api"):
+        for key in ("deepseek/deepseek-v4-pro/api", "deepseek/deepseek-v4-flash/api"):
             assert AGENT_REGISTRY[key].transport.kind == "api"
 
     def test_openai_api_transport_entries_exist(self):
@@ -135,7 +135,7 @@ class TestAgentRegistry:
         assert resolve_agent_spec("claude/opus") is AGENT_REGISTRY["anthropic/opus/cli"]
 
     def test_resolve_agent_spec_known(self):
-        spec = resolve_agent_spec("deepseek/deepseek-reasoner/api")
+        spec = resolve_agent_spec("deepseek/deepseek-v4-pro/api")
         assert spec.provider == "deepseek"
         assert spec.transport.kind == "api"
         assert spec.transport.runner == "deepseek"
@@ -178,14 +178,14 @@ class TestRoleDerivationDoesNotBranchOnCliIdentity:
     """AC: Role derivation selects by tier/capability/cost/dev_capable — not by CLI string."""
 
     def test_dev_role_uses_cheapest_regardless_of_transport(self):
-        # deepseek-chat (API, cost_rank=1) vs claude/opus (CLI, cost_rank=3).
+        # deepseek-v4-flash (API, cost_rank=1) vs claude/opus (CLI, cost_rank=3).
         # If role derivation branched on CLI identity it might prefer CLI for dev,
-        # but it must pick the cheapest — the API-backed deepseek-chat.
+        # but it must pick the cheapest — the API-backed deepseek-v4-flash.
         assignment = derive_roles(
-            ["deepseek/deepseek-chat/api", "anthropic/opus/cli"],
+            ["deepseek/deepseek-v4-flash/api", "anthropic/opus/cli"],
             budget_usd=10.0,
         )
-        assert assignment.dev.ref.model == "deepseek-chat"
+        assert assignment.dev.ref.model == "deepseek-v4-flash"
         assert assignment.dev.ref.provider == "deepseek"
 
 
@@ -213,9 +213,7 @@ class TestTransportPropagatesToProfile:
     def test_api_transport_reaches_profile(self):
         from theforge.config.bridge import role_assignment_to_profiles
 
-        ra = derive_roles(
-            ["deepseek/deepseek-reasoner/api", "anthropic/opus/cli"], budget_usd=10.0
-        )
+        ra = derive_roles(["deepseek/deepseek-v4-pro/api", "anthropic/opus/cli"], budget_usd=10.0)
         profiles = role_assignment_to_profiles(ra)
         dev_profile = profiles["dev_profile"]
         assert dev_profile.transport is not None
@@ -241,7 +239,7 @@ class TestRunnerDispatchUsesTransportKind:
         assert _profile_transport_kind(p) == "cli"
 
     def test_api_profile_dispatches_as_api(self):
-        p = self._profile(provider="deepseek", model="deepseek-reasoner")
+        p = self._profile(provider="deepseek", model="deepseek-v4-pro")
         assert _profile_transport_kind(p) == "api"
 
     def test_api_profile_for_openai_dispatches_as_api(self):

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -316,7 +316,7 @@ class TestCheckConfigHappyPath:
             models=[
                 "anthropic/sonnet/cli",
                 "openai/gpt-5.4/cli",
-                "deepseek/deepseek-reasoner/api",
+                "deepseek/deepseek-v4-pro/api",
                 "openai/gpt-5.4/api",
             ],
             models_budget_usd=10.0,
@@ -346,12 +346,12 @@ class TestCheckConfigHappyPath:
             models=[
                 "anthropic/sonnet/cli",
                 "openai/gpt-5.4/cli",
-                "deepseek/deepseek-reasoner/api",
+                "deepseek/deepseek-v4-pro/api",
                 "openai/gpt-5.4/api",
             ],
             models_budget_usd=10.0,
             review_pool=[
-                _api_profile("deepseek-reviewer", provider="deepseek", model="deepseek-reasoner")
+                _api_profile("deepseek-reviewer", provider="deepseek", model="deepseek-v4-pro")
             ],
         )
         with (
@@ -365,7 +365,7 @@ class TestCheckConfigHappyPath:
             cmd_check_config(_make_args())
         out = capsys.readouterr().out
         assert "DERIVED ROLES (complexity-aware)" in out
-        assert "deepseek  api       deepseek-reasoner" in out
+        assert "deepseek  api       deepseek-v4-pro" in out
         deepseek_review_line = next(
             line for line in out.splitlines() if "deepseek-reviewer" in line
         )
@@ -448,7 +448,7 @@ class TestCheckConfigWarnings:
     def test_exit_1_auth_failure(self, tmp_path: Path, capsys) -> None:
         review_pool = [
             _api_profile("claude-reviewer"),
-            _api_profile("deepseek-reviewer", provider="deepseek", model="deepseek-chat"),
+            _api_profile("deepseek-reviewer", provider="deepseek", model="deepseek-v4-flash"),
         ]
         config = _make_forge_config(tmp_path, review_pool=review_pool)
 
@@ -1090,7 +1090,7 @@ class TestComplexityAwareDisplay:
 
     def test_providers_header_reports_api_transport(self, tmp_path: Path, capsys) -> None:
         config = self._make_v08_forge_config(tmp_path)
-        config = replace(config, models=["openai/gpt-5.4/api", "deepseek/deepseek-reasoner/api"])
+        config = replace(config, models=["openai/gpt-5.4/api", "deepseek/deepseek-v4-pro/api"])
         with (
             patch("theforge.cli.check_config._find_config", return_value=tmp_path / "forge.yaml"),
             patch("theforge.cli.check_config.load_config", return_value=config),

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -248,7 +248,7 @@ class TestModelsKeyConfig:
         """DeepSeek entries in models: derive API-backed profiles, not CLI profiles."""
         config_path = _write_config(
             {
-                "models": ["claude/sonnet", "deepseek/deepseek-reasoner"],
+                "models": ["claude/sonnet", "deepseek/deepseek-v4-pro"],
                 "budget_usd": 50.0,
             },
             tmp_path,
@@ -257,7 +257,7 @@ class TestModelsKeyConfig:
         deepseek_profiles = [
             p
             for p in [config.dev_profile, config.preflight_profile, *config.review_pool]
-            if p.model == "deepseek-reasoner"
+            if p.model == "deepseek-v4-pro"
         ]
         assert deepseek_profiles
         assert all(p.cli is None for p in deepseek_profiles)
@@ -801,10 +801,10 @@ class TestCurrentGenModelRegistry:
                 False,
             ),
             (
-                "deepseek/deepseek-reasoner/api",
+                "deepseek/deepseek-v4-pro/api",
                 None,
                 "deepseek",
-                "deepseek-reasoner",
+                "deepseek-v4-pro",
                 "strong",
                 9,
                 2,

--- a/tests/test_config_transport_identity.py
+++ b/tests/test_config_transport_identity.py
@@ -658,7 +658,7 @@ class TestTransportCrossesPhaseBoundaries:
             tmp_path,
             {
                 "project": "p",
-                "models": ["anthropic/sonnet/cli", "deepseek/deepseek-reasoner/api"],
+                "models": ["anthropic/sonnet/cli", "deepseek/deepseek-v4-pro/api"],
                 "budget_usd": 30.0,
             },
         )
@@ -668,7 +668,7 @@ class TestTransportCrossesPhaseBoundaries:
         assert dev.transport is not None
         # Whichever model won, dispatch state is internally consistent.
         assert dev.mode == dev.transport.kind
-        if dev.model == "deepseek-reasoner":
+        if dev.model == "deepseek-v4-pro":
             assert dev.mode == "api"
             assert dev.cli is None
         else:

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -39,7 +39,7 @@ from theforge.config.model_catalog import (
     resolve_packaged,
     resolve_project,
 )
-from theforge.config.models import AGENT_REGISTRY, transport_for
+from theforge.config.models import AGENT_REGISTRY, RETIRED_MODEL_REGISTRY, transport_for
 from theforge.config.pricing import (
     COST_BAND_BASIS_DECLARED_POLICY,
     COST_BAND_BASIS_VENDOR_TIER,
@@ -137,8 +137,8 @@ _ALL_PHASES = ("dev", "plan", "preflight", "review")
 _SHIPPED_ROUTING: dict[str, tuple[str, int, int, bool, tuple[str, ...]]] = {
     "anthropic/opus/cli": ("strong", 10, 3, True, _ALL_PHASES),
     "anthropic/sonnet/cli": ("fast", 7, 1, True, _ALL_PHASES),
-    "deepseek/deepseek-chat/api": ("fast", 7, 1, True, _ALL_PHASES),
-    "deepseek/deepseek-reasoner/api": ("strong", 9, 2, True, _ALL_PHASES),
+    "deepseek/deepseek-v4-flash/api": ("fast", 7, 1, True, _ALL_PHASES),
+    "deepseek/deepseek-v4-pro/api": ("strong", 9, 2, True, _ALL_PHASES),
     "google/gemini-2.5-pro/api": ("strong", 8, 2, True, _ALL_PHASES),
     "google/gemini-2.5-pro/cli": ("strong", 8, 2, False, _ALL_PHASES),
     "google/gemini-3-flash-preview/api": ("cheap", 7, 1, True, _ALL_PHASES),
@@ -177,7 +177,11 @@ class TestPackagedCatalog:
         resource = resources.files("theforge.config").joinpath("data/models.yaml")
         assert resource.is_file()
         document = yaml.safe_load(resource.read_text(encoding="utf-8"))
-        assert len(document["models"]) == len(AGENT_REGISTRY)
+        # The document holds both halves of the catalog: routable entries and the
+        # retired identifiers kept so a configuration naming one is told what the
+        # provider did with it (#2352). Every entry lands in exactly one.
+        assert len(document["models"]) == len(AGENT_REGISTRY) + len(RETIRED_MODEL_REGISTRY)
+        assert not (AGENT_REGISTRY.keys() & RETIRED_MODEL_REGISTRY.keys())
 
     def test_the_built_wheel_carries_the_catalog(self, tmp_path):
         """Build a real wheel and look inside it.
@@ -215,7 +219,7 @@ class TestPackagedCatalog:
         assert sonnet.pricing_provenance is None
         assert sonnet.routing.cost_rank_basis == COST_BAND_BASIS_VENDOR_TIER
         assert sonnet.cost_rank == 1
-        reasoner = AGENT_REGISTRY["deepseek/deepseek-reasoner/api"]
+        reasoner = AGENT_REGISTRY["deepseek/deepseek-v4-pro/api"]
         assert reasoner.routing.cost_rank_basis == COST_BAND_BASIS_DECLARED_POLICY
         assert AGENT_REGISTRY["openai/gpt-5.4/cli"].pricing_provenance == "gpt-5.4"
 

--- a/tests/test_model_identity_verification.py
+++ b/tests/test_model_identity_verification.py
@@ -21,6 +21,7 @@ These tests pin the four properties that make that non-repeatable:
 
 from __future__ import annotations
 
+import inspect
 import json
 from datetime import date, timedelta
 from types import SimpleNamespace
@@ -29,6 +30,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from theforge.agent_types import (
+    COST_ESTIMATED,
+    COST_ESTIMATED_UNCONFIRMED,
+    COST_PROVENANCE_VALUES,
+    COST_UNKNOWN,
+    AgentResult,
+    ModelUsage,
+)
 from theforge.config import load_config
 from theforge.config.model_catalog import (
     parse_definition,
@@ -48,7 +57,14 @@ from theforge.config.models import (
 from theforge.config.types import ModelProfile
 from theforge.runners.adapters.deepseek import _run_deepseek, deepseek_request_kwargs
 from theforge.runners.adapters.openai import _read_chat_usage
-from theforge.runners.schema_utils import PRICING_TABLE, _estimate_cost, pricing_for
+from theforge.runners.api import _estimated_provenance
+from theforge.runners.schema_utils import (
+    PRICING_TABLE,
+    ToolCallRequest,
+    _estimate_cost,
+    pricing_for,
+    rate_card_confirmed,
+)
 
 RETIRED = ("deepseek/deepseek-reasoner/api", "deepseek/deepseek-chat/api")
 SERVED = ("deepseek/deepseek-v4-pro/api", "deepseek/deepseek-v4-flash/api")
@@ -389,8 +405,34 @@ class TestReasoningModeReachesTheProvider:
     def test_request_kwargs_carry_the_mode_and_the_routed_effort(self):
         profile = _deepseek_profile(reasoning_mode="enabled", reasoning_effort="high")
         assert deepseek_request_kwargs(profile) == {
-            "thinking": {"type": "enabled", "reasoning_effort": "max"}
+            "extra_body": {"thinking": {"type": "enabled", "reasoning_effort": "max"}}
         }
+
+    def test_the_control_is_shaped_as_a_kwarg_the_real_sdk_accepts(self):
+        """Bound against the installed SDK's actual signature, not a mock's.
+
+        ``thinking`` is DeepSeek's extension to the request body, not an OpenAI
+        SDK parameter, and ``create()`` declares an explicit parameter list with
+        no ``**kwargs``. Passing it top-level raises TypeError in the client
+        before any request is sent — so the mode is never requested and the call
+        never happens. A MagicMock accepts anything and cannot see that, which is
+        why this binds the kwargs to the real signature instead.
+        """
+        openai = pytest.importorskip("openai")
+        create = openai.resources.chat.completions.Completions.create
+        signature = inspect.signature(create)
+        assert not [p for p in signature.parameters.values() if p.kind is p.VAR_KEYWORD], (
+            "SDK grew **kwargs; this guard needs rethinking"
+        )
+
+        profile = _deepseek_profile(reasoning_mode="enabled", reasoning_effort="high")
+        request = {
+            "model": profile.model,
+            "messages": [{"role": "user", "content": "go"}],
+            **deepseek_request_kwargs(profile),
+        }
+        signature.bind_partial(None, **request)  # raises TypeError on an unknown kwarg
+        assert request["extra_body"]["thinking"]["type"] == "enabled"
 
     def test_forges_effort_vocabulary_is_mapped_not_passed_through(self):
         """DeepSeek has no "medium"; sending one is not a no-op.
@@ -399,7 +441,8 @@ class TestReasoningModeReachesTheProvider:
         recorded in the audit is not the effort that ran.
         """
         profile = _deepseek_profile(reasoning_mode="enabled", reasoning_effort="medium")
-        assert deepseek_request_kwargs(profile)["thinking"]["reasoning_effort"] == "high"
+        thinking = deepseek_request_kwargs(profile)["extra_body"]["thinking"]
+        assert thinking["reasoning_effort"] == "high"
 
     def test_a_profile_declaring_nothing_sends_nothing(self):
         """No mode is invented for a profile built outside the registry path."""
@@ -427,7 +470,7 @@ class TestReasoningModeReachesTheProvider:
 
         assert result.success
         kwargs = client.chat.completions.create.call_args[1]
-        assert kwargs["thinking"] == {"type": "enabled", "reasoning_effort": "low"}
+        assert kwargs["extra_body"] == {"thinking": {"type": "enabled", "reasoning_effort": "low"}}
 
     def test_the_tool_loop_path_forwards_the_thinking_block(self):
         """The loop is the path a routed reviewer actually takes.
@@ -452,7 +495,7 @@ class TestReasoningModeReachesTheProvider:
             _run_loop_deepseek("review this", profile, working_dir=None)
 
         kwargs = client.chat.completions.create.call_args[1]
-        assert kwargs["thinking"] == {"type": "enabled", "reasoning_effort": "max"}
+        assert kwargs["extra_body"] == {"thinking": {"type": "enabled", "reasoning_effort": "max"}}
 
     def test_the_finalizer_path_forwards_the_thinking_block(self):
         """Finalization is still an invocation of the model the role was filled with."""
@@ -471,7 +514,324 @@ class TestReasoningModeReachesTheProvider:
         finalizer([{"role": "user", "content": "go"}])
 
         kwargs = client.chat.completions.create.call_args[1]
-        assert kwargs["thinking"] == {"type": "enabled", "reasoning_effort": "low"}
+        assert kwargs["extra_body"] == {"thinking": {"type": "enabled", "reasoning_effort": "low"}}
+
+
+# ── A retirement cannot be undone from the project layer ──────────────────
+
+
+class TestRetiredIdentifiersCannotBeRedeclared:
+    """The retirement has to be a property of the *identifier*, not of one file.
+
+    Declaring it only on the shipped entry left the whole point defeatable by a
+    project: redeclare the same name with your own routing and cost, and it is
+    selectable again — now priced off figures an operator wrote for a model the
+    provider no longer serves, which is strictly worse than the original defect.
+    """
+
+    def test_an_inline_models_enabled_mapping_cannot_revive_a_retired_name(self, tmp_path):
+        path = tmp_path / "forge.yaml"
+        path.write_text(
+            yaml.dump(
+                {
+                    "models": {
+                        "enabled": [
+                            {
+                                "provider": "deepseek",
+                                "model": "deepseek-reasoner",
+                                "transport": {"kind": "api"},
+                                "routing": {
+                                    "tier": "strong",
+                                    "capability": 9,
+                                    "cost_rank": 2,
+                                    "cost_rank_basis": "declared-policy",
+                                },
+                                "cost": {"input_per_mtok": 0.55, "output_per_mtok": 2.19},
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="retired"):
+            load_config(path)
+
+    def test_a_models_custom_declaration_cannot_revive_a_retired_name(self, tmp_path):
+        path = tmp_path / "forge.yaml"
+        path.write_text(
+            yaml.dump(
+                {
+                    "models": {
+                        "enabled": ["anthropic/sonnet/cli"],
+                        "custom": {
+                            "deepseek/deepseek-reasoner/api": {
+                                "provider": "deepseek",
+                                "model": "deepseek-reasoner",
+                                "tier": "strong",
+                                "input_cost_per_mtok": 0.55,
+                                "output_cost_per_mtok": 2.19,
+                            }
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="retired"):
+            load_config(path)
+
+    def test_the_refusal_names_the_identifier_and_the_reason(self):
+        """Both project surfaces resolve through one guard, so both say the same thing."""
+        from theforge.config.model_catalog import resolve_project
+
+        defn = parse_definition(
+            _base_definition(model="deepseek-reasoner"), where="models.custom.x"
+        )
+        with pytest.raises(ValueError) as excinfo:
+            resolve_project(defn, where="models.custom.x", builtin=None)
+        message = str(excinfo.value)
+        assert "deepseek/deepseek-reasoner/api" in message
+        assert "deepseek-v4-pro" in message  # the replacement, from the retirement reason
+
+    def test_a_served_identifier_still_overlays_normally(self):
+        """The guard is scoped to retired identities and nothing else."""
+        from theforge.config.model_catalog import resolve_project
+
+        defn = parse_definition(
+            _base_definition(cost={"input_per_mtok": 9.0, "output_per_mtok": 9.0}),
+            where="models.custom.x",
+        )
+        resolved = resolve_project(
+            defn, where="models.custom.x", builtin=AGENT_REGISTRY["deepseek/deepseek-v4-pro/api"]
+        )
+        assert resolved.spec.input_cost_per_mtok == 9.0
+
+
+# ── Reasoning content survives the turn without being replayed ────────────
+
+
+class TestReasoningContentHandling:
+    def test_the_adapter_captures_reasoning_content(self):
+        """DeepSeek returns the chain of thought beside ``content``, not inside it."""
+        from theforge.runners.adapters.openai import _make_openai_chat_adapter
+
+        client = MagicMock()
+        response = MagicMock()
+        response.choices[0].message.content = "calling a tool"
+        response.choices[0].message.tool_calls = []
+        response.choices[0].message.reasoning_content = "let me check the file first"
+        response.usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        client.chat.completions.create.return_value = response
+
+        adapter = _make_openai_chat_adapter(
+            _deepseek_profile(reasoning_mode="enabled"), None, client=client
+        )
+        turn = adapter([{"role": "user", "content": "go"}], [])
+        assert turn.reasoning_content == "let me check the file first"
+
+    def test_a_provider_that_reports_no_reasoning_leaves_it_none(self):
+        from theforge.runners.adapters.openai import _make_openai_chat_adapter
+
+        client = MagicMock()
+        response = MagicMock()
+        response.choices[0].message.content = "done"
+        response.choices[0].message.tool_calls = []
+        response.choices[0].message.reasoning_content = None
+        response.usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        client.chat.completions.create.return_value = response
+
+        adapter = _make_openai_chat_adapter(_deepseek_profile(), None, client=client)
+        assert adapter([{"role": "user", "content": "go"}], []).reasoning_content is None
+
+    def test_the_assistant_turn_keeps_its_text_and_its_reasoning(self):
+        """The loop hardcoded ``content: None``, erasing what the model said.
+
+        A model that explains itself and then calls a tool had that sentence
+        dropped from its own history on the next turn, alongside the reasoning.
+        """
+        from theforge.runners.api import AgentLoopManager
+
+        manager = AgentLoopManager.__new__(AgentLoopManager)
+        messages = manager._append_tool_results(
+            [{"role": "user", "content": "go"}],
+            [ToolCallRequest(id="c1", name="read_file", arguments={"path": "a.py"})],
+            [{"id": "c1", "content": "ok"}],
+            content="I will read the file",
+            reasoning_content="the file is the likely source",
+        )
+        assistant = messages[1]
+        assert assistant["content"] == "I will read the file"
+        assert assistant["reasoning_content"] == "the file is the likely source"
+
+    def test_reasoning_content_is_not_replayed_into_the_next_request(self):
+        """Not an oversight — the provider defines that field for another feature.
+
+        DeepSeek's API reference scopes an input assistant ``reasoning_content``
+        to Chat Prefix Completion, where ``prefix`` must be true. Emitting it on
+        an ordinary tool-loop turn would opt every thinking-mode review into a
+        beta feature it never asked for, so the translator builds each outgoing
+        message from named keys and leaves it behind.
+        """
+        from theforge.runners.adapters.openai import _translate_messages_openai_chat
+
+        translated = _translate_messages_openai_chat(
+            [
+                {
+                    "role": "assistant",
+                    "content": "I will read the file",
+                    "reasoning_content": "the file is the likely source",
+                    "tool_calls": [
+                        ToolCallRequest(id="c1", name="read_file", arguments={"path": "a.py"})
+                    ],
+                }
+            ]
+        )
+        assert translated[0]["content"] == "I will read the file"
+        assert "reasoning_content" not in translated[0]
+        assert translated[0]["tool_calls"][0]["id"] == "c1"
+
+    def test_a_thinking_mode_tool_call_turn_round_trips_into_a_second_request(self):
+        """Two provider calls, so the second one's body is the thing under test.
+
+        The single-turn tests cannot see this: the failure they would miss is a
+        second request that either drops the assistant's text or carries a field
+        the provider rejects.
+        """
+        from theforge.runners.api import _run_loop_deepseek
+
+        profile = _deepseek_profile(
+            reasoning_mode="enabled", reasoning_effort="high", allowed_tools=("read_file",)
+        )
+        first = MagicMock()
+        first.choices[0].message.content = "I will read the file"
+        first.choices[0].message.reasoning_content = "the file is the likely source"
+        tool_call = MagicMock()
+        tool_call.id = "c1"
+        tool_call.function.name = "read_file"
+        tool_call.function.arguments = json.dumps({"path": "a.py"})
+        first.choices[0].message.tool_calls = [tool_call]
+        first.usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+
+        second = MagicMock()
+        second.choices[0].message.content = "done"
+        second.choices[0].message.tool_calls = []
+        second.choices[0].message.reasoning_content = None
+        second.usage = SimpleNamespace(prompt_tokens=20, completion_tokens=6)
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = [first, second]
+
+        with patch("theforge.runners.api._deepseek_client", return_value=client):
+            _run_loop_deepseek("review this", profile, working_dir=None)
+
+        assert client.chat.completions.create.call_count == 2
+        follow_up = client.chat.completions.create.call_args_list[1][1]
+        # The mode is still requested on the follow-up turn, in SDK-legal shape.
+        assert follow_up["extra_body"] == {
+            "thinking": {"type": "enabled", "reasoning_effort": "max"}
+        }
+        assistant = [m for m in follow_up["messages"] if m["role"] == "assistant"][0]
+        assert assistant["content"] == "I will read the file"
+        assert "reasoning_content" not in assistant
+        assert assistant["tool_calls"][0]["id"] == "c1"
+
+
+# ── An estimate says what rate card it rests on ───────────────────────────
+
+
+class TestCostProvenanceDistinguishesTheRateCard:
+    def test_provenance_values_include_the_unconfirmed_estimate(self):
+        assert COST_ESTIMATED_UNCONFIRMED in COST_PROVENANCE_VALUES
+
+    def test_a_confirmed_rate_card_yields_a_plain_estimate(self):
+        assert rate_card_confirmed("deepseek", "deepseek-v4-pro") is True
+        assert _estimated_provenance("deepseek", "deepseek-v4-pro") == COST_ESTIMATED
+
+    def test_a_pricing_table_rate_is_never_confirmed(self):
+        """That table records no identity and no date.
+
+        It is how the superseded DeepSeek rates survived two revisions of the
+        provider's published pricing without anything noticing.
+        """
+        assert rate_card_confirmed("openai", "gpt-4o") is False
+        assert _estimated_provenance("openai", "gpt-4o") == COST_ESTIMATED_UNCONFIRMED
+
+    def test_an_aged_out_check_stops_confirming_the_rate_card(self):
+        stale = date(2026, 8, 10) + timedelta(days=IDENTITY_VERIFICATION_MAX_AGE_DAYS + 1)
+        assert rate_card_confirmed("deepseek", "deepseek-v4-pro", today=stale) is False
+
+    def test_the_stamp_records_which_kind_of_estimate_each_component_is(self):
+        """A result can span models, so the claim is made per component."""
+        from theforge.runners.api import _stamp_api_cost_provenance
+
+        result = AgentResult(
+            success=True,
+            output="ok",
+            session_id=None,
+            cost_usd=0.5,
+            exit_code=0,
+            raw={},
+            model_used="deepseek-v4-pro",
+            model_usage=(
+                ModelUsage(
+                    model="deepseek-v4-pro",
+                    input_tokens=10,
+                    output_tokens=5,
+                    cache_read_tokens=0,
+                    cache_creation_tokens=0,
+                    cost_usd=0.5,
+                ),
+            ),
+        )
+        stamped = _stamp_api_cost_provenance(result, "deepseek")
+        assert stamped.model_usage[0].cost_provenance == COST_ESTIMATED
+        assert stamped.cost_provenance == COST_ESTIMATED
+
+    def test_an_unconfirmed_component_makes_the_whole_invocation_unconfirmed(self):
+        """The invocation-level statement is the weakest of its components'."""
+        from theforge.runners.api import _stamp_api_cost_provenance
+
+        def _usage(model: str) -> ModelUsage:
+            return ModelUsage(
+                model=model,
+                input_tokens=10,
+                output_tokens=5,
+                cache_read_tokens=0,
+                cache_creation_tokens=0,
+                cost_usd=0.25,
+            )
+
+        result = AgentResult(
+            success=True,
+            output="ok",
+            session_id=None,
+            cost_usd=0.5,
+            exit_code=0,
+            raw={},
+            model_used="deepseek-v4-pro",
+            model_usage=(_usage("deepseek-v4-pro"), _usage("some-unlisted-model")),
+        )
+        stamped = _stamp_api_cost_provenance(result, "deepseek")
+        assert [u.cost_provenance for u in stamped.model_usage] == [
+            COST_ESTIMATED,
+            COST_ESTIMATED_UNCONFIRMED,
+        ]
+        assert stamped.cost_provenance == COST_ESTIMATED_UNCONFIRMED
+
+    def test_a_none_cost_still_records_unknown(self):
+        """Nothing observed means nothing to characterize — unchanged."""
+        from theforge.runners.api import _stamp_api_cost_provenance
+
+        result = AgentResult(
+            success=False,
+            output="boom",
+            session_id=None,
+            cost_usd=None,
+            exit_code=1,
+            raw={},
+        )
+        assert _stamp_api_cost_provenance(result, "deepseek").cost_provenance == COST_UNKNOWN
 
 
 # ── The provider's own usage report is read, not discarded ────────────────

--- a/tests/test_model_identity_verification.py
+++ b/tests/test_model_identity_verification.py
@@ -1,0 +1,545 @@
+"""A model identifier is a claim about the provider, and it can stop being true (#2352).
+
+The catalog, the alias map and the accounting table each named a DeepSeek
+identifier the provider had retired. None of them could notice: the name kept
+resolving upstream, so runs completed with exit 0 and real token counts while the
+capability, tier and price recorded against it described a model that was no
+longer there. The estimate those runs recorded was several times the rate the
+provider actually charges, and it was stamped ``estimated`` like any other.
+
+These tests pin the four properties that make that non-repeatable:
+
+- a retired identifier is unreachable by routing and, when a configuration still
+  names it, resolves to an *explanation* rather than to a model or to "unknown";
+- the served identifiers carry the rate card in force, including the cache-hit
+  tier DeepSeek bills separately, and that tier actually reaches the estimator;
+- the reasoning mode the routing band claims is requested at invocation — on
+  every path a run takes, not just the one that happened to be wired;
+- an identifier nothing has checked recently is *reported* from configuration,
+  before a run spends against it.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from theforge.config import load_config
+from theforge.config.model_catalog import (
+    parse_definition,
+    resolve_packaged,
+    unconfirmed_identities,
+)
+from theforge.config.model_identity import (
+    IDENTITY_VERIFICATION_MAX_AGE_DAYS,
+    IdentityVerification,
+)
+from theforge.config.models import (
+    AGENT_REGISTRY,
+    RETIRED_MODEL_REGISTRY,
+    AgentDef,
+    resolve_agent_spec,
+)
+from theforge.config.types import ModelProfile
+from theforge.runners.adapters.deepseek import _run_deepseek, deepseek_request_kwargs
+from theforge.runners.adapters.openai import _read_chat_usage
+from theforge.runners.schema_utils import PRICING_TABLE, _estimate_cost, pricing_for
+
+RETIRED = ("deepseek/deepseek-reasoner/api", "deepseek/deepseek-chat/api")
+SERVED = ("deepseek/deepseek-v4-pro/api", "deepseek/deepseek-v4-flash/api")
+
+
+def _base_definition(**overrides) -> dict:
+    entry = {
+        "provider": "deepseek",
+        "model": "deepseek-v4-pro",
+        "transport": {"kind": "api"},
+        "routing": {"tier": "strong", "capability": 9, "cost_rank": 1},
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _deepseek_profile(**overrides) -> ModelProfile:
+    fields = {
+        "name": "deepseek-reviewer",
+        "provider": "deepseek",
+        "cli": None,
+        "model": "deepseek-v4-pro",
+        "budget_usd": 1.0,
+        "timeout_seconds": 300,
+        "allowed_tools": (),
+    }
+    fields.update(overrides)
+    return ModelProfile(**fields)
+
+
+# ── Retired identifiers are unroutable and self-explaining ────────────────
+
+
+class TestRetiredIdentifiers:
+    def test_retired_names_are_absent_from_the_routable_registry(self):
+        """Nothing that selects a model can reach one."""
+        for key in RETIRED:
+            assert key not in AGENT_REGISTRY
+            assert key in RETIRED_MODEL_REGISTRY
+
+    def test_resolving_a_retired_name_explains_the_retirement(self):
+        """The failure names what the provider did, not merely that lookup failed.
+
+        "Unknown model" reads as a typo and sends an operator looking for the
+        misspelling. The whole reason a retirement is *declared* rather than the
+        entry deleted is that the operator needs the other message.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            resolve_agent_spec("deepseek/deepseek-reasoner/api")
+        message = str(excinfo.value)
+        assert "retired" in message
+        assert "deepseek-v4-pro" in message  # names the replacement
+        assert "not in AGENT_REGISTRY" not in message
+
+    def test_the_legacy_alias_no_longer_masks_the_retirement(self):
+        """The un-suffixed spelling reaches the same explanation.
+
+        The alias map was one of the three places the retired name resolved
+        cleanly. Keeping the alias is deliberate — it is what routes the old
+        spelling to the explanation instead of to "unknown model" — but it must
+        not resolve to a *model*.
+        """
+        for alias in ("deepseek/deepseek-reasoner", "deepseek/deepseek-chat"):
+            with pytest.raises(ValueError, match="retired"):
+                resolve_agent_spec(alias)
+
+    def test_a_retired_name_in_models_enabled_fails_configuration_load(self, tmp_path):
+        """Discoverable when the operator can still act on it, not after a run."""
+        path = tmp_path / "forge.yaml"
+        path.write_text(
+            yaml.dump({"models": {"enabled": ["deepseek/deepseek-reasoner"]}}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="retired"):
+            load_config(path)
+
+    def test_a_retired_entry_carries_no_price(self):
+        """A replaced rate card must not be able to price anything.
+
+        The retired entries used to carry the figures that produced the wrong
+        estimate. Dropping the price rather than keeping it "for reference" is
+        what stops it from being read by anything downstream.
+        """
+        for key in RETIRED:
+            spec = RETIRED_MODEL_REGISTRY[key]
+            assert spec.input_cost_per_mtok is None
+            assert spec.output_cost_per_mtok is None
+            assert spec.pricing_provenance is None
+            assert pricing_for(spec.provider, spec.model) is None
+
+    def test_the_accounting_table_no_longer_carries_deepseek_at_all(self):
+        """The third hand-maintained copy of the rate card is gone.
+
+        It held four rows, two commented as aliases of a generation two releases
+        old, at the superseded rates. Rates now live on the catalog entry beside
+        the identity and verification date they were recorded with.
+        """
+        assert not [key for key in PRICING_TABLE if key[0] == "deepseek"]
+
+    def test_a_retirement_must_state_a_reason(self):
+        """A withdrawn name with no stated reason tells an operator nothing."""
+        entry = _base_definition(identity={"status": "retired"})
+        with pytest.raises(ValueError, match="retired_reason"):
+            parse_definition(entry, where="models[0]")
+
+
+# ── The served identifiers carry the rate card in force ───────────────────
+
+
+class TestServedIdentifiers:
+    def test_both_served_entries_declare_a_checked_identifier(self):
+        for key in SERVED:
+            spec = AGENT_REGISTRY[key]
+            assert spec.identity.verified_on is not None
+            assert spec.identity.verified_against
+
+    @pytest.mark.parametrize(
+        "key,expected",
+        [
+            ("deepseek/deepseek-v4-pro/api", (0.435, 0.87, 0.003625)),
+            ("deepseek/deepseek-v4-flash/api", (0.14, 0.28, 0.0028)),
+        ],
+    )
+    def test_served_entries_carry_the_published_rates_including_the_cache_tier(
+        self, key, expected
+    ):
+        spec = AGENT_REGISTRY[key]
+        assert (
+            spec.input_cost_per_mtok,
+            spec.output_cost_per_mtok,
+            spec.cached_input_cost_per_mtok,
+        ) == expected
+        assert spec.pricing_provenance == spec.model
+
+    def test_the_estimator_reads_the_catalog_rate_card(self):
+        rates = pricing_for("deepseek", "deepseek-v4-pro")
+        assert rates is not None
+        assert rates.input_per_mtok == 0.435
+        assert rates.cached_input_per_mtok == 0.003625
+
+    def test_a_cache_hit_is_billed_at_the_provider_rate_not_a_flat_discount(self):
+        """The tier is ~2% of uncached, which no fixed fraction approximates.
+
+        Pricing it as 10%-of-input (the generic assumption) would overstate the
+        cached half by roughly five times.
+        """
+        one_million_all_cached = _estimate_cost(
+            "deepseek",
+            "deepseek-v4-pro",
+            input_tokens=1_000_000,
+            output_tokens=0,
+            cached_input_tokens=1_000_000,
+        )
+        assert one_million_all_cached == pytest.approx(0.003625)
+        generic_discount = 0.435 * 0.1
+        assert one_million_all_cached < generic_discount
+
+    def test_a_provider_without_a_declared_cache_tier_keeps_the_generic_discount(self):
+        """Unchanged behaviour for everyone else — this is an addition, not a swap."""
+        cost = _estimate_cost(
+            "openai",
+            "gpt-5.4",
+            input_tokens=1_000_000,
+            output_tokens=0,
+            cached_input_tokens=1_000_000,
+        )
+        assert cost == pytest.approx(1.25 * 0.1)
+
+    def test_the_recorded_estimate_matches_the_rate_card_in_force(self):
+        """The shape of the original defect, priced against the current card.
+
+        The two runs that surfaced this recorded ≈ $3.73 for ~6.4M input / ~78k
+        output, off the superseded rates *and* with the cache tier neither
+        requested nor accounted for. Both halves of the correction are asserted
+        because either alone leaves most of the error in place: the rate card
+        move is worth ~25%, and reading the cache tier is worth the rest.
+        """
+        recorded_before = 3.727
+        rates_only = _estimate_cost(
+            "deepseek", "deepseek-v4-pro", input_tokens=6_400_000, output_tokens=78_000
+        )
+        assert rates_only is not None
+        assert rates_only < recorded_before
+
+        # A review re-reads a largely identical prompt each turn, so most of its
+        # input is a cache hit — which is the tier the old model had no place for.
+        with_cache = _estimate_cost(
+            "deepseek",
+            "deepseek-v4-pro",
+            input_tokens=6_400_000,
+            output_tokens=78_000,
+            cached_input_tokens=6_000_000,
+        )
+        assert with_cache is not None
+        assert with_cache < recorded_before / 5
+
+    def test_a_local_endpoints_zero_does_not_leak_into_the_rate_map(self):
+        """0.00 is true of the endpoint, not of the model name.
+
+        ``openai/codestral/api`` is priced 0.00 because it is served locally. The
+        same name reached over a vendor API is billed, so the catalog figure must
+        not answer for it.
+        """
+        assert pricing_for("openai", "codestral") is None
+
+
+# ── Verification ages out ─────────────────────────────────────────────────
+
+
+class TestIdentityVerificationWindow:
+    def test_a_recent_check_confirms_the_identifier(self):
+        today = date(2026, 8, 10)
+        identity = IdentityVerification(
+            verified_against="provider model list", verified_on=today - timedelta(days=1)
+        )
+        assert identity.confirmed_on(today) is True
+
+    def test_a_check_older_than_the_window_stops_confirming_it(self):
+        """Evidence is about the day it was gathered, not forever.
+
+        Without this, an entry marked verified stays verified through a later
+        retirement — the original failure mode with an extra field on it.
+        """
+        today = date(2026, 8, 10)
+        identity = IdentityVerification(
+            verified_against="provider model list",
+            verified_on=today - timedelta(days=IDENTITY_VERIFICATION_MAX_AGE_DAYS + 1),
+        )
+        assert identity.confirmed_on(today) is False
+        assert "over the" in identity.describe(today)
+
+    def test_an_entry_that_declares_nothing_is_unconfirmed_but_still_loads(self):
+        """Absence degrades the claim; it does not break the catalog.
+
+        Every entry that predates this block declares no check, and failing the
+        whole load on that would stop forge starting rather than surface a defect.
+        """
+        resolved = resolve_packaged(
+            parse_definition(_base_definition(), where="models[0]"), where="models[0]"
+        )
+        assert resolved.spec.identity.confirmed_on(date(2026, 8, 10)) is False
+        assert "never checked" in resolved.spec.identity.describe(date(2026, 8, 10))
+
+    def test_unconfirmed_entries_are_reportable_from_the_registry(self):
+        reported = dict(unconfirmed_identities(AGENT_REGISTRY, today=date(2026, 8, 10)))
+        # The DeepSeek entries were checked on 2026-08-10, so they are not in it;
+        # the shorthands that declare nothing are.
+        for key in SERVED:
+            assert key not in reported
+        assert "anthropic/sonnet/cli" in reported
+
+    def test_check_config_reports_an_unconfirmed_identifier(self, tmp_path, capsys):
+        """Reported where configuration is read, before a run can spend on it."""
+        import argparse
+
+        from theforge.cli.check_config import cmd_check_config
+
+        path = tmp_path / "forge.yaml"
+        path.write_text(
+            yaml.dump({"models": {"enabled": ["anthropic/sonnet/cli"]}}), encoding="utf-8"
+        )
+        cmd_check_config(argparse.Namespace(config=str(path), verbose=False))
+        out = capsys.readouterr().out
+        assert "upstream identifier not confirmed" in out
+        assert "anthropic/sonnet/cli" in out
+
+
+# ── Schema validation at the config integrity boundary ────────────────────
+
+
+class TestCatalogSchemaValidation:
+    @pytest.mark.parametrize(
+        "block,expected",
+        [
+            ({"status": "sunsetting"}, "must be one of"),
+            ({"verified_on": "last tuesday"}, "ISO date"),
+            ({"checked": True}, "only supports"),
+        ],
+    )
+    def test_a_malformed_identity_block_is_a_load_error(self, block, expected):
+        with pytest.raises(ValueError, match=expected):
+            parse_definition(_base_definition(identity=block), where="models[0]")
+
+    @pytest.mark.parametrize(
+        "block,expected",
+        [
+            ({"reasoning_mode": "maybe"}, "must be one of"),
+            ({"reasoning": "enabled"}, "only supports"),
+        ],
+    )
+    def test_a_malformed_invocation_block_is_a_load_error(self, block, expected):
+        with pytest.raises(ValueError, match=expected):
+            parse_definition(_base_definition(invocation=block), where="models[0]")
+
+    def test_a_negative_cache_rate_is_a_load_error(self):
+        entry = _base_definition(
+            cost={
+                "input_per_mtok": 1.0,
+                "output_per_mtok": 2.0,
+                "cached_input_per_mtok": -0.1,
+                "pricing_provenance": "deepseek-v4-pro",
+            }
+        )
+        with pytest.raises(ValueError, match="cached_input_per_mtok"):
+            parse_definition(entry, where="models[0]")
+
+
+# ── The declared mode is the mode that gets requested ─────────────────────
+
+
+class TestReasoningModeReachesTheProvider:
+    def test_the_catalog_declares_the_mode_the_band_was_recorded_about(self):
+        assert AGENT_REGISTRY["deepseek/deepseek-v4-pro/api"].reasoning_mode == "enabled"
+
+    def test_the_mode_survives_the_whole_projection_to_a_profile(self):
+        """AgentSpec → ModelInfo → AgentDef → ModelProfile.
+
+        The adapter reads a ModelProfile, and the pool is the only route a routed
+        model takes to get there. A field that stops anywhere along this chain is
+        a declaration the invocation never sees.
+        """
+        from theforge.config.models import _spec_to_model_info
+
+        spec = AGENT_REGISTRY["deepseek/deepseek-v4-pro/api"]
+        info = _spec_to_model_info("deepseek/deepseek-v4-pro/api", spec)
+        assert info.reasoning_mode == "enabled"
+        agent = AgentDef(
+            name="deepseek",
+            provider="deepseek",
+            model=info.model,
+            budget_usd=1.0,
+            timeout_seconds=300,
+            tier="strong",
+            reasoning_mode=info.reasoning_mode,
+        )
+        assert agent.to_model_profile().reasoning_mode == "enabled"
+
+    def test_request_kwargs_carry_the_mode_and_the_routed_effort(self):
+        profile = _deepseek_profile(reasoning_mode="enabled", reasoning_effort="high")
+        assert deepseek_request_kwargs(profile) == {
+            "thinking": {"type": "enabled", "reasoning_effort": "max"}
+        }
+
+    def test_forges_effort_vocabulary_is_mapped_not_passed_through(self):
+        """DeepSeek has no "medium"; sending one is not a no-op.
+
+        Either it 400s or the provider remaps it, in which case the effort forge
+        recorded in the audit is not the effort that ran.
+        """
+        profile = _deepseek_profile(reasoning_mode="enabled", reasoning_effort="medium")
+        assert deepseek_request_kwargs(profile)["thinking"]["reasoning_effort"] == "high"
+
+    def test_a_profile_declaring_nothing_sends_nothing(self):
+        """No mode is invented for a profile built outside the registry path."""
+        assert deepseek_request_kwargs(_deepseek_profile()) == {}
+
+    def test_the_single_shot_path_forwards_the_thinking_block(self):
+        profile = _deepseek_profile(reasoning_mode="enabled", reasoning_effort="low")
+        client = MagicMock()
+        response = MagicMock()
+        response.choices[0].message.content = json.dumps(
+            {
+                "verdict": "APPROVE",
+                "summary": "ok",
+                "findings": [],
+                "story_compliance": {"matches_spec": True, "mismatches": []},
+                "test_coverage": {"adequate": True, "gaps": []},
+            }
+        )
+        response.usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        response.model_dump.return_value = {}
+        client.chat.completions.create.return_value = response
+
+        with patch("theforge.runners.adapters.deepseek._deepseek_client", return_value=client):
+            result = _run_deepseek("review this", profile)
+
+        assert result.success
+        kwargs = client.chat.completions.create.call_args[1]
+        assert kwargs["thinking"] == {"type": "enabled", "reasoning_effort": "low"}
+
+    def test_the_tool_loop_path_forwards_the_thinking_block(self):
+        """The loop is the path a routed reviewer actually takes.
+
+        It builds its adapter directly rather than through the DeepSeek wrapper,
+        so wiring the wrapper alone would leave every real review call without
+        the mode its band was recorded about.
+        """
+        from theforge.runners.api import _run_loop_deepseek
+
+        profile = _deepseek_profile(
+            reasoning_mode="enabled", reasoning_effort="high", allowed_tools=("read_file",)
+        )
+        client = MagicMock()
+        response = MagicMock()
+        response.choices[0].message.content = "done"
+        response.choices[0].message.tool_calls = []
+        response.usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        client.chat.completions.create.return_value = response
+
+        with patch("theforge.runners.api._deepseek_client", return_value=client):
+            _run_loop_deepseek("review this", profile, working_dir=None)
+
+        kwargs = client.chat.completions.create.call_args[1]
+        assert kwargs["thinking"] == {"type": "enabled", "reasoning_effort": "max"}
+
+    def test_the_finalizer_path_forwards_the_thinking_block(self):
+        """Finalization is still an invocation of the model the role was filled with."""
+        from theforge.runners.finalizers import _make_deepseek_finalizer
+
+        profile = _deepseek_profile(
+            reasoning_mode="enabled", reasoning_effort="low", phase="review"
+        )
+        client = MagicMock()
+        response = MagicMock()
+        response.choices[0].message.content = "{}"
+        response.usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        client.chat.completions.create.return_value = response
+
+        finalizer = _make_deepseek_finalizer(profile, None, client=client)
+        finalizer([{"role": "user", "content": "go"}])
+
+        kwargs = client.chat.completions.create.call_args[1]
+        assert kwargs["thinking"] == {"type": "enabled", "reasoning_effort": "low"}
+
+
+# ── The provider's own usage report is read, not discarded ────────────────
+
+
+class TestUsageExtraction:
+    def test_deepseeks_cache_and_reasoning_counts_are_read(self):
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=300,
+            prompt_cache_hit_tokens=800,
+            prompt_cache_miss_tokens=200,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=120),
+        )
+        parsed = _read_chat_usage(usage)
+        assert parsed.cache_read_tokens == 800
+        assert parsed.thinking_tokens == 120
+
+    def test_reasoning_tokens_are_split_out_of_the_completion_count(self):
+        """``completion_tokens`` already includes reasoning on this wire format.
+
+        ``_estimate_cost`` bills ``output_tokens + thinking_tokens``, so carrying
+        both through unchanged would bill the reasoning twice.
+        """
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=300,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=120),
+        )
+        parsed = _read_chat_usage(usage)
+        assert parsed.output_tokens == 180
+        assert parsed.output_tokens + parsed.thinking_tokens == 300
+
+    def test_openais_cached_tokens_spelling_is_also_read(self):
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=10,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=640),
+        )
+        assert _read_chat_usage(usage).cache_read_tokens == 640
+
+    def test_a_usage_object_reporting_neither_yields_zeroes(self):
+        usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        parsed = _read_chat_usage(usage)
+        assert (parsed.cache_read_tokens, parsed.thinking_tokens) == (0, 0)
+        assert (parsed.input_tokens, parsed.output_tokens) == (10, 5)
+
+    def test_the_accumulated_cache_count_reaches_the_estimator(self):
+        """Accumulating cache reads and then not pricing them was the gap.
+
+        The loop recorded ``cache_read_tokens`` and passed only input/output to
+        ``_estimate_cost``, so every cached token was billed at the uncached rate.
+        """
+        from theforge.runners.api import _UsageAccumulator
+
+        accumulator = _UsageAccumulator(input_tokens=1_000_000, cache_read_tokens=1_000_000)
+        usage = accumulator.to_model_usage("deepseek-v4-pro", "deepseek")
+        assert usage.cost_usd == pytest.approx(0.003625)
+
+    def test_a_provider_reporting_cache_reads_outside_input_is_left_alone(self):
+        """Anthropic's ``input_tokens`` already excludes its cache reads.
+
+        Handing that count to the estimator would subtract real uncached input
+        from the bill, so the adjustment is scoped to the providers whose input
+        count contains the cache hits.
+        """
+        from theforge.runners.api import _UsageAccumulator
+
+        accumulator = _UsageAccumulator(input_tokens=1_000_000, cache_read_tokens=1_000_000)
+        usage = accumulator.to_model_usage("claude-sonnet-4-6", "anthropic")
+        assert usage.cost_usd == pytest.approx(3.00)

--- a/tests/test_model_identity_verification.py
+++ b/tests/test_model_identity_verification.py
@@ -664,14 +664,13 @@ class TestReasoningContentHandling:
         assert assistant["content"] == "I will read the file"
         assert assistant["reasoning_content"] == "the file is the likely source"
 
-    def test_reasoning_content_is_not_replayed_into_the_next_request(self):
-        """Not an oversight — the provider defines that field for another feature.
+    def test_reasoning_content_round_trips_onto_the_outgoing_assistant_message(self):
+        """DeepSeek requires it back once tools are in play.
 
-        DeepSeek's API reference scopes an input assistant ``reasoning_content``
-        to Chat Prefix Completion, where ``prefix`` must be true. Emitting it on
-        an ordinary tool-loop turn would opt every thinking-mode review into a
-        beta feature it never asked for, so the translator builds each outgoing
-        message from named keys and leaves it behind.
+        Per the provider's thinking-mode guide: with tool calls the intermediate
+        assistant's ``reasoning_content`` "must participate in the context
+        concatenation and must be passed back to the API in all subsequent user
+        interaction turns", and omitting it returns 400.
         """
         from theforge.runners.adapters.openai import _translate_messages_openai_chat
 
@@ -688,15 +687,38 @@ class TestReasoningContentHandling:
             ]
         )
         assert translated[0]["content"] == "I will read the file"
-        assert "reasoning_content" not in translated[0]
+        assert translated[0]["reasoning_content"] == "the file is the likely source"
         assert translated[0]["tool_calls"][0]["id"] == "c1"
+
+    def test_a_provider_that_reports_no_reasoning_sends_no_such_key(self):
+        """The replay is data-driven, so nothing changes for OpenAI.
+
+        OpenAI's Chat Completions never returns ``reasoning_content``, so an
+        OpenAI history never carries it and its request bodies are byte-identical
+        to before. That is what lets the round-trip live in shared code without a
+        branch on provider.
+        """
+        from theforge.runners.adapters.openai import _translate_messages_openai_chat
+
+        translated = _translate_messages_openai_chat(
+            [
+                {
+                    "role": "assistant",
+                    "content": "calling a tool",
+                    "tool_calls": [
+                        ToolCallRequest(id="c1", name="read_file", arguments={"path": "a.py"})
+                    ],
+                }
+            ]
+        )
+        assert "reasoning_content" not in translated[0]
 
     def test_a_thinking_mode_tool_call_turn_round_trips_into_a_second_request(self):
         """Two provider calls, so the second one's body is the thing under test.
 
-        The single-turn tests cannot see this: the failure they would miss is a
-        second request that either drops the assistant's text or carries a field
-        the provider rejects.
+        This is the shape that 400s in production: the first turn thinks and
+        calls a tool, and the continuation is rejected unless it carries the
+        reasoning back. A single-call test cannot see it.
         """
         from theforge.runners.api import _run_loop_deepseek
 
@@ -733,8 +755,46 @@ class TestReasoningContentHandling:
         }
         assistant = [m for m in follow_up["messages"] if m["role"] == "assistant"][0]
         assert assistant["content"] == "I will read the file"
-        assert "reasoning_content" not in assistant
+        assert assistant["reasoning_content"] == "the file is the likely source"
         assert assistant["tool_calls"][0]["id"] == "c1"
+
+    def test_the_finalizer_also_replays_the_reasoning_it_was_handed(self):
+        """The finalizer replays the *whole* history, so it 400s on the same rule.
+
+        It is the second DeepSeek call site that concatenates a prior tool-call
+        turn, and it runs at the end of every review that ran out of iterations
+        or time — exactly when the history is longest and a rejection costs most.
+        """
+        from theforge.runners.finalizers import _make_deepseek_finalizer
+
+        profile = _deepseek_profile(
+            reasoning_mode="enabled", reasoning_effort="low", phase="review"
+        )
+        client = MagicMock()
+        response = MagicMock()
+        response.choices[0].message.content = "{}"
+        response.usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        client.chat.completions.create.return_value = response
+
+        finalizer = _make_deepseek_finalizer(profile, None, client=client)
+        finalizer(
+            [
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": "I will read the file",
+                    "reasoning_content": "the file is the likely source",
+                    "tool_calls": [
+                        ToolCallRequest(id="c1", name="read_file", arguments={"path": "a.py"})
+                    ],
+                },
+                {"role": "tool_results", "results": [{"id": "c1", "content": "ok"}]},
+            ]
+        )
+
+        sent = client.chat.completions.create.call_args[1]["messages"]
+        assistant = [m for m in sent if m["role"] == "assistant"][0]
+        assert assistant["reasoning_content"] == "the file is the likely source"
 
 
 # ── An estimate says what rate card it rests on ───────────────────────────

--- a/tests/test_profile_transport_mutation.py
+++ b/tests/test_profile_transport_mutation.py
@@ -144,19 +144,19 @@ def test_preflight_complexity_adaptation_cli_to_api_dev_profile(tmp_path: Path) 
     config = _config(
         tmp_path,
         dev_profile=_profile_from("anthropic/sonnet/cli"),
-        models=["anthropic/sonnet/cli", "deepseek/deepseek-reasoner/api"],
+        models=["anthropic/sonnet/cli", "deepseek/deepseek-v4-pro/api"],
     )
 
     updated = _apply_complexity_adaptation(config, "medium")
 
-    _assert_api_profile(updated.dev_profile, provider="deepseek", model="deepseek-reasoner")
+    _assert_api_profile(updated.dev_profile, provider="deepseek", model="deepseek-v4-pro")
 
 
 def test_preflight_complexity_adaptation_api_to_cli_dev_profile(tmp_path: Path) -> None:
     config = _config(
         tmp_path,
-        dev_profile=_profile_from("deepseek/deepseek-chat/api"),
-        models=["deepseek/deepseek-chat/api", "anthropic/opus/cli"],
+        dev_profile=_profile_from("deepseek/deepseek-v4-flash/api"),
+        models=["deepseek/deepseek-v4-flash/api", "anthropic/opus/cli"],
     )
 
     updated = _apply_complexity_adaptation(config, "large")
@@ -187,7 +187,7 @@ def test_review_phase_dev_escalation_cli_to_api_updates_transport(
     config = _config(
         tmp_path,
         dev_profile=_profile_from("anthropic/sonnet/cli"),
-        models=["anthropic/sonnet/cli", "deepseek/deepseek-reasoner/api"],
+        models=["anthropic/sonnet/cli", "deepseek/deepseek-v4-pro/api"],
         retry=RetryPolicy(
             max_dev_iterations=2,
             max_review_cycles=3,
@@ -227,7 +227,7 @@ def test_review_phase_dev_escalation_cli_to_api_updates_transport(
 
     assert outcome is _ReviewOutcome.RETRY_DEV
     assert result is None
-    _assert_api_profile(updated.dev_profile, provider="deepseek", model="deepseek-reasoner")
+    _assert_api_profile(updated.dev_profile, provider="deepseek", model="deepseek-v4-pro")
 
 
 def test_plan_review_escalation_cli_to_api_updates_regen_profile(
@@ -239,7 +239,7 @@ def test_plan_review_escalation_cli_to_api_updates_regen_profile(
     config = _config(
         tmp_path,
         dev_profile=_profile_from("anthropic/sonnet/cli"),
-        models=["anthropic/sonnet/cli", "deepseek/deepseek-reasoner/api"],
+        models=["anthropic/sonnet/cli", "deepseek/deepseek-v4-pro/api"],
         retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=3, plan_escalation_threshold=1),
         plan_agent_review=PlanAgentReviewConfig.of(
             enabled=True,
@@ -298,4 +298,4 @@ def test_plan_review_escalation_cli_to_api_updates_regen_profile(
 
     assert result is None
     assert captured_profiles
-    _assert_api_profile(captured_profiles[0], provider="deepseek", model="deepseek-reasoner")
+    _assert_api_profile(captured_profiles[0], provider="deepseek", model="deepseek-v4-pro")

--- a/tests/test_profiles_migration.py
+++ b/tests/test_profiles_migration.py
@@ -116,8 +116,7 @@ def test_legacy_key_resolves_via_cli_suffix():
 
 def test_legacy_key_resolves_via_provider_model_concatenation():
     assert (
-        canonical_id_for_legacy_key("deepseek-deepseek-reasoner")
-        == "deepseek/deepseek-reasoner/api"
+        canonical_id_for_legacy_key("deepseek-deepseek-v4-pro") == "deepseek/deepseek-v4-pro/api"
     )
 
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -159,8 +159,13 @@ def test_axis_decision_reasoning_effort_without_score_records_fallback():
 def test_transport_support_metadata_classifies_every_known_runner():
     """Provider capability metadata lives in the routing SSOT, not in runners."""
     assert effort_knob_for("codex").kind == KNOB_EFFORT
+    # DeepSeek takes an effort string too: it expresses reasoning as a request
+    # parameter rather than as a distinct model name, and meters it back as
+    # reasoning tokens (#2352).
+    assert effort_knob_for("deepseek").kind == KNOB_EFFORT
+    assert effort_knob_for("deepseek").captures_thinking_spend is True
     assert effort_knob_for("google").kind == KNOB_BUDGET
-    for runner in ("claude", "gemini", "ghaw", "anthropic", "openai", "deepseek"):
+    for runner in ("claude", "gemini", "ghaw", "anthropic", "openai"):
         assert effort_knob_for(runner).kind == KNOB_NONE
     # An unknown or absent transport must opt in explicitly, never inherit a knob.
     assert effort_knob_for("brand-new-runner").kind == KNOB_NONE


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Cycle-3 review found the prior P1s fixed and no new blocking regression; focused coverage passed with 59 tests in tests/test_model_identity_verification.py. | [google-gemini-3.5-flash-api] All previous findings resolved. DeepSeek thinking-mode with tool loops and finalization successfully round-trip the reasoning_content on continuations, while retired identifiers are fully reserved. | [anthropic-claude-haiku-4-5-cli] Cycle-3 implementation comprehensively fixes all prior P1 findings and fully implements the spec; all five acceptance criteria are verified with concrete evidence and test coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** unknown (>= $52.22 measured)
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

A catalog entry names an upstream identifier the provider has retired, so a superseded model is selected and priced from a rate card that no longer applies (GitHub Issue #2352)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2352