### PR TITLE
A model priced in project configuration is absent from the accounting table, so it routes as priced and records its spend as unknown

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -588,6 +588,29 @@ A `models.custom` declaration stands alone: it does not inherit from a shipped
 entry, and replacing a shipped identity requires `override: true` alongside the
 definition.
 
+**A declared price is the price that gets recorded.** The `cost:` figures are
+read once, at load, into a rate registry keyed by
+`(provider, model, transport.kind)`, and every run prices its tokens from the
+identity it actually dispatched on. Declaring a price is all that is needed for
+that model's spend to be measured — no code change, no second table to update.
+
+Two consequences worth knowing:
+
+- **A price belongs to one transport.** `openai/gpt-5.5/cli` and
+  `openai/gpt-5.5/api` are different identities and are priced separately. If
+  you price one and dispatch on the other, the unpriced one records cost as
+  unknown — it does not borrow its sibling's rate, because the two genuinely
+  bill differently often enough that guessing is worse than saying nothing.
+- **You are told before you spend.** Any model the configuration can dispatch
+  on — seated profile, adaptive-pool candidate, `fallback_models` entry, or
+  `api_fallback` target — that cannot be priced is warned about when the config
+  loads, naming the paths it is reachable on. `forge check-config` shows these
+  in its WARNINGS section. The load does not fail: an unpriced model still runs
+  and records its cost as unknown.
+
+Transports that report their own spend (the Claude CLI's billed total, gh-aw's
+AI-credit accounting) need no `cost:` block and are never warned about.
+
 **Existing configuration keeps loading.** The flat `models.custom` form below
 and inline `models.enabled` mappings written before this schema existed are
 translated into it at the parse boundary — adopting the canonical shape is

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -607,6 +607,12 @@ Two consequences worth knowing:
   loads, naming the paths it is reachable on. `forge check-config` shows these
   in its WARNINGS section. The load does not fail: an unpriced model still runs
   and records its cost as unknown.
+- **A `fallback_models` entry is checked as an API identity, even on a CLI
+  profile.** That is where it actually runs: the failures that trigger a model
+  fallback are quota exhaustion and model-not-found, which the CLI that just
+  refused would only reproduce, so forge retries through the provider's API
+  adapter. Price the fallback on `<provider>/<model>/api`, not on the CLI
+  identity the primary uses.
 
 Transports that report their own spend (the Claude CLI's billed total, gh-aw's
 AI-credit accounting) need no `cost:` block and are never warned about.

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -2209,17 +2209,22 @@ def _thinking_spend_captured(profile: ModelProfile, knob: EffortKnob) -> bool:
 
     Two independent facts, both required: the transport's accounting path must
     fold thinking tokens into the priced total (``knob.captures_thinking_spend``),
-    *and* the selected model must have a rate card — a model with none records
-    cost-unknown, which is precisely "spend not captured". Asked through
-    ``pricing_for`` rather than by indexing ``PRICING_TABLE``, so a model priced
-    from its catalog entry counts exactly like one priced from the table (#2352).
-    Imported lazily so this module stays import-time pure.
+    *and* the identity that will actually dispatch must be accountable.
+
+    "Accountable" is asked of the registry, not of pricing-table membership
+    (#2335). Membership was a proxy for something it does not measure in both
+    directions: a provider-reporting transport captures thinking spend with no
+    static rate card at all, and a transport that reports no usage does not
+    capture it even when a rate card exists. The lookup is keyed by
+    ``(provider, model, transport)``, so a model priced on one transport is not
+    read as accountable on another. Imported lazily so this module stays
+    import-time pure.
     """
     if not knob.captures_thinking_spend:
         return False
-    from .runners.schema_utils import pricing_for  # noqa: PLC0415
+    from .runners.rate_registry import entry_for_profile  # noqa: PLC0415
 
-    return pricing_for(profile.provider_family or "", profile.model) is not None
+    return entry_for_profile(profile).accountable
 
 
 def _apply_effort_to_profile(

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -2222,7 +2222,7 @@ def _thinking_spend_captured(profile: ModelProfile, knob: EffortKnob) -> bool:
     """
     if not knob.captures_thinking_spend:
         return False
-    from .runners.rate_registry import entry_for_profile  # noqa: PLC0415
+    from .runners.schema_utils import entry_for_profile  # noqa: PLC0415
 
     return entry_for_profile(profile).accountable
 

--- a/src/theforge/config/dispatch_rates.py
+++ b/src/theforge/config/dispatch_rates.py
@@ -1,0 +1,381 @@
+"""Compile the identity-keyed rate registry from a loaded configuration (#2335).
+
+This is the half of the fix that lives at configuration load: the merged model
+registry — the very specs routing reads its prices from — is consumed ONCE into
+a :class:`~theforge.runners.rate_registry.RateRegistry`, and every accounting
+site thereafter looks the dispatched identity up in that registry. One
+declaration of a model's cost therefore serves both the decision to use it and
+the record of what using it cost.
+
+Three things happen here, in order:
+
+1. **Compile.** Every ``AgentSpec`` in the merged registry yields an entry keyed
+   by ``(provider, model, transport.kind)``. Because the key includes the
+   transport, the same model offered over CLI and API no longer collides — the
+   ambiguity-drop ``_catalog_rates`` performs does not apply and is not
+   reproduced (the merged dict is itself keyed by canonical id, so two specs
+   cannot collide on one identity by construction).
+
+2. **Materialize legacy prices.** The packaged, transport-agnostic
+   :data:`PRICING_TABLE` keeps working by being resolved onto concrete
+   transport identities *here*, under three restrictions spelled out in
+   :func:`_materialize_legacy_rates`. This is what replaces a transport-agnostic
+   fallback tier at query time, and it is why a CLI price an operator declared
+   can never become the API path's price.
+
+3. **Report.** Identities the configuration can actually dispatch on but cannot
+   account for are warned about at load, naming the paths they are reachable on,
+   rather than discovered as a cost-unknown after the spend has happened.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from theforge.runners.rate_registry import (
+    AccountingMode,
+    DispatchIdentity,
+    RateEntry,
+    RateRegistry,
+    RateSource,
+    accounting_mode_for,
+    make_identity,
+)
+
+from .model_identity import AgentSpec, canonical_model_id
+
+log = logging.getLogger("theforge.config")
+
+
+@dataclass(frozen=True)
+class ReachableIdentity:
+    """An identity this configuration can dispatch on, and how it gets there."""
+
+    identity: DispatchIdentity
+    runner: str | None
+    paths: tuple[str, ...] = ()
+
+
+@dataclass
+class _Reach:
+    runner: str | None = None
+    paths: list[str] = field(default_factory=list)
+
+
+# ── Enumeration of dispatchable identities ────────────────────────────
+
+
+def _add(
+    found: dict[DispatchIdentity, _Reach],
+    identity: DispatchIdentity | None,
+    runner: str | None,
+    path: str,
+) -> None:
+    if identity is None:
+        return
+    reach = found.setdefault(identity, _Reach())
+    if reach.runner is None:
+        reach.runner = runner
+    if path not in reach.paths:
+        reach.paths.append(path)
+
+
+def _profile_identities(
+    found: dict[DispatchIdentity, _Reach],
+    profile: object,
+    path: str,
+) -> None:
+    """Record the primary, model-fallback and transport-fallback identities.
+
+    A profile can reach a runner as three different billed identities and each
+    one is priced separately: its primary model, any ``fallback_models`` entry
+    tried on quota/not-found failure (same provider and transport, different
+    model), and its ``api_fallback`` target (same provider, API transport,
+    possibly a different model identifier).
+    """
+    if profile is None:
+        return
+    provider = getattr(profile, "provider_family", None)
+    kind = getattr(profile, "mode", None)
+    transport = getattr(profile, "transport", None)
+    runner = getattr(transport, "runner", None)
+    _add(found, make_identity(provider, getattr(profile, "model", None), kind), runner, path)
+    for fallback_model in getattr(profile, "fallback_models", ()) or ():
+        _add(
+            found,
+            make_identity(provider, fallback_model, kind),
+            runner,
+            f"{path} (model fallback)",
+        )
+    api_fallback = getattr(profile, "api_fallback", None)
+    if api_fallback is not None:
+        fb_transport = None
+        try:
+            fb_transport = api_fallback.transport()
+        except Exception:  # pragma: no cover - defensive: malformed fallback
+            fb_transport = None
+        _add(
+            found,
+            make_identity(
+                getattr(api_fallback, "provider", None),
+                getattr(api_fallback, "model", None),
+                "api",
+            ),
+            getattr(fb_transport, "runner", None),
+            f"{path} (transport fallback)",
+        )
+
+
+def reachable_identities(config: object) -> tuple[ReachableIdentity, ...]:
+    """Every identity the loaded configuration can dispatch on.
+
+    Computed once and used for BOTH the legacy-materialization target
+    restriction and the load-time report, so what is widened and what is
+    reported are derived from one list rather than two enumerations that can
+    drift apart.
+    """
+    found: dict[DispatchIdentity, _Reach] = {}
+
+    _profile_identities(found, getattr(config, "dev_profile", None), "dev")
+    _profile_identities(found, getattr(config, "preflight_profile", None), "preflight")
+    for entry in getattr(config, "review_pool", None) or ():
+        _profile_identities(found, entry, f"review pool ({entry.name})")
+    _profile_identities(found, getattr(config, "synthesis_profile", None), "synthesis")
+
+    plan = getattr(config, "plan", None)
+    if plan is not None and getattr(plan, "enabled", False):
+        _profile_identities(found, plan, "plan")
+    plan_agent_review = getattr(config, "plan_agent_review", None)
+    if plan_agent_review is not None and getattr(plan_agent_review, "enabled", False):
+        for entry in getattr(plan_agent_review, "profiles", None) or ():
+            _profile_identities(found, entry, f"plan review ({entry.name})")
+    for entry in getattr(config, "agents", None) or ():
+        _profile_identities(found, entry, f"agent ({entry.name})")
+
+    # Adaptive routing selects from the whole registry, so with it enabled every
+    # registered identity is genuinely reachable — narrowing to the seated
+    # profiles here is exactly the omission that let an adaptive-pool candidate
+    # dispatch unpriced.
+    assignment = getattr(config, "assignment", None)
+    if assignment is not None and getattr(assignment, "adaptive_enabled", False):
+        for canonical_id, spec in (getattr(config, "model_registry", None) or {}).items():
+            _add(
+                found,
+                make_identity(spec.provider, spec.model, spec.transport.kind),
+                spec.transport.runner,
+                f"adaptive pool ({canonical_id})",
+            )
+
+    return tuple(
+        ReachableIdentity(identity=identity, runner=reach.runner, paths=tuple(reach.paths))
+        for identity, reach in sorted(found.items(), key=lambda item: item[0].label)
+    )
+
+
+# ── Compilation ───────────────────────────────────────────────────────
+
+
+def _spec_rates(spec: AgentSpec):  # -> ModelRates | None
+    """The rate card an ``AgentSpec`` declares, honouring attribution rules."""
+    from theforge.runners.schema_utils import ModelRates  # noqa: PLC0415
+
+    from .pricing import PRICING_PROVENANCE_LOCAL_ENDPOINT  # noqa: PLC0415
+
+    if spec.input_cost_per_mtok is None or spec.output_cost_per_mtok is None:
+        return None
+    if not spec.pricing_attributable:
+        return None
+    if spec.pricing_provenance == PRICING_PROVENANCE_LOCAL_ENDPOINT:
+        # A local endpoint's 0.00 is true of the *endpoint*, not of the model
+        # name — the runners already zero a genuinely local invocation by
+        # base_url, so importing the figure here would only mis-price the rest.
+        return None
+    return ModelRates(
+        input_per_mtok=spec.input_cost_per_mtok,
+        output_per_mtok=spec.output_cost_per_mtok,
+        cached_input_per_mtok=spec.cached_input_cost_per_mtok,
+    )
+
+
+def _materialize_legacy_rates(
+    entries: dict[DispatchIdentity, RateEntry],
+    reachable: tuple[ReachableIdentity, ...],
+    project_priced: set[tuple[str, str]],
+) -> set[DispatchIdentity]:
+    """Widen packaged transport-agnostic prices onto concrete identities.
+
+    Three restrictions, each closing one way a price could reach an identity it
+    was never recorded for:
+
+    (a) **Source.** Materialization draws ONLY from the packaged
+        :data:`PRICING_TABLE`. A project-declared per-transport entry never
+        widens to another transport — that is the reported failure (a model
+        priced on the CLI lending its rate to the API path) and it is refused
+        structurally, not by convention.
+    (b) **Target.** A legacy price is materialized only onto an identity this
+        configuration can actually dispatch on. Entries that resolve onto no
+        reachable identity are dropped; nothing unscoped enters the registry.
+    (c) **Conflict.** Materialization is refused for a ``(provider, model)``
+        that carries any project-declared per-transport price. A genuine
+        per-transport disagreement must surface at load, not be resolved by
+        borrowing either figure.
+
+    Returns the identities whose widening rule (c) suppressed, so the load-time
+    report can name the conflict as the operator-actionable case it is.
+    """
+    from theforge.runners.schema_utils import PRICING_TABLE, ModelRates  # noqa: PLC0415
+
+    conflicted: set[DispatchIdentity] = set()
+    for reach in reachable:
+        identity = reach.identity
+        existing = entries.get(identity)
+        if existing is not None and (
+            existing.priced or existing.mode is AccountingMode.INDEPENDENTLY_MEASURED
+        ):
+            continue
+        legacy = PRICING_TABLE.get((identity.provider, identity.model))
+        if legacy is None:
+            continue
+        if (identity.provider, identity.model) in project_priced:
+            conflicted.add(identity)
+            continue
+        mode = accounting_mode_for(identity.transport, reach.runner)
+        origin = f"PRICING_TABLE[{identity.provider}/{identity.model}]"
+        entries[identity] = RateEntry(
+            identity=identity,
+            rates=ModelRates(input_per_mtok=legacy[0], output_per_mtok=legacy[1]),
+            mode=mode,
+            source=RateSource.LEGACY_COMPAT,
+            origin=origin,
+        )
+        log.info(
+            "Pricing %s from the packaged rate table (%s): no per-transport entry declares it.",
+            identity.label,
+            origin,
+        )
+    return conflicted
+
+
+def compile_rate_registry(
+    model_registry: dict[str, AgentSpec],
+    reachable: tuple[ReachableIdentity, ...],
+) -> tuple[RateRegistry, set[DispatchIdentity]]:
+    """Build the registry for one configuration.
+
+    Returns ``(registry, conflicted)`` where ``conflicted`` names identities
+    whose legacy widening was suppressed by a per-transport pricing conflict.
+    """
+    entries: dict[DispatchIdentity, RateEntry] = {}
+    project_priced: set[tuple[str, str]] = set()
+
+    from .pricing import PRICING_PROVENANCE_LOCAL_ENDPOINT  # noqa: PLC0415
+
+    for canonical_id, spec in (model_registry or {}).items():
+        identity = make_identity(spec.provider, spec.model, spec.transport.kind)
+        if identity is None:  # pragma: no cover - AgentSpec cannot be partial
+            continue
+        rates = _spec_rates(spec)
+        is_project = spec.registry_source == "forge.yaml"
+        if spec.pricing_provenance == PRICING_PROVENANCE_LOCAL_ENDPOINT:
+            # A local endpoint's spend IS measured — the runners record 0.00 for
+            # it from base_url, with no rate card involved. Recording it as
+            # rate-estimated would make the load-time report announce that a
+            # genuinely free, already-measured identity cannot be accounted for.
+            entries[identity] = RateEntry(
+                identity=identity,
+                rates=None,
+                mode=AccountingMode.INDEPENDENTLY_MEASURED,
+                source=RateSource.NONE,
+                origin=canonical_id,
+            )
+            continue
+        if rates is not None and is_project:
+            project_priced.add((identity.provider, identity.model))
+        entries[identity] = RateEntry(
+            identity=identity,
+            rates=rates,
+            mode=accounting_mode_for(spec.transport.kind, spec.transport.runner),
+            source=(
+                (RateSource.PROJECT if is_project else RateSource.CATALOG)
+                if rates is not None
+                else RateSource.NONE
+            ),
+            origin=canonical_id
+            or canonical_model_id(spec.provider, spec.model, spec.transport.kind),
+        )
+
+    conflicted = _materialize_legacy_rates(entries, reachable, project_priced)
+
+    # Every reachable identity gets an entry even when it is unpriced, so its
+    # accounting mode survives the lookup and the report can classify it.
+    for reach in reachable:
+        if reach.identity in entries:
+            continue
+        entries[reach.identity] = RateEntry(
+            identity=reach.identity,
+            rates=None,
+            mode=accounting_mode_for(reach.identity.transport, reach.runner),
+            source=RateSource.NONE,
+        )
+
+    registry = RateRegistry(
+        entries=entries,
+        reachable={reach.identity: reach.paths for reach in reachable},
+    )
+    return registry, conflicted
+
+
+def report_unaccountable_identities(
+    registry: RateRegistry,
+    reachable: tuple[ReachableIdentity, ...],
+    conflicted: set[DispatchIdentity],
+) -> list[str]:
+    """Warn once per dispatchable identity whose spend could not be accounted for.
+
+    Warn-and-name rather than raise: an unpriced model is allowed to run and
+    record its cost as unknown, so refusing the load would be a behaviour change
+    beyond the bug. ``check-config`` captures ``theforge.config`` warnings into
+    its own WARNINGS section, so this reaches the operator on every entry point.
+    """
+    messages: list[str] = []
+    for reach in reachable:
+        entry = registry.lookup(reach.identity)
+        reason = entry.unaccountable_reason()
+        if reason is None:
+            continue
+        if reach.identity in conflicted:
+            reason = (
+                f"{reach.identity.provider}/{reach.identity.model} is priced on another "
+                f"transport but dispatched on {reach.identity.transport} with no "
+                f"{reach.identity.transport} price — a per-transport pricing conflict "
+                "suppressed the packaged fallback rather than borrowing the other "
+                "transport's rate"
+            )
+        paths = ", ".join(reach.paths) or "unknown path"
+        message = (
+            f"Cost cannot be accounted for {reach.identity.label}: {reason}. "
+            f"Reachable on: {paths}. Runs on this identity will record cost as unknown. "
+            "Declare input_cost_per_mtok/output_cost_per_mtok (with pricing_provenance) "
+            "on this model's entry to fix it."
+        )
+        messages.append(message)
+        log.warning("%s", message)
+    return messages
+
+
+def install_rate_registry(config: object) -> RateRegistry:
+    """Compile, install and report the rate registry for a loaded config.
+
+    Called once, after the ``ForgeConfig`` is fully constructed and validated,
+    so a load that raises never leaves its partial rates installed.
+    """
+    from theforge.runners import rate_registry as _rate_registry  # noqa: PLC0415
+
+    reachable = reachable_identities(config)
+    registry, conflicted = compile_rate_registry(
+        getattr(config, "model_registry", None) or {}, reachable
+    )
+    _rate_registry.install(registry)
+    report_unaccountable_identities(registry, reachable, conflicted)
+    return registry

--- a/src/theforge/config/dispatch_rates.py
+++ b/src/theforge/config/dispatch_rates.py
@@ -46,7 +46,7 @@ from theforge.runners.rate_registry import (
     make_identity,
 )
 
-from .model_identity import AgentSpec, canonical_model_id
+from .model_identity import AgentSpec, canonical_model_id, model_fallback_transport
 
 log = logging.getLogger("theforge.config")
 
@@ -93,9 +93,17 @@ def _profile_identities(
 
     A profile can reach a runner as three different billed identities and each
     one is priced separately: its primary model, any ``fallback_models`` entry
-    tried on quota/not-found failure (same provider and transport, different
-    model), and its ``api_fallback`` target (same provider, API transport,
-    possibly a different model identifier).
+    tried on quota/not-found failure, and its ``api_fallback`` target (same
+    provider, API transport, possibly a different model identifier).
+
+    A ``fallback_models`` entry dispatches on the transport
+    :func:`model_fallback_transport` names, NOT on the primary's transport. For
+    an API profile those coincide; for a CLI profile they do not — the runner
+    sends the fallback through the provider's API adapter, because the failure
+    that triggered it (quota exhausted, model not found) is one the CLI would
+    just reproduce. Enumerating it under the CLI transport meant the identity
+    that could actually run unpriced was never the one named at load, and the
+    API identity it really dispatches was never checked at all.
     """
     if profile is None:
         return
@@ -104,30 +112,40 @@ def _profile_identities(
     transport = getattr(profile, "transport", None)
     runner = getattr(transport, "runner", None)
     _add(found, make_identity(provider, getattr(profile, "model", None), kind), runner, path)
-    for fallback_model in getattr(profile, "fallback_models", ()) or ():
-        _add(
-            found,
-            make_identity(provider, fallback_model, kind),
-            runner,
-            f"{path} (model fallback)",
-        )
+    fallback_models = getattr(profile, "fallback_models", ()) or ()
+    # None when the provider has no API adapter: no model fallback can be
+    # attempted at all, so those entries name no reachable identity and are not
+    # enumerated (target restriction, rule b).
+    model_fb_transport = model_fallback_transport(provider) if fallback_models else None
+    if model_fb_transport is not None:
+        for fallback_model in fallback_models:
+            _add(
+                found,
+                make_identity(provider, fallback_model, model_fb_transport.kind),
+                model_fb_transport.runner,
+                f"{path} (model fallback)",
+            )
     api_fallback = getattr(profile, "api_fallback", None)
     if api_fallback is not None:
-        fb_transport = None
+        # Read the transport off the same TransportFallbackConfig.transport()
+        # the runner dispatches through (runners/cli.py:_build_api_fallback_profile)
+        # rather than assuming "api" here — one definition of where it goes, for
+        # the same reason the model-fallback transport is not assumed above.
         try:
             fb_transport = api_fallback.transport()
         except Exception:  # pragma: no cover - defensive: malformed fallback
             fb_transport = None
-        _add(
-            found,
-            make_identity(
-                getattr(api_fallback, "provider", None),
-                getattr(api_fallback, "model", None),
-                "api",
-            ),
-            getattr(fb_transport, "runner", None),
-            f"{path} (transport fallback)",
-        )
+        if fb_transport is not None:
+            _add(
+                found,
+                make_identity(
+                    getattr(api_fallback, "provider", None),
+                    getattr(api_fallback, "model", None),
+                    fb_transport.kind,
+                ),
+                fb_transport.runner,
+                f"{path} (transport fallback)",
+            )
 
 
 def reachable_identities(config: object) -> tuple[ReachableIdentity, ...]:

--- a/src/theforge/config/dispatch_rates.py
+++ b/src/theforge/config/dispatch_rates.py
@@ -34,12 +34,15 @@ import logging
 from dataclasses import dataclass, field
 
 from theforge.runners.rate_registry import (
+    PRICING_TABLE,
     AccountingMode,
     DispatchIdentity,
+    ModelRates,
     RateEntry,
     RateRegistry,
     RateSource,
     accounting_mode_for,
+    install,
     make_identity,
 )
 
@@ -176,10 +179,8 @@ def reachable_identities(config: object) -> tuple[ReachableIdentity, ...]:
 # ── Compilation ───────────────────────────────────────────────────────
 
 
-def _spec_rates(spec: AgentSpec):  # -> ModelRates | None
+def _spec_rates(spec: AgentSpec) -> ModelRates | None:
     """The rate card an ``AgentSpec`` declares, honouring attribution rules."""
-    from theforge.runners.schema_utils import ModelRates  # noqa: PLC0415
-
     from .pricing import PRICING_PROVENANCE_LOCAL_ENDPOINT  # noqa: PLC0415
 
     if spec.input_cost_per_mtok is None or spec.output_cost_per_mtok is None:
@@ -224,8 +225,6 @@ def _materialize_legacy_rates(
     Returns the identities whose widening rule (c) suppressed, so the load-time
     report can name the conflict as the operator-actionable case it is.
     """
-    from theforge.runners.schema_utils import PRICING_TABLE, ModelRates  # noqa: PLC0415
-
     conflicted: set[DispatchIdentity] = set()
     for reach in reachable:
         identity = reach.identity
@@ -370,12 +369,10 @@ def install_rate_registry(config: object) -> RateRegistry:
     Called once, after the ``ForgeConfig`` is fully constructed and validated,
     so a load that raises never leaves its partial rates installed.
     """
-    from theforge.runners import rate_registry as _rate_registry  # noqa: PLC0415
-
     reachable = reachable_identities(config)
     registry, conflicted = compile_rate_registry(
         getattr(config, "model_registry", None) or {}, reachable
     )
-    _rate_registry.install(registry)
+    install(registry)
     report_unaccountable_identities(registry, reachable, conflicted)
     return registry

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -1807,4 +1807,13 @@ def load_config(config_path: Path) -> ForgeConfig:
     # Configuration identity is derived here, once, from the fully-resolved
     # config (#2056) — consumers record what the run executed under instead of
     # each re-deriving it (or, as before, recording nothing at all).
-    return dataclasses.replace(config, provenance=build_provenance(config, config_path))
+    config = dataclasses.replace(config, provenance=build_provenance(config, config_path))
+    # Pricing is resolved ONCE, here, from the same merged registry routing reads
+    # its figures from, into a process-level registry every accounting site
+    # consults by the identity that actually dispatched (#2335). Installed only
+    # after the ForgeConfig is fully constructed, so a load that raises during
+    # validation never leaves partial rates active; last install wins.
+    from .dispatch_rates import install_rate_registry  # noqa: PLC0415
+
+    install_rate_registry(config)
+    return config

--- a/src/theforge/config/model_identity.py
+++ b/src/theforge/config/model_identity.py
@@ -255,6 +255,36 @@ def transport_for(provider: str, kind: str, runner: str | None = None) -> Transp
     return TransportSpec(kind="api", runner=api_runner)
 
 
+def model_fallback_transport(provider: str | None) -> TransportSpec | None:
+    """The transport a ``fallback_models`` entry actually dispatches on.
+
+    Always the provider's API transport, whichever transport the *primary* uses,
+    and both dispatch paths agree on that:
+
+    - An API profile retries the next model on its own API transport
+      (``runners/api.py`` replaces only ``model``).
+    - A CLI profile's fallback entries are sent through the provider's API
+      adapter (``runners/cli.py:_build_cli_fallback_api_profile``). A CLI failure
+      that triggers a model fallback is a quota or model-not-found refusal, so
+      retrying on the CLI that just refused would reproduce it.
+
+    Returns ``None`` when the provider has no API adapter — no fallback can be
+    attempted at all, so that entry names no reachable identity.
+
+    This function exists so the runner that builds the fallback profile and the
+    load-time enumeration that prices it read ONE definition of the rule. They
+    disagreed before: load reported a CLI profile's fallback entries as CLI
+    identities while the runner dispatched them on the API, so the identity that
+    could actually run unpriced was never the one named (#2335).
+    """
+    if not provider:
+        return None
+    try:
+        return transport_for(provider, "api")
+    except ValueError:
+        return None
+
+
 @dataclass(frozen=True)
 class AgentSpec(AttributablePricing):
     """First-class description of an agent: canonical identity + routing policy.

--- a/src/theforge/config/models.py
+++ b/src/theforge/config/models.py
@@ -56,6 +56,7 @@ from .model_identity import custom_model_dev_capable as custom_model_dev_capable
 from .model_identity import is_canonical_model_id as is_canonical_model_id
 from .model_identity import known_model_overlay_providers as known_model_overlay_providers
 from .model_identity import mirror_fields_for_transport as mirror_fields_for_transport
+from .model_identity import model_fallback_transport as model_fallback_transport
 from .model_identity import overlay_transport as overlay_transport
 from .model_identity import provider_for_cli_runner as provider_for_cli_runner
 from .model_identity import provider_for_transport as provider_for_transport

--- a/src/theforge/runners/adapters/anthropic.py
+++ b/src/theforge/runners/adapters/anthropic.py
@@ -67,6 +67,7 @@ def _run_anthropic(
             profile.model,
             response.usage.input_tokens,
             response.usage.output_tokens,
+            transport="api",
         )
         model_usage = ModelUsage(
             model=profile.model,

--- a/src/theforge/runners/adapters/google.py
+++ b/src/theforge/runners/adapters/google.py
@@ -116,6 +116,7 @@ def _make_google_usage(profile: "ModelProfile", usage: Any) -> ModelUsage | None
             profile.model,
             input_tokens,
             output_tokens,
+            transport="api",
             thinking_tokens=thinking_tokens,
         ),
         thinking_tokens=thinking_tokens,
@@ -149,6 +150,7 @@ def _merge_google_usage(
             profile.model,
             input_tokens,
             output_tokens,
+            transport="api",
             thinking_tokens=thinking_tokens,
         ),
         thinking_tokens=thinking_tokens,
@@ -246,6 +248,7 @@ def _run_google(
             profile.model,
             input_tokens,
             output_tokens,
+            transport="api",
             thinking_tokens=thinking_tokens,
         )
         model_usage: ModelUsage | None = None

--- a/src/theforge/runners/adapters/openai.py
+++ b/src/theforge/runners/adapters/openai.py
@@ -126,6 +126,7 @@ def _openai_result(
         profile.model,
         input_tokens,
         output_tokens,
+        transport="api",
         thinking_tokens=thinking_tokens,
         cached_input_tokens=cache_read_tokens,
     )

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -160,7 +160,14 @@ class _UsageAccumulator:
         self.cache_read_tokens += usage.cache_read_tokens
         self.cache_creation_tokens += usage.cache_creation_tokens
 
-    def to_model_usage(self, model: str, provider: str) -> ModelUsage:
+    def to_model_usage(self, model: str, provider: str, transport: str = "api") -> ModelUsage:
+        """Price the accumulated usage for the identity that ran.
+
+        ``transport`` defaults to ``"api"`` because this accumulator only ever
+        runs inside the API agent loop; it is named rather than assumed so the
+        rate lookup identifies ``(provider, model, transport)`` and can never
+        borrow a CLI-declared price for the same model name (#2335).
+        """
         # The accumulated cache-read count is passed through, not just recorded:
         # a provider that bills prompt-cache hits at a distinct rate only gets
         # that rate applied if the estimator is told how many hits there were.
@@ -176,6 +183,7 @@ class _UsageAccumulator:
             model,
             self.input_tokens,
             self.output_tokens,
+            transport=transport,
             thinking_tokens=self.thinking_tokens,
             cached_input_tokens=cached_input_tokens,
         )

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -24,7 +24,7 @@ from theforge.log_level import LogLevel
 from theforge.log_util import _log_line
 
 from ..config import ModelProfile
-from ..config.models import transport_for
+from ..config.models import model_fallback_transport
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -295,13 +295,14 @@ def _build_cli_fallback_api_profile(
     The provider is the profile's own provider family — a transport fallback
     never changes provider. Returns None when the profile has no provider
     identity or the provider has no API adapter.
+
+    The transport comes from :func:`model_fallback_transport`, which is the same
+    function the load-time pricing enumeration reads, so what gets dispatched
+    here and what gets priced and reported at load cannot disagree (#2335).
     """
     provider = profile.provider_family
-    if not provider:
-        return None
-    try:
-        transport = transport_for(provider, "api")
-    except ValueError:
+    transport = model_fallback_transport(provider)
+    if transport is None:
         return None
     return replace(
         profile,

--- a/src/theforge/runners/rate_registry.py
+++ b/src/theforge/runners/rate_registry.py
@@ -1,0 +1,384 @@
+"""One resolved rate card per dispatched identity, keyed by what actually ran.
+
+Pricing used to be resolved twice from two different surfaces: routing read the
+figures declared on the model registry, accounting read a table compiled into
+:mod:`theforge.runners.schema_utils`. A model present in the first and absent
+from the second routed as priced and recorded its spend as unknown (#2335).
+
+The fix inverts the direction of resolution. Nothing *carries* a rate. One
+registry is compiled at configuration load, keyed by :class:`DispatchIdentity` —
+``(provider, model, transport)``, the same triple that forms a canonical model
+id — and every accounting site looks up the identity that ACTUALLY RAN at the
+moment it prices tokens. That is why no candidate-construction path has to be
+converted and none can be missed: a profile produced by ``dataclasses.replace``,
+by ``apply_model_info``, by a transport fallback or by the adaptive router is
+priced by what it dispatched, not by what it was seated as.
+
+**The lookup never crosses transports.** Every key in a compiled registry is a
+concrete ``(provider, model, transport)``. An exact miss is unpriced, full stop.
+Cross-transport reuse of a legacy, transport-agnostic price exists only as a
+COMPILE-TIME materialization (see :mod:`theforge.config.dispatch_rates`) that is
+recorded on the entry as :attr:`RateSource.LEGACY_COMPAT` with the key it came
+from, so it is inspectable rather than implicit at query time. That is what stops
+a model priced by the operator on the CLI from silently lending its price to the
+same model reached over the API.
+
+Deliberately stdlib-only at module scope. :class:`ModelRates` and
+:func:`pricing_for` live in ``schema_utils`` and are imported lazily where the
+no-registry baseline needs them, so ``schema_utils`` may import this module but
+never the reverse at import time.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from theforge.config.types import ModelProfile
+
+    from .schema_utils import ModelRates
+
+logger = logging.getLogger(__name__)
+
+
+class AccountingMode(str, Enum):
+    """How — and whether — spend on a transport can be established at all.
+
+    Static rates and measurable spend are different questions, and conflating
+    them is half of #2335: the Claude CLI reports a billed total and needs no
+    rate card, while the Gemini CLI carries perfectly good catalog rates and
+    reports nothing to multiply them by on most invocations.
+    """
+
+    #: The transport reports a price it was billed (Claude CLI's total_cost_usd).
+    PROVIDER_REPORTED = "provider_reported"
+    #: The transport measures spend by its own means, independent of any rate
+    #: card (gh-aw converts AI-credit consumption).
+    INDEPENDENTLY_MEASURED = "independently_measured"
+    #: Spend is token count × rate card. No rates means no cost record.
+    TOKEN_ESTIMATED = "token_estimated"
+    #: Token count × rate card *when the transport reports a token count at all*.
+    #: The Gemini CLI reports usage on some invocations and not others; where it
+    #: does not, cost stays unknown rather than being fabricated.
+    TOKEN_ESTIMATED_IF_REPORTED = "token_estimated_if_reported"
+    #: Nothing observable to price. Recorded so it is reported, not guessed at.
+    UNMEASURABLE = "unmeasurable"
+    #: Not classified — an identity that never went through a compiled registry.
+    UNKNOWN = "unknown"
+
+    @property
+    def needs_rates(self) -> bool:
+        """Does an absent rate card make this transport's spend unrecordable?"""
+        return self in (
+            AccountingMode.TOKEN_ESTIMATED,
+            AccountingMode.TOKEN_ESTIMATED_IF_REPORTED,
+        )
+
+    @property
+    def measures_without_rates(self) -> bool:
+        """Does this transport record spend whether or not a rate card exists?"""
+        return self in (
+            AccountingMode.PROVIDER_REPORTED,
+            AccountingMode.INDEPENDENTLY_MEASURED,
+        )
+
+
+class RateSource(str, Enum):
+    """Where an entry's figures came from — reported, never inferred."""
+
+    PROJECT = "project"  # declared in forge.yaml
+    CATALOG = "catalog"  # shipped model catalog entry
+    LEGACY_COMPAT = "legacy_compat"  # widened from the transport-agnostic table
+    BASELINE = "baseline"  # no registry installed: today's pricing_for answer
+    NONE = "none"  # unpriced
+
+
+@dataclass(frozen=True)
+class DispatchIdentity:
+    """``(provider, model, transport)`` — the thing a price belongs to.
+
+    ``transport`` is the transport *kind* (``"cli"`` / ``"api"``), matching
+    :func:`theforge.config.model_identity.canonical_model_id`. Two runners of the
+    same kind (Claude CLI and Codex CLI) never share a provider+model, so the
+    kind is a sufficient discriminator and the key stays the canonical triple.
+    """
+
+    provider: str
+    model: str
+    transport: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.provider}/{self.model} ({self.transport})"
+
+
+def make_identity(
+    provider: str | None,
+    model: str | None,
+    transport: str | None,
+) -> DispatchIdentity | None:
+    """Build a *concrete* identity, or None when any component is missing.
+
+    A partial key can never match a registry entry, so it is refused at
+    construction rather than inserted and silently missed forever. Callers treat
+    ``None`` as "this profile is not resolvable to a billed identity" and fall
+    back to the no-registry baseline (see :func:`resolve`).
+    """
+    if not provider or not model or not transport:
+        return None
+    return DispatchIdentity(
+        provider=str(provider).strip(),
+        model=str(model).strip(),
+        transport=str(transport).strip(),
+    )
+
+
+def identity_of(profile: "ModelProfile") -> DispatchIdentity | None:
+    """The one place a :class:`ModelProfile` becomes a pricing key.
+
+    Reads ``provider_family`` (the provider identity for *both* transports) and
+    ``mode`` (the transport kind), so a replaced/derived profile resolves to the
+    identity it will actually dispatch on. ``provider_family`` is None on a
+    profile carrying neither a provider nor a transport; that yields None here.
+    """
+    return make_identity(
+        getattr(profile, "provider_family", None),
+        getattr(profile, "model", None),
+        getattr(profile, "mode", None),
+    )
+
+
+# ── Accounting capability by transport ────────────────────────────────
+
+# Keyed by TransportSpec.runner for CLI transports. A runner absent from this
+# map is UNMEASURABLE rather than assumed estimable: an unrecognised CLI has no
+# demonstrated usage-reporting path, and claiming otherwise is how "has rates"
+# came to be read as "spend is captured".
+_CLI_ACCOUNTING: dict[str, AccountingMode] = {
+    # Reports total_cost_usd per run; that figure wins over any estimate.
+    "claude": AccountingMode.PROVIDER_REPORTED,
+    # `codex exec --json` reports a real per-turn token split (#2019).
+    "codex": AccountingMode.TOKEN_ESTIMATED,
+    # Reports usage only on invocations that emit a stats block.
+    "gemini": AccountingMode.TOKEN_ESTIMATED_IF_REPORTED,
+    # Converts AI-credit consumption to a cost independently of any rate card.
+    "ghaw": AccountingMode.INDEPENDENTLY_MEASURED,
+}
+
+
+def accounting_mode_for(transport_kind: str | None, runner: str | None) -> AccountingMode:
+    """Classify how spend on ``(transport_kind, runner)`` can be established."""
+    if transport_kind == "api":
+        # No API transport forge speaks returns a price; every one reports tokens.
+        return AccountingMode.TOKEN_ESTIMATED
+    if transport_kind == "cli":
+        return _CLI_ACCOUNTING.get(runner or "", AccountingMode.UNMEASURABLE)
+    return AccountingMode.UNKNOWN
+
+
+# ── Entries and the registry ──────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RateEntry:
+    """The resolved accounting answer for one identity."""
+
+    identity: DispatchIdentity | None
+    rates: "ModelRates | None" = None
+    mode: AccountingMode = AccountingMode.UNKNOWN
+    source: RateSource = RateSource.NONE
+    #: For LEGACY_COMPAT, the transport-agnostic key this was materialized from;
+    #: otherwise the registry key or catalog id the figures were declared on.
+    origin: str = ""
+
+    @property
+    def priced(self) -> bool:
+        return self.rates is not None
+
+    @property
+    def accountable(self) -> bool:
+        """Can a run on this identity produce a cost record at all?"""
+        if self.mode.measures_without_rates:
+            return True
+        if self.mode is AccountingMode.UNMEASURABLE:
+            return False
+        return self.priced
+
+    def unaccountable_reason(self) -> str | None:
+        """Operator-facing reason this identity cannot be accounted for."""
+        if self.accountable:
+            return None
+        if self.mode is AccountingMode.UNMEASURABLE:
+            return "transport reports no usage and no price"
+        return "no rate card for this transport"
+
+
+@dataclass(frozen=True)
+class RateRegistry:
+    """Compiled ``DispatchIdentity -> RateEntry`` map with a strict lookup.
+
+    ``lookup`` matches the exact key only. There is no transport-agnostic tier
+    and no fallthrough to :data:`PRICING_TABLE`: once a registry is installed, a
+    miss is unpriced and says so. Cross-transport reuse happens at compile time
+    or not at all.
+    """
+
+    entries: Mapping[DispatchIdentity, RateEntry] = field(default_factory=dict)
+    #: Identities the loaded configuration can dispatch on, with the paths each
+    #: is reachable through. Populated at compile time; consulted by the
+    #: load-time report.
+    reachable: Mapping[DispatchIdentity, tuple[str, ...]] = field(default_factory=dict)
+
+    def lookup(self, identity: DispatchIdentity) -> RateEntry:
+        entry = self.entries.get(identity)
+        if entry is not None:
+            return entry
+        # Compilation records an entry for every reachable identity, priced or
+        # not, so a miss here is an identity the loaded configuration cannot
+        # dispatch on. Classify it from its transport kind alone.
+        return RateEntry(
+            identity=identity,
+            rates=None,
+            mode=accounting_mode_for(identity.transport, None),
+            source=RateSource.NONE,
+        )
+
+
+# ── Process-level install contract ────────────────────────────────────
+#
+# The compiled registry is consumed ONCE, at configuration load, into this
+# process-level slot. No function signature gains a registry parameter and no
+# runner imports configuration loading; the alternative — threading the registry
+# through every dispatch signature — is the shape that made the previous attempt
+# miss a path per review cycle.
+#
+# Semantics: last install wins, and installation happens only after a
+# ForgeConfig has been fully constructed, so a load that raises during
+# validation never leaves its partial rates active. A second load (a second
+# project in one process, or a test) replaces the previous registry and logs at
+# debug so the swap is visible in the audit.
+
+_ACTIVE: RateRegistry | None = None
+_LOCK = threading.Lock()
+
+
+def install(registry: RateRegistry) -> None:
+    """Make ``registry`` the process-wide answer for pricing lookups."""
+    global _ACTIVE
+    with _LOCK:
+        previous = _ACTIVE
+        _ACTIVE = registry
+    if previous is not None and previous.entries:
+        logger.debug(
+            "Rate registry replaced: %d entries -> %d entries (last install wins)",
+            len(previous.entries),
+            len(registry.entries),
+        )
+
+
+def active() -> RateRegistry | None:
+    """The installed registry, or None when nothing has been installed."""
+    return _ACTIVE
+
+
+def reset() -> None:
+    """Uninstall any registry, restoring the no-registry baseline."""
+    global _ACTIVE
+    with _LOCK:
+        _ACTIVE = None
+
+
+@contextmanager
+def scoped_registry(registry: RateRegistry | None) -> Iterator[RateRegistry | None]:
+    """Install ``registry`` for the duration of the block, then restore.
+
+    ``None`` scopes the *no-registry baseline* in, which is how a test asserts
+    that uninstalled behaviour is unchanged without leaking a previous load's
+    rates into the next test.
+    """
+    global _ACTIVE
+    with _LOCK:
+        previous = _ACTIVE
+        _ACTIVE = registry
+    try:
+        yield registry
+    finally:
+        with _LOCK:
+            _ACTIVE = previous
+
+
+# ── Resolution ────────────────────────────────────────────────────────
+
+
+def resolve(identity: DispatchIdentity | None) -> RateEntry:
+    """Resolve one identity to its accounting entry.
+
+    With a registry installed this is an exact, transport-respecting lookup.
+    With nothing installed — unit tests, and any code path that never loads a
+    configuration — it delegates to :func:`pricing_for`, reproducing today's
+    transport-blind behaviour bit for bit. That baseline is the ONLY place
+    transport-blind pricing survives.
+    """
+    if identity is None:
+        return RateEntry(identity=None)
+    registry = active()
+    if registry is None:
+        from .schema_utils import pricing_for  # noqa: PLC0415
+
+        rates = pricing_for(identity.provider, identity.model)
+        return RateEntry(
+            identity=identity,
+            rates=rates,
+            mode=AccountingMode.UNKNOWN,
+            source=RateSource.BASELINE if rates is not None else RateSource.NONE,
+            origin="no-registry-baseline",
+        )
+    return registry.lookup(identity)
+
+
+def rates_for(
+    provider: str | None,
+    model: str | None,
+    transport: str | None,
+) -> "ModelRates | None":
+    """Rate card for the identity that ran, or None when it is not priced."""
+    identity = make_identity(provider, model, transport)
+    if identity is None:
+        # A caller that cannot name the transport takes the baseline rather than
+        # a key that could never match — see make_identity.
+        from .schema_utils import pricing_for  # noqa: PLC0415
+
+        if not provider or not model:
+            return None
+        return pricing_for(provider, model)
+    return resolve(identity).rates
+
+
+def entry_for_profile(profile: "ModelProfile") -> RateEntry:
+    """Resolve the entry for the identity ``profile`` would dispatch on."""
+    return resolve(identity_of(profile))
+
+
+def known_models(provider: str, transport: str) -> tuple[str, ...]:
+    """Model names the installed registry prices for ``(provider, transport)``.
+
+    Used by the Claude CLI's dated-id prefix match, which must run against keys
+    of the SAME transport only. Empty when nothing is installed; the caller
+    falls back to the packaged table in that case.
+    """
+    registry = active()
+    if registry is None:
+        return ()
+    return tuple(
+        sorted(
+            identity.model
+            for identity, entry in registry.entries.items()
+            if identity.provider == provider and identity.transport == transport and entry.priced
+        )
+    )

--- a/src/theforge/runners/rate_registry.py
+++ b/src/theforge/runners/rate_registry.py
@@ -23,10 +23,17 @@ from, so it is inspectable rather than implicit at query time. That is what stop
 a model priced by the operator on the CLI from silently lending its price to the
 same model reached over the API.
 
-Deliberately stdlib-only at module scope. :class:`ModelRates` and
-:func:`pricing_for` live in ``schema_utils`` and are imported lazily where the
-no-registry baseline needs them, so ``schema_utils`` may import this module but
-never the reverse at import time.
+**This module is an import leaf.** It has no ``theforge`` imports at all — not
+at module scope, not inside a function. That is deliberate and load-bearing:
+configuration load compiles the registry, so ``theforge.config.dispatch_rates``
+imports this module, and anything this module reached would become reachable
+from ``theforge.config`` — which is how a pricing key ends up in an import cycle
+with half the runners package. So the pure rate *data* (:class:`ModelRates`,
+:data:`PRICING_TABLE`) lives here, while the catalog-backed resolution that
+needs ``theforge.config.models`` stays in :mod:`theforge.runners.schema_utils`,
+which imports this module one way and re-exports these names for compatibility.
+:func:`resolve` returns None when no registry is installed rather than falling
+back to ``pricing_for``; ``schema_utils.rates_for`` owns that baseline.
 """
 
 from __future__ import annotations
@@ -37,14 +44,113 @@ from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    from theforge.config.types import ModelProfile
-
-    from .schema_utils import ModelRates
+from typing import Protocol
 
 logger = logging.getLogger(__name__)
+
+
+class PricedProfile(Protocol):
+    """The three attributes a profile needs to become a pricing key.
+
+    Structural rather than an import of ``ModelProfile``: importing
+    ``theforge.config.types`` here — even under ``TYPE_CHECKING`` — would put a
+    ``theforge`` edge on this module, and the whole point of the module is that
+    it has none (see the module docstring). ``ModelProfile`` satisfies this
+    shape; nothing else has to.
+    """
+
+    @property
+    def provider_family(self) -> str | None: ...
+
+    @property
+    def model(self) -> str: ...
+
+    @property
+    def mode(self) -> str: ...
+
+
+# ── Rate data (pure, packaged) ────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ModelRates:
+    """The rate card in force for one billed identity.
+
+    ``cached_input_per_mtok`` is ``None`` for a provider that has no separately
+    published cache tier; the generic :data:`CACHED_INPUT_RATE_MULT` discount
+    applies in that case. Zero is a real rate and is honoured as one.
+    """
+
+    input_per_mtok: float
+    output_per_mtok: float
+    cached_input_per_mtok: float | None = None
+
+
+# Fraction of the uncached input rate charged for a cache HIT, for providers that
+# express their cache tier that way. OpenAI and Anthropic both bill cached input
+# at 10% of the normal input rate. A provider that publishes an independent
+# cache-hit rate instead (DeepSeek bills roughly 2%, which no fixed fraction of
+# the uncached rate approximates) states it on its catalog entry and is priced
+# from that figure rather than from this multiplier — see :class:`ModelRates`.
+CACHED_INPUT_RATE_MULT = 0.1
+
+
+# The PACKAGED BASELINE rate card (per 1M tokens). Since #2335 this is no longer
+# a second, competing source of truth that accounting reads while routing reads
+# the model registry — the two could disagree, and a model priced in
+# configuration and absent here routed as priced and recorded its spend as
+# unknown.
+#
+# What it is now: transport-agnostic figures that config load MATERIALIZES onto
+# concrete (provider, model, transport) identities when compiling the rate
+# registry, and only onto identities the configuration can actually dispatch on
+# (theforge.config.dispatch_rates._materialize_legacy_rates). A row here can
+# therefore never widen onto a transport a project already priced separately,
+# and it is not consulted at all once a registry is installed.
+#
+# It remains authoritative for concrete billed identifiers that are not registry
+# entries in their own right — a vendor CLI reports ``claude-sonnet-4-6`` while
+# the profile dispatches under the ``sonnet`` shorthand — and it is the answer
+# for any process that never loads a configuration (unit tests).
+#
+# Key: (provider, model_name)
+# Value: (input_cost_per_mtok, output_cost_per_mtok)
+PRICING_TABLE: dict[tuple[str, str], tuple[float, float]] = {
+    ("openai", "o4-mini"): (1.10, 4.40),
+    ("openai", "gpt-4o"): (2.50, 10.00),
+    ("openai", "gpt-4o-mini"): (0.15, 0.60),
+    ("openai", "gpt-5.1-codex-mini"): (1.50, 6.00),
+    ("openai", "gpt-5.1-codex"): (3.00, 12.00),
+    ("openai", "gpt-5.1-codex-max"): (6.00, 24.00),
+    ("openai", "gpt-5.4-mini"): (0.25, 2.00),
+    ("openai", "gpt-5.4"): (1.25, 10.00),
+    ("openai", "gpt-5.4-pro"): (15.00, 120.00),
+    # Was a hand-kept mirror of the forge.yaml figures, because routing read the
+    # config and accounting read this table. It no longer has to be: a project
+    # price now reaches accounting through the compiled registry (#2335). Kept as
+    # the packaged baseline for a project that does not declare this model.
+    ("openai", "gpt-5.5"): (5.00, 30.00),
+    ("anthropic", "claude-opus-4-6"): (15.00, 75.00),
+    ("anthropic", "claude-sonnet-4-6"): (3.00, 15.00),
+    # Mirrors the figures the `haiku` shorthand carries and the pinned
+    # `anthropic/claude-haiku-4-5/cli` catalog entry attributes to this name.
+    ("anthropic", "claude-haiku-4-5"): (1.00, 5.00),
+    ("google", "gemini-3.5-flash"): (1.50, 9.00),  # mirrors forge.yaml overlay
+    ("google", "gemini-3.1-pro-preview"): (2.00, 12.00),  # ≤200k tokens
+    ("google", "gemini-3.1-pro-preview-customtools"): (2.00, 12.00),
+    ("google", "gemini-2.5-pro"): (1.25, 10.00),  # ≤200k tokens
+    ("google", "gemini-2.5-flash"): (0.30, 2.50),
+    ("google", "gemini-2.5-flash-lite"): (0.10, 0.40),
+    ("google", "gemini-2.0-flash"): (0.10, 0.40),
+    ("google", "gemini-2.0-flash-lite"): (0.075, 0.30),
+    # DeepSeek is deliberately absent. Its rates — including the cache-hit tier
+    # it bills separately, which this table has no column for — are declared on
+    # the catalog entries in config/data/models.yaml and read through
+    # :func:`theforge.runners.schema_utils.pricing_for`. The rows that used to
+    # sit here were the third hand-maintained copy of a rate card and outlived
+    # two of its revisions (#2352); the retired identifiers they priced now
+    # record no price at all.
+}
 
 
 class AccountingMode(str, Enum):
@@ -139,7 +245,7 @@ def make_identity(
     )
 
 
-def identity_of(profile: "ModelProfile") -> DispatchIdentity | None:
+def identity_of(profile: PricedProfile) -> DispatchIdentity | None:
     """The one place a :class:`ModelProfile` becomes a pricing key.
 
     Reads ``provider_family`` (the provider identity for *both* transports) and
@@ -190,7 +296,7 @@ class RateEntry:
     """The resolved accounting answer for one identity."""
 
     identity: DispatchIdentity | None
-    rates: "ModelRates | None" = None
+    rates: ModelRates | None = None
     mode: AccountingMode = AccountingMode.UNKNOWN
     source: RateSource = RateSource.NONE
     #: For LEGACY_COMPAT, the transport-agnostic key this was materialized from;
@@ -316,53 +422,25 @@ def scoped_registry(registry: RateRegistry | None) -> Iterator[RateRegistry | No
 # ── Resolution ────────────────────────────────────────────────────────
 
 
-def resolve(identity: DispatchIdentity | None) -> RateEntry:
-    """Resolve one identity to its accounting entry.
+def resolve(identity: DispatchIdentity | None) -> RateEntry | None:
+    """Exact, transport-respecting lookup — or None when nothing is installed.
 
-    With a registry installed this is an exact, transport-respecting lookup.
-    With nothing installed — unit tests, and any code path that never loads a
-    configuration — it delegates to :func:`pricing_for`, reproducing today's
-    transport-blind behaviour bit for bit. That baseline is the ONLY place
-    transport-blind pricing survives.
+    Returning None rather than falling back to :func:`pricing_for` here is what
+    keeps this module a leaf. The transport-blind baseline lives with the
+    catalog resolution it reads, in ``schema_utils.rates_for`` / ``entry_for``;
+    this module never imports it, so the pricing key type cannot end up in an
+    import cycle with the pricing table.
+
+    A ``None`` *identity* (a profile with no resolvable provider or transport)
+    is answered with an explicitly unpriced entry: there is no key to look up,
+    and inventing a partial one would produce a key that can never match.
     """
     if identity is None:
         return RateEntry(identity=None)
     registry = active()
     if registry is None:
-        from .schema_utils import pricing_for  # noqa: PLC0415
-
-        rates = pricing_for(identity.provider, identity.model)
-        return RateEntry(
-            identity=identity,
-            rates=rates,
-            mode=AccountingMode.UNKNOWN,
-            source=RateSource.BASELINE if rates is not None else RateSource.NONE,
-            origin="no-registry-baseline",
-        )
+        return None
     return registry.lookup(identity)
-
-
-def rates_for(
-    provider: str | None,
-    model: str | None,
-    transport: str | None,
-) -> "ModelRates | None":
-    """Rate card for the identity that ran, or None when it is not priced."""
-    identity = make_identity(provider, model, transport)
-    if identity is None:
-        # A caller that cannot name the transport takes the baseline rather than
-        # a key that could never match — see make_identity.
-        from .schema_utils import pricing_for  # noqa: PLC0415
-
-        if not provider or not model:
-            return None
-        return pricing_for(provider, model)
-    return resolve(identity).rates
-
-
-def entry_for_profile(profile: "ModelProfile") -> RateEntry:
-    """Resolve the entry for the identity ``profile`` would dispatch on."""
-    return resolve(identity_of(profile))
 
 
 def known_models(provider: str, transport: str) -> tuple[str, ...]:

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -169,8 +169,7 @@ def _anthropic_cli_pricing_names() -> tuple[str, ...]:
     registry installed (unit tests, non-config code paths) this falls back to the
     packaged table, reproducing the previous behaviour exactly.
     """
-    from theforge.runners.rate_registry import known_models  # noqa: PLC0415
-    from theforge.runners.schema_utils import PRICING_TABLE  # noqa: PLC0415
+    from theforge.runners.rate_registry import PRICING_TABLE, known_models  # noqa: PLC0415
 
     # The packaged table is unioned in rather than used only as a fallback: the
     # names the CLI reports are concrete *billed* ids (``claude-sonnet-4-6``)
@@ -217,8 +216,8 @@ def _estimate_anthropic_cost(
     the resolved rate card publishes its own cache-read figure — that is
     preferred over the generic 0.1x multiplier when declared.
     """
-    from theforge.runners.rate_registry import rates_for  # noqa: PLC0415
-    from theforge.runners.schema_utils import PRICING_TABLE, ModelRates  # noqa: PLC0415
+    from theforge.runners.rate_registry import PRICING_TABLE, ModelRates  # noqa: PLC0415
+    from theforge.runners.schema_utils import rates_for  # noqa: PLC0415
 
     key = _resolve_anthropic_pricing_key(model)
     if key is None:

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -160,23 +160,45 @@ _EXIT_GRACE_SECONDS = 10.0
 _COST_UNMEASURED_WARNED: set[str] = set()
 
 
-def _resolve_anthropic_pricing_key(raw_model: str) -> str | None:
-    """Map a stream-event model id to a PRICING_TABLE anthropic key.
+def _anthropic_cli_pricing_names() -> tuple[str, ...]:
+    """Anthropic model names priced for the *CLI* transport, most specific first.
 
-    Claude reports the fully-resolved model id (e.g. ``claude-sonnet-4-6`` or a
-    dated variant) in each message, while the pricing table is keyed on the
-    undated family id. Match exactly, then by prefix in either direction so a
-    dated id resolves to its family entry. Returns None when unknown.
+    Drawn from the installed rate registry, which is keyed by ``(provider, model,
+    transport)`` — so the prefix match below can never resolve a CLI stream event
+    onto a price declared for the same model name over the API (#2335). With no
+    registry installed (unit tests, non-config code paths) this falls back to the
+    packaged table, reproducing the previous behaviour exactly.
     """
+    from theforge.runners.rate_registry import known_models  # noqa: PLC0415
     from theforge.runners.schema_utils import PRICING_TABLE  # noqa: PLC0415
 
+    # The packaged table is unioned in rather than used only as a fallback: the
+    # names the CLI reports are concrete *billed* ids (``claude-sonnet-4-6``)
+    # that are never registry entries in their own right — the registry knows the
+    # shorthand (``sonnet``) the profile dispatches under. Both halves are
+    # packaged baseline, so nothing project-declared for another transport can
+    # enter here.
+    names = set(known_models("anthropic", "cli"))
+    names.update(model for provider, model in PRICING_TABLE if provider == "anthropic")
+    # Longest first so a dated id matches its most specific family entry rather
+    # than whichever shorter prefix happened to be enumerated first.
+    return tuple(sorted(names, key=len, reverse=True))
+
+
+def _resolve_anthropic_pricing_key(raw_model: str) -> str | None:
+    """Map a stream-event model id to a priced anthropic CLI model name.
+
+    Claude reports the fully-resolved model id (e.g. ``claude-sonnet-4-6`` or a
+    dated variant) in each message, while rate cards are keyed on the undated
+    family id. Match exactly, then by prefix in either direction so a dated id
+    resolves to its family entry. Returns None when unknown.
+    """
     if not raw_model:
         return None
-    if ("anthropic", raw_model) in PRICING_TABLE:
+    names = _anthropic_cli_pricing_names()
+    if raw_model in names:
         return raw_model
-    for provider, key in PRICING_TABLE:
-        if provider != "anthropic":
-            continue
+    for key in names:
         if raw_model.startswith(key) or key.startswith(raw_model):
             return key
     return None
@@ -189,17 +211,39 @@ def _estimate_anthropic_cost(
     cache_read_tokens: int,
     cache_creation_tokens: int,
 ) -> float | None:
-    """Price reconstructed Anthropic token usage; None when model is unpriced."""
-    from theforge.runners.schema_utils import PRICING_TABLE  # noqa: PLC0415
+    """Price reconstructed Anthropic token usage; None when model is unpriced.
+
+    Cache tiers are expressed as multiples of the base input rate, except where
+    the resolved rate card publishes its own cache-read figure — that is
+    preferred over the generic 0.1x multiplier when declared.
+    """
+    from theforge.runners.rate_registry import rates_for  # noqa: PLC0415
+    from theforge.runners.schema_utils import PRICING_TABLE, ModelRates  # noqa: PLC0415
 
     key = _resolve_anthropic_pricing_key(model)
     if key is None:
         return None
-    in_rate, out_rate = PRICING_TABLE[("anthropic", key)]
+    rates = rates_for("anthropic", key, "cli")
+    if rates is None:
+        # Packaged-baseline-only last resort, for the concrete billed ids above
+        # that no registry entry names. Deliberately reads PRICING_TABLE rather
+        # than pricing_for: a project-declared price for another transport must
+        # never reach this path.
+        packaged = PRICING_TABLE.get(("anthropic", key))
+        if packaged is None:
+            return None
+        rates = ModelRates(input_per_mtok=packaged[0], output_per_mtok=packaged[1])
+    in_rate = rates.input_per_mtok
+    out_rate = rates.output_per_mtok
+    cache_read_rate = (
+        rates.cached_input_per_mtok
+        if rates.cached_input_per_mtok is not None
+        else in_rate * _CACHE_READ_RATE_MULT
+    )
     return (
         (input_tokens / 1_000_000) * in_rate
         + (output_tokens / 1_000_000) * out_rate
-        + (cache_read_tokens / 1_000_000) * in_rate * _CACHE_READ_RATE_MULT
+        + (cache_read_tokens / 1_000_000) * cache_read_rate
         + (cache_creation_tokens / 1_000_000) * in_rate * _CACHE_WRITE_RATE_MULT
     )
 

--- a/src/theforge/runners/runner_codex.py
+++ b/src/theforge/runners/runner_codex.py
@@ -626,6 +626,9 @@ def _price_codex_usage(
         profile.model,
         usage.input_tokens,
         usage.output_tokens,
+        # Codex is a CLI transport: its tokens are priced from the codex identity,
+        # never from the same model name reached over the OpenAI API (#2335).
+        transport="cli",
         cached_input_tokens=usage.cached_input_tokens,
     )
     model_usage = (

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -19,8 +19,8 @@ from theforge.workspace_env import build_workspace_env
 
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
+from .rate_registry import CACHED_INPUT_RATE_MULT as _CACHED_INPUT_RATE_MULT
 from .sandbox import SandboxCapabilityError, workspace_effect_sandbox_command
-from .schema_utils import CACHED_INPUT_RATE_MULT as _CACHED_INPUT_RATE_MULT
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -58,7 +58,7 @@ def _parse_gemini_usage(
     ``(None, ())`` and the caller records cost-unknown: an estimate is never
     fabricated from an absent measurement.
     """
-    from .rate_registry import rates_for  # noqa: PLC0415
+    from .schema_utils import rates_for  # noqa: PLC0415
 
     stats = result_json.get("stats")
     models = stats.get("models") if isinstance(stats, dict) else None

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from theforge import process_group
-from theforge.agent_types import AgentResult
+from theforge.agent_types import COST_ESTIMATED, COST_UNKNOWN, AgentResult, ModelUsage
 from theforge.log_util import _log_line
 from theforge.task.handoff_parser import ParseError, extract_dev_handoff
 from theforge.workspace_env import build_workspace_env
@@ -20,6 +20,7 @@ from theforge.workspace_env import build_workspace_env
 from ..config import ModelProfile
 from .cli import _handle_exception, _run_with_heartbeat
 from .sandbox import SandboxCapabilityError, workspace_effect_sandbox_command
+from .schema_utils import CACHED_INPUT_RATE_MULT as _CACHED_INPUT_RATE_MULT
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -33,6 +34,84 @@ def _log_verbose(msg: str) -> None:
 
     if _LOG_LEVEL >= LogLevel.VERBOSE:
         _log_line("[forge]", msg)
+
+
+def _int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _parse_gemini_usage(
+    result_json: dict[str, Any],
+    profile: "ModelProfile",
+) -> tuple[float | None, tuple[ModelUsage, ...]]:
+    """Price whatever token usage the Gemini CLI reported, or return nothing.
+
+    The Gemini CLI reports usage in a ``stats.models`` block on the invocations
+    that emit one and reports nothing on the others (parse failures, sandbox
+    refusals, error exits). Where a count exists it is priced from the rate card
+    for the *gemini CLI* identity specifically — never from a gemini API
+    identity's rates, which the transport-keyed lookup makes structural rather
+    than a matter of care (#2335). Where no count exists this returns
+    ``(None, ())`` and the caller records cost-unknown: an estimate is never
+    fabricated from an absent measurement.
+    """
+    from .rate_registry import rates_for  # noqa: PLC0415
+
+    stats = result_json.get("stats")
+    models = stats.get("models") if isinstance(stats, dict) else None
+    if not isinstance(models, dict) or not models:
+        return None, ()
+
+    total = 0.0
+    any_priced = False
+    usages: list[ModelUsage] = []
+    for model_name, block in models.items():
+        tokens = block.get("tokens") if isinstance(block, dict) else None
+        if not isinstance(tokens, dict):
+            continue
+        cached = _int(tokens.get("cached"))
+        # ``prompt`` is the full prompt count and includes the cached portion,
+        # which is what _estimate_cost documents ``cached_input_tokens`` to be.
+        input_tokens = _int(tokens.get("prompt"))
+        output_tokens = _int(tokens.get("candidates"))
+        thinking_tokens = _int(tokens.get("thoughts"))
+        if not (input_tokens or output_tokens or thinking_tokens):
+            continue
+        rates = rates_for("google", str(model_name), "cli")
+        cost: float | None = None
+        if rates is not None:
+            uncached = max(0, input_tokens - min(cached, input_tokens))
+            cached_rate = (
+                rates.cached_input_per_mtok
+                if rates.cached_input_per_mtok is not None
+                else rates.input_per_mtok * _CACHED_INPUT_RATE_MULT
+            )
+            cost = (
+                (uncached / 1_000_000) * rates.input_per_mtok
+                + (min(cached, input_tokens) / 1_000_000) * cached_rate
+                + ((output_tokens + thinking_tokens) / 1_000_000) * rates.output_per_mtok
+            )
+            total += cost
+            any_priced = True
+        usages.append(
+            ModelUsage(
+                model=str(model_name),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=min(cached, input_tokens),
+                cache_creation_tokens=0,
+                cost_usd=cost,
+                thinking_tokens=thinking_tokens,
+                # Forge multiplied tokens by a rate card; the CLI billed nothing.
+                cost_provenance=COST_ESTIMATED if cost is not None else COST_UNKNOWN,
+            )
+        )
+    if not usages:
+        return None, ()
+    return (total if any_priced else None), tuple(usages)
 
 
 def _try_parse_handoff(output: str) -> dict | None:
@@ -217,14 +296,20 @@ def _run_gemini(
     # would trample each other since --resume latest is not invocation-scoped.
     resume_sid = None if is_pool else "latest"
     _gemini_output = result_json.get("response", result_json.get("result", proc.stdout))
+    # Only this path — the one that parsed a result — can carry usage. The
+    # error, sandbox-refusal and no-JSON returns above keep cost_usd=None, so an
+    # error's cost never changes from unknown to an estimate.
+    _cost, _usage = _parse_gemini_usage(result_json, profile)
     return AgentResult(
         success=proc.returncode == 0,
         output=_gemini_output,
         session_id=resume_sid,
-        cost_usd=None,
+        cost_usd=_cost,
         exit_code=proc.returncode,
         raw=result_json,
         profile_name=profile.name,
         dev_handoff=_try_parse_handoff(_gemini_output),
         process_teardown=_teardown,
+        model_usage=_usage,
+        cost_provenance=COST_ESTIMATED if _cost is not None else COST_UNKNOWN,
     )

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -54,7 +54,23 @@ def _sanitize_schema_for_google(schema: dict) -> dict:
 
 # ── Pricing table (per 1M tokens) ──────────────────────────────────────
 
-# Fallback for when API response doesn't include cost.
+# The PACKAGED BASELINE rate card. Since #2335 this is no longer a second,
+# competing source of truth that accounting reads while routing reads the model
+# registry — the two could disagree, and a model priced in configuration and
+# absent here routed as priced and recorded its spend as unknown.
+#
+# What it is now: transport-agnostic figures that config load MATERIALIZES onto
+# concrete (provider, model, transport) identities when compiling the rate
+# registry, and only onto identities the configuration can actually dispatch on
+# (theforge.config.dispatch_rates._materialize_legacy_rates). A row here can
+# therefore never widen onto a transport a project already priced separately,
+# and it is not consulted at all once a registry is installed.
+#
+# It remains authoritative for concrete billed identifiers that are not registry
+# entries in their own right — a vendor CLI reports ``claude-sonnet-4-6`` while
+# the profile dispatches under the ``sonnet`` shorthand — and it is the answer
+# for any process that never loads a configuration (unit tests).
+#
 # Key: (provider, model_name)
 # Value: (input_cost_per_mtok, output_cost_per_mtok)
 PRICING_TABLE: dict[tuple[str, str], tuple[float, float]] = {
@@ -67,10 +83,10 @@ PRICING_TABLE: dict[tuple[str, str], tuple[float, float]] = {
     ("openai", "gpt-5.4-mini"): (0.25, 2.00),
     ("openai", "gpt-5.4"): (1.25, 10.00),
     ("openai", "gpt-5.4-pro"): (15.00, 120.00),
-    # Mirrors the input/output_cost_per_mtok declared for this model in
-    # forge.yaml. Routing already reads those config values; accounting reads
-    # this table, so a model priced in one and absent from the other routes
-    # fine and then records cost-unknown, which fails the budget check closed.
+    # Was a hand-kept mirror of the forge.yaml figures, because routing read the
+    # config and accounting read this table. It no longer has to be: a project
+    # price now reaches accounting through the compiled registry (#2335). Kept as
+    # the packaged baseline for a project that does not declare this model.
     ("openai", "gpt-5.5"): (5.00, 30.00),
     ("anthropic", "claude-opus-4-6"): (15.00, 75.00),
     ("anthropic", "claude-sonnet-4-6"): (3.00, 15.00),
@@ -203,7 +219,7 @@ _MAX_MALFORMED = 3
 _DEFAULT_MAX_ITERATIONS = 75
 
 
-_MISSING_PRICING_WARNED: set[tuple[str, str]] = set()
+_MISSING_PRICING_WARNED: set[tuple[str, str, str | None]] = set()
 
 # Fraction of the uncached input rate charged for a cache HIT, for providers that
 # express their cache tier that way. OpenAI and Anthropic both bill cached input
@@ -302,6 +318,13 @@ def catalog_rates() -> dict[tuple[str, str], ModelRates]:
 def pricing_for(provider: str, model: str) -> ModelRates | None:
     """Return the rate card for ``(provider, model)``, or None if none is known.
 
+    **Transport-blind, and therefore the no-registry baseline only.** Accounting
+    resolves through :func:`theforge.runners.rate_registry.rates_for`, which is
+    keyed by ``(provider, model, transport)``; this function answers when no
+    registry is installed, which is the case for unit tests and for any process
+    that never loads a configuration. Its behaviour is deliberately unchanged so
+    that baseline is bit-for-bit what it was before #2335.
+
     Catalog first, :data:`PRICING_TABLE` second. The catalog is the surface where
     a rate is declared next to the identity it was recorded for and the date that
     identity was last checked against the provider, so it is the one that gets to
@@ -350,11 +373,19 @@ def _estimate_cost(
     input_tokens: int,
     output_tokens: int,
     *,
+    transport: str | None = None,
     thinking_tokens: int = 0,
     cached_input_tokens: int = 0,
     cached_input_rate_mult: float = CACHED_INPUT_RATE_MULT,
 ) -> float | None:
     """Estimate cost from the rate card in force; returns None if model unknown.
+
+    ``transport`` names the transport kind (``"cli"`` / ``"api"``) the tokens
+    being priced were actually spent on. It is what makes the lookup identify
+    the thing that *dispatched* rather than a model name two transports can
+    share (#2335). It defaults to None purely so an unconverted caller still
+    compiles; None takes the transport-blind :func:`pricing_for` baseline. Every
+    call site in this repository passes it.
 
     ``cached_input_tokens`` is the SUBSET of ``input_tokens`` that was served from
     the provider's prompt cache. It is billed at the provider's own published
@@ -362,16 +393,21 @@ def _estimate_cost(
     ``cached_input_rate_mult`` of the input rate. Callers that cannot distinguish
     the cache tier leave it at 0 and get the flat-rate behaviour unchanged.
     """
-    rates = pricing_for(provider, model)
+    from .rate_registry import rates_for  # noqa: PLC0415
+
+    rates = rates_for(provider, model, transport)
     if rates is None:
-        key = (provider, model)
+        # Keyed on the transport too, so the same model name unpriced over two
+        # transports warns about each rather than reporting one and hiding one.
+        key = (provider, model, transport)
         if key not in _MISSING_PRICING_WARNED:
             logger.warning(
-                "Missing pricing entry for provider=%s model=%s; cost cannot be estimated. "
-                "Declare a cost block on the model's catalog entry (or add it to "
-                "PRICING_TABLE) so audit and budget totals stay accurate.",
+                "Missing pricing entry for provider=%s model=%s transport=%s; cost cannot "
+                "be estimated. Declare a cost block on the model's catalog entry (or add "
+                "it to PRICING_TABLE) so audit and budget totals stay accurate.",
                 provider,
                 model,
+                transport or "unspecified",
             )
             _MISSING_PRICING_WARNED.add(key)
         return None

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -8,7 +8,19 @@ from datetime import date
 from typing import TYPE_CHECKING, Any, Protocol
 
 from theforge.agent_types import ModelUsage
+from theforge.runners.rate_registry import (
+    CACHED_INPUT_RATE_MULT,
+    PRICING_TABLE,
+    AccountingMode,
+    ModelRates,
+    RateEntry,
+    RateSource,
+    identity_of,
+    make_identity,
+)
 from theforge.schemas import plan_review_json_schema, review_json_schema
+
+from . import rate_registry as _rate_registry
 
 logger = logging.getLogger(__name__)
 
@@ -51,63 +63,6 @@ def _sanitize_schema_for_google(schema: dict) -> dict:
             cleaned[key] = value
     return cleaned
 
-
-# ── Pricing table (per 1M tokens) ──────────────────────────────────────
-
-# The PACKAGED BASELINE rate card. Since #2335 this is no longer a second,
-# competing source of truth that accounting reads while routing reads the model
-# registry — the two could disagree, and a model priced in configuration and
-# absent here routed as priced and recorded its spend as unknown.
-#
-# What it is now: transport-agnostic figures that config load MATERIALIZES onto
-# concrete (provider, model, transport) identities when compiling the rate
-# registry, and only onto identities the configuration can actually dispatch on
-# (theforge.config.dispatch_rates._materialize_legacy_rates). A row here can
-# therefore never widen onto a transport a project already priced separately,
-# and it is not consulted at all once a registry is installed.
-#
-# It remains authoritative for concrete billed identifiers that are not registry
-# entries in their own right — a vendor CLI reports ``claude-sonnet-4-6`` while
-# the profile dispatches under the ``sonnet`` shorthand — and it is the answer
-# for any process that never loads a configuration (unit tests).
-#
-# Key: (provider, model_name)
-# Value: (input_cost_per_mtok, output_cost_per_mtok)
-PRICING_TABLE: dict[tuple[str, str], tuple[float, float]] = {
-    ("openai", "o4-mini"): (1.10, 4.40),
-    ("openai", "gpt-4o"): (2.50, 10.00),
-    ("openai", "gpt-4o-mini"): (0.15, 0.60),
-    ("openai", "gpt-5.1-codex-mini"): (1.50, 6.00),
-    ("openai", "gpt-5.1-codex"): (3.00, 12.00),
-    ("openai", "gpt-5.1-codex-max"): (6.00, 24.00),
-    ("openai", "gpt-5.4-mini"): (0.25, 2.00),
-    ("openai", "gpt-5.4"): (1.25, 10.00),
-    ("openai", "gpt-5.4-pro"): (15.00, 120.00),
-    # Was a hand-kept mirror of the forge.yaml figures, because routing read the
-    # config and accounting read this table. It no longer has to be: a project
-    # price now reaches accounting through the compiled registry (#2335). Kept as
-    # the packaged baseline for a project that does not declare this model.
-    ("openai", "gpt-5.5"): (5.00, 30.00),
-    ("anthropic", "claude-opus-4-6"): (15.00, 75.00),
-    ("anthropic", "claude-sonnet-4-6"): (3.00, 15.00),
-    # Mirrors the figures the `haiku` shorthand carries and the pinned
-    # `anthropic/claude-haiku-4-5/cli` catalog entry attributes to this name.
-    ("anthropic", "claude-haiku-4-5"): (1.00, 5.00),
-    ("google", "gemini-3.5-flash"): (1.50, 9.00),  # mirrors forge.yaml overlay
-    ("google", "gemini-3.1-pro-preview"): (2.00, 12.00),  # ≤200k tokens
-    ("google", "gemini-3.1-pro-preview-customtools"): (2.00, 12.00),
-    ("google", "gemini-2.5-pro"): (1.25, 10.00),  # ≤200k tokens
-    ("google", "gemini-2.5-flash"): (0.30, 2.50),
-    ("google", "gemini-2.5-flash-lite"): (0.10, 0.40),
-    ("google", "gemini-2.0-flash"): (0.10, 0.40),
-    ("google", "gemini-2.0-flash-lite"): (0.075, 0.30),
-    # DeepSeek is deliberately absent. Its rates — including the cache-hit tier
-    # it bills separately, which this table has no column for — are declared on
-    # the catalog entries in config/data/models.yaml and read through
-    # :func:`pricing_for`. The rows that used to sit here were the third
-    # hand-maintained copy of a rate card and outlived two of its revisions
-    # (#2352); the retired identifiers they priced now record no price at all.
-}
 
 # Models we intentionally route to the Responses API (/v1/responses).
 # Some current OpenAI models (for example gpt-5.4 and o4-mini) accept both
@@ -221,14 +176,6 @@ _DEFAULT_MAX_ITERATIONS = 75
 
 _MISSING_PRICING_WARNED: set[tuple[str, str, str | None]] = set()
 
-# Fraction of the uncached input rate charged for a cache HIT, for providers that
-# express their cache tier that way. OpenAI and Anthropic both bill cached input
-# at 10% of the normal input rate. A provider that publishes an independent
-# cache-hit rate instead (DeepSeek bills roughly 2%, which no fixed fraction of
-# the uncached rate approximates) states it on its catalog entry and is priced
-# from that figure rather than from this multiplier — see :class:`ModelRates`.
-CACHED_INPUT_RATE_MULT = 0.1
-
 
 # Providers whose reported prompt-token count INCLUDES the tokens served from
 # cache. ``_estimate_cost`` documents ``cached_input_tokens`` as a subset of
@@ -242,20 +189,6 @@ _CACHE_READS_INSIDE_INPUT: frozenset[str] = frozenset({"openai", "deepseek"})
 def cache_reads_are_subset_of_input(provider: str) -> bool:
     """Is this provider's cache-read count part of its reported input count?"""
     return provider in _CACHE_READS_INSIDE_INPUT
-
-
-@dataclass(frozen=True)
-class ModelRates:
-    """The rate card in force for one ``(provider, model)``.
-
-    ``cached_input_per_mtok`` is ``None`` for a provider that has no separately
-    published cache tier; the generic :data:`CACHED_INPUT_RATE_MULT` discount
-    applies in that case. Zero is a real rate and is honoured as one.
-    """
-
-    input_per_mtok: float
-    output_per_mtok: float
-    cached_input_per_mtok: float | None = None
 
 
 def _catalog_rates() -> dict[tuple[str, str], ModelRates]:
@@ -319,11 +252,11 @@ def pricing_for(provider: str, model: str) -> ModelRates | None:
     """Return the rate card for ``(provider, model)``, or None if none is known.
 
     **Transport-blind, and therefore the no-registry baseline only.** Accounting
-    resolves through :func:`theforge.runners.rate_registry.rates_for`, which is
-    keyed by ``(provider, model, transport)``; this function answers when no
-    registry is installed, which is the case for unit tests and for any process
-    that never loads a configuration. Its behaviour is deliberately unchanged so
-    that baseline is bit-for-bit what it was before #2335.
+    resolves through :func:`rates_for`, which is keyed by
+    ``(provider, model, transport)``; this function answers when no registry is
+    installed, which is the case for unit tests and for any process that never
+    loads a configuration. Its behaviour is deliberately unchanged so that
+    baseline is bit-for-bit what it was before #2335.
 
     Catalog first, :data:`PRICING_TABLE` second. The catalog is the surface where
     a rate is declared next to the identity it was recorded for and the date that
@@ -367,6 +300,67 @@ def rate_card_confirmed(provider: str, model: str, *, today: date | None = None)
     )
 
 
+def entry_for(
+    provider: str | None,
+    model: str | None,
+    transport: str | None,
+) -> RateEntry:
+    """Resolve one dispatched identity to its accounting entry.
+
+    This is the seam between the two halves of the fix, and it lives here rather
+    than in :mod:`rate_registry` because it is the only function that needs
+    both: the strict, transport-respecting registry lookup, and the
+    transport-blind :func:`pricing_for` baseline that answers when no
+    configuration has been loaded. Keeping the baseline on this side is what lets
+    ``rate_registry`` stay an import leaf that configuration load can consume.
+
+    With a registry installed the answer is an exact ``(provider, model,
+    transport)`` match and nothing else — a miss is unpriced, and no other
+    transport's rate is borrowed. With nothing installed the answer is exactly
+    what ``pricing_for`` returned before #2335.
+    """
+    identity = make_identity(provider, model, transport)
+    if identity is not None:
+        entry = _rate_registry.resolve(identity)
+        if entry is not None:
+            return entry
+    # Either nothing is installed, or the caller could not name a transport and
+    # so has no concrete key to look up. Both take today's transport-blind
+    # baseline, unchanged.
+    if not provider or not model:
+        return RateEntry(identity=identity)
+    rates = pricing_for(provider, model)
+    return RateEntry(
+        identity=identity,
+        rates=rates,
+        mode=AccountingMode.UNKNOWN,
+        source=RateSource.BASELINE if rates is not None else RateSource.NONE,
+        origin="no-registry-baseline",
+    )
+
+
+def rates_for(
+    provider: str | None,
+    model: str | None,
+    transport: str | None,
+) -> ModelRates | None:
+    """Rate card for the identity that ran, or None when it is not priced."""
+    return entry_for(provider, model, transport).rates
+
+
+def entry_for_profile(profile: Any) -> RateEntry:
+    """Resolve the entry for the identity ``profile`` would dispatch on.
+
+    ``identity_of`` returns None for a profile carrying neither a provider nor a
+    transport; that resolves to an explicitly unpriced entry rather than a
+    partial key that could never match.
+    """
+    identity = identity_of(profile)
+    if identity is None:
+        return RateEntry(identity=None)
+    return entry_for(identity.provider, identity.model, identity.transport)
+
+
 def _estimate_cost(
     provider: str,
     model: str,
@@ -393,8 +387,6 @@ def _estimate_cost(
     ``cached_input_rate_mult`` of the input rate. Callers that cannot distinguish
     the cache tier leave it at 0 and get the flat-rate behaviour unchanged.
     """
-    from .rate_registry import rates_for  # noqa: PLC0415
-
     rates = rates_for(provider, model, transport)
     if rates is None:
         # Keyed on the transport too, so the same model name unpriced over two

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -59,6 +59,7 @@ from ..intake import (
 )
 from ..log_util import _log_line
 from ..process_group import ProcessTeardown
+from ..runners.rate_registry import AccountingMode, accounting_mode_for
 from ..task import BatchMember, TaskStory
 from . import unmeasured as unmeasured_spend_policy
 from .abnormal import (
@@ -138,13 +139,30 @@ from .story_state import (
 )
 from .unmeasured import AcceptedUnmeasuredSpend, UnmeasuredSource
 
-# CLI transports whose spend forge cannot measure at all, warned about up front.
-# `codex` left this set in #2019: `codex exec --json` reports a real token split
-# per turn, so codex runs now carry measured cost like the claude transport.
+# Whether a CLI transport's spend is measurable is now a property of its
+# accounting mode (theforge.runners.rate_registry.AccountingMode), not of a
+# hardcoded name list: the runner that prices a transport and the warning that
+# announces it cannot measure one must read the same classification or they
+# drift apart (#2335). `codex` left the untracked set in #2019 because
+# `codex exec --json` reports a real token split; `gemini` is still warned about
+# because it reports usage only on the invocations that emit a stats block, so
+# its cost record is conditional rather than guaranteed.
 # Actual per-run measurement failures are still caught downstream by the
-# cost-is-None checks that feed `unmeasured_spend` — this set is only the
-# pre-sprint warning, evaluated over config profiles before any run exists.
-_UNTRACKED_COST_CLIS: frozenset[str] = frozenset({"gemini"})
+# cost-is-None checks that feed `unmeasured_spend` — this is only the pre-sprint
+# warning, evaluated over config profiles before any run exists.
+_UNTRACKED_ACCOUNTING_MODES = frozenset(
+    {
+        AccountingMode.UNMEASURABLE,
+        AccountingMode.TOKEN_ESTIMATED_IF_REPORTED,
+    }
+)
+
+
+def _cli_cost_untracked(runner: str | None) -> bool:
+    """Is a CLI transport's spend unmeasurable, or measurable only sometimes?"""
+    return accounting_mode_for("cli", runner) in _UNTRACKED_ACCOUNTING_MODES
+
+
 _STORY_RUN_AUDIT_DIR = ".forge/audits/runs"
 _STORY_RUN_AUDIT_COMMIT_CMD = (
     f'git commit -m "chore(audit): record sprint run audits" -- {_STORY_RUN_AUDIT_DIR}'
@@ -1723,7 +1741,7 @@ def _agent_cost_tracking_warnings(config: ForgeConfig) -> list[str]:
     warnings: list[str] = []
     seen: set[tuple[str, str, str, str | None, str | None]] = set()
     for agent in agents:
-        if agent.transport_kind != "cli" or agent.runner not in _UNTRACKED_COST_CLIS:
+        if agent.transport_kind != "cli" or not _cli_cost_untracked(agent.runner):
             continue
         fallback_provider = getattr(agent.api_fallback, "provider", None)
         fallback_model = getattr(agent.api_fallback, "model", None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,6 +298,28 @@ def gemini_profile() -> ModelProfile:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_rate_registry():
+    """Prevent a config load's compiled rate registry from leaking across tests.
+
+    ``load_config`` installs a process-level
+    :class:`~theforge.runners.rate_registry.RateRegistry` (#2335). That is right
+    in production — pricing is resolved once per configuration — but in a test
+    session it would mean whichever test loaded a config last decides how the
+    next one prices tokens. Each test starts from the no-registry baseline
+    unless it installs one itself.
+    """
+    import theforge.runners.rate_registry as _rr_mod
+
+    original = _rr_mod.active()
+    _rr_mod.reset()
+    yield
+    if original is None:
+        _rr_mod.reset()
+    else:
+        _rr_mod.install(original)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_log_level():
     """Prevent log-level mutations from leaking across tests.
 

--- a/tests/test_dispatch_rate_registry.py
+++ b/tests/test_dispatch_rate_registry.py
@@ -1,0 +1,787 @@
+"""Identity-keyed pricing: one resolution, consumed by routing and accounting (#2335).
+
+A model could be priced in project configuration, routed on the strength of
+those figures, run, and still record its spend as unknown — routing read the
+merged model registry while accounting read a table compiled into the code. The
+fix compiles ONE registry at configuration load, keyed by
+``(provider, model, transport)``, and every accounting site looks up the
+identity that actually dispatched.
+
+The dispatch paths exercised here are the ones a prior attempt discovered one
+review cycle at a time: seated primary, adaptive pool candidate, model fallback,
+transport fallback with the model identifier unchanged and changed, CLI and API
+for the same model name, a model priced only in ``forge.yaml``, and a model
+priced nowhere. Plus the invariant that keeps them from recurring: **a lookup
+never crosses transports**.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from theforge.config import load_config
+from theforge.config.dispatch_rates import (
+    compile_rate_registry,
+    reachable_identities,
+)
+from theforge.config.types import ModelProfile, TransportFallbackConfig
+from theforge.runners import rate_registry as rr
+from theforge.runners.rate_registry import (
+    AccountingMode,
+    DispatchIdentity,
+    RateEntry,
+    RateRegistry,
+    RateSource,
+    identity_of,
+    make_identity,
+)
+from theforge.runners.schema_utils import ModelRates, _estimate_cost, pricing_for
+
+_auth_ok = patch("theforge.config.load.check_agent_auth", return_value=(True, ""))
+_import_ok = patch("importlib.import_module")
+
+
+def _write(tmp_path: Path, raw: dict) -> Path:
+    path = tmp_path / "forge.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    return path
+
+
+def _load(tmp_path: Path, raw: dict):
+    with _auth_ok, _import_ok:
+        return load_config(_write(tmp_path, raw))
+
+
+def _custom(model: str, kind: str, *, runner: str | None = None, cost: dict | None = None) -> dict:
+    transport: dict = {"kind": kind}
+    if runner is not None:
+        transport["runner"] = runner
+    entry: dict = {
+        "provider": "openai",
+        "model": model,
+        "transport": transport,
+        "routing": {"tier": "strong", "capability": 9, "cost_rank": 2},
+    }
+    if cost is not None:
+        entry["cost"] = cost
+    return entry
+
+
+# ── The invariant: a lookup never crosses transports ──────────────────
+
+
+class TestNoBorrowAcrossTransports:
+    def test_installed_registry_refuses_to_price_another_transport(self):
+        """A CLI price is not an API price, even for the identical model name."""
+        cli = DispatchIdentity("anthropic", "model-x", "cli")
+        api = DispatchIdentity("anthropic", "model-x", "api")
+        registry = RateRegistry(
+            entries={
+                cli: RateEntry(
+                    identity=cli,
+                    rates=ModelRates(input_per_mtok=3.0, output_per_mtok=15.0),
+                    mode=AccountingMode.PROVIDER_REPORTED,
+                    source=RateSource.PROJECT,
+                )
+            }
+        )
+        with rr.scoped_registry(registry):
+            assert rr.resolve(cli).rates == ModelRates(3.0, 15.0)
+            assert rr.resolve(api).rates is None
+            assert rr.resolve(api).priced is False
+
+    def test_lookup_never_returns_an_entry_for_a_different_transport(self):
+        """Whatever comes back is keyed to the transport that was asked about."""
+        entries = {
+            DispatchIdentity("openai", "m", "cli"): RateEntry(
+                identity=DispatchIdentity("openai", "m", "cli"),
+                rates=ModelRates(1.0, 2.0),
+                mode=AccountingMode.TOKEN_ESTIMATED,
+                source=RateSource.CATALOG,
+            ),
+            DispatchIdentity("openai", "m", "api"): RateEntry(
+                identity=DispatchIdentity("openai", "m", "api"),
+                rates=ModelRates(9.0, 18.0),
+                mode=AccountingMode.TOKEN_ESTIMATED,
+                source=RateSource.CATALOG,
+            ),
+        }
+        registry = RateRegistry(entries=entries)
+        with rr.scoped_registry(registry):
+            for transport in ("cli", "api", "nonsense"):
+                identity = DispatchIdentity("openai", "m", transport)
+                entry = rr.resolve(identity)
+                assert entry.identity is not None
+                assert entry.identity.transport == transport
+
+    def test_project_cli_price_does_not_leak_to_the_api_path(self, tmp_path, caplog):
+        """The reported P1, end to end.
+
+        ``zeta-9`` is priced by the project on the CLI and dispatched on the API
+        with no API price. The API run must record cost as unknown, the load must
+        warn naming the conflict, and no figure derived from the CLI rate may
+        appear anywhere.
+        """
+        with caplog.at_level(logging.WARNING, logger="theforge.config"):
+            _load(
+                tmp_path,
+                {
+                    "models": {
+                        "enabled": ["openai/zeta-9/cli", "openai/zeta-9/api"],
+                        "custom": {
+                            "openai/zeta-9/cli": _custom(
+                                "zeta-9",
+                                "cli",
+                                runner="codex",
+                                cost={"input_per_mtok": 7.0, "output_per_mtok": 21.0},
+                            ),
+                            "openai/zeta-9/api": _custom("zeta-9", "api"),
+                        },
+                    },
+                    "budget_usd": 50.0,
+                },
+            )
+
+        cli_cost = _estimate_cost("openai", "zeta-9", 1_000_000, 1_000_000, transport="cli")
+        api_cost = _estimate_cost("openai", "zeta-9", 1_000_000, 1_000_000, transport="api")
+        assert cli_cost == pytest.approx(28.0)
+        assert api_cost is None, "the API path must not borrow the CLI's declared rate"
+
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if "zeta-9" in record.getMessage() and "(api)" in record.getMessage()
+        ]
+        assert warnings, "load must name the unaccountable API identity"
+        assert "transport fallback" in warnings[0] or "review pool" in warnings[0]
+
+    def test_a_pricing_conflict_suppresses_the_packaged_widening_and_is_named(
+        self, tmp_path, caplog
+    ):
+        """Rule (c): a per-transport disagreement surfaces, it is not resolved.
+
+        ``gpt-5.5`` carries a packaged PRICING_TABLE row. The project prices it
+        on the CLI only. The API path must therefore NOT inherit the packaged
+        figure either — the conflict is operator-actionable and is reported as
+        such rather than papered over with whichever number is nearest.
+        """
+        with caplog.at_level(logging.WARNING, logger="theforge.config"):
+            _load(
+                tmp_path,
+                {
+                    "models": {
+                        "enabled": ["openai/gpt-5.5/cli", "openai/gpt-5.5/api"],
+                        "custom": {
+                            "openai/gpt-5.5/cli": {
+                                **_custom(
+                                    "gpt-5.5",
+                                    "cli",
+                                    runner="codex",
+                                    cost={"input_per_mtok": 4.0, "output_per_mtok": 25.0},
+                                ),
+                                "override": True,
+                            },
+                            "openai/gpt-5.5/api": {
+                                **_custom("gpt-5.5", "api"),
+                                "override": True,
+                            },
+                        },
+                    },
+                    "budget_usd": 50.0,
+                },
+            )
+
+        assert _estimate_cost("openai", "gpt-5.5", 1_000_000, 0, transport="cli") == pytest.approx(
+            4.0
+        )
+        assert _estimate_cost("openai", "gpt-5.5", 1_000_000, 0, transport="api") is None
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "gpt-5.5" in message and "per-transport pricing conflict" in message
+            for message in messages
+        ), messages
+
+
+# ── Legacy materialization: rules (a), (b), (c) ───────────────────────
+
+
+class TestLegacyMaterialization:
+    def test_packaged_price_materializes_onto_a_reachable_api_identity(self, tmp_path):
+        """Rule (a)/(b): a transport-agnostic packaged row still prices, as today."""
+        cfg = _load(tmp_path, {"models": ["openai/gpt-5.4/api"], "budget_usd": 50.0})
+        assert cfg.dev_profile.mode == "api"
+
+        registry = rr.active()
+        assert registry is not None
+        entry = registry.lookup(DispatchIdentity("openai", "gpt-5.4", "api"))
+        assert entry.priced
+        assert _estimate_cost("openai", "gpt-5.4", 1_000_000, 0, transport="api") == pytest.approx(
+            pricing_for("openai", "gpt-5.4").input_per_mtok
+        )
+
+    def test_an_unreachable_packaged_row_is_absent_from_the_compiled_registry(self):
+        """Rule (b): nothing unscoped enters the registry.
+
+        ``gpt-4o`` is in the packaged table but reachable on nothing here, so it
+        is dropped at compile time rather than retained as a wildcard that some
+        later identity could match against.
+        """
+        reachable = (rr.make_identity("openai", "gpt-5.4", "api"),)
+        from theforge.config.dispatch_rates import ReachableIdentity
+
+        registry, _ = compile_rate_registry(
+            {},
+            (ReachableIdentity(identity=reachable[0], runner="openai", paths=("dev",)),),
+        )
+        assert DispatchIdentity("openai", "gpt-4o", "api") not in registry.entries
+        assert registry.lookup(DispatchIdentity("openai", "gpt-4o", "api")).priced is False
+
+    def test_a_materialized_entry_records_where_it_was_widened_from(self, tmp_path):
+        """The widening is inspectable, not implicit."""
+        _load(tmp_path, {"models": ["openai/gpt-5.4/api"], "budget_usd": 50.0})
+        registry = rr.active()
+        entry = registry.lookup(DispatchIdentity("openai", "gpt-5.4", "api"))
+        if entry.source is RateSource.LEGACY_COMPAT:
+            assert entry.origin.startswith("PRICING_TABLE[")
+        else:
+            # A catalog entry already prices this identity per-transport, which
+            # is strictly better than a widening — assert it says so.
+            assert entry.source in (RateSource.CATALOG, RateSource.PROJECT)
+
+
+# ── Every dispatch path is priced by what it dispatched ───────────────
+
+
+class TestDispatchPathsAreEnumerated:
+    def test_seated_primary_and_model_fallback_are_both_reachable(self):
+        profile = ModelProfile(
+            name="dev",
+            model="gpt-5.4",
+            budget_usd=10.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+            provider="openai",
+            fallback_models=("gpt-5.4-mini",),
+        )
+        config = type("_Cfg", (), {"dev_profile": profile})()
+        labels = {reach.identity.label for reach in reachable_identities(config)}
+        assert "openai/gpt-5.4 (api)" in labels
+        assert "openai/gpt-5.4-mini (api)" in labels
+
+    def test_transport_fallback_is_reachable_with_the_identifier_unchanged(self):
+        """CLI→API on the SAME model name is a distinct identity, not the same one."""
+        profile = ModelProfile(
+            name="dev",
+            model="gpt-5.4",
+            budget_usd=10.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+            cli="codex",
+            api_fallback=TransportFallbackConfig(provider="openai", model="gpt-5.4"),
+        )
+        config = type("_Cfg", (), {"dev_profile": profile})()
+        by_label = {reach.identity.label: reach for reach in reachable_identities(config)}
+        assert "openai/gpt-5.4 (cli)" in by_label
+        assert "openai/gpt-5.4 (api)" in by_label
+        assert "transport fallback" in " ".join(by_label["openai/gpt-5.4 (api)"].paths)
+
+    def test_transport_fallback_is_reachable_with_a_changed_identifier(self):
+        profile = ModelProfile(
+            name="dev",
+            model="sonnet",
+            budget_usd=10.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+            cli="claude",
+            api_fallback=TransportFallbackConfig(provider="anthropic", model="claude-sonnet-4-6"),
+        )
+        config = type("_Cfg", (), {"dev_profile": profile})()
+        labels = {reach.identity.label for reach in reachable_identities(config)}
+        assert "anthropic/sonnet (cli)" in labels
+        assert "anthropic/claude-sonnet-4-6 (api)" in labels
+
+    def test_adaptive_pool_candidates_are_reachable(self, tmp_path):
+        """Adaptive routing selects from the registry, so the registry is reachable."""
+        cfg = _load(tmp_path, {"models": ["anthropic/sonnet/cli"], "budget_usd": 50.0})
+        assert cfg.assignment.adaptive_enabled
+        paths = {reach.identity.label: reach.paths for reach in reachable_identities(cfg)}
+        assert any("adaptive pool" in " ".join(entry_paths) for entry_paths in paths.values())
+
+
+class TestSameNameTwoTransports:
+    def test_cli_and_api_for_one_model_name_resolve_to_different_rates(self, tmp_path):
+        _load(
+            tmp_path,
+            {
+                "models": {
+                    "enabled": ["openai/zeta-9/cli", "openai/zeta-9/api"],
+                    "custom": {
+                        "openai/zeta-9/cli": _custom(
+                            "zeta-9",
+                            "cli",
+                            runner="codex",
+                            cost={"input_per_mtok": 1.0, "output_per_mtok": 2.0},
+                        ),
+                        "openai/zeta-9/api": _custom(
+                            "zeta-9",
+                            "api",
+                            cost={"input_per_mtok": 10.0, "output_per_mtok": 20.0},
+                        ),
+                    },
+                },
+                "budget_usd": 50.0,
+            },
+        )
+        cli = _estimate_cost("openai", "zeta-9", 1_000_000, 1_000_000, transport="cli")
+        api = _estimate_cost("openai", "zeta-9", 1_000_000, 1_000_000, transport="api")
+        assert cli == pytest.approx(3.0)
+        assert api == pytest.approx(30.0)
+
+
+class TestProjectDeclaredPricingNeedsNoCodeChange:
+    def test_a_model_priced_only_in_forge_yaml_reports_measured_cost(self, tmp_path):
+        """The acceptance criterion, stated directly."""
+        assert pricing_for("openai", "zeta-9") is None, "fixture model must be code-unknown"
+
+        _load(
+            tmp_path,
+            {
+                "models": {
+                    "enabled": ["openai/zeta-9/api"],
+                    "custom": {
+                        "openai/zeta-9/api": _custom(
+                            "zeta-9",
+                            "api",
+                            cost={"input_per_mtok": 6.0, "output_per_mtok": 12.0},
+                        )
+                    },
+                },
+                "budget_usd": 50.0,
+            },
+        )
+        assert _estimate_cost(
+            "openai", "zeta-9", 2_000_000, 1_000_000, transport="api"
+        ) == pytest.approx(24.0)
+
+    def test_declaring_a_price_does_not_mutate_the_shipped_registry(self, tmp_path):
+        from theforge.config.models import AGENT_REGISTRY
+
+        before = dict(AGENT_REGISTRY)
+        _load(
+            tmp_path,
+            {
+                "models": {
+                    "enabled": ["openai/zeta-9/api"],
+                    "custom": {
+                        "openai/zeta-9/api": _custom(
+                            "zeta-9",
+                            "api",
+                            cost={"input_per_mtok": 6.0, "output_per_mtok": 12.0},
+                        )
+                    },
+                },
+                "budget_usd": 50.0,
+            },
+        )
+        assert dict(AGENT_REGISTRY) == before
+        assert "openai/zeta-9/api" not in AGENT_REGISTRY
+
+
+class TestUnpriceableCandidate:
+    def test_it_is_reported_at_load_and_records_cost_none_at_runtime(self, tmp_path, caplog):
+        with caplog.at_level(logging.WARNING, logger="theforge.config"):
+            _load(
+                tmp_path,
+                {
+                    "models": {
+                        "enabled": ["openai/no-price-at-all/api"],
+                        "custom": {
+                            "openai/no-price-at-all/api": _custom("no-price-at-all", "api")
+                        },
+                    },
+                    "budget_usd": 50.0,
+                },
+            )
+        messages = [record.getMessage() for record in caplog.records]
+        named = [m for m in messages if "no-price-at-all" in m]
+        assert named, messages
+        assert "dev" in named[0], "the report must name the paths it is dispatched on"
+        assert _estimate_cost("openai", "no-price-at-all", 1_000, 1_000, transport="api") is None
+
+    def test_load_warns_rather_than_raising(self, tmp_path):
+        """An unpriced model is allowed to run and record cost as unknown."""
+        cfg = _load(
+            tmp_path,
+            {
+                "models": {
+                    "enabled": ["openai/no-price-at-all/api"],
+                    "custom": {"openai/no-price-at-all/api": _custom("no-price-at-all", "api")},
+                },
+                "budget_usd": 50.0,
+            },
+        )
+        assert cfg.dev_profile.model == "no-price-at-all"
+
+
+# ── Identity replacement sites price the NEW identity ─────────────────
+
+
+class TestReplacedProfilesPriceWhatTheyBecame:
+    """The reason no candidate-construction path needs converting.
+
+    Nothing carries a rate, so a profile produced by ``dataclasses.replace``,
+    ``apply_model_info``, ``model_ref_to_profile`` or ``_make_fast_profile``
+    cannot carry a stale one: ``identity_of`` reads the replaced profile.
+    """
+
+    @staticmethod
+    def _registry() -> RateRegistry:
+        cli = DispatchIdentity("openai", "zeta-9", "cli")
+        api = DispatchIdentity("openai", "zeta-9", "api")
+        other = DispatchIdentity("openai", "zeta-10", "api")
+        return RateRegistry(
+            entries={
+                cli: RateEntry(cli, ModelRates(1.0, 1.0), AccountingMode.TOKEN_ESTIMATED),
+                api: RateEntry(api, ModelRates(2.0, 2.0), AccountingMode.TOKEN_ESTIMATED),
+                other: RateEntry(other, ModelRates(3.0, 3.0), AccountingMode.TOKEN_ESTIMATED),
+            }
+        )
+
+    def test_a_transport_swap_prices_the_new_transport(self):
+        import dataclasses
+
+        profile = ModelProfile(
+            name="dev",
+            model="zeta-9",
+            budget_usd=10.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+            cli="codex",
+        )
+        swapped = dataclasses.replace(profile, cli=None, provider="openai")
+        with rr.scoped_registry(self._registry()):
+            assert rr.entry_for_profile(profile).rates == ModelRates(1.0, 1.0)
+            assert rr.entry_for_profile(swapped).rates == ModelRates(2.0, 2.0)
+
+    def test_a_model_swap_prices_the_new_model(self):
+        import dataclasses
+
+        profile = ModelProfile(
+            name="dev",
+            model="zeta-9",
+            budget_usd=10.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+            provider="openai",
+        )
+        swapped = dataclasses.replace(profile, model="zeta-10")
+        with rr.scoped_registry(self._registry()):
+            assert rr.entry_for_profile(profile).rates == ModelRates(2.0, 2.0)
+            assert rr.entry_for_profile(swapped).rates == ModelRates(3.0, 3.0)
+
+    def test_apply_model_info_result_prices_the_model_it_applied(self):
+        from theforge.config.model_identity import AgentSpec, RoutingPolicy, TransportSpec
+        from theforge.config.models import _spec_to_model_info, apply_model_info
+
+        profile = ModelProfile(
+            name="dev",
+            model="zeta-9",
+            budget_usd=10.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+            provider="openai",
+        )
+        spec = AgentSpec(
+            provider="openai",
+            model="zeta-10",
+            transport=TransportSpec(kind="api", runner="openai"),
+            routing=RoutingPolicy(tier="strong", capability=9, cost_rank=2),
+        )
+        applied = apply_model_info(profile, _spec_to_model_info(spec))
+        with rr.scoped_registry(self._registry()):
+            assert identity_of(applied) == DispatchIdentity("openai", "zeta-10", "api")
+            assert rr.entry_for_profile(applied).rates == ModelRates(3.0, 3.0)
+
+
+# ── Partial identities, and the no-registry baseline ──────────────────
+
+
+class TestPartialIdentities:
+    def test_a_profile_with_no_provider_or_transport_has_no_identity(self):
+        profile = ModelProfile(
+            name="bare",
+            model="whatever",
+            budget_usd=1.0,
+            timeout_seconds=1,
+            allowed_tools=(),
+        )
+        assert profile.provider_family is None
+        assert identity_of(profile) is None
+
+    def test_an_unresolvable_identity_is_unpriced_rather_than_a_partial_key(self):
+        assert make_identity(None, "m", "cli") is None
+        assert make_identity("openai", "m", None) is None
+        entry = rr.resolve(None)
+        assert entry.priced is False
+        assert entry.identity is None
+
+    def test_an_unresolvable_profile_is_not_enumerated(self):
+        profile = ModelProfile(
+            name="bare",
+            model="whatever",
+            budget_usd=1.0,
+            timeout_seconds=1,
+            allowed_tools=(),
+        )
+        config = type("_Cfg", (), {"dev_profile": profile})()
+        assert reachable_identities(config) == ()
+
+
+class TestNoRegistryBaseline:
+    def test_uninstalled_registry_reproduces_pricing_for_exactly(self):
+        with rr.scoped_registry(None):
+            for provider, model in (
+                ("openai", "gpt-5.4"),
+                ("anthropic", "claude-sonnet-4-6"),
+                ("google", "gemini-2.5-flash"),
+                ("openai", "codestral"),
+            ):
+                for transport in ("cli", "api", None):
+                    assert rr.rates_for(provider, model, transport) == pricing_for(provider, model)
+
+    def test_estimate_cost_without_a_transport_takes_the_baseline(self):
+        with rr.scoped_registry(None):
+            assert _estimate_cost("openai", "gpt-5.4", 1_000_000, 0) == pytest.approx(
+                _estimate_cost("openai", "gpt-5.4", 1_000_000, 0, transport="api")
+            )
+
+
+class TestInstallContract:
+    def test_last_install_wins_and_scoping_restores(self):
+        first = RateRegistry(entries={})
+        second = RateRegistry(
+            entries={
+                DispatchIdentity("openai", "m", "api"): RateEntry(
+                    DispatchIdentity("openai", "m", "api"), ModelRates(1.0, 1.0)
+                )
+            }
+        )
+        with rr.scoped_registry(first):
+            assert rr.active() is first
+            with rr.scoped_registry(second):
+                assert rr.active() is second
+            assert rr.active() is first
+        assert rr.active() is None
+
+    def test_a_load_that_raises_leaves_no_registry_installed(self, tmp_path):
+        """Installation happens only after the ForgeConfig is fully constructed."""
+        assert rr.active() is None
+        with pytest.raises(Exception):
+            _load(tmp_path, {"models": ["openai/definitely-not-a-model/api"], "budget_usd": 50.0})
+        assert rr.active() is None
+
+
+# ── Accounting capability, per transport ──────────────────────────────
+
+
+class TestAccountingModes:
+    def test_claude_cli_is_provider_reported_and_needs_no_rate_card(self):
+        mode = rr.accounting_mode_for("cli", "claude")
+        assert mode is AccountingMode.PROVIDER_REPORTED
+        assert mode.measures_without_rates
+        assert not mode.needs_rates
+        assert RateEntry(None, None, mode).accountable
+
+    def test_ghaw_measures_spend_independently_of_any_rate_card(self):
+        """gh-aw converts AI-credit consumption, so it must not draw a missing-rate
+        warning for a transport that already measures (runner_ghaw._parse_agent_usage)."""
+        mode = rr.accounting_mode_for("cli", "ghaw")
+        assert mode is AccountingMode.INDEPENDENTLY_MEASURED
+        assert RateEntry(None, None, mode).accountable
+        assert RateEntry(None, None, mode).unaccountable_reason() is None
+
+    def test_api_transports_need_a_rate_card(self):
+        mode = rr.accounting_mode_for("api", "openai")
+        assert mode is AccountingMode.TOKEN_ESTIMATED
+        assert not RateEntry(None, None, mode).accountable
+        assert RateEntry(None, ModelRates(1.0, 1.0), mode).accountable
+
+    def test_gemini_cli_measures_only_when_the_cli_reports_usage(self):
+        assert rr.accounting_mode_for("cli", "gemini") is (
+            AccountingMode.TOKEN_ESTIMATED_IF_REPORTED
+        )
+
+    def test_an_unrecognised_cli_is_unmeasurable_not_assumed_estimable(self):
+        mode = rr.accounting_mode_for("cli", "some-new-binary")
+        assert mode is AccountingMode.UNMEASURABLE
+        entry = RateEntry(None, ModelRates(1.0, 1.0), mode)
+        assert not entry.accountable, "rates alone do not make spend measurable"
+        assert "reports no usage" in entry.unaccountable_reason()
+
+
+class TestThinkingSpendCapture:
+    """``_thinking_spend_captured`` no longer uses table membership as a proxy."""
+
+    @staticmethod
+    def _profile(**kwargs) -> ModelProfile:
+        base = dict(
+            name="dev",
+            model="zeta-9",
+            budget_usd=10.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+        )
+        base.update(kwargs)
+        return ModelProfile(**base)
+
+    def test_a_provider_reporting_transport_captures_spend_without_rates(self):
+        from theforge.assignment import _thinking_spend_captured
+        from theforge.routing import EffortKnob
+
+        knob = EffortKnob(kind="token_budget", captures_thinking_spend=True)
+        profile = self._profile(cli="claude", model="sonnet")
+        identity = identity_of(profile)
+        registry = RateRegistry(
+            entries={
+                identity: RateEntry(
+                    identity, None, AccountingMode.PROVIDER_REPORTED, RateSource.NONE
+                )
+            }
+        )
+        with rr.scoped_registry(registry):
+            assert _thinking_spend_captured(profile, knob) is True
+
+    def test_an_unmeasurable_transport_does_not_capture_spend_despite_rates(self):
+        from theforge.assignment import _thinking_spend_captured
+        from theforge.routing import EffortKnob
+
+        knob = EffortKnob(kind="token_budget", captures_thinking_spend=True)
+        profile = self._profile(provider="openai")
+        identity = identity_of(profile)
+        registry = RateRegistry(
+            entries={
+                identity: RateEntry(
+                    identity,
+                    ModelRates(1.0, 1.0),
+                    AccountingMode.UNMEASURABLE,
+                    RateSource.PROJECT,
+                )
+            }
+        )
+        with rr.scoped_registry(registry):
+            assert _thinking_spend_captured(profile, knob) is False
+
+
+# ── Behaviour that must NOT change ────────────────────────────────────
+
+
+class TestUnchangedBehaviour:
+    def test_claude_cli_self_reported_cost_still_wins(self):
+        """The CLI's billed total is untouched by any of this."""
+        from theforge.runners import runner_claude
+
+        assert runner_claude._resolve_anthropic_pricing_key("claude-sonnet-4-6") is not None
+        # A dated id still resolves to its family entry.
+        assert (
+            runner_claude._resolve_anthropic_pricing_key("claude-sonnet-4-6-20260101")
+            == "claude-sonnet-4-6"
+        )
+
+    def test_anthropic_kill_path_pricing_matches_the_packaged_rates(self):
+        from theforge.runners.runner_claude import _estimate_anthropic_cost
+
+        cost = _estimate_anthropic_cost("claude-sonnet-4-6", 1_000_000, 1_000_000, 0, 0)
+        rates = pricing_for("anthropic", "claude-sonnet-4-6")
+        assert cost == pytest.approx(rates.input_per_mtok + rates.output_per_mtok)
+
+    def test_a_cli_price_cannot_reach_the_anthropic_kill_path_reconstruction(self):
+        """The dated-id prefix match runs against CLI keys only."""
+        from theforge.runners.runner_claude import _estimate_anthropic_cost
+
+        api_only = DispatchIdentity("anthropic", "claude-invented-9", "api")
+        registry = RateRegistry(entries={api_only: RateEntry(api_only, ModelRates(999.0, 999.0))})
+        with rr.scoped_registry(registry):
+            assert _estimate_anthropic_cost("claude-invented-9", 1_000_000, 0, 0, 0) is None
+
+    def test_a_model_carrying_a_rate_card_prices_as_before(self):
+        with rr.scoped_registry(None):
+            assert _estimate_cost(
+                "deepseek", "deepseek-v4-pro", 1_000_000, 0, transport="api"
+            ) == pytest.approx(pricing_for("deepseek", "deepseek-v4-pro").input_per_mtok)
+
+
+class TestGeminiCliAccounting:
+    def test_reported_usage_is_priced_from_the_gemini_cli_identity(self):
+        from theforge.runners.runner_gemini import _parse_gemini_usage
+
+        cli = DispatchIdentity("google", "gemini-2.5-pro", "cli")
+        api = DispatchIdentity("google", "gemini-2.5-pro", "api")
+        registry = RateRegistry(
+            entries={
+                cli: RateEntry(cli, ModelRates(1.0, 2.0), AccountingMode.TOKEN_ESTIMATED),
+                api: RateEntry(api, ModelRates(500.0, 500.0), AccountingMode.TOKEN_ESTIMATED),
+            }
+        )
+        result_json = {
+            "response": "ok",
+            "stats": {
+                "models": {
+                    "gemini-2.5-pro": {
+                        "tokens": {"prompt": 1_000_000, "candidates": 1_000_000, "cached": 0}
+                    }
+                }
+            },
+        }
+        profile = ModelProfile(
+            name="r",
+            model="gemini-2.5-pro",
+            budget_usd=1.0,
+            timeout_seconds=1,
+            allowed_tools=(),
+            cli="gemini",
+        )
+        with rr.scoped_registry(registry):
+            cost, usage = _parse_gemini_usage(result_json, profile)
+        assert cost == pytest.approx(3.0), "must use the CLI rate, not the API rate"
+        assert len(usage) == 1
+        assert usage[0].cost_provenance == "estimated"
+
+    def test_absent_usage_stays_unknown_rather_than_fabricated(self):
+        from theforge.runners.runner_gemini import _parse_gemini_usage
+
+        profile = ModelProfile(
+            name="r",
+            model="gemini-2.5-pro",
+            budget_usd=1.0,
+            timeout_seconds=1,
+            allowed_tools=(),
+            cli="gemini",
+        )
+        assert _parse_gemini_usage({"response": "ok"}, profile) == (None, ())
+        assert _parse_gemini_usage({"stats": {"models": {}}}, profile) == (None, ())
+
+    def test_unpriced_reported_usage_records_tokens_with_cost_unknown(self):
+        from theforge.runners.runner_gemini import _parse_gemini_usage
+
+        profile = ModelProfile(
+            name="r",
+            model="mystery",
+            budget_usd=1.0,
+            timeout_seconds=1,
+            allowed_tools=(),
+            cli="gemini",
+        )
+        result_json = {
+            "stats": {"models": {"mystery": {"tokens": {"prompt": 10, "candidates": 5}}}}
+        }
+        with rr.scoped_registry(RateRegistry(entries={})):
+            cost, usage = _parse_gemini_usage(result_json, profile)
+        assert cost is None
+        assert usage[0].input_tokens == 10
+        assert usage[0].cost_provenance == "unknown"

--- a/tests/test_dispatch_rate_registry.py
+++ b/tests/test_dispatch_rate_registry.py
@@ -31,6 +31,7 @@ from theforge.config.dispatch_rates import (
 )
 from theforge.config.types import ModelProfile, TransportFallbackConfig
 from theforge.runners import rate_registry as rr
+from theforge.runners import schema_utils as su
 from theforge.runners.rate_registry import (
     AccountingMode,
     DispatchIdentity,
@@ -466,8 +467,8 @@ class TestReplacedProfilesPriceWhatTheyBecame:
         )
         swapped = dataclasses.replace(profile, cli=None, provider="openai")
         with rr.scoped_registry(self._registry()):
-            assert rr.entry_for_profile(profile).rates == ModelRates(1.0, 1.0)
-            assert rr.entry_for_profile(swapped).rates == ModelRates(2.0, 2.0)
+            assert su.entry_for_profile(profile).rates == ModelRates(1.0, 1.0)
+            assert su.entry_for_profile(swapped).rates == ModelRates(2.0, 2.0)
 
     def test_a_model_swap_prices_the_new_model(self):
         import dataclasses
@@ -482,8 +483,8 @@ class TestReplacedProfilesPriceWhatTheyBecame:
         )
         swapped = dataclasses.replace(profile, model="zeta-10")
         with rr.scoped_registry(self._registry()):
-            assert rr.entry_for_profile(profile).rates == ModelRates(2.0, 2.0)
-            assert rr.entry_for_profile(swapped).rates == ModelRates(3.0, 3.0)
+            assert su.entry_for_profile(profile).rates == ModelRates(2.0, 2.0)
+            assert su.entry_for_profile(swapped).rates == ModelRates(3.0, 3.0)
 
     def test_apply_model_info_result_prices_the_model_it_applied(self):
         from theforge.config.model_identity import AgentSpec, RoutingPolicy, TransportSpec
@@ -506,7 +507,7 @@ class TestReplacedProfilesPriceWhatTheyBecame:
         applied = apply_model_info(profile, _spec_to_model_info(spec))
         with rr.scoped_registry(self._registry()):
             assert identity_of(applied) == DispatchIdentity("openai", "zeta-10", "api")
-            assert rr.entry_for_profile(applied).rates == ModelRates(3.0, 3.0)
+            assert su.entry_for_profile(applied).rates == ModelRates(3.0, 3.0)
 
 
 # ── Partial identities, and the no-registry baseline ──────────────────
@@ -553,7 +554,7 @@ class TestNoRegistryBaseline:
                 ("openai", "codestral"),
             ):
                 for transport in ("cli", "api", None):
-                    assert rr.rates_for(provider, model, transport) == pricing_for(provider, model)
+                    assert su.rates_for(provider, model, transport) == pricing_for(provider, model)
 
     def test_estimate_cost_without_a_transport_takes_the_baseline(self):
         with rr.scoped_registry(None):
@@ -785,3 +786,48 @@ class TestGeminiCliAccounting:
         assert cost is None
         assert usage[0].input_tokens == 10
         assert usage[0].cost_provenance == "unknown"
+
+
+class TestRateRegistryIsAnImportLeaf:
+    """The registry module must not reach back into ``theforge`` at all.
+
+    Configuration load compiles the registry, so ``theforge.config`` imports
+    this module. Anything it imported — even lazily, inside a function — would
+    become reachable from ``theforge.config`` and put the pricing key type in a
+    cycle with half the runners package, which is exactly what the first
+    iteration of this change did. The catalog-backed resolution that genuinely
+    needs ``theforge.config.models`` lives in ``schema_utils`` instead, one
+    direction only.
+    """
+
+    def test_no_theforge_import_anywhere_in_the_module(self):
+        import ast
+        from pathlib import Path
+
+        from theforge.runners import rate_registry
+
+        source = Path(rate_registry.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        offenders: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                offenders.extend(
+                    alias.name for alias in node.names if alias.name.startswith("theforge")
+                )
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    # A relative import is a theforge import by definition.
+                    offenders.append(f".{node.module or ''}")
+                elif node.module and node.module.startswith("theforge"):
+                    offenders.append(node.module)
+        # TYPE_CHECKING-only imports are erased at runtime and create no edge,
+        # but the convention checker walks the AST, so they count too.
+        assert offenders == [], f"rate_registry must stay an import leaf; found {offenders}"
+
+    def test_schema_utils_re_exports_the_moved_names(self):
+        """Existing imports keep working after the pricing data moved."""
+        from theforge.runners import rate_registry, schema_utils
+
+        assert schema_utils.PRICING_TABLE is rate_registry.PRICING_TABLE
+        assert schema_utils.ModelRates is rate_registry.ModelRates
+        assert schema_utils.CACHED_INPUT_RATE_MULT == rate_registry.CACHED_INPUT_RATE_MULT

--- a/tests/test_dispatch_rate_registry.py
+++ b/tests/test_dispatch_rate_registry.py
@@ -275,6 +275,115 @@ class TestDispatchPathsAreEnumerated:
         assert "openai/gpt-5.4 (api)" in labels
         assert "openai/gpt-5.4-mini (api)" in labels
 
+    def test_a_cli_profiles_model_fallback_is_enumerated_on_the_api_transport(self):
+        """A CLI ``fallback_models`` entry dispatches on the API, so price it there.
+
+        ``runners/cli.py:_build_cli_fallback_api_profile`` sends a CLI profile's
+        fallback entries through the provider's API adapter — the failure that
+        triggers a model fallback is a quota or model-not-found refusal, which
+        the CLI would only reproduce. Enumerating the entry under the primary's
+        CLI transport named an identity that never runs and left the one that
+        does unchecked.
+        """
+        profile = ModelProfile(
+            name="dev",
+            model="gpt-5.4",
+            budget_usd=10.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+            cli="codex",
+            fallback_models=("gpt-5.4-mini",),
+        )
+        assert profile.mode == "cli"
+        config = type("_Cfg", (), {"dev_profile": profile})()
+        by_label = {reach.identity.label: reach for reach in reachable_identities(config)}
+
+        assert "openai/gpt-5.4 (cli)" in by_label, "the primary still dispatches on the CLI"
+        assert "openai/gpt-5.4-mini (api)" in by_label, (
+            "the fallback dispatches on the API and must be priced there"
+        )
+        assert "openai/gpt-5.4-mini (cli)" not in by_label, (
+            "no CLI identity for the fallback — nothing ever dispatches it there"
+        )
+        assert "model fallback" in " ".join(by_label["openai/gpt-5.4-mini (api)"].paths)
+
+    def test_the_enumerated_fallback_identity_is_the_one_the_runner_builds(self):
+        """Load-time enumeration and the runner read ONE definition of the rule.
+
+        Asserting against ``_build_cli_fallback_api_profile`` directly, rather
+        than against a second copy of the expectation, is what stops the two
+        drifting apart again: if the runner's transport choice changes, this
+        fails rather than silently mispricing.
+        """
+        from theforge.runners.cli import _build_cli_fallback_api_profile
+
+        profile = ModelProfile(
+            name="dev",
+            model="gpt-5.4",
+            budget_usd=10.0,
+            timeout_seconds=60,
+            allowed_tools=(),
+            cli="codex",
+            fallback_models=("gpt-5.4-mini",),
+        )
+        dispatched = _build_cli_fallback_api_profile(profile, "gpt-5.4-mini")
+        assert dispatched is not None
+        expected = identity_of(dispatched)
+
+        enumerated = {
+            reach.identity
+            for reach in reachable_identities(type("_Cfg", (), {"dev_profile": profile})())
+            if "model fallback" in " ".join(reach.paths)
+        }
+        assert enumerated == {expected}
+
+    def test_a_provider_with_no_api_adapter_yields_no_fallback_identity(self):
+        """No API adapter means the runner can never attempt it (rule b).
+
+        Both sides read :func:`model_fallback_transport`, so both answer None and
+        the entry names no reachable identity. Warning about a path that cannot
+        run is noise an operator cannot act on.
+        """
+        from theforge.config.model_identity import model_fallback_transport
+
+        assert model_fallback_transport("not-a-provider") is None
+        assert model_fallback_transport(None) is None
+        assert model_fallback_transport("openai") is not None
+
+    def test_an_unpriced_cli_model_fallback_is_reported_under_its_api_identity(
+        self, tmp_path, caplog
+    ):
+        """The finding, end to end: the API identity is named before it can run."""
+        with caplog.at_level(logging.WARNING, logger="theforge.config"):
+            _load(
+                tmp_path,
+                {
+                    "models": {
+                        "enabled": ["openai/zeta-9/cli"],
+                        "custom": {
+                            "openai/zeta-9/cli": _custom(
+                                "zeta-9",
+                                "cli",
+                                runner="codex",
+                                cost={"input_per_mtok": 7.0, "output_per_mtok": 21.0},
+                            )
+                        },
+                    },
+                    "overrides": {"dev": {"fallback_models": ["zeta-unpriced"]}},
+                    "budget_usd": 50.0,
+                },
+            )
+
+        named = [
+            record.getMessage()
+            for record in caplog.records
+            if "zeta-unpriced" in record.getMessage()
+        ]
+        assert named, "the unpriced model fallback must be named at load"
+        assert "(api)" in named[0], f"named under the wrong transport: {named[0]}"
+        assert "model fallback" in named[0]
+        assert _estimate_cost("openai", "zeta-unpriced", 1_000, 1_000, transport="api") is None
+
     def test_transport_fallback_is_reachable_with_the_identifier_unchanged(self):
         """CLI→API on the SAME model name is a distinct identity, not the same one."""
         profile = ModelProfile(


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Cycle 1 fallback transport issue is fixed; focused pricing-registry tests pass and I found no blocking regressions. | [google-gemini-3.5-flash-api] The pricing and accounting reconciliation has been successfully resolved, with full verification of all fallback model transports. | [anthropic-claude-haiku-4-5-cli] Cycle 1 P1 (fallback_models enumerated on CLI but dispatching on API) is fixed via shared model_fallback_transport() function ensuring both runner and enumeration read one definition. No new P1s identified; tests verify the fix comprehensively.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** unknown (>= $49.70 measured)
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

A model priced in project configuration is absent from the accounting table, so it routes as priced and records its spend as unknown (GitHub Issue #2335)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2335