### PR TITLE
A routing decision is passed as 36 positional parameters because the evidence it accumulates has no name

### DIFF
--- a/docs/adr/0008-module-size-ratchet.md
+++ b/docs/adr/0008-module-size-ratchet.md
@@ -311,6 +311,8 @@ withdrawal: 48 advisory findings, 0 blocking.
 - #2314 — implementation
 - #2309 — the story that paid for the ratchet; evidence for Amendment 3
 - #2325 — first reduction unit (naming `run_sprint`'s execution context)
+- #2349 — the same unit for `assignment.py`: naming the routing evidence its
+  routing pass accumulates (`theforge/routing_evidence.py`)
 - #1617 — cold-start starvation, closed v0.12.0; ruled out as a cause of the model-mix shift
 - Amendment figures: `.forge/audits/index.sqlite` (`audit_records`, `invocation_identities`,
   `reviews`); `git log --merges --shortstat` for the per-merge columns

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -42,6 +42,7 @@ from .routing import (
     score_to_plan_tier,
     score_to_reviewer_target,
 )
+from .routing_evidence import RoutingEvidence, RoutingInputs
 
 log = logging.getLogger(__name__)
 
@@ -2414,50 +2415,39 @@ def resolve_reasoning_effort(
 def _build_routing_decision(
     decision: AssignmentDecision,
     agents: list[AgentDef],
-    *,
-    origin: str,
-    score: int | None,
-    dev_base_tier: str,
-    dev_effective_tier: str,
-    preflight_tier: str | None,
-    planner_tier: str | None,
-    dev_signals: dict[str, dict],
-    promotion_block: dict[str, object],
-    planner_model: str,
-    dev_model: str,
-    explicit_roles: set[str],
-    secrets: dict[str, str] | None,
-    unhealthy_models: set[str] | None = None,
-    domains: list[str] | None = None,
-    dev_domain_signals: dict[str, dict] | None = None,
-    dev_cost_signals: dict[str, dict] | None = None,
-    dev_domain_match: dict[str, object] | None = None,
-    excluded_for_taint: int = 0,
-    dev_exploration: dict[str, object] | None = None,
-    pr_completion_signals: dict[str, dict] | None = None,
-    pr_completion_audit: dict[str, object] | None = None,
-    cr_completion_signals: dict[str, dict] | None = None,
-    cr_completion_audit: dict[str, object] | None = None,
-    pr_value_signals: dict[str, dict] | None = None,
-    pr_value_audit: dict[str, object] | None = None,
-    cr_value_signals: dict[str, dict] | None = None,
-    cr_value_audit: dict[str, object] | None = None,
-    preflight_reliability_signals: dict[str, dict] | None = None,
-    preflight_reliability_audit: dict[str, object] | None = None,
-    planner_reliability_signals: dict[str, dict] | None = None,
-    planner_reliability_audit: dict[str, object] | None = None,
-    min_reviewers: int = 1,
-    max_reviewers: int = 1,
-    reasoning_effort_block: dict[str, object] | None = None,
+    inputs: RoutingInputs,
+    evidence: RoutingEvidence,
 ) -> dict[str, object]:
     """Assemble the per-role routing_decision explainability block (#1391).
 
     Built at the end of :func:`assign_models` from the FINAL decision (after any
     budget-driven downgrades) so the recorded models/tiers match what runs. Pure
-    assembly: no LLM calls, no profile re-reads — profile signals come from the
-    ``dev_signals`` already collected during routing.
+    assembly: no LLM calls, no profile re-reads — every profile signal is read
+    from the :class:`~theforge.routing_evidence.RoutingEvidence` the routing pass
+    already accumulated (#2349), never looked up again here.
+
+    ``inputs`` carries what was fixed before candidate scoring; ``evidence``
+    carries what the routing and budget passes produced. Both are read-only to
+    this function: it renders the audit block, it does not decide anything.
     """
     rationale = decision.rationale
+    origin = inputs.origin
+    score = inputs.score
+    explicit_roles = inputs.explicit_roles
+    secrets = inputs.secrets
+    unhealthy_models = inputs.unhealthy_models
+    min_reviewers = inputs.min_reviewers
+    max_reviewers = inputs.max_reviewers
+    dev_base_tier = inputs.dev_base_tier
+    preflight_tier = inputs.preflight_tier
+    planner_tier = inputs.planner_tier
+    dev_effective_tier = evidence.dev_effective_tier
+    dev_signals = evidence.dev_signals
+    promotion_block = evidence.promotion_block
+    # The seated models double as the reviewer self-exclusion targets; read from
+    # the final decision so a budget downgrade can never leave them stale.
+    planner_model = decision.planner.model
+    dev_model = decision.dev.model
 
     def _rat(role: str) -> str:
         # Origin-labeled so future post-assignment checkpoints (#1387) can write
@@ -2470,9 +2460,9 @@ def _build_routing_decision(
     dev_pool = _single_model_pool(
         agents, dev_effective_tier, decision.dev.name, "dev" in explicit_roles, secrets
     )
-    dev_domain_signals = dev_domain_signals or {}
-    dev_cost_signals = dev_cost_signals or {}
-    requested_domains = [d for d in (domains or []) if isinstance(d, str) and d]
+    dev_domain_signals = evidence.dev_domain_signals
+    dev_cost_signals = evidence.dev_cost_signals
+    requested_domains = inputs.requested_domains
     for entry in dev_pool:
         if entry.get("included") and entry["name"] in dev_signals:
             signals: dict[str, object] = {"success_rate": dev_signals[entry["name"]]}
@@ -2500,7 +2490,7 @@ def _build_routing_decision(
     # Domain-match block (#155 / ADR-0006 clause 7). Present but explicitly
     # non-influential when domains exist yet did not move the selection; omitted
     # entirely when the story carried no domains (nothing to explain).
-    dev_domain_match = dev_domain_match or {}
+    dev_domain_match = evidence.dev_domain_match
     domain_block: dict[str, object] | None = None
     if requested_domains:
         influenced = bool(dev_domain_match.get("domain_influenced"))
@@ -2537,26 +2527,38 @@ def _build_routing_decision(
 
     # Reviewer completion-rate rerank (#1388) explanation per reviewer role.
     pr_completion_block = _reviewer_completion_check(
-        pr_completion_signals, pr_completion_audit, pr_selected
+        evidence.plan_review.completion.signals,
+        evidence.plan_review.completion.audit,
+        pr_selected,
     )
     cr_completion_block = _reviewer_completion_check(
-        cr_completion_signals, cr_completion_audit, cr_selected
+        evidence.code_review.completion.signals,
+        evidence.code_review.completion.audit,
+        cr_selected,
     )
     # Reviewer value rerank explanation, per reviewer role: plan review (#1443)
     # and code review (#2156). Each reads its own persisted value section, so the
     # two blocks are independently populated and independently omitted when their
     # phase's mechanism was not consulted.
-    pr_value_block = _reviewer_value_check(pr_value_signals, pr_value_audit, pr_selected)
-    cr_value_block = _reviewer_value_check(cr_value_signals, cr_value_audit, cr_selected)
+    pr_value_block = _reviewer_value_check(
+        evidence.plan_review.value.signals, evidence.plan_review.value.audit, pr_selected
+    )
+    cr_value_block = _reviewer_value_check(
+        evidence.code_review.value.signals, evidence.code_review.value.audit, cr_selected
+    )
 
     # Non-dev single-model reliability rerank (#1489) explanation for the preflight
     # and planner roles. Empty (and omitted) when the mechanism was not consulted
     # (static routing / cold-start with no profile), keeping the block additive.
     preflight_reliability_block = _role_reliability_check(
-        preflight_reliability_signals, preflight_reliability_audit, decision.preflight.name
+        evidence.preflight_reliability.signals,
+        evidence.preflight_reliability.audit,
+        decision.preflight.name,
     )
     planner_reliability_block = _role_reliability_check(
-        planner_reliability_signals, planner_reliability_audit, decision.planner.name
+        evidence.planner_reliability.signals,
+        evidence.planner_reliability.audit,
+        decision.planner.name,
     )
 
     return {
@@ -2567,15 +2569,15 @@ def _build_routing_decision(
         # Surfaced at the top level so operators see how much history was
         # discounted for taint before any per-role explanation. The runs remain in
         # the substrate (ADR-0002 refusal-to-forget); this is a read-time count.
-        "excluded_for_taint": int(excluded_for_taint),
+        "excluded_for_taint": int(inputs.excluded_for_taint),
         # Score-to-routing policy axis resolved per PHASE rather than per role
         # (#1108): plan/dev/review each get their own bucket, and each seated
         # model records how (or whether) its transport took the value. Recorded
         # top-level because it spans phases; the per-role score_policy blocks
         # below cover the role-scoped axes (dev tier, plan tier, reviewer count).
         "reasoning_effort": (
-            reasoning_effort_block
-            if reasoning_effort_block is not None
+            evidence.reasoning_effort_block
+            if evidence.reasoning_effort_block is not None
             else axis_decision("reasoning_effort", score, phase="dev")
         ),
         "preflight": {
@@ -2663,7 +2665,11 @@ def _build_routing_decision(
             # decision for the dev slot (mode + routing_key + pool + selection).
             # Falls back to the on-policy winner marker when the router did not
             # produce an exploration decision (static/explicit dev).
-            "exploration": dev_exploration if dev_exploration is not None else dict(exploration),
+            "exploration": (
+                evidence.dev_exploration
+                if evidence.dev_exploration is not None
+                else dict(exploration)
+            ),
             "final": {
                 "model": decision.dev.model,
                 "tier": _selected_tier(agents, decision.dev.name, dev_effective_tier),
@@ -3185,70 +3191,41 @@ def assign_models(
 
     norm_complexity = _normalize_complexity(complexity)
     rationale: dict[str, str] = {}
-    # ── Routing explainability accumulators (#1391) ────────────────────
-    # Populated during the routing pass and consumed by _build_routing_decision
-    # at the end so the block reflects the final (post-budget) decision.
-    _dev_signals: dict[str, dict] = {}
-    # Per-domain dev signals (#155), keyed by agent name, collected in the same
-    # rerank pass as _dev_signals. _dev_domain_match records whether the domain
-    # tiebreak actually moved the selection so the routing_decision block can mark
-    # the decision influential or explicitly non-influential.
-    _dev_domain_signals: dict[str, dict] = {}
-    _dev_cost_signals: dict[str, dict] = {}
-    _dev_domain_match: dict[str, object] = {}
-    # Reviewer completion-rate rerank accumulators (#1388), per reviewer role.
-    # Populated by _select_reviewers and consumed by _build_routing_decision so
-    # the routing_decision block records the consulted signal and ranking effect
-    # only when reviewer completion actually shaped selection.
-    _pr_completion_signals: dict[str, dict] = {}
-    _pr_completion_audit: dict[str, object] = {}
-    _cr_completion_signals: dict[str, dict] = {}
-    _cr_completion_audit: dict[str, object] = {}
-    # Plan-reviewer value rerank accumulators (#1443). Populated by
-    # _select_reviewers when reviewer_value_enabled and consumed by
-    # _build_routing_decision so the routing_decision records the consulted
-    # uniqueness / latency-per-P1 signals and the ranking effect.
-    _pr_value_signals: dict[str, dict] = {}
-    _pr_value_audit: dict[str, object] = {}
-    # Code-review counterparts (#2156), read from the separate code_review_value
-    # profile section so the two phases' value histories never mix.
-    _cr_value_signals: dict[str, dict] = {}
-    _cr_value_audit: dict[str, object] = {}
-    # Non-dev single-model reliability rerank accumulators (#1489), per role.
-    # Populated by _pick_agent when preflight/planner selection consults role
-    # reliability history and consumed by _build_routing_decision so the block
-    # records the consulted signal, sample/floor status, and ranking effect.
-    _preflight_reliability_signals: dict[str, dict] = {}
-    _preflight_reliability_audit: dict[str, object] = {}
-    _planner_reliability_signals: dict[str, dict] = {}
-    _planner_reliability_audit: dict[str, object] = {}
+    # ── Routing evidence (#1391, named in #2349) ───────────────────────
+    # ``assign_models`` owns this value: it is the sole writer. The selection
+    # helpers below receive its sub-objects as out-params, each mechanism
+    # overwrites its own block as it resolves, and _build_routing_decision reads
+    # the finished value at the end so the block reflects the final (post-budget)
+    # decision. Anything fixed before candidate scoring lives in RoutingInputs
+    # instead, built at the point of use below.
+    evidence = RoutingEvidence(
+        # Default dev promotion_check block: overwritten by _promotion_check_block
+        # once the profile-backed pre-promotion (#158) runs. The "not_checked"
+        # outcome stands for explicit-override / static-mode dev where the check
+        # never fires.
+        promotion_block={
+            "mechanism": MECHANISM_DEV_PROMOTION,
+            "fired": False,
+            "outcome": "not_checked",
+            "model": "",
+            "complexity": None,
+            "raw_success_rate": None,
+            "weighted_success_rate": None,
+            "sample_size": 0,
+            "tainted_runs": 0,
+            "threshold": assignment_config.dev_promotion_threshold,
+            "min_runs": assignment_config.dev_promotion_min_runs,
+            "floor": "not_checked",
+            "resulting_tier": None,
+        },
+    )
+    # Tier the preflight candidate pool was drawn from — a routing input, held
+    # here until RoutingInputs is assembled at the end of the pass.
     _preflight_tier: str | None = None
-    _dev_effective_tier: str = "cheap"
-    # Challenger-sampling exploration block for the dev role (#325). None until
-    # the dev pick is finalized; then set to the recorded exploration decision
-    # (labeled winner/challenger with routing_key + pool). ``_dev_budget_floor``
-    # holds the tier the budget enforcer must respect — the challenger's tier in
-    # challenger mode so the run spends from the challenger's envelope (clause 8).
-    _dev_exploration: dict[str, object] | None = None
+    # ``_dev_budget_floor`` holds the tier the budget enforcer must respect — the
+    # challenger's tier in challenger mode so the run spends from the
+    # challenger's envelope (#325, ADR-0006 clause 8).
     _dev_budget_floor: str | None = None
-    # Default dev promotion_check block: overwritten by _promotion_check_block once
-    # the profile-backed pre-promotion (#158) runs. The "not_checked" outcome
-    # stands for explicit-override / static-mode dev where the check never fires.
-    _promotion_block: dict[str, object] = {
-        "mechanism": MECHANISM_DEV_PROMOTION,
-        "fired": False,
-        "outcome": "not_checked",
-        "model": "",
-        "complexity": None,
-        "raw_success_rate": None,
-        "weighted_success_rate": None,
-        "sample_size": 0,
-        "tainted_runs": 0,
-        "threshold": assignment_config.dev_promotion_threshold,
-        "min_runs": assignment_config.dev_promotion_min_runs,
-        "floor": "not_checked",
-        "resulting_tier": None,
-    }
     adaptive_enabled = assignment_config.adaptive_enabled
     # In static mode, ignore the numeric score, capability profiles, and
     # escalation/promotion learning — fall through to PHASE_TIER + min_reviewers.
@@ -3314,7 +3291,7 @@ def assign_models(
             # outcome is PROMOTION_OUTCOME_PROMOTED, which requires the sample floor
             # met AND a non-None weighted rate below threshold.
             effective_dev_tier = _promote_tier(dev_base_tier)
-            _promotion_block = _promotion_check_block(promo_signal, effective_dev_tier)
+            evidence.promotion_block = _promotion_check_block(promo_signal, effective_dev_tier)
             rationale["dev"] = (
                 f"{norm_complexity} dev pre-promoted {dev_model_name} "
                 f"(tier {dev_base_tier} → {effective_dev_tier}) — "
@@ -3323,7 +3300,7 @@ def assign_models(
                 f"admissible {norm_complexity} runs"
             )
         else:
-            _promotion_block = _promotion_check_block(promo_signal, effective_dev_tier)
+            evidence.promotion_block = _promotion_check_block(promo_signal, effective_dev_tier)
             if score is not None:
                 rationale["dev"] = (
                     f"complexity score {score} ({norm_complexity}) → tier {effective_dev_tier}"
@@ -3337,7 +3314,7 @@ def assign_models(
                     f"over {promo_signal.runs} admissible runs — pre-promotion held)"
                 )
 
-        _dev_effective_tier = effective_dev_tier
+        evidence.dev_effective_tier = effective_dev_tier
         dev_agent = _pick_agent(
             agents,
             effective_dev_tier,
@@ -3345,11 +3322,11 @@ def assign_models(
             model_profiles=effective_profiles,
             role="dev",
             complexity=norm_complexity,
-            signals_out=_dev_signals,
+            signals_out=evidence.dev_signals,
             domains=effective_domains,
-            domain_signals_out=_dev_domain_signals,
-            cost_signals_out=_dev_cost_signals,
-            rerank_audit=_dev_domain_match,
+            domain_signals_out=evidence.dev_domain_signals,
+            cost_signals_out=evidence.dev_cost_signals,
+            rerank_audit=evidence.dev_domain_match,
             recency=effective_recency,
             observed_costs=effective_observed_costs,
             reasoning_effort=dev_requested_reasoning_effort,
@@ -3371,8 +3348,8 @@ def assign_models(
             # Domain match note (#155): only surfaced when the horizontal tiebreak
             # actually moved the selection — the selected model's admissible
             # per-domain rate over the story's domains.
-            if _dev_domain_match.get("domain_influenced") and dev_agent is not None:
-                _dsig = _dev_domain_signals.get(dev_agent.name)
+            if evidence.dev_domain_match.get("domain_influenced") and dev_agent is not None:
+                _dsig = evidence.dev_domain_signals.get(dev_agent.name)
                 if _dsig and _dsig.get("rate") is not None:
                     rationale["dev"] += (
                         f" (domain match {effective_domains}: "
@@ -3442,15 +3419,15 @@ def assign_models(
                 secrets=secrets,
                 rng=explore_rng,
             )
-            _dev_exploration = _exp.block
+            evidence.dev_exploration = _exp.block
             if _exp.route_agent is not None:
                 dev_agent = _exp.route_agent
                 dev_selected_tier = dev_agent.tier
                 dev_profile = _agent_to_profile(
                     dev_agent, role="dev", transport_fallbacks=transport_fallbacks
                 )
-                _dev_effective_tier = dev_agent.tier
-                if _dev_exploration.get("mode") == "challenger":
+                evidence.dev_effective_tier = dev_agent.tier
+                if _exp.block.get("mode") == "challenger":
                     # Challenger-tier budget envelope (clause 8): the run spends
                     # from the challenger's tier, so the enforcer must not
                     # downgrade below it.
@@ -3487,8 +3464,8 @@ def assign_models(
             reliability_role="preflight",
             reliability_threshold=assignment_config.reviewer_completion_threshold,
             reliability_min_runs=assignment_config.reviewer_completion_min_runs,
-            reliability_signals_out=_preflight_reliability_signals,
-            reliability_audit=_preflight_reliability_audit,
+            reliability_signals_out=evidence.preflight_reliability.signals,
+            reliability_audit=evidence.preflight_reliability.audit,
         )
         if agent is None:
             authed = [a for a in agents if _has_auth(a, secrets)]
@@ -3522,8 +3499,8 @@ def assign_models(
             reliability_role="planner",
             reliability_threshold=assignment_config.reviewer_completion_threshold,
             reliability_min_runs=assignment_config.reviewer_completion_min_runs,
-            reliability_signals_out=_planner_reliability_signals,
-            reliability_audit=_planner_reliability_audit,
+            reliability_signals_out=evidence.planner_reliability.signals,
+            reliability_audit=evidence.planner_reliability.audit,
         )
         if agent is None:
             authed = [a for a in agents if _has_auth(a, secrets)]
@@ -3575,14 +3552,14 @@ def assign_models(
             completion_threshold=assignment_config.reviewer_completion_threshold,
             completion_min_runs=assignment_config.reviewer_completion_min_runs,
             recency=effective_recency,
-            completion_signals_out=_pr_completion_signals,
-            completion_audit=_pr_completion_audit,
+            completion_signals_out=evidence.plan_review.completion.signals,
+            completion_audit=evidence.plan_review.completion.audit,
             value_enabled=assignment_config.reviewer_value_enabled,
             value_uniqueness_threshold=assignment_config.reviewer_value_uniqueness_threshold,
             value_min_runs=assignment_config.reviewer_value_min_runs,
             value_complexity=norm_complexity,
-            value_signals_out=_pr_value_signals,
-            value_audit=_pr_value_audit,
+            value_signals_out=evidence.plan_review.value.signals,
+            value_audit=evidence.plan_review.value.audit,
         )
         plan_reviewers = [
             _agent_to_profile(a, role="review", transport_fallbacks=transport_fallbacks)
@@ -3641,14 +3618,14 @@ def assign_models(
             completion_threshold=assignment_config.reviewer_completion_threshold,
             completion_min_runs=assignment_config.reviewer_completion_min_runs,
             recency=effective_recency,
-            completion_signals_out=_cr_completion_signals,
-            completion_audit=_cr_completion_audit,
+            completion_signals_out=evidence.code_review.completion.signals,
+            completion_audit=evidence.code_review.completion.audit,
             value_enabled=assignment_config.code_review_value_enabled,
             value_uniqueness_threshold=(assignment_config.code_review_value_uniqueness_threshold),
             value_min_runs=assignment_config.code_review_value_min_runs,
             value_complexity=norm_complexity,
-            value_signals_out=_cr_value_signals,
-            value_audit=_cr_value_audit,
+            value_signals_out=evidence.code_review.value.signals,
+            value_audit=evidence.code_review.value.audit,
             value_phase="code_review",
         )
         code_reviewers = [
@@ -3667,7 +3644,9 @@ def assign_models(
             agents, selected, tier, exclude_model=dev_model, unhealthy_models=unhealthy_models
         )
         value_note = _reviewer_value_rationale(
-            assignment_config.code_review_value_enabled, _cr_value_signals, _cr_value_audit
+            assignment_config.code_review_value_enabled,
+            evidence.code_review.value.signals,
+            evidence.code_review.value.audit,
         )
         rationale["code_review"] = (
             f"{len(code_reviewers)} reviewer(s), tier {tier}, "
@@ -3696,44 +3675,25 @@ def assign_models(
         dec, _effort_block = resolve_reasoning_effort(
             dec, score=score, cfg=assignment_config.reasoning_effort
         )
-        block = _build_routing_decision(
-            dec,
-            agents,
+        # The reasoning-effort axis is the one block produced after the routing
+        # pass proper; it is still this pass's evidence, so it lands on the same
+        # value rather than being spliced in at the call site.
+        evidence.reasoning_effort_block = _effort_block
+        inputs = RoutingInputs(
             origin=routing_origin,
             score=score,
             dev_base_tier=dev_base_tier,
-            dev_effective_tier=_dev_effective_tier,
             preflight_tier=_preflight_tier,
             planner_tier=planner_target_tier,
-            min_reviewers=assignment_config.min_reviewers,
-            max_reviewers=assignment_config.max_reviewers,
-            dev_signals=_dev_signals,
-            promotion_block=_promotion_block,
-            planner_model=dec.planner.model,
-            dev_model=dec.dev.model,
-            explicit_roles=set(explicit_profiles),
+            explicit_roles=frozenset(explicit_profiles),
             secrets=secrets,
             unhealthy_models=unhealthy_models,
-            domains=effective_domains,
-            dev_domain_signals=_dev_domain_signals,
-            dev_cost_signals=_dev_cost_signals,
-            dev_domain_match=_dev_domain_match,
+            domains=tuple(effective_domains or ()),
+            min_reviewers=assignment_config.min_reviewers,
+            max_reviewers=assignment_config.max_reviewers,
             excluded_for_taint=excluded_for_taint,
-            dev_exploration=_dev_exploration,
-            pr_completion_signals=_pr_completion_signals,
-            pr_completion_audit=_pr_completion_audit,
-            cr_completion_signals=_cr_completion_signals,
-            cr_completion_audit=_cr_completion_audit,
-            pr_value_signals=_pr_value_signals,
-            pr_value_audit=_pr_value_audit,
-            cr_value_signals=_cr_value_signals,
-            cr_value_audit=_cr_value_audit,
-            preflight_reliability_signals=_preflight_reliability_signals,
-            preflight_reliability_audit=_preflight_reliability_audit,
-            planner_reliability_signals=_planner_reliability_signals,
-            planner_reliability_audit=_planner_reliability_audit,
-            reasoning_effort_block=_effort_block,
         )
+        block = _build_routing_decision(dec, agents, inputs, evidence)
         return _dc_replace(dec, routing_decision=block)
 
     # Enforce per-story routing cost target — pass dev floor so the enforcer never

--- a/src/theforge/routing_evidence.py
+++ b/src/theforge/routing_evidence.py
@@ -1,0 +1,139 @@
+"""Named routing state for a single assignment pass (#2349).
+
+:func:`theforge.assignment.assign_models` decides which model runs each phase
+and, along the way, accumulates the evidence for *why*. Before this module that
+evidence had no name: it lived as ~76 locals inside ``assign_models`` and was
+handed to ``_build_routing_decision`` one field at a time as a 36-parameter
+call. This module gives that state a name and an owner so the routing trace is
+a value the system holds rather than something reconstructed at the call site.
+
+Two types, split by **when the value becomes known**:
+
+- :class:`RoutingInputs` — everything fixed *before* candidate scoring begins:
+  the caller's request (origin, score, domains, reviewer bounds, explicit role
+  overrides) and the environment the router selects against (secrets, unhealthy
+  models, the score-derived tier floors). Frozen: nothing in the routing pass
+  may edit its own inputs.
+- :class:`RoutingEvidence` — everything *produced* by the routing pass and the
+  post-budget pass: profile signals consulted, rerank audits, the promoted dev
+  tier, the exploration decision, and the resolved reasoning-effort block.
+  Mutable and owned by ``assign_models``, which is the only writer.
+
+**The rule for new fields**: known before candidate scoring → ``RoutingInputs``;
+produced by the routing or budget pass → ``RoutingEvidence``. Two cases that
+read the other way and are classified by that rule, not by how they read:
+
+- ``excluded_for_taint`` is *evidence about history* but is computed by the
+  caller before ``assign_models`` runs, so it is an input.
+- ``dev_effective_tier`` reads like a tier input but is the promotion pass's
+  output, so it is evidence.
+
+Pure data only — stdlib imports, no I/O, no policy. The blocks stored here are
+the same plain dicts the audit trail records; this module names their owner, it
+does not reshape them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SignalAudit:
+    """One mechanism's consulted signals plus its ranking-effect audit.
+
+    ``signals`` is keyed by agent name (the per-candidate evidence the rerank
+    weighed); ``audit`` is the single block describing whether the mechanism
+    fired and what it changed. Both are populated in place by the selection
+    helpers that receive them as out-params, so a caller can hand the same
+    instance to a selector and read the result back afterwards.
+    """
+
+    signals: dict[str, dict] = field(default_factory=dict)
+    audit: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class ReviewerEvidence:
+    """Rerank evidence accumulated for one reviewer phase.
+
+    Plan review and code review each own an instance so their completion-rate
+    (#1388) and value (#1443 / #2156) histories never mix — the two phases read
+    separate profile sections and are independently omitted from the routing
+    block when their mechanism was not consulted.
+    """
+
+    completion: SignalAudit = field(default_factory=SignalAudit)
+    value: SignalAudit = field(default_factory=SignalAudit)
+
+
+@dataclass(frozen=True)
+class RoutingInputs:
+    """The fixed inputs of one routing pass — known before candidate scoring.
+
+    Frozen because the routing pass is a consumer of its inputs, never an
+    editor of them: anything the pass computes belongs in
+    :class:`RoutingEvidence`.
+    """
+
+    origin: str
+    score: int | None
+    dev_base_tier: str
+    preflight_tier: str | None = None
+    planner_tier: str | None = None
+    explicit_roles: frozenset[str] = frozenset()
+    secrets: dict[str, str] | None = None
+    unhealthy_models: set[str] | None = None
+    domains: tuple[str, ...] = ()
+    min_reviewers: int = 1
+    max_reviewers: int = 1
+    # Count of historical runs the centralized taint gate set aside before the
+    # router read them (ADR-0006 clause 4). Computed by the caller, hence an
+    # input despite being evidence about history.
+    excluded_for_taint: int = 0
+
+    @property
+    def requested_domains(self) -> list[str]:
+        """The story's domain tags, filtered to the non-empty strings."""
+        return [d for d in self.domains if isinstance(d, str) and d]
+
+
+@dataclass
+class RoutingEvidence:
+    """Evidence accumulated *during* one routing pass. Owner: ``assign_models``.
+
+    ``assign_models`` is the sole writer: it constructs one instance at the top
+    of the pass, hands the sub-objects to the selection helpers as out-params,
+    overwrites the scalar/block fields as each mechanism resolves, and passes
+    the whole value to ``_build_routing_decision``. Every other reader treats it
+    as read-only.
+
+    Because it is a value, the routing trace can be constructed and asserted
+    against without running ``assign_models`` — see
+    ``tests/test_routing_evidence.py``.
+    """
+
+    # Dev tier after the profile-backed pre-promotion (#158) resolves. Output of
+    # the promotion pass, not an input tier.
+    dev_effective_tier: str = "cheap"
+    # Per-candidate dev signals the router weighed, keyed by agent name.
+    dev_signals: dict[str, dict] = field(default_factory=dict)
+    # Per-domain (#155) and cost-tiebreak slices of the same rerank pass.
+    dev_domain_signals: dict[str, dict] = field(default_factory=dict)
+    dev_cost_signals: dict[str, dict] = field(default_factory=dict)
+    # Whether the domain tiebreak actually moved the dev selection.
+    dev_domain_match: dict[str, object] = field(default_factory=dict)
+    # Dev pre-promotion check block (#158); the "not_checked" default stands for
+    # explicit-override / static-mode dev where the check never fires.
+    promotion_block: dict[str, object] = field(default_factory=dict)
+    # Challenger-sampling exploration decision for the dev slot (#325). None
+    # when the router produced no exploration decision (static / explicit dev).
+    dev_exploration: dict[str, object] | None = None
+    plan_review: ReviewerEvidence = field(default_factory=ReviewerEvidence)
+    code_review: ReviewerEvidence = field(default_factory=ReviewerEvidence)
+    # Single-model reliability rerank for the non-dev roles (#1489).
+    preflight_reliability: SignalAudit = field(default_factory=SignalAudit)
+    planner_reliability: SignalAudit = field(default_factory=SignalAudit)
+    # Per-phase reasoning-effort axis (#1108). Resolved after budget enforcement
+    # so it lands on the profiles that actually run; None until then.
+    reasoning_effort_block: dict[str, object] | None = None

--- a/tests/test_assignment_routing_decision.py
+++ b/tests/test_assignment_routing_decision.py
@@ -22,6 +22,7 @@ from theforge.assignment import (
     assign_models,
 )
 from theforge.config import AgentDef
+from theforge.routing_evidence import RoutingEvidence, RoutingInputs
 
 
 @pytest.fixture()
@@ -242,32 +243,32 @@ def test_block_building_does_not_re_read_profiles(monkeypatch):
     rebuilt = _build_routing_decision(
         decision,
         agents,
-        origin="preflight",
-        score=9,
-        dev_base_tier="strong",
-        dev_effective_tier="strong",
-        preflight_tier="cheap",
-        planner_tier="strong",
-        dev_signals=dev_signals,
-        promotion_block={
-            "mechanism": "_check_promotion",
-            "fired": False,
-            "outcome": "recovered_at_or_above_threshold",
-            "model": "opus",
-            "complexity": "HIGH",
-            "raw_success_rate": 0.30,
-            "weighted_success_rate": 0.72,
-            "sample_size": 12,
-            "tainted_runs": 0,
-            "threshold": 0.60,
-            "min_runs": 5,
-            "floor": "pass",
-            "resulting_tier": "strong",
-        },
-        planner_model=decision.planner.model,
-        dev_model=decision.dev.model,
-        explicit_roles=set(),
-        secrets=None,
+        RoutingInputs(
+            origin="preflight",
+            score=9,
+            dev_base_tier="strong",
+            preflight_tier="cheap",
+            planner_tier="strong",
+        ),
+        RoutingEvidence(
+            dev_effective_tier="strong",
+            dev_signals=dev_signals,
+            promotion_block={
+                "mechanism": "_check_promotion",
+                "fired": False,
+                "outcome": "recovered_at_or_above_threshold",
+                "model": "opus",
+                "complexity": "HIGH",
+                "raw_success_rate": 0.30,
+                "weighted_success_rate": 0.72,
+                "sample_size": 12,
+                "tainted_runs": 0,
+                "threshold": 0.60,
+                "min_runs": 5,
+                "floor": "pass",
+                "resulting_tier": "strong",
+            },
+        ),
     )
     assert calls["n"] == 0, "block building must not perform profile lookups"
     assert calls_during_assign > 0  # sanity: routing did consult profiles

--- a/tests/test_routing_evidence.py
+++ b/tests/test_routing_evidence.py
@@ -1,0 +1,212 @@
+"""Routing evidence as a value (#2349).
+
+The routing trace used to exist only as a 36-argument call into
+``_build_routing_decision``: it could not be constructed, mutated, or asserted
+against without running ``assign_models`` end to end. These tests exercise the
+named value directly — building evidence by hand, handing it to
+``_build_routing_decision``, and reading the audit block back — so routing
+evidence can change independently of the 650-line routing pass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+
+import pytest
+
+from theforge.assignment import AssignmentDecision, _build_routing_decision
+from theforge.config import AgentDef
+from theforge.config.types import ModelProfile
+from theforge.routing_evidence import (
+    ReviewerEvidence,
+    RoutingEvidence,
+    RoutingInputs,
+    SignalAudit,
+)
+
+
+def _agents() -> list[AgentDef]:
+    return [
+        AgentDef(
+            name="sonnet",
+            provider="anthropic",
+            model="sonnet",
+            budget_usd=3.0,
+            timeout_seconds=600,
+            tier="mid",
+        ),
+        AgentDef(
+            name="opus",
+            provider="anthropic",
+            model="opus",
+            budget_usd=5.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+        AgentDef(
+            name="gpt",
+            provider="openai",
+            model="gpt-5.4",
+            budget_usd=8.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+    ]
+
+
+def _profile(name: str, provider: str, model: str) -> ModelProfile:
+    return ModelProfile(
+        name=name,
+        provider=provider,
+        model=model,
+        budget_usd=1.0,
+        timeout_seconds=600,
+        allowed_tools=[],
+    )
+
+
+def _decision() -> AssignmentDecision:
+    return AssignmentDecision(
+        preflight=_profile("sonnet", "anthropic", "sonnet"),
+        planner=_profile("opus", "anthropic", "opus"),
+        plan_reviewers=[_profile("gpt", "openai", "gpt-5.4")],
+        dev=_profile("opus", "anthropic", "opus"),
+        code_reviewers=[_profile("gpt", "openai", "gpt-5.4")],
+        rationale={"dev": "hand-built", "code_review": "hand-built"},
+    )
+
+
+def _inputs(**kwargs) -> RoutingInputs:
+    defaults: dict = {
+        "origin": "preflight",
+        "score": 9,
+        "dev_base_tier": "strong",
+        "preflight_tier": "mid",
+        "planner_tier": "strong",
+        "secrets": {"ANTHROPIC_API_KEY": "k", "OPENAI_API_KEY": "k"},
+    }
+    defaults.update(kwargs)
+    return RoutingInputs(**defaults)
+
+
+def test_evidence_is_constructible_without_assign_models():
+    """The accumulator has a name and a default shape of its own (AC 1/3)."""
+    evidence = RoutingEvidence()
+    assert evidence.dev_signals == {}
+    assert evidence.dev_exploration is None
+    assert evidence.reasoning_effort_block is None
+    # Each reviewer phase owns an independent completion/value pair — writing one
+    # must never leak into the other's history (#1443 / #2156).
+    evidence.plan_review.value.signals["gpt"] = {"uniqueness": 0.9}
+    assert evidence.code_review.value.signals == {}
+    assert isinstance(evidence.plan_review, ReviewerEvidence)
+    assert isinstance(evidence.preflight_reliability, SignalAudit)
+
+    # Two instances share no mutable state (default_factory, not a class attr).
+    other = RoutingEvidence()
+    assert other.plan_review.value.signals == {}
+
+
+def test_inputs_are_frozen_and_normalize_domains():
+    inputs = _inputs(domains=("backend", "", "cli"))
+    assert inputs.requested_domains == ["backend", "cli"]
+    with pytest.raises(FrozenInstanceError):
+        inputs.origin = "post_plan"  # type: ignore[misc]
+
+
+def test_build_routing_decision_reads_evidence_not_call_site():
+    """Every accumulated block reaches the audit trail from the named value."""
+    evidence = RoutingEvidence(
+        dev_effective_tier="strong",
+        dev_signals={"opus": {"raw": 0.75, "weighted": 0.7, "runs": 12, "floor": "pass"}},
+        dev_domain_signals={"opus": {"rate": 0.8, "runs": 9}},
+        dev_cost_signals={
+            "opus": {"value": 1.2, "source": "observed", "observations": 4, "cohort": "dev"}
+        },
+        dev_domain_match={
+            "domain_influenced": True,
+            "complexity_only_head": "gpt",
+            "domain_head": "opus",
+        },
+        promotion_block={"mechanism": "_check_promotion", "fired": True, "outcome": "promoted"},
+        dev_exploration={"mode": "challenger", "routing_key": "dev:large"},
+        reasoning_effort_block={"applied": True, "phases": {}},
+    )
+    block = _build_routing_decision(
+        _decision(), _agents(), _inputs(domains=("backend",), excluded_for_taint=3), evidence
+    )
+
+    assert block["origin"] == "preflight"
+    assert block["excluded_for_taint"] == 3
+    assert block["reasoning_effort"] is evidence.reasoning_effort_block
+    assert block["dev"]["promotion_check"] is evidence.promotion_block
+    assert block["dev"]["exploration"] is evidence.dev_exploration
+    assert block["dev"]["base_tier_from_score"] == "strong"
+
+    opus_entry = next(e for e in block["dev"]["candidate_pool"] if e["name"] == "opus")
+    assert opus_entry["signals"]["success_rate"] is evidence.dev_signals["opus"]
+    assert opus_entry["signals"]["domain"] is evidence.dev_domain_signals["opus"]
+    assert opus_entry["signals"]["cost_tiebreak"] is evidence.dev_cost_signals["opus"]
+
+    assert block["dev"]["domain_match"]["influenced"] is True
+    assert block["dev"]["domain_match"]["domains"] == ["backend"]
+    assert block["dev"]["cost_tiebreak"]["selected_model"] == "opus"
+
+
+def test_domain_and_cost_blocks_absent_when_evidence_is_empty():
+    """Omission is driven by the evidence, not by the caller's argument list."""
+    block = _build_routing_decision(_decision(), _agents(), _inputs(), RoutingEvidence())
+    assert "domain_match" not in block["dev"]
+    assert "cost_tiebreak" not in block["dev"]
+    assert block["dev"]["exploration"] == {"mode": "winner"}
+    # No completion/value/reliability evidence was collected → those blocks stay
+    # omitted rather than being recorded as empty.
+    assert "completion_check" not in block["plan_review"]
+    assert "value_check" not in block["code_review"]
+    assert "reliability_check" not in block["planner"]
+
+
+def test_reviewer_evidence_lands_on_its_own_phase():
+    """plan_review and code_review evidence never cross-contaminate."""
+    evidence = RoutingEvidence(
+        plan_review=ReviewerEvidence(
+            completion=SignalAudit(
+                signals={"gpt": {"completion_rate": 0.9, "runs": 10, "floor": "pass"}},
+                audit={"applied": True, "threshold": 0.7, "min_runs": 5},
+            )
+        ),
+    )
+    block = _build_routing_decision(_decision(), _agents(), _inputs(), evidence)
+    assert "completion_check" in block["plan_review"]
+    assert block["plan_review"]["completion_check"]["fired"] is True
+    assert "completion_check" not in block["code_review"]
+
+
+def test_evidence_can_be_mutated_after_construction():
+    """The accumulator is writable between routing steps, as assign_models needs."""
+    evidence = RoutingEvidence()
+    evidence.dev_signals["opus"] = {"raw": 0.5}
+    evidence.dev_effective_tier = "strong"
+    evidence.reasoning_effort_block = {"applied": False, "phases": {}}
+
+    block = _build_routing_decision(_decision(), _agents(), _inputs(), evidence)
+    opus_entry = next(e for e in block["dev"]["candidate_pool"] if e["name"] == "opus")
+    assert opus_entry["signals"]["success_rate"] == {"raw": 0.5}
+    assert block["reasoning_effort"] == {"applied": False, "phases": {}}
+
+
+def test_final_models_track_the_decision_not_the_inputs():
+    """Post-budget downgrades reach the block through the decision argument, so
+    the self-exclusion targets can never go stale (the reason planner_model /
+    dev_model are read from the decision rather than passed separately)."""
+    downgraded = replace(_decision(), dev=_profile("sonnet", "anthropic", "sonnet"))
+    block = _build_routing_decision(
+        downgraded,
+        _agents(),
+        _inputs(dev_base_tier="mid"),
+        RoutingEvidence(dev_effective_tier="mid"),
+    )
+    assert block["dev"]["final"]["model"] == "sonnet"
+    cr_pool = {e["name"]: e for e in block["code_review"]["candidate_pool"]}
+    # The seated dev model is the anti-self-review exclusion target.
+    assert cr_pool["sonnet"]["included"] is False


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The refactor names routing inputs/evidence, routes the production call through that value, and keeps the covered routing audit behavior intact. | [google-gemini-3.5-flash-api] Introduced structured, pure-data RoutingInputs and RoutingEvidence types, eliminating the 36-parameter positional list in _build_routing_decision. | [anthropic-claude-haiku-4-5-cli] Implementation correctly names and structures routing evidence as per spec, introducing RoutingInputs/RoutingEvidence with clear ownership and classification rules; all acceptance criteria verified; comprehensive test coverage; no convention violations.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $5.90
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A routing decision is passed as 36 positional parameters because the evidence it accumulates has no name (GitHub Issue #2349)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2349