### PR TITLE
Unmeasured cost overwrites a story's recorded outcome, so approved work is reported as failed and an investigation is recommended for a dependency skip

### DIFF
--- a/src/theforge/cli/sprint_digest.py
+++ b/src/theforge/cli/sprint_digest.py
@@ -81,11 +81,17 @@ from theforge.sprint.status_reader import (
 # resume/reconcile (not reshaping/scheduling), so it must render under its own
 # FAILED heading via ``_print_failed_by_class`` — the generic recovery path for
 # any primary class not routed to SKIPPED / INTAKE.
+#
+# ``skip_reason_unrecorded`` belongs here for the plainest reason of all: the
+# sprint recorded that it skipped the story, so it is a skip — the missing
+# reason does not make it a failure, and rendering it under FAILED is how a
+# dependency skip reached the operator as work needing investigation (#2373).
 _SKIPPED_INTAKE_CLASSES = frozenset(
     {
         "intake_shape",
         "dependency_skip",
         "launch_collision",
+        "skip_reason_unrecorded",
     }
 )
 
@@ -423,6 +429,7 @@ def _print_failed_by_class(non_done: list[dict], rca_stories: dict) -> None:
             for index, line in enumerate(evidence_lines):
                 label = "evidence:    " if index == 0 else "             "
                 print(f"       {label} {line}")
+            _print_entry_notes(entry)
 
 
 def _print_skipped_intake(non_done: list[dict], rca_stories: dict) -> None:
@@ -444,6 +451,26 @@ def _print_skipped_intake(non_done: list[dict], rca_stories: dict) -> None:
             print(f"       {primary} — {detail}")
         else:
             print(f"       {primary}")
+        _print_entry_notes(entry)
+
+
+def _print_entry_notes(entry: dict) -> None:
+    """Print the accounting and cross-surface notes an RCA entry carries.
+
+    Both are reported *beside* the story's classification, never as it: an
+    unmeasured cost is a condition of the run's accounting, and a disagreement
+    between the audit and the summary is a fact about the surfaces rather than
+    about the work (#2373). Absent on RCA artifacts written by an older ruleset,
+    in which case nothing is printed.
+    """
+    accounting = entry.get("cost_accounting")
+    if isinstance(accounting, dict) and accounting.get("measured") is False:
+        print("       accounting:   cost unmeasured for this story (not a failure)")
+    consistency = entry.get("outcome_consistency")
+    if isinstance(consistency, dict) and consistency.get("agrees") is False:
+        note = str(consistency.get("note") or "").strip()
+        if note:
+            print(f"       inconsistent: {note}")
 
 
 def _print_partial_value(non_done: list[dict], rca_stories: dict) -> None:

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -1300,6 +1300,22 @@ def _write_sprint_summary(
             outcome_lower = canonical_entry.outcome.name.lower()
             entry["outcome_code"] = entry.get("error_type") or outcome_lower
             entry["cost_usd"] = canonical_entry.cost_usd
+            # The canonical outcome arrives with the sentence the sprint recorded
+            # when it set it. Projecting the outcome without that sentence leaves
+            # a row saying SKIPPED and nothing else, which every downstream
+            # reader has to explain from something other than the run's own
+            # words: an approved-then-dependency-skipped story reached the
+            # operator as unclassifiable work needing a paid investigation
+            # (#2373). Only filled when the row carries no error of its own — a
+            # cause the story itself recorded is never overwritten.
+            if (
+                canonical_entry.outcome.is_skipped
+                and canonical_entry.reason
+                and not entry.get("error")
+            ):
+                entry["error"] = canonical_entry.reason
+                if accumulated_by_slug.get(slug) is not None:
+                    accumulated_by_slug[slug]["error"] = canonical_entry.reason
             accumulated = accumulated_by_slug.get(slug)
             if accumulated is not None:
                 accumulated["cost_usd"] = canonical_entry.cost_usd

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -50,7 +50,7 @@ SCHEMA_VERSION = 1
 # (schema_version stays 1) rather than a silent rewrite of historical judgement:
 # an operator can tell whether two RCA files for one sprint were produced by the
 # same rule set by comparing this field.
-RULESET_VERSION = 11
+RULESET_VERSION = 12
 RCA_FILENAME = "sprint-rca.yaml"
 
 # Outcomes that mean the story landed / succeeded. These stay accounted for in
@@ -71,6 +71,27 @@ UNKNOWN_CLASS = "unknown_needs_rca"
 # sentence, so an operator reads what the run said instead of acting on a class
 # assembled from somewhere else.
 TAXONOMY_GAP_CLASS = "taxonomy_gap"
+
+# Class assigned when the sprint recorded that it *skipped* a story but recorded
+# no reason on the row (#2373). The story's end state is not unknown — the run
+# stated it — so it must not fall to ``unknown_needs_rca``, whose attached
+# recommendation buys an LLM investigation to establish something the run already
+# recorded. What is missing is the sentence saying why, and that is read from the
+# run log, not from a paid diagnosis.
+SKIP_REASON_UNRECORDED_CLASS = "skip_reason_unrecorded"
+
+# Summary ``outcome`` values that mean the sprint recorded the story as skipped
+# rather than failed. Keep in sync with ``StoryOutcome.is_skipped`` in
+# ``sprint.story_state`` — this module is a pure function over on-disk artifacts
+# and deliberately imports no coordinator/sprint runtime modules.
+SKIPPED_OUTCOMES = frozenset({"SKIPPED", "PRESERVED", "OPERATOR_ACTION"})
+
+# Per-story accounting status the coordinator records when a story's spend could
+# not be measured. Keep in sync with ``coordinator.story_budget.STATUS_UNKNOWN``.
+# It is accounting metadata reported *beside* the outcome and is never an input
+# to classification: how a story ended and how well its cost was measured are
+# separate facts (#2373).
+COST_UNKNOWN_STATUS = "cost_unknown"
 
 # ``error_type`` the coordinator stamps when a story's monetary allocation (or the
 # non-review part of it a review reservation leaves) can no longer fund the work.
@@ -878,6 +899,24 @@ def _classify_story(
                 }
             )
             primary = TAXONOMY_GAP_CLASS
+        elif outcome in SKIPPED_OUTCOMES:
+            # The sprint recorded that it skipped this story. That IS its end
+            # state, recorded by the run itself, so the residual class — and the
+            # paid investigation attached to it — must not claim the end state is
+            # unknown (#2373). Only the reason is missing, and the run log is
+            # where it is read from.
+            evidence.append(
+                {
+                    "source": summary_source,
+                    "rule_id": "skip_reason_unrecorded",
+                    "excerpt": _truncate(
+                        f"the sprint recorded outcome={outcome} for this story but recorded "
+                        "no reason on its row; the story's end state is known and only the "
+                        "reason is missing"
+                    ),
+                }
+            )
+            primary = SKIP_REASON_UNRECORDED_CLASS
         else:
             primary = UNKNOWN_CLASS
 
@@ -907,12 +946,14 @@ def _classify_story(
     # trust than declining to guess. Field-derived (structured) factors are the
     # run's own recorded facts, not an inference, so they still stand. A taxonomy
     # gap is the same state of knowledge — no rule classified the story — so it
-    # withholds text-derived amplifiers on the same grounds.
+    # withholds text-derived amplifiers on the same grounds, as does an
+    # unrecorded skip reason (#2373).
     contributing = _dedupe_ordered(
         [
             failure_class
             for failure_class, source_kind in contributing_hits
-            if primary not in {UNKNOWN_CLASS, TAXONOMY_GAP_CLASS} or source_kind == "structured"
+            if primary not in {UNKNOWN_CLASS, TAXONOMY_GAP_CLASS, SKIP_REASON_UNRECORDED_CLASS}
+            or source_kind == "structured"
         ]
     )
 
@@ -928,12 +969,77 @@ def _classify_story(
         unclassified_skip_reason=unclassified_skip_reason,
     )
 
-    return {
+    entry = {
         "primary_failure_class": primary,
         "contributing_factors": contributing,
         "evidence": evidence,
         "partial_value": partial_value,
+        # How well the story's spend was measured, recorded beside the outcome
+        # and never folded into it (#2373).
+        "cost_accounting": _cost_accounting(story),
         "recommended_next_actions": actions,
+    }
+    # Only present when the surfaces describing this one story disagree; an
+    # operator reading one of them otherwise has no way to know (#2373).
+    consistency = _outcome_consistency(story, audit, outcome, summary_source, audit_source)
+    if consistency is not None:
+        entry["outcome_consistency"] = consistency
+    return entry
+
+
+def _cost_accounting(story: dict) -> dict:
+    """Report whether the story's spend was measured — accounting, not outcome.
+
+    Unmeasured spend is a condition of the run's accounting, not a statement
+    about how the story ended, so it is reported here rather than allowed to
+    consume the outcome or the recommendation derived from it (#2373).
+    """
+    # Same default as ``status_reader._story_cost_usd``: an explicit ``None`` is
+    # unmeasured spend, an absent key is a legacy row and not a claim either way.
+    cost = story.get("cost_usd", 0.0)
+    measured = isinstance(cost, (int, float)) and not isinstance(cost, bool)
+    accounting: dict = {"measured": measured}
+    if not measured:
+        accounting["status"] = COST_UNKNOWN_STATUS
+    return accounting
+
+
+def _outcome_consistency(
+    story: dict,
+    audit: dict,
+    outcome: str,
+    summary_source: str,
+    audit_source: str,
+) -> dict | None:
+    """Report disagreement between the summary row and the per-story audit.
+
+    The sprint's recorded outcome is authoritative — it is the run's statement
+    about how the story ended — while the audit's ``final_phase``/``success``
+    describe how far the story got and whether the phase it reached succeeded. A
+    story approved at PLAN_REVIEW and then skipped for a failed dependency
+    carries both, and they read as a contradiction to an operator holding only
+    one of them (#2373). Returns ``None`` when there is nothing to report.
+    """
+    outcome_block = audit.get("outcome") if isinstance(audit, dict) else None
+    if not isinstance(outcome_block, dict) or not outcome:
+        return None
+    success = outcome_block.get("success")
+    final_phase = _nonempty(outcome_block.get("final_phase"))
+    if success is not True or outcome in DONE_OUTCOMES:
+        return None
+    return {
+        "agrees": False,
+        "summary_outcome": outcome,
+        "summary_source": summary_source,
+        "audit_final_phase": final_phase,
+        "audit_success": True,
+        "audit_source": audit_source,
+        "authoritative": "summary_outcome",
+        "note": _truncate(
+            f"the per-story audit records a successful {final_phase or 'phase'} while the "
+            f"sprint recorded outcome={outcome}; the sprint's recorded outcome is how the "
+            "story ended and the audit names the phase it reached"
+        ),
     }
 
 
@@ -2184,6 +2290,12 @@ def _recommend_actions(
         "allocation_exhaustion": _allocation_exhaustion_action(ref, allocation_shortfall),
         TAXONOMY_GAP_CLASS: _taxonomy_gap_action(
             ref, unclassified_code, skip_reason=unclassified_skip_reason
+        ),
+        SKIP_REASON_UNRECORDED_CLASS: (
+            f"read the sprint log for the line recording the skip of {ref}: the sprint "
+            "skipped the story and recorded no reason on its row, so the reason — not the "
+            "outcome — is what is missing. Nothing about the story's work failed and there "
+            "is nothing to diagnose"
         ),
         UNKNOWN_CLASS: (
             f"run 'forge diagnose --issue {diagnose_ref}' for LLM-assisted root cause"

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -599,7 +599,7 @@ def test_unknown_needs_rca_residual(tmp_path: Path) -> None:
     d = _sprint_dir(tmp_path)
     _write(
         d / "sprint-summary.yaml",
-        _summary([{"slug": "issue-77", "outcome": "SKIPPED"}]),
+        _summary([{"slug": "issue-77", "outcome": "FAILED"}]),
     )
     entry = _build(d)["stories"]["issue-77"]
     assert entry["primary_failure_class"] == UNKNOWN_CLASS
@@ -607,6 +607,23 @@ def test_unknown_needs_rca_residual(tmp_path: Path) -> None:
     assert entry["evidence"]
     assert entry["evidence"][-1]["rule_id"] == "captured_outcome"
     assert any("diagnose" in a for a in entry["recommended_next_actions"])
+
+
+def test_reasonless_skip_is_not_the_unknown_residual(tmp_path: Path) -> None:
+    """A recorded skip has a recorded end state; only its reason is missing.
+
+    The residual class carries "buy an investigation", which on a story the
+    sprint recorded as skipped spends money to establish the skip (#2373).
+    """
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary([{"slug": "issue-77", "outcome": "SKIPPED"}]),
+    )
+    entry = _build(d)["stories"]["issue-77"]
+    assert entry["primary_failure_class"] == "skip_reason_unrecorded"
+    assert entry["evidence"][-1]["rule_id"] == "captured_outcome"
+    assert not any("forge diagnose" in a for a in entry["recommended_next_actions"])
 
 
 # ── Engine: monetary allocation exhaustion (#2292) ────────────────────────────
@@ -1303,7 +1320,7 @@ def test_ruleset_version_stamped(tmp_path: Path) -> None:
     payload = _build(d)
     assert payload["schema_version"] == rca_mod.SCHEMA_VERSION
     assert payload["ruleset_version"] == rca_mod.RULESET_VERSION
-    assert payload["ruleset_version"] == 11
+    assert payload["ruleset_version"] == 12
 
 
 def test_improved_ruleset_regenerates_versioned(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_sprint_rca_cost_unknown_outcome.py
+++ b/tests/test_sprint_rca_cost_unknown_outcome.py
@@ -1,0 +1,382 @@
+"""A recorded outcome survives an unmeasured cost across every surface (#2373).
+
+A story that ran preflight/plan/plan-review, was approved there, and was then
+skipped because the story it had been made to depend on failed, reached the
+operator as *failed*, classified ``unknown_needs_rca``, with a recommendation to
+buy an LLM diagnosis. Three surfaces described it three ways: the per-story audit
+recorded a successful PLAN_REVIEW, the summary row recorded a skip whose reason
+never reached it, and the operator digest classified what was left.
+
+These tests hold the seam end to end — summary writer → RCA → digest / status —
+so the sprint's recorded outcome stays the story's outcome, an unmeasured cost is
+reported as accounting rather than as a result, and a disagreement between the
+surfaces is reported instead of silently resolved to the worst-looking one.
+"""
+
+from __future__ import annotations
+
+import datetime
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from theforge.sprint.rca import build_sprint_rca
+
+_BLOCKED_STORY = "issue-2372"
+_SKIP_REASON = f"dependency failed: {_BLOCKED_STORY}"
+
+
+# ── Fixture builders ─────────────────────────────────────────────────────────
+
+
+def _write_story_audit(sprint_log_dir: Path, slug: str) -> None:
+    """The audit half of the disagreement: a successful PLAN_REVIEW, no cost."""
+    story_dir = sprint_log_dir / slug
+    story_dir.mkdir(parents=True, exist_ok=True)
+    (story_dir / "audit.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "story": {"slug": slug, "path": f"Issue #{slug.rsplit('-', 1)[-1]}"},
+                "outcome": {
+                    "final_phase": "PLAN_REVIEW",
+                    "success": True,
+                    "error": None,
+                    "error_type": None,
+                },
+                "cost": {"total_cost_usd": None},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_summary(
+    tmp_path: Path,
+    *,
+    error: str | None,
+    slug: str = "issue-2373",
+    with_audit: bool = True,
+) -> Path:
+    """Summary carrying the approved-then-skipped story with unmeasured cost."""
+    sprint_log_dir = tmp_path / ".forge" / "logs" / "v0.13"
+    sprint_log_dir.mkdir(parents=True, exist_ok=True)
+    if with_audit:
+        _write_story_audit(sprint_log_dir, slug)
+    summary = {
+        "sprint": {
+            "name": "v0.13",
+            "run_id": "run-2373",
+            "finished_at": "2026-08-11T03:00:00Z",
+            "total_cost_usd": None,
+            "duration_seconds": 600.0,
+        },
+        "stories": [
+            {
+                "slug": slug,
+                "path": f"Issue #{slug.rsplit('-', 1)[-1]}",
+                "outcome": "SKIPPED",
+                "outcome_code": "skipped",
+                "verdict": "APPROVE",
+                # Unmeasured — the accounting gap that used to consume the outcome.
+                "cost_usd": None,
+                "status": "cost_unknown",
+                "error": error,
+                "error_type": None,
+                # The blocking edge was injected by the scheduler after a file
+                # collision, so the row's declared dependency list is empty.
+                "depends_on": [],
+                "started_at": "2026-08-11T02:00:00Z",
+                "finished_at": "2026-08-11T02:10:00Z",
+            },
+            {
+                "slug": _BLOCKED_STORY,
+                "path": "Issue #2372",
+                "outcome": "ESCALATE",
+                "outcome_code": "escalate",
+                "cost_usd": 3.0,
+                "error": "review requested changes",
+            },
+        ],
+    }
+    summary_path = sprint_log_dir / "sprint-summary.yaml"
+    summary_path.write_text(yaml.safe_dump(summary), encoding="utf-8")
+    return summary_path
+
+
+def _entry(summary_path: Path, slug: str = "issue-2373") -> dict:
+    payload = build_sprint_rca(summary_path)
+    assert payload is not None
+    return payload["stories"][slug]
+
+
+def _actions_text(entry: dict) -> str:
+    return " ".join(entry["recommended_next_actions"]).lower()
+
+
+# ── RCA classification ───────────────────────────────────────────────────────
+
+
+def test_dependency_skip_with_unmeasured_cost_stays_a_dependency_skip(tmp_path: Path) -> None:
+    summary_path = _write_summary(tmp_path, error=_SKIP_REASON)
+    entry = _entry(summary_path)
+
+    assert entry["primary_failure_class"] == "dependency_skip"
+    assert "forge diagnose" not in _actions_text(entry)
+
+
+def test_skip_with_no_recorded_reason_is_not_unknown_needs_rca(tmp_path: Path) -> None:
+    """The end state is recorded; only the reason is missing.
+
+    ``unknown_needs_rca`` carries a recommendation to buy an investigation, and
+    attaching it here spends money to establish that a skip was a skip.
+    """
+    summary_path = _write_summary(tmp_path, error=None)
+    entry = _entry(summary_path)
+
+    assert entry["primary_failure_class"] == "skip_reason_unrecorded"
+    assert "forge diagnose" not in _actions_text(entry)
+    assert "sprint log" in _actions_text(entry)
+
+
+def test_unmeasured_cost_is_reported_as_accounting_beside_the_outcome(tmp_path: Path) -> None:
+    summary_path = _write_summary(tmp_path, error=_SKIP_REASON)
+    entry = _entry(summary_path)
+
+    assert entry["cost_accounting"] == {"measured": False, "status": "cost_unknown"}
+    # The accounting condition is reported; it does not become the class.
+    assert entry["primary_failure_class"] == "dependency_skip"
+
+
+def test_measured_cost_reports_measured_accounting(tmp_path: Path) -> None:
+    summary_path = _write_summary(tmp_path, error=_SKIP_REASON)
+    summary = yaml.safe_load(summary_path.read_text())
+    summary["stories"][0]["cost_usd"] = 0.47
+    summary["stories"][0].pop("status")
+    summary_path.write_text(yaml.safe_dump(summary), encoding="utf-8")
+
+    entry = _entry(summary_path)
+    assert entry["cost_accounting"] == {"measured": True}
+    assert entry["primary_failure_class"] == "dependency_skip"
+
+
+# ── Cross-surface disagreement ───────────────────────────────────────────────
+
+
+def test_audit_summary_disagreement_is_reported(tmp_path: Path) -> None:
+    summary_path = _write_summary(tmp_path, error=_SKIP_REASON)
+    entry = _entry(summary_path)
+
+    consistency = entry["outcome_consistency"]
+    assert consistency["agrees"] is False
+    assert consistency["summary_outcome"] == "SKIPPED"
+    assert consistency["audit_final_phase"] == "PLAN_REVIEW"
+    assert consistency["audit_success"] is True
+    assert consistency["authoritative"] == "summary_outcome"
+
+
+def test_no_disagreement_reported_when_surfaces_agree(tmp_path: Path) -> None:
+    summary_path = _write_summary(tmp_path, error=_SKIP_REASON, with_audit=False)
+    sprint_log_dir = summary_path.parent
+    story_dir = sprint_log_dir / "issue-2373"
+    story_dir.mkdir(parents=True, exist_ok=True)
+    (story_dir / "audit.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "story": {"slug": "issue-2373"},
+                "outcome": {"final_phase": "SKIPPED", "success": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert "outcome_consistency" not in _entry(summary_path)
+
+
+# ── Operator-facing surfaces ─────────────────────────────────────────────────
+
+
+def test_status_reports_the_story_as_skipped(tmp_path: Path) -> None:
+    from theforge.sprint.status_reader import read_completed_status
+
+    summary_path = _write_summary(tmp_path, error=_SKIP_REASON)
+    entries = {e.slug: e for e in read_completed_status(summary_path)}
+
+    assert entries["issue-2373"].status == "skipped"
+    # Unmeasured, not free.
+    assert entries["issue-2373"].cost_usd is None
+
+
+def _render_digest(tmp_path: Path, run_id: str = "run-2373") -> str:
+    from theforge.cli.sprint_digest import display_sprint_digest
+
+    buf = io.StringIO()
+    with patch("sys.stdout", buf):
+        rc = display_sprint_digest(run_id, tmp_path)
+    assert rc == 0, buf.getvalue()
+    return buf.getvalue()
+
+
+def _persist_rca(summary_path: Path) -> None:
+    from theforge.sprint.rca import write_sprint_rca
+
+    write_sprint_rca(summary_path.parent, summary_path=summary_path)
+
+
+def test_digest_renders_the_skip_under_skipped_not_failed(tmp_path: Path) -> None:
+    summary_path = _write_summary(tmp_path, error=_SKIP_REASON)
+    _persist_rca(summary_path)
+    out = _render_digest(tmp_path)
+
+    skipped_section = out.split("SKIPPED / INTAKE", 1)
+    assert len(skipped_section) == 2, out
+    assert "#2373" in skipped_section[1]
+    # Every FAILED heading in the digest belongs to the blocking story, not to
+    # the story that was skipped because of it.
+    failed_block = out.split("FAILED — ", 1)[1].split("SKIPPED / INTAKE")[0]
+    assert "#2373" not in failed_block
+    assert "unknown_needs_rca" not in skipped_section[1]
+    assert "forge diagnose --issue 2373" not in out
+
+
+def test_digest_reports_accounting_and_disagreement_beside_the_row(tmp_path: Path) -> None:
+    summary_path = _write_summary(tmp_path, error=_SKIP_REASON)
+    _persist_rca(summary_path)
+    out = _render_digest(tmp_path)
+
+    assert "cost unmeasured for this story" in out
+    assert "inconsistent:" in out
+    assert "PLAN_REVIEW" in out
+
+
+def test_unrecorded_skip_reason_also_renders_under_skipped(tmp_path: Path) -> None:
+    summary_path = _write_summary(tmp_path, error=None)
+    _persist_rca(summary_path)
+    out = _render_digest(tmp_path)
+
+    assert "skip_reason_unrecorded" in out.split("SKIPPED / INTAKE", 1)[1]
+    assert "forge diagnose --issue 2373" not in out
+
+
+# ── Summary writer seam: the canonical skip reason reaches the row ───────────
+
+
+def test_summary_projects_canonical_skip_reason_onto_the_story_row(tmp_path: Path) -> None:
+    """The sprint's own sentence must travel with the outcome it explains.
+
+    The canonical ``SprintStoryState`` holds both the terminal SKIPPED and the
+    reason the sprint recorded with it, while the per-story row was built from
+    the coordinator result (which succeeded at PLAN_REVIEW and recorded no
+    error). Projecting the outcome without the reason is what left a bare
+    ``SKIPPED`` for every downstream reader to explain from something else.
+    """
+    from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+    from theforge.sprint.audit import _write_sprint_summary
+    from theforge.sprint.manifest import ResolvedSprint, SprintResult
+    from theforge.sprint.story_state import SprintStoryState, StoryOutcome
+
+    state = SprintStoryState()
+    state.register("issue-2373", "Issue #2373", canonical_ref="issue:2373")
+    state.transition("issue-2373", outcome=StoryOutcome.SKIPPED, reason=_SKIP_REASON)
+
+    coord_state = CoordinatorState(
+        phase=Phase.PLAN_REVIEW,
+        started_at="2026-08-11T02:00:00Z",
+        workspace_path=tmp_path,
+        log_dir=tmp_path,
+    )
+    coord_result = CoordinatorResult(
+        success=True, phase=Phase.PLAN_REVIEW, state=coord_state, message="plan approved"
+    )
+    sprint_res = SprintResult(
+        name="v0.13",
+        specs_total=1,
+        specs_succeeded=0,
+        specs_failed=0,
+        specs_skipped=1,
+        total_cost_usd=0.0,
+        budget_usd=10.0,
+        results=[("issue:2373", coord_result)],
+    )
+    manifest = ResolvedSprint(name="v0.13", budget_usd=10.0, stories=[], max_parallel=1)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    _write_sprint_summary(
+        manifest=manifest,
+        result=sprint_res,
+        canonical_refs=["issue:2373"],
+        started_at=now,
+        finished_at=now,
+        duration=0.0,
+        sprint_log_dir=log_dir,
+        slug_map={"issue:2373": "issue-2373"},
+        tasks_by_slug={"issue-2373": MagicMock(depends_on=[])},
+        story_state=state,
+    )
+
+    summary = yaml.safe_load((log_dir / "sprint-summary.yaml").read_text())
+    row = {s["slug"]: s for s in summary["stories"]}["issue-2373"]
+    assert row["outcome"] == "SKIPPED"
+    assert row["error"] == _SKIP_REASON
+
+    # And the row now classifies as the dependency skip it is.
+    entry = _entry(log_dir / "sprint-summary.yaml")
+    assert entry["primary_failure_class"] == "dependency_skip"
+    assert "forge diagnose" not in _actions_text(entry)
+
+
+def test_summary_never_overwrites_a_cause_the_story_recorded(tmp_path: Path) -> None:
+    """A story that recorded its own error keeps it when canonical says SKIPPED."""
+    from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+    from theforge.sprint.audit import _write_sprint_summary
+    from theforge.sprint.manifest import ResolvedSprint, SprintResult
+    from theforge.sprint.story_state import SprintStoryState, StoryOutcome
+
+    state = SprintStoryState()
+    state.register("issue-2373", "Issue #2373", canonical_ref="issue:2373")
+    state.transition("issue-2373", outcome=StoryOutcome.SKIPPED, reason=_SKIP_REASON)
+
+    coord_state = CoordinatorState(
+        phase=Phase.ESCALATE,
+        started_at="2026-08-11T02:00:00Z",
+        workspace_path=tmp_path,
+        log_dir=tmp_path,
+    )
+    coord_state.error = "agent credential rejected"
+    coord_result = CoordinatorResult(
+        success=False, phase=Phase.ESCALATE, state=coord_state, message="stopped"
+    )
+    sprint_res = SprintResult(
+        name="v0.13",
+        specs_total=1,
+        specs_succeeded=0,
+        specs_failed=0,
+        specs_skipped=1,
+        total_cost_usd=0.0,
+        budget_usd=10.0,
+        results=[("issue:2373", coord_result)],
+    )
+    manifest = ResolvedSprint(name="v0.13", budget_usd=10.0, stories=[], max_parallel=1)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    _write_sprint_summary(
+        manifest=manifest,
+        result=sprint_res,
+        canonical_refs=["issue:2373"],
+        started_at=now,
+        finished_at=now,
+        duration=0.0,
+        sprint_log_dir=log_dir,
+        slug_map={"issue:2373": "issue-2373"},
+        tasks_by_slug={"issue-2373": MagicMock(depends_on=[])},
+        story_state=state,
+    )
+
+    summary = yaml.safe_load((log_dir / "sprint-summary.yaml").read_text())
+    row = {s["slug"]: s for s in summary["stories"]}["issue-2373"]
+    assert row["error"] == "agent credential rejected"


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change keeps recorded skipped outcomes separate from cost-accounting gaps and covers the reported three-surface symptom with focused regressions. | [google-gemini-3.5-flash-api] The implementation successfully preserves story outcomes when cost is unmeasured and correctly reports surface disagreements and cost-unmeasured conditions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $12.02
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Unmeasured cost overwrites a story's recorded outcome, so approved work is reported as failed and an investigation is recommended for a dependency skip (GitHub Issue #2373)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2373