### PR TITLE
A commit that merely mentions an issue number is accepted as evidence its branch merged, so an open story with preserved work is skipped as complete

### DIFF
--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -129,6 +129,31 @@ def has_review_approve(
     return False
 
 
+def latest_run_outcome(project_root: Path, slug: str) -> dict | None:
+    """Return the recorded outcome of the most recent run for ``slug``.
+
+    Read-only companion to :func:`has_review_approve`, which is a positive-only
+    signal (did *any* run APPROVE?). Merge-evidence resolution also needs the
+    negative case — the last run ended unsuccessfully with nothing landed — so
+    a textual commit-message match cannot claim a merge the audit trail
+    contradicts (#2374).
+
+    Returns ``None`` when the repo has no audit history at all or no record for
+    the slug. Substrate errors propagate: a caller that wants to treat an
+    unreadable audit as "no opinion" must catch them itself.
+    """
+    from theforge.coordinator import audit_substrate
+
+    sub_path = audit_substrate.substrate_path(project_root)
+    if not sub_path.exists() and not audit_substrate.has_audit_inputs(project_root):
+        return None
+    conn = audit_substrate.require_substrate(project_root)
+    try:
+        return audit_substrate.latest_run_outcome_in_substrate(conn, slug)
+    finally:
+        conn.close()
+
+
 def _serialize_plan_review_result(result: object, attempt: int) -> dict:
     profile_name = getattr(result, "profile_name", "") or "unknown"
     # Preserve an unmeasured cost (None) rather than coercing to 0.0 — a

--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -2088,6 +2088,38 @@ def has_review_approve_in_substrate(
             yield record
 
 
+def latest_run_outcome_in_substrate(
+    conn: sqlite3.Connection,
+    slug: str,
+) -> dict | None:
+    """Return the most recent run's recorded outcome fields for ``slug``.
+
+    Yields the three record-level dimensions merge-evidence resolution needs to
+    tell "this story landed" from "this story's last run ended badly":
+    ``outcome_success`` (1/0/None), ``verdict`` (run-level final review verdict)
+    and ``landing_status``. Returns ``None`` when no record exists for the slug.
+
+    Ordering is by ``started_at`` descending with ``run_id`` as a deterministic
+    tiebreak, so records written within the same timestamp resolve stably.
+    """
+    row = conn.execute(
+        "SELECT outcome_success, verdict, landing_status FROM audit_records "
+        "WHERE slug = ? ORDER BY started_at DESC, run_id DESC LIMIT 1",
+        (slug,),
+    ).fetchone()
+    if row is None:
+        return None
+    if isinstance(row, sqlite3.Row):
+        outcome, verdict, landing = row["outcome_success"], row["verdict"], row["landing_status"]
+    else:
+        outcome, verdict, landing = row[0], row[1], row[2]
+    return {
+        "outcome_success": outcome,
+        "verdict": verdict,
+        "landing_status": landing,
+    }
+
+
 def iter_records(conn: sqlite3.Connection, *, order_by_started: bool = True) -> Iterable[dict]:
     """Iterate raw_json dicts for all audit records."""
     sql = "SELECT raw_json, record_schema_version FROM audit_records"

--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -99,7 +99,7 @@ _COMMIT_RECORD_SEP = "\x1e"
 #: and checked for a closing reference.
 _MAX_COMMIT_SCAN = 200
 
-#: GitHub's closing keywords. Only these turn a ``#N`` reference into a claim
+#: GitHub's closing keywords. Only these turn an issue reference into a claim
 #: that the issue was completed by the commit; every other mention is a
 #: cross-reference, which is what cross-references are for.
 _CLOSING_KEYWORDS = (
@@ -114,6 +114,19 @@ _CLOSING_KEYWORDS = (
     "resolved",
 )
 
+#: The sigils GitHub accepts immediately before an issue number. Both the git
+#: prefilter and the authoritative Python matcher are built from this tuple, so
+#: a spelling can never be advertised by one and silently dropped by the other
+#: — the drift that made ``Closes GH-N`` unreachable at runtime. Neither entry
+#: may contain a regex metacharacter, since both are interpolated into an ERE
+#: (for ``git log --grep``) and a Python pattern unescaped.
+_REFERENCE_SIGILS = ("#", "GH-")
+
+
+def _reference_alternation() -> str:
+    """Return the ``#|GH-`` alternation shared by the prefilter and matcher."""
+    return "|".join(_REFERENCE_SIGILS)
+
 
 def _closing_reference_pattern(issue_number: int) -> re.Pattern[str]:
     """Return a matcher for an explicit closing reference to ``issue_number``.
@@ -125,10 +138,21 @@ def _closing_reference_pattern(issue_number: int) -> re.Pattern[str]:
     keywords = "|".join(_CLOSING_KEYWORDS)
     return re.compile(
         rf"\b(?:{keywords})\b\s*:?\s*"
-        rf"(?:[\w.-]+/[\w.-]+)?(?:#|GH-)"
+        rf"(?:[\w.-]+/[\w.-]+)?(?:{_reference_alternation()})"
         rf"{issue_number}(?![0-9])",
         re.IGNORECASE,
     )
+
+
+def _reference_grep_pattern(issue_number: int) -> str:
+    """Return the ``git log --grep`` ERE that retrieves every supported spelling.
+
+    This is only a prefilter — it narrows the commits git hands back, and
+    :func:`_closing_reference_pattern` decides. It must therefore be at least as
+    permissive as the matcher for every sigil in :data:`_REFERENCE_SIGILS`;
+    anything it drops the matcher never sees (#2374).
+    """
+    return f"({_reference_alternation()}){issue_number}"
 
 
 def _has_base_commit_closing_issue(
@@ -155,9 +179,14 @@ def _has_base_commit_closing_issue(
                 "git",
                 "log",
                 f"--format=%B{_COMMIT_RECORD_SEP}",
-                "--fixed-strings",
-                f"--grep=#{issue_number}",
-                # Bound the scan: ``--grep`` is a substring match, so a
+                # Extended regex + case-insensitive so the prefilter covers
+                # every sigil the matcher accepts (``#N`` and ``GH-N``, in any
+                # case). The issue number is an int, so nothing user-controlled
+                # reaches the pattern.
+                "--extended-regexp",
+                "--regexp-ignore-case",
+                f"--grep={_reference_grep_pattern(issue_number)}",
+                # Bound the scan: the prefilter is a substring match, so a
                 # low-numbered issue can match a great many commits. Missing a
                 # closing reference older than this window costs a re-run of a
                 # landed story; the opposite error discards live work.

--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import ForgeConfig
-from ..coordinator.audit import has_review_approve
+from ..coordinator.audit import has_review_approve, latest_run_outcome
 from ..coordinator.gate import _run_gate
 from ..coordinator.state import GateLabel
 from ..log_util import _log_line
@@ -91,38 +91,114 @@ def _has_prior_review_approve(
     )
 
 
-def _has_base_commit_referencing_issue(
+#: Record separator used to split ``git log`` output into whole commit messages.
+#: ``\x1e`` cannot appear in a commit message produced by git's own tooling.
+_COMMIT_RECORD_SEP = "\x1e"
+
+#: Most base-branch commits whose message mentions the issue that are read back
+#: and checked for a closing reference.
+_MAX_COMMIT_SCAN = 200
+
+#: GitHub's closing keywords. Only these turn a ``#N`` reference into a claim
+#: that the issue was completed by the commit; every other mention is a
+#: cross-reference, which is what cross-references are for.
+_CLOSING_KEYWORDS = (
+    "close",
+    "closes",
+    "closed",
+    "fix",
+    "fixes",
+    "fixed",
+    "resolve",
+    "resolves",
+    "resolved",
+)
+
+
+def _closing_reference_pattern(issue_number: int) -> re.Pattern[str]:
+    """Return a matcher for an explicit closing reference to ``issue_number``.
+
+    Matches GitHub's own closing syntax — ``fixes #12``, ``Closes GH-12``,
+    ``resolved owner/repo#12`` — and nothing else. The trailing boundary keeps
+    ``#12`` from matching inside ``#123``.
+    """
+    keywords = "|".join(_CLOSING_KEYWORDS)
+    return re.compile(
+        rf"\b(?:{keywords})\b\s*:?\s*"
+        rf"(?:[\w.-]+/[\w.-]+)?(?:#|GH-)"
+        rf"{issue_number}(?![0-9])",
+        re.IGNORECASE,
+    )
+
+
+def _has_base_commit_closing_issue(
     project_root: Path,
     base_branch: str,
     issue_number: int,
 ) -> bool:
-    """Return True when base has a commit message that references the issue.
+    """Return True when a base commit message *asserts* the issue was closed.
 
-    GitHub squash commits commonly preserve PR or issue references in the final
-    base-branch commit even though the branch tip is not topologically merged.
-    This git-level check catches externally merged branches that never produced
-    a forge APPROVE audit record.
+    GitHub squash commits commonly preserve the closing reference from the PR
+    body in the final base-branch commit even though the branch tip is not
+    topologically merged. This git-level check catches externally merged
+    branches that never produced a forge APPROVE audit record.
+
+    A bare mention (``disabled model X, see #12``) is deliberately *not*
+    evidence: a reference to a unit of work is not a statement that the work
+    landed, and treating it as one skipped open stories with preserved work
+    on the strength of unrelated configuration commits (#2374).
     """
+    pattern = _closing_reference_pattern(issue_number)
     try:
         result = subprocess.run(
             [
                 "git",
                 "log",
-                "--format=%H",
-                "--max-count=1",
+                f"--format=%B{_COMMIT_RECORD_SEP}",
                 "--fixed-strings",
-                f"--grep=(#{issue_number})",
+                f"--grep=#{issue_number}",
+                # Bound the scan: ``--grep`` is a substring match, so a
+                # low-numbered issue can match a great many commits. Missing a
+                # closing reference older than this window costs a re-run of a
+                # landed story; the opposite error discards live work.
+                f"--max-count={_MAX_COMMIT_SCAN}",
                 base_branch,
             ],
             cwd=str(project_root),
             capture_output=True,
             timeout=30,
         )
-        return result.returncode == 0 and bool(
-            result.stdout.decode("utf-8", errors="replace").strip()
-        )
+        if result.returncode != 0:
+            return False
+        messages = result.stdout.decode("utf-8", errors="replace").split(_COMMIT_RECORD_SEP)
+        return any(pattern.search(message) for message in messages)
     except (subprocess.TimeoutExpired, OSError):
         return False
+
+
+def _audit_contradicts_merge(project_root: Path, slug: str) -> bool:
+    """Return True when the last recorded run for ``slug`` says it did not land.
+
+    A recorded outcome of unsuccessful — or a final review verdict of
+    REQUEST_CHANGES — with no landing status is the run's own account of having
+    finished without landing. It is stronger evidence than prose in someone
+    else's commit message, so it vetoes the textual fallback (#2374).
+
+    Any audit-read failure returns False: an unreadable audit has no opinion and
+    must not silently invert into a veto.
+    """
+    try:
+        record = latest_run_outcome(project_root, slug)
+    except Exception:
+        return False
+    if record is None:
+        return False
+    landing = str(record.get("landing_status") or "").strip().lower()
+    if landing == "landed":
+        return False
+    verdict = str(record.get("verdict") or "").strip().upper()
+    outcome = record.get("outcome_success")
+    return outcome == 0 or verdict == "REQUEST_CHANGES"
 
 
 def _lookup_merged_pr_for_branch(
@@ -221,9 +297,10 @@ def _branch_merge_evidence(
        branch. Owned evidence is consulted before any external signal.
     2. Git topology — a regular merge, provable locally.
     3. GitHub's own record of a merged PR for the branch.
-    4. A base commit whose message references the issue. This is the loosest
-       signal (any commit mentioning ``(#N)`` matches), so it runs last, only
-       once every stronger source has declined.
+    4. A base commit whose message *closes* the issue. This is the weakest
+       signal — prose about the code rather than the code — so it runs last,
+       only once every stronger source has declined, and only when neither git
+       topology nor the audit trail contradicts it (#2374).
     """
     no_merge = MergeEvidence(merged=False)
     issue_number = _issue_number_from_slug(slug) if slug is not None else None
@@ -245,7 +322,10 @@ def _branch_merge_evidence(
             # evidence sources below — fall through rather than claim no_merge.
             pass
 
-    # 2. Git topology.
+    # 2. Git topology. ``branch_has_unique_work`` is retained for the veto in
+    # step 4: it is only meaningful for a *non*-ancestor branch, where unique
+    # commits prove the branch's work is absent from base.
+    branch_has_unique_work: bool | None = None
     try:
         merge_result = subprocess.run(
             ["git", "merge-base", "--is-ancestor", branch, base_branch],
@@ -253,7 +333,18 @@ def _branch_merge_evidence(
             capture_output=True,
             timeout=30,
         )
-        if merge_result.returncode == 0:
+        if merge_result.returncode != 0:
+            unique_result = subprocess.run(
+                ["git", "rev-list", f"{base_branch}..{branch}", "--count"],
+                cwd=str(project_root),
+                capture_output=True,
+                timeout=30,
+            )
+            if unique_result.returncode == 0:
+                branch_has_unique_work = (
+                    int(unique_result.stdout.decode("utf-8", errors="replace").strip() or "0") > 0
+                )
+        else:
             # Count commits in base_branch NOT reachable from branch.
             ahead_result = subprocess.run(
                 ["git", "rev-list", f"{branch}..{base_branch}", "--count"],
@@ -296,14 +387,24 @@ def _branch_merge_evidence(
     if merged_pr is not None:
         return merged_pr
 
-    # 4. Loosest signal last: a base commit message referencing the issue. The
+    # 4. Weakest signal last: a base commit message that closes the issue. The
     #    merged-PR lookup above already declined, so there is no PR metadata to
     #    attach here.
-    if issue_number is not None and _has_base_commit_referencing_issue(
-        project_root,
-        base_branch,
-        issue_number,
-    ):
+    #
+    #    Sources that describe the code beat sources that describe prose about
+    #    the code. A branch that is not an ancestor of base and still carries
+    #    unique commits has not landed, whatever a message says; and a last run
+    #    recorded as unsuccessful with nothing landed is not overridden by a
+    #    textual match (#2374). The ancestor case is left entirely to the
+    #    topology logic above — after a fast-forward merge the branch *is* an
+    #    ancestor with no unique work, which is a merge, not a veto.
+    if issue_number is None:
+        return no_merge
+    if branch_has_unique_work:
+        return no_merge
+    if slug is not None and _audit_contradicts_merge(project_root, slug):
+        return no_merge
+    if _has_base_commit_closing_issue(project_root, base_branch, issue_number):
         return MergeEvidence(merged=True, source="issue_commit")
 
     return no_merge
@@ -333,7 +434,7 @@ def _is_branch_merged(
        on base, but the squash commit on base is a new commit with no parent
        relationship to the branch. Git topology alone therefore cannot prove
        the merge, so the forge APPROVE audit trail (when slug is provided), a
-       merged PR for the branch, and finally a base commit referencing the
+       merged PR for the branch, and finally a base commit that *closes* the
        issue stand in for it.
 
     See :func:`_branch_merge_evidence` for the order these are consulted in and
@@ -550,6 +651,27 @@ def _branch_tip_sha(commits_ahead: list[str] | None) -> str | None:
     return head[0] if head else None
 
 
+def _merged_skip_reason(evidence: MergeEvidence, base_branch: str) -> str:
+    """Render a skip reason that names the evidence the skip rests on.
+
+    A skip discards preserved work, so it is reported as a skip and states what
+    produced it — an operator reading ``SKIP issue-N (...)`` can then contest
+    the specific claim instead of reading a bare "already merged" as completion
+    (#2374). Every source is named, including the weakest one.
+    """
+    if evidence.pr_number is not None:
+        detail = f"merged PR #{evidence.pr_number}"
+    elif evidence.source == "audit":
+        detail = "prior APPROVE in audit trail"
+    elif evidence.source == "topology":
+        detail = f"branch merged into {base_branch} history"
+    elif evidence.source == "issue_commit":
+        detail = f"closing reference in a {base_branch} commit message"
+    else:
+        detail = evidence.source or "unknown"
+    return f"already merged to {base_branch} (evidence: {detail})"
+
+
 def _triage_spec(
     story_path: str,
     config: ForgeConfig,
@@ -624,15 +746,10 @@ def _triage_spec(
     # for fast-forward merges where branch and base land on the same commit.
     merge_evidence = _branch_merge_evidence(branch, base_branch, project_root, slug=slug)
     if merge_evidence.merged:
-        merged_reason = f"already merged to {base_branch}"
-        if merge_evidence.pr_number is not None:
-            merged_reason = f"already merged in PR #{merge_evidence.pr_number}, skipping"
-        elif merge_evidence.source == "audit":
-            merged_reason = f"prior APPROVE in audit trail; already merged to {base_branch}"
         return StoryTriage(
             story_path=story_path,
             action="skip_merged",
-            reason=merged_reason,
+            reason=_merged_skip_reason(merge_evidence, base_branch),
             worktree_path=None,
             slug=slug,
         )

--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -205,6 +205,62 @@ def _has_base_commit_closing_issue(
         return False
 
 
+def _branch_adds_content_to_base(
+    project_root: Path,
+    base_branch: str,
+    branch: str,
+) -> bool:
+    """Return True when ``branch`` provably contributes content base does not have.
+
+    Git *topology* cannot tell a squash-merged branch from an unmerged one: both
+    leave the branch a non-ancestor of base with unique commits of its own. That
+    is the whole reason the issue-commit source exists, so topology must never
+    veto it — an earlier revision of this fix vetoed on non-ancestor-plus-unique-
+    commits and thereby suppressed every genuine squash merge whose branch still
+    existed (#2374).
+
+    Content does distinguish them. Merging ``branch`` into ``base_branch`` is a
+    no-op exactly when the branch's work is already present in base, whether it
+    got there by squash, rebase, or cherry-pick, and that holds even after base
+    advances with unrelated commits. ``git merge-tree --write-tree`` computes
+    that merge without touching the worktree.
+
+    Only a *positive* proof vetoes: this returns True solely when the merge
+    succeeds and yields a tree different from base's. Any inconclusive outcome —
+    a conflict, a git too old for ``--write-tree``, an unparseable oid, a
+    timeout — returns False, leaving the closing reference to stand. Failing the
+    other way would resurrect the regression this function exists to prevent,
+    and the reported bug is independently held shut by the closing-reference
+    requirement and :func:`_audit_contradicts_merge`.
+    """
+    try:
+        merged = subprocess.run(
+            ["git", "merge-tree", "--write-tree", base_branch, branch],
+            cwd=str(project_root),
+            capture_output=True,
+            timeout=30,
+        )
+        if merged.returncode != 0:
+            return False
+        merged_tree = merged.stdout.decode("utf-8", errors="replace").strip().splitlines()
+        if not merged_tree:
+            return False
+        base_tree = subprocess.run(
+            ["git", "rev-parse", f"{base_branch}^{{tree}}"],
+            cwd=str(project_root),
+            capture_output=True,
+            timeout=30,
+        )
+        if base_tree.returncode != 0:
+            return False
+        base_oid = base_tree.stdout.decode("utf-8", errors="replace").strip()
+        if not base_oid:
+            return False
+        return merged_tree[0].strip() != base_oid
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
 def _audit_contradicts_merge(project_root: Path, slug: str) -> bool:
     """Return True when the last recorded run for ``slug`` says it did not land.
 
@@ -351,10 +407,7 @@ def _branch_merge_evidence(
             # evidence sources below — fall through rather than claim no_merge.
             pass
 
-    # 2. Git topology. ``branch_has_unique_work`` is retained for the veto in
-    # step 4: it is only meaningful for a *non*-ancestor branch, where unique
-    # commits prove the branch's work is absent from base.
-    branch_has_unique_work: bool | None = None
+    # 2. Git topology.
     try:
         merge_result = subprocess.run(
             ["git", "merge-base", "--is-ancestor", branch, base_branch],
@@ -362,18 +415,7 @@ def _branch_merge_evidence(
             capture_output=True,
             timeout=30,
         )
-        if merge_result.returncode != 0:
-            unique_result = subprocess.run(
-                ["git", "rev-list", f"{base_branch}..{branch}", "--count"],
-                cwd=str(project_root),
-                capture_output=True,
-                timeout=30,
-            )
-            if unique_result.returncode == 0:
-                branch_has_unique_work = (
-                    int(unique_result.stdout.decode("utf-8", errors="replace").strip() or "0") > 0
-                )
-        else:
+        if merge_result.returncode == 0:
             # Count commits in base_branch NOT reachable from branch.
             ahead_result = subprocess.run(
                 ["git", "rev-list", f"{branch}..{base_branch}", "--count"],
@@ -421,15 +463,17 @@ def _branch_merge_evidence(
     #    attach here.
     #
     #    Sources that describe the code beat sources that describe prose about
-    #    the code. A branch that is not an ancestor of base and still carries
-    #    unique commits has not landed, whatever a message says; and a last run
-    #    recorded as unsuccessful with nothing landed is not overridden by a
-    #    textual match (#2374). The ancestor case is left entirely to the
-    #    topology logic above — after a fast-forward merge the branch *is* an
-    #    ancestor with no unique work, which is a merge, not a veto.
+    #    the code: a branch whose work is provably absent from base has not
+    #    landed whatever a message says, and a last run recorded as unsuccessful
+    #    with nothing landed is not overridden by a textual match (#2374).
+    #
+    #    The absence test is deliberately about *content*, not topology. A
+    #    squash-merged branch and an unmerged one are topologically identical
+    #    (non-ancestor, unique commits), so vetoing on that shape suppressed
+    #    exactly the squash merges this source exists to detect.
     if issue_number is None:
         return no_merge
-    if branch_has_unique_work:
+    if _branch_adds_content_to_base(project_root, base_branch, branch):
         return no_merge
     if slug is not None and _audit_contradicts_merge(project_root, slug):
         return no_merge

--- a/src/theforge/sprint/dag.py
+++ b/src/theforge/sprint/dag.py
@@ -91,6 +91,11 @@ def _has_prior_review_approve(
     )
 
 
+#: A git object id: 40 hex chars under sha1, 64 under sha256. Used to tell a
+#: tree oid on ``merge-tree``'s first output line from an error message, since
+#: both can accompany exit status 1.
+_OID_RE = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?")
+
 #: Record separator used to split ``git log`` output into whole commit messages.
 #: ``\x1e`` cannot appear in a commit message produced by git's own tooling.
 _COMMIT_RECORD_SEP = "\x1e"
@@ -225,13 +230,26 @@ def _branch_adds_content_to_base(
     advances with unrelated commits. ``git merge-tree --write-tree`` computes
     that merge without touching the worktree.
 
-    Only a *positive* proof vetoes: this returns True solely when the merge
-    succeeds and yields a tree different from base's. Any inconclusive outcome —
-    a conflict, a git too old for ``--write-tree``, an unparseable oid, a
-    timeout — returns False, leaving the closing reference to stand. Failing the
-    other way would resurrect the regression this function exists to prevent,
-    and the reported bug is independently held shut by the closing-reference
-    requirement and :func:`_audit_contradicts_merge`.
+    Only a *positive* proof vetoes, and a conflict is one. ``merge-tree`` exits
+    0 for a clean merge and 1 for a conflicted one; a conflict means base and
+    branch changed the same lines differently, so the branch's work as written
+    is demonstrably not what base carries. That is content evidence, not an
+    inconclusive result, and it vetoes (#2374).
+
+    Everything genuinely inconclusive returns False and leaves the closing
+    reference standing: a git too old for ``--write-tree`` (exit 129), an
+    unreadable ref, an unparseable oid, a timeout. A missing branch lands here
+    too, and needs care: ``merge-tree`` rejects an unknown ref with exit 1 —
+    the *same* status as a conflict — writing "not something we can merge" to
+    stderr and nothing to stdout. So the exit code alone cannot separate the
+    two; a merge that actually ran is identified by the tree oid on its first
+    stdout line. That distinction matters, because an externally merged branch
+    that was then deleted has no evidence left *but* the closing reference.
+
+    One accepted false negative: a branch squash-merged long ago whose files
+    base has since rewritten conflicts on replay and is vetoed. That re-runs a
+    landed story, which is the safe direction — the failure this whole change
+    exists to prevent is discarding live work.
     """
     try:
         merged = subprocess.run(
@@ -240,11 +258,18 @@ def _branch_adds_content_to_base(
             capture_output=True,
             timeout=30,
         )
-        if merged.returncode != 0:
+        # 0 = clean merge, 1 = conflict, anything else = could not run.
+        if merged.returncode not in (0, 1):
             return False
         merged_tree = merged.stdout.decode("utf-8", errors="replace").strip().splitlines()
-        if not merged_tree:
+        if not merged_tree or not _OID_RE.fullmatch(merged_tree[0].strip()):
+            # No tree oid on the first line: git refused the merge rather than
+            # performing one, so nothing was proved either way. Today an
+            # unknown ref yields empty stdout; the oid check also covers a
+            # refusal that writes some other diagnostic there.
             return False
+        if merged.returncode == 1:
+            return True
         base_tree = subprocess.run(
             ["git", "rev-parse", f"{base_branch}^{{tree}}"],
             cwd=str(project_root),

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -34,6 +34,18 @@ from theforge.task import TaskStory
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
+def _is_issue_grep(cmd: list[str], issue_number: int) -> bool:
+    """True when ``cmd`` is the base-commit closing-reference scan for the issue.
+
+    Matches on the presence of a ``--grep=`` argument mentioning the issue
+    rather than its exact spelling, so these mocks do not silently stop
+    matching when the prefilter pattern changes (#2374).
+    """
+    return cmd[:2] == ["git", "log"] and any(
+        c.startswith("--grep=") and str(issue_number) in c for c in cmd
+    )
+
+
 def _make_config(tmp_path: Path) -> ForgeConfig:
     return ForgeConfig(
         project="test",
@@ -436,7 +448,7 @@ class TestReadPriorSprintCost:
                     '[{"number":1111,"url":"https://github.com/o/r/pull/1111",'
                     '"mergedAt":"2026-05-01T12:34:56Z"}]'
                 )
-            elif cmd[:2] == ["git", "log"] and "--grep=(#1102)" in cmd:
+            elif _is_issue_grep(cmd, 1102):
                 m.returncode = 0
                 m.stdout = b""
             elif "log" in cmd:
@@ -600,7 +612,7 @@ class TestReadPriorSprintCost:
 
         def _mock_run(cmd, **kwargs):
             m = MagicMock()
-            if cmd[:2] == ["git", "log"] and "--grep=#1072" in cmd:
+            if _is_issue_grep(cmd, 1072):
                 m.returncode = 0
                 m.stdout = b"fix(sprint): land it\n\nCloses #1072\n\x1e"
             elif "log" in cmd:
@@ -657,7 +669,7 @@ class TestReadPriorSprintCost:
 
         def _mock_run(cmd, **kwargs):
             m = MagicMock()
-            if cmd[:2] == ["git", "log"] and "--grep=#1074" in cmd:
+            if _is_issue_grep(cmd, 1074):
                 m.returncode = 0
                 m.stdout = b"config: raise timeout, disable model\n\nContext: #1074\n\x1e"
             elif cmd[:2] == ["git", "log"]:

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -461,7 +461,7 @@ class TestReadPriorSprintCost:
             triage = _triage_spec("issue-1102.md", config, tmp_path)
 
         assert triage.action == "skip_merged"
-        assert triage.reason == "already merged in PR #1111, skipping"
+        assert triage.reason == "already merged to main (evidence: merged PR #1111)"
 
     def test_triage_same_tip_failed_landing_audit_stays_full(self, tmp_path: Path) -> None:
         """A zero-delta APPROVE with failed landing stays eligible during resume."""
@@ -590,19 +590,19 @@ class TestReadPriorSprintCost:
         assert triage.action == "skip_merged"
         assert "audit trail" in triage.reason
 
-    def test_triage_open_issue_with_base_commit_reference_skips_merged(
+    def test_triage_open_issue_with_base_commit_closing_reference_skips_merged(
         self, tmp_path: Path
     ) -> None:
-        """A base commit referencing the open issue is enough to skip (#2111)."""
+        """A base commit *closing* the open issue is enough to skip (#2111, #2374)."""
 
         _make_spec_file(tmp_path, "Issue 1072", "issue-1072")
         config = _make_config(tmp_path)
 
         def _mock_run(cmd, **kwargs):
             m = MagicMock()
-            if cmd[:2] == ["git", "log"] and "--grep=(#1072)" in cmd:
+            if cmd[:2] == ["git", "log"] and "--grep=#1072" in cmd:
                 m.returncode = 0
-                m.stdout = b"abc123\n"
+                m.stdout = b"fix(sprint): land it\n\nCloses #1072\n\x1e"
             elif "log" in cmd:
                 m.returncode = 0
                 m.stdout = b""
@@ -625,7 +625,67 @@ class TestReadPriorSprintCost:
             triage = _triage_spec("issue-1072.md", config, tmp_path)
 
         assert triage.action == "skip_merged"
-        assert triage.reason == "already merged to main"
+        assert triage.reason == (
+            "already merged to main (evidence: closing reference in a main commit message)"
+        )
+
+    def test_triage_bare_issue_mention_with_preserved_work_does_not_skip(
+        self, tmp_path: Path
+    ) -> None:
+        """The #2374 shape end-to-end: a passing mention must not discard preserved work.
+
+        Base carries an unrelated configuration commit citing the issue as
+        context. The branch is not an ancestor of base, has five commits of
+        preserved work, and its last recorded run was unsuccessful with a
+        REQUEST_CHANGES verdict and no landing. Every authoritative source says
+        the story has not landed, so triage must not skip it.
+        """
+
+        _make_spec_file(tmp_path, "Issue 1074", "issue-1074")
+        config = _make_config(tmp_path)
+        worktree = tmp_path / "issue-1074"
+        worktree.mkdir()
+
+        record = {
+            "task": {"slug": "issue-1074"},
+            "run_id": "sr-1074",
+            "landing_status": "",
+            "outcome": {"success": False},
+            "reviews": [{"verdict": "REQUEST_CHANGES"}],
+        }
+        audit_substrate.seed_records(tmp_path, [record])
+
+        def _mock_run(cmd, **kwargs):
+            m = MagicMock()
+            if cmd[:2] == ["git", "log"] and "--grep=#1074" in cmd:
+                m.returncode = 0
+                m.stdout = b"config: raise timeout, disable model\n\nContext: #1074\n\x1e"
+            elif cmd[:2] == ["git", "log"]:
+                m.returncode = 0
+                m.stdout = b"aaa1 five\nbbb2 four\nccc3 three\nddd4 two\neee5 one\n"
+            elif "rev-list" in cmd and "--count" in cmd:
+                m.returncode = 0
+                m.stdout = b"5"
+            elif "--is-ancestor" in cmd:
+                m.returncode = 1
+                m.stdout = b""
+            else:
+                m.returncode = 0
+                m.stdout = b""
+            return m
+
+        with (
+            patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_run),
+            patch("theforge.sprint.dag.has_review_approve", return_value=False),
+            patch(
+                "theforge.sprint.dag._run_gate",
+                return_value=("dev", "gate failed", ""),
+            ),
+        ):
+            triage = _triage_spec("issue-1074.md", config, tmp_path)
+
+        assert triage.action != "skip_merged"
+        assert "merged" not in triage.reason
 
     def test_triage_open_issue_with_topology_merge_skips_merged(self, tmp_path: Path) -> None:
         """A topologically merged branch skips even while its issue is open (#2111)."""
@@ -659,7 +719,9 @@ class TestReadPriorSprintCost:
             triage = _triage_spec("issue-1073.md", config, tmp_path)
 
         assert triage.action == "skip_merged"
-        assert triage.reason == "already merged to main"
+        assert triage.reason == (
+            "already merged to main (evidence: branch merged into main history)"
+        )
 
     def test_triage_worktree_with_prior_approve(self, tmp_path: Path) -> None:
         """Worktree has commits ahead and prior APPROVE in audit trail → skip."""

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -28,6 +28,7 @@ from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phas
 from theforge.sprint.dag import (
     StoryDAG,
     _branch_merge_evidence,
+    _has_base_commit_closing_issue,
     _is_branch_merged,
     build_dag,
     resolve_satisfied_dependencies,
@@ -682,6 +683,19 @@ def test_is_branch_merged_not_ancestor_without_audit(tmp_path: Path) -> None:
     assert result is False
 
 
+def _is_issue_grep(cmd: list[str], issue_number: int) -> bool:
+    """True when ``cmd`` is the base-commit scan for ``issue_number``.
+
+    Matches on the presence of a ``--grep=`` argument mentioning the issue
+    rather than on its exact spelling: the prefilter pattern is an
+    implementation detail, and pinning it here would make these mocks agree
+    with a prefilter that no longer matches what git is actually asked.
+    """
+    return cmd[:2] == ["git", "log"] and any(
+        c.startswith("--grep=") and str(issue_number) in c for c in cmd
+    )
+
+
 def _mock_base_commit(message: bytes, issue_number: int = 265):
     """Git mock: branch is not an ancestor, base carries ``message`` for the issue."""
 
@@ -690,7 +704,7 @@ def _mock_base_commit(message: bytes, issue_number: int = 265):
         if "--is-ancestor" in cmd:
             m.returncode = 1
             m.stdout = b""
-        elif cmd[:2] == ["git", "log"] and f"--grep=#{issue_number}" in cmd:
+        elif _is_issue_grep(cmd, issue_number):
             m.returncode = 0
             m.stdout = message
         else:
@@ -826,6 +840,50 @@ def test_branch_merge_evidence_landed_audit_does_not_veto_closing_reference(
         evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
     assert evidence.merged is True
     assert evidence.source == "issue_commit"
+
+
+def _init_repo_with_commit(path: Path, message: str) -> None:
+    """Create a real single-branch git repo whose HEAD commit carries ``message``."""
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "README.md").write_text("seed\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", message], cwd=path, check=True)
+
+
+@pytest.mark.parametrize(
+    ("message", "issue_number", "expected"),
+    [
+        # Every spelling the matcher advertises must survive the git prefilter.
+        ("fix: land it\n\nCloses #265", 265, True),
+        ("fix: land it\n\nCloses GH-265", 265, True),
+        ("fix: land it\n\ncloses gh-265", 265, True),
+        ("fix: land it\n\nResolves owner/repo#265", 265, True),
+        ("fix: land it\n\nFixes: #265", 265, True),
+        # Bare mentions are not evidence.
+        ("config: disable model\n\nDisabled pending #265", 265, False),
+        ("feat: thing (#265)", 265, False),
+        # Adjacent issue numbers must not collide.
+        ("fix: other\n\nCloses #2650", 265, False),
+        ("fix: other\n\nCloses GH-2650", 265, False),
+    ],
+)
+def test_has_base_commit_closing_issue_against_real_git(
+    tmp_path: Path, message: str, issue_number: int, expected: bool
+) -> None:
+    """Exercise the real ``git log`` prefilter, not a mock of it (#2374).
+
+    The prefilter and the Python matcher are two separate patterns over the
+    same message. A mocked ``subprocess.run`` cannot catch them disagreeing —
+    which is exactly how ``Closes GH-N`` came to be advertised by the matcher
+    while the ``--fixed-strings --grep=#N`` prefilter dropped it before the
+    matcher ever ran.
+    """
+    _init_repo_with_commit(tmp_path, message)
+    assert _has_base_commit_closing_issue(tmp_path, "main", issue_number) is expected
 
 
 def test_branch_merge_evidence_audit_veto_reads_real_substrate(tmp_path: Path) -> None:

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -766,30 +766,127 @@ def test_is_branch_merged_closing_reference_for_other_issue_does_not_match(
     assert evidence.merged is False
 
 
-def test_branch_merge_evidence_unique_commits_veto_closing_reference(tmp_path: Path) -> None:
-    """A non-ancestor branch with unique work has not landed, whatever base says (#2374)."""
+def _git(path: Path, *args: str) -> None:
+    import subprocess
 
-    def _mock_ahead(cmd: list[str], **kwargs: object) -> MagicMock:
-        m = MagicMock()
-        if "--is-ancestor" in cmd:
-            m.returncode = 1
-            m.stdout = b""
-        elif cmd[:2] == ["git", "rev-list"] and cmd[2] == "main..feat/issue-265":
-            m.returncode = 0
-            m.stdout = b"5"  # five preserved development commits
-        elif cmd[:2] == ["git", "log"] and "--grep=#265" in cmd:
-            m.returncode = 0
-            m.stdout = b"chore: sweep\n\nCloses #265\n\x1e"
-        else:
-            m.returncode = 0
-            m.stdout = b""
-        return m
+    subprocess.run(["git", *args], cwd=path, check=True, capture_output=True)
 
+
+def _seed_repo(path: Path) -> None:
+    _git(path, "init", "-q", "-b", "main")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+    (path / "README.md").write_text("seed\n")
+    _git(path, "add", ".")
+    _git(path, "commit", "-q", "-m", "seed")
+
+
+def _squash_merged_repo(path: Path, base_message: str) -> None:
+    """Real squash merge: branch survives with unique commits, work is on base.
+
+    This is the shape ``git merge-base --is-ancestor`` fails on while
+    ``git rev-list main..branch`` is non-zero — topologically indistinguishable
+    from an unmerged branch, which is why this evidence source exists.
+    """
+    _seed_repo(path)
+    _git(path, "checkout", "-q", "-b", "feat/issue-265")
+    for i in (1, 2):
+        (path / f"w{i}.txt").write_text(f"work {i}\n")
+        _git(path, "add", ".")
+        _git(path, "commit", "-q", "-m", f"wip {i}")
+    _git(path, "checkout", "-q", "main")
+    _git(path, "merge", "-q", "--squash", "feat/issue-265")
+    _git(path, "commit", "-q", "-m", base_message)
+
+
+def _unmerged_repo(path: Path, base_message: str) -> None:
+    """The reported shape: five preserved commits, none of that work on base."""
+    _seed_repo(path)
+    _git(path, "checkout", "-q", "-b", "feat/issue-265")
+    for i in range(1, 6):
+        (path / f"w{i}.txt").write_text(f"work {i}\n")
+        _git(path, "add", ".")
+        _git(path, "commit", "-q", "-m", f"wip {i}")
+    _git(path, "checkout", "-q", "main")
+    (path / "config.yml").write_text("timeout: 30\n")
+    _git(path, "add", ".")
+    _git(path, "commit", "-q", "-m", base_message)
+
+
+def _real_git_evidence(tmp_path: Path):
+    """Resolve merge evidence against real git, with only external deps mocked."""
     with (
-        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_ahead),
+        patch("theforge.sprint.dag._lookup_merged_pr_for_branch", return_value=None),
         patch("theforge.sprint.dag.has_review_approve", return_value=False),
     ):
-        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+        return _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+
+
+def test_real_squash_merge_with_closing_reference_is_merged(tmp_path: Path) -> None:
+    """A real squash merge is detected even though the branch still has unique commits.
+
+    Regression for the cycle-2 P1: vetoing on non-ancestor-plus-unique-commits
+    suppressed every genuine squash merge whose source branch still existed,
+    which is exactly what the issue-commit source is for. Topology cannot tell
+    this repo from the unmerged one below; only content can.
+    """
+    _squash_merged_repo(tmp_path, "feat: the thing (#900)\n\nCloses #265")
+
+    evidence = _real_git_evidence(tmp_path)
+
+    assert evidence.merged is True
+    assert evidence.source == "issue_commit"
+
+
+def test_real_unmerged_branch_with_closing_reference_is_not_merged(tmp_path: Path) -> None:
+    """A closing reference does not land work that is absent from base.
+
+    Same topology as the squash repo above — non-ancestor, unique commits — but
+    the branch's files are genuinely not on base, so the content veto fires.
+    """
+    _unmerged_repo(tmp_path, "chore: sweep\n\nCloses #265")
+
+    evidence = _real_git_evidence(tmp_path)
+
+    assert evidence.merged is False
+
+
+def test_real_unmerged_branch_with_bare_mention_is_not_merged(tmp_path: Path) -> None:
+    """The reported incident, end to end against real git (#2374)."""
+    _unmerged_repo(
+        tmp_path,
+        "config: raise timeout, disable model\n\nDisabled pending #265",
+    )
+
+    evidence = _real_git_evidence(tmp_path)
+
+    assert evidence.merged is False
+
+
+def test_real_squash_merge_vetoed_by_unsuccessful_audit(tmp_path: Path) -> None:
+    """A recorded unsuccessful run with nothing landed still outranks the text.
+
+    Content alone would accept this repo — the work *is* on base — so this pins
+    the audit veto specifically, not the content check.
+    """
+    _squash_merged_repo(tmp_path, "feat: the thing (#900)\n\nCloses #265")
+    from theforge.coordinator import audit_substrate
+
+    audit_substrate.seed_records(
+        tmp_path,
+        [
+            {
+                "task": {"slug": "issue-265"},
+                "run_id": "sr-265",
+                "landing_status": "",
+                "outcome": {"success": False},
+                "reviews": [{"verdict": "REQUEST_CHANGES"}],
+            }
+        ],
+    )
+
+    evidence = _real_git_evidence(tmp_path)
+
     assert evidence.merged is False
 
 
@@ -944,7 +1041,7 @@ def test_is_branch_merged_external_squash_merge_by_merged_pr_lookup(tmp_path: Pa
         if "--is-ancestor" in cmd:
             m.returncode = 1
             m.stdout = b""
-        elif cmd[:2] == ["git", "log"] and "--grep=(#1102)" in cmd:
+        elif _is_issue_grep(cmd, 1102):
             m.returncode = 0
             m.stdout = b""
         elif cmd[:3] == ["gh", "pr", "list"]:
@@ -975,7 +1072,7 @@ def test_is_branch_merged_issue_branch_without_base_commit_or_audit(tmp_path: Pa
         if "--is-ancestor" in cmd:
             m.returncode = 1
             m.stdout = b""
-        elif cmd[:2] == ["git", "log"] and "--grep=(#265)" in cmd:
+        elif _is_issue_grep(cmd, 265):
             m.returncode = 0
             m.stdout = b""
         else:

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -27,6 +27,7 @@ from theforge.config.types import IntakeConfig
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.sprint.dag import (
     StoryDAG,
+    _branch_adds_content_to_base,
     _branch_merge_evidence,
     _has_base_commit_closing_issue,
     _is_branch_merged,
@@ -861,6 +862,76 @@ def test_real_unmerged_branch_with_bare_mention_is_not_merged(tmp_path: Path) ->
     evidence = _real_git_evidence(tmp_path)
 
     assert evidence.merged is False
+
+
+def test_merge_tree_refusal_on_stdout_is_not_read_as_a_conflict(tmp_path: Path) -> None:
+    """Exit 1 with a non-oid first line is a refusal, not a conflict.
+
+    Today git writes "not something we can merge" to stderr and leaves stdout
+    empty, so this shape cannot be produced from a real repo — it is mocked
+    deliberately. It guards the branch of the exit-1 check that the real-git
+    deleted-branch test cannot reach.
+    """
+
+    def _mock_refusal(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        if cmd[:2] == ["git", "merge-tree"]:
+            m.returncode = 1
+            m.stdout = b"merge-tree: nosuch - not something we can merge\n"
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    with patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_refusal):
+        assert _branch_adds_content_to_base(tmp_path, "main", "feat/issue-265") is False
+
+
+def _conflicting_repo(path: Path, base_message: str) -> None:
+    """Unmerged branch that edits the same lines base edits, so replay conflicts."""
+    _seed_repo(path)
+    (path / "f.txt").write_text("one\n")
+    _git(path, "add", ".")
+    _git(path, "commit", "-q", "-m", "add f")
+    _git(path, "checkout", "-q", "-b", "feat/issue-265")
+    (path / "f.txt").write_text("branch side\n")
+    _git(path, "add", ".")
+    _git(path, "commit", "-q", "-m", "branch edit")
+    _git(path, "checkout", "-q", "main")
+    (path / "f.txt").write_text("base side\n")
+    _git(path, "add", ".")
+    _git(path, "commit", "-q", "-m", base_message)
+
+
+def test_real_conflicting_unmerged_branch_is_not_merged(tmp_path: Path) -> None:
+    """A conflict is content evidence of divergence, not an inconclusive result.
+
+    Regression for the cycle-3 P1: treating every non-zero ``merge-tree`` exit
+    as "cannot determine" let a conflicting, definitively unmerged branch be
+    skipped on the strength of a closing reference in a base commit.
+    """
+    _conflicting_repo(tmp_path, "fix: base side wins\n\nCloses #265")
+
+    evidence = _real_git_evidence(tmp_path)
+
+    assert evidence.merged is False
+
+
+def test_real_deleted_branch_with_closing_reference_is_merged(tmp_path: Path) -> None:
+    """A missing branch must not be mistaken for a conflict.
+
+    ``merge-tree`` reports an unknown ref with exit 1 — the same status as a
+    conflict — so only the tree-oid check separates them. An externally merged
+    branch that was then deleted has no evidence left but the closing
+    reference, and vetoing it here would discard that entirely.
+    """
+    _seed_repo(tmp_path)
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "feat: landed\n\nCloses #265")
+
+    evidence = _real_git_evidence(tmp_path)
+
+    assert evidence.merged is True
+    assert evidence.source == "issue_commit"
 
 
 def test_real_squash_merge_vetoed_by_unsuccessful_audit(tmp_path: Path) -> None:

--- a/tests/test_sprint_runner.py
+++ b/tests/test_sprint_runner.py
@@ -682,28 +682,200 @@ def test_is_branch_merged_not_ancestor_without_audit(tmp_path: Path) -> None:
     assert result is False
 
 
-def test_is_branch_merged_external_squash_merge_by_issue_commit(tmp_path: Path) -> None:
-    """A GitHub squash commit referencing the issue counts even without audit."""
+def _mock_base_commit(message: bytes, issue_number: int = 265):
+    """Git mock: branch is not an ancestor, base carries ``message`` for the issue."""
 
-    def _mock_external_squash(cmd: list[str], **kwargs: object) -> MagicMock:
+    def _run(cmd: list[str], **kwargs: object) -> MagicMock:
         m = MagicMock()
         if "--is-ancestor" in cmd:
             m.returncode = 1
             m.stdout = b""
-        elif cmd[:2] == ["git", "log"] and "--grep=(#265)" in cmd:
+        elif cmd[:2] == ["git", "log"] and f"--grep=#{issue_number}" in cmd:
             m.returncode = 0
-            m.stdout = b"abc123\n"
+            m.stdout = message
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    return _run
+
+
+def test_is_branch_merged_external_squash_merge_by_closing_reference(tmp_path: Path) -> None:
+    """A GitHub squash commit that *closes* the issue counts even without audit."""
+
+    with (
+        patch(
+            "theforge.sprint.dag.subprocess.run",
+            side_effect=_mock_base_commit(b"fix(sprint): tighten evidence\n\nCloses #265\n\x1e"),
+        ),
+        patch("theforge.sprint.dag._is_issue_closed", return_value=True),
+    ):
+        result = _is_branch_merged("feat/issue-265", "main", tmp_path)
+    assert result is True
+
+
+def test_is_branch_merged_bare_issue_mention_is_not_merge_evidence(tmp_path: Path) -> None:
+    """A commit that merely mentions the issue is not evidence its branch merged (#2374).
+
+    The commit below is the shape that caused the bug: a configuration change
+    citing an unrelated open issue as context for a separate decision.
+    """
+
+    with (
+        patch(
+            "theforge.sprint.dag.subprocess.run",
+            side_effect=_mock_base_commit(
+                b"config: raise timeout and disable model\n\nDisabled pending #265\n\x1e"
+            ),
+        ),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
+    ):
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+    assert evidence.merged is False
+    assert evidence.source is None
+
+
+def test_is_branch_merged_closing_reference_for_other_issue_does_not_match(
+    tmp_path: Path,
+) -> None:
+    """``Closes #2650`` must not satisfy issue 265 — the digits are a prefix."""
+
+    with (
+        patch(
+            "theforge.sprint.dag.subprocess.run",
+            side_effect=_mock_base_commit(b"fix: other thing\n\nCloses #2650\n\x1e"),
+        ),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
+    ):
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+    assert evidence.merged is False
+
+
+def test_branch_merge_evidence_unique_commits_veto_closing_reference(tmp_path: Path) -> None:
+    """A non-ancestor branch with unique work has not landed, whatever base says (#2374)."""
+
+    def _mock_ahead(cmd: list[str], **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        if "--is-ancestor" in cmd:
+            m.returncode = 1
+            m.stdout = b""
+        elif cmd[:2] == ["git", "rev-list"] and cmd[2] == "main..feat/issue-265":
+            m.returncode = 0
+            m.stdout = b"5"  # five preserved development commits
+        elif cmd[:2] == ["git", "log"] and "--grep=#265" in cmd:
+            m.returncode = 0
+            m.stdout = b"chore: sweep\n\nCloses #265\n\x1e"
         else:
             m.returncode = 0
             m.stdout = b""
         return m
 
     with (
-        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_external_squash),
-        patch("theforge.sprint.dag._is_issue_closed", return_value=True),
+        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_ahead),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
     ):
-        result = _is_branch_merged("feat/issue-265", "main", tmp_path)
-    assert result is True
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+    assert evidence.merged is False
+
+
+def test_branch_merge_evidence_unsuccessful_audit_vetoes_closing_reference(
+    tmp_path: Path,
+) -> None:
+    """An unsuccessful last run with nothing landed outranks a textual match (#2374)."""
+
+    with (
+        patch(
+            "theforge.sprint.dag.subprocess.run",
+            side_effect=_mock_base_commit(b"chore: sweep\n\nCloses #265\n\x1e"),
+        ),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
+        patch(
+            "theforge.sprint.dag.latest_run_outcome",
+            return_value={
+                "outcome_success": 0,
+                "verdict": "REQUEST_CHANGES",
+                "landing_status": "",
+            },
+        ),
+    ):
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+    assert evidence.merged is False
+
+
+def test_branch_merge_evidence_landed_audit_does_not_veto_closing_reference(
+    tmp_path: Path,
+) -> None:
+    """A landed prior run is not a contradiction, so the closing reference stands."""
+
+    with (
+        patch(
+            "theforge.sprint.dag.subprocess.run",
+            side_effect=_mock_base_commit(b"chore: sweep\n\nCloses #265\n\x1e"),
+        ),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
+        patch(
+            "theforge.sprint.dag.latest_run_outcome",
+            return_value={
+                "outcome_success": 1,
+                "verdict": "APPROVE",
+                "landing_status": "landed",
+            },
+        ),
+    ):
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+    assert evidence.merged is True
+    assert evidence.source == "issue_commit"
+
+
+def test_branch_merge_evidence_audit_veto_reads_real_substrate(tmp_path: Path) -> None:
+    """The audit veto works end-to-end against a seeded substrate, not just a mock.
+
+    Topology here is squash-merge-shaped (not an ancestor, no unique commits) so
+    it cannot veto on its own — the recorded unsuccessful outcome must.
+    """
+    from theforge.coordinator import audit_substrate
+
+    audit_substrate.seed_records(
+        tmp_path,
+        [
+            {
+                "task": {"slug": "issue-265"},
+                "run_id": "sr-265",
+                "landing_status": "",
+                "outcome": {"success": False},
+                "reviews": [{"verdict": "REQUEST_CHANGES"}],
+            }
+        ],
+    )
+
+    with (
+        patch(
+            "theforge.sprint.dag.subprocess.run",
+            side_effect=_mock_base_commit(b"chore: sweep\n\nCloses #265\n\x1e"),
+        ),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
+    ):
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+    assert evidence.merged is False
+
+
+def test_branch_merge_evidence_audit_read_failure_does_not_veto(tmp_path: Path) -> None:
+    """An unreadable audit has no opinion — it must not invert into a veto."""
+
+    with (
+        patch(
+            "theforge.sprint.dag.subprocess.run",
+            side_effect=_mock_base_commit(b"chore: sweep\n\nCloses #265\n\x1e"),
+        ),
+        patch("theforge.sprint.dag.has_review_approve", return_value=False),
+        patch(
+            "theforge.sprint.dag.latest_run_outcome",
+            side_effect=OSError("audit unreadable"),
+        ),
+    ):
+        evidence = _branch_merge_evidence("feat/issue-265", "main", tmp_path, slug="issue-265")
+    assert evidence.merged is True
 
 
 def test_is_branch_merged_external_squash_merge_by_merged_pr_lookup(tmp_path: Path) -> None:
@@ -768,21 +940,11 @@ def test_is_branch_merged_open_issue_does_not_block_merge_evidence(tmp_path: Pat
     lands, so issue state is not a precondition for detecting the merge.
     """
 
-    def _mock_external_squash(cmd: list[str], **kwargs: object) -> MagicMock:
-        m = MagicMock()
-        if "--is-ancestor" in cmd:
-            m.returncode = 1
-            m.stdout = b""
-        elif cmd[:2] == ["git", "log"] and "--grep=(#265)" in cmd:
-            m.returncode = 0
-            m.stdout = b"abc123\n"
-        else:
-            m.returncode = 0
-            m.stdout = b""
-        return m
-
     with (
-        patch("theforge.sprint.dag.subprocess.run", side_effect=_mock_external_squash),
+        patch(
+            "theforge.sprint.dag.subprocess.run",
+            side_effect=_mock_base_commit(b"fix: land it\n\nCloses #265\n\x1e"),
+        ),
         patch("theforge.sprint.dag._is_issue_closed", return_value=False),
         patch("theforge.sprint.dag.has_review_approve", return_value=False),
     ):


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior P1s are resolved; the latest iteration adds the conflict veto without introducing a blocking regression. | [google-gemini-3.5-flash-api] Verified all previous cycle P1 findings resolved with no new regressions or defects introduced.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** unknown (>= $20.65 measured)
- **Dev iterations:** 4
- **Tests:** N/A

## Findings

_No findings._

## Story

A commit that merely mentions an issue number is accepted as evidence its branch merged, so an open story with preserved work is skipped as complete (GitHub Issue #2374)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2374