### PR TITLE
Plan review certifies coverage as complete on a plan whose own risk list names an unaddressed gap on the surface its criteria depend on

### DIFF
--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -447,6 +447,16 @@ def build_plan_review_prompt(
                 steps_str = ", ".join(f"Step {s}" for s in steps)
                 mapping_lines.append(f"- **{criterion}** → {steps_str}")
             criteria_mapping_section = "\n" + "\n".join(mapping_lines) + "\n"
+
+        risks = plan_content.get("risks")
+        if risks:
+            risk_lines = ["## Risks Stated By The Plan (from structured plan)", ""]
+            for entry in risks:
+                description = entry.get("description", "")
+                mitigation = entry.get("mitigation", "")
+                risk_lines.append(f"- **Risk:** {description}")
+                risk_lines.append(f"  **Mitigation:** {mitigation}" if mitigation else "  **Mitigation:** (none stated)")
+            criteria_mapping_section += "\n" + "\n".join(risk_lines) + "\n"
     else:
         plan_content_str = plan_content
 
@@ -506,6 +516,25 @@ def build_plan_review_prompt(
            callers accounted for?
         3. **Feasibility** — are the proposed APIs, function signatures, and module
            paths real? Use your tools to verify against the actual codebase.
+        4. **Risk reconciliation** — if the plan states a "Risks" list (rendered
+           above), you MUST resolve every stated risk against the plan's coverage
+           before you can APPROVE. For each risk, determine one of:
+           - **Retired**: the plan's steps or mitigation actually enumerate the
+             affected surface, or add a test that would fail if the risk
+             materialized. Cite where.
+           - **Carried**: the risk is real and NOT resolved by the plan as
+             written. You MUST report it as a `findings` entry (severity
+             `P1-impl` unless it threatens an acceptance criterion, in which
+             case `P1`) so the carried risk is visible in the review output —
+             not silently dropped. A risk on a surface an acceptance criterion
+             depends on (e.g. "some paths may not reach the code this story
+             must fix") is a P1: the plan cannot be said to cover that
+             criterion while the risk is unaddressed.
+           - **Does not apply**: record in `summary` why the risk is moot for
+             this plan.
+           A stated risk with no mention anywhere in your output is not a
+           valid review — every risk the plan names must show up as retired,
+           carried, or explicitly dismissed.
 
         Do NOT evaluate: code style, plan verbosity, alternative approaches,
         or hypothetical edge cases that the dev agent can handle at implementation time.
@@ -530,6 +559,16 @@ def build_plan_review_prompt(
           (P1-impl findings do NOT count as blockers)
         - verdict MUST be REJECT if any P0 or P1 finding exists
         - REJECT MUST include at least one P0 or P1 finding
+        - A plan risk that names a coverage gap on a surface an acceptance
+          criterion depends on, and that the plan does not retire (no
+          enumeration, no test, no recorded "does not apply" judgement), MUST
+          be reported as a P1 finding. You cannot APPROVE a plan while such a
+          risk is unaddressed and unreported — an approval with an empty or
+          risk-silent `findings` list is invalid if the plan's own risk list
+          named an unresolved gap on AC-relevant surface.
+        - A carried risk that does NOT threaten an acceptance criterion still
+          MUST be reported (as `P1-impl` or `P2`) so it is visible in the
+          approval rather than dropped.
         - **List ALL issues in a single pass.** Multiple findings in one REJECT
           is far better than discovering new issues across multiple cycles.
         - APPROVE with P1-impl and P2 suggestions is valid and encouraged

--- a/src/theforge/task/plan_prompts.py
+++ b/src/theforge/task/plan_prompts.py
@@ -455,7 +455,8 @@ def build_plan_review_prompt(
                 description = entry.get("description", "")
                 mitigation = entry.get("mitigation", "")
                 risk_lines.append(f"- **Risk:** {description}")
-                risk_lines.append(f"  **Mitigation:** {mitigation}" if mitigation else "  **Mitigation:** (none stated)")
+                mitigation_text = mitigation if mitigation else "(none stated)"
+                risk_lines.append(f"  **Mitigation:** {mitigation_text}")
             criteria_mapping_section += "\n" + "\n".join(risk_lines) + "\n"
     else:
         plan_content_str = plan_content

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -370,6 +370,110 @@ def test_plan_review_prompt_api_mode_uses_submit_tool(tmp_path):
     assert "```yaml" not in prompt
 
 
+def test_plan_review_prompt_renders_plan_risks(tmp_path):
+    """build_plan_review_prompt must surface the plan's stated risks to the reviewer."""
+    from theforge.task.plan_prompts import build_plan_review_prompt
+    from theforge.task.story import TaskStory
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n", encoding="utf-8")
+    task = TaskStory(
+        name="Test Task",
+        story_path=spec,
+        slug="test-task",
+        test_target="tests/",
+    )
+    plan_content = {
+        "approach": "Thread pricing data through to schema_utils._estimate_cost.",
+        "steps": [
+            {
+                "id": 1,
+                "description": "Pass pricing data down",
+                "files": ["src/theforge/schema_utils.py"],
+                "action": "modify",
+                "details": "...",
+            },
+        ],
+        "criteria_mapping": [],
+        "risks": [
+            {
+                "description": (
+                    "Some runner paths may not currently carry AgentSpec/ModelProfile "
+                    "pricing data down to schema_utils._estimate_cost."
+                ),
+                "mitigation": "",
+            }
+        ],
+    }
+    prompt = build_plan_review_prompt(
+        task,
+        story_content="## Spec\n- AC: something",
+        plan_content=plan_content,
+    )
+    assert "Risks Stated By The Plan" in prompt
+    assert "Some runner paths may not currently carry" in prompt
+    assert "Risk reconciliation" in prompt
+
+
+def test_plan_review_prompt_no_risks_omits_risk_section(tmp_path):
+    """When the plan has no risks list, no risk section is rendered into plan content."""
+    from theforge.task.plan_prompts import build_plan_review_prompt
+    from theforge.task.story import TaskStory
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n", encoding="utf-8")
+    task = TaskStory(
+        name="Test Task",
+        story_path=spec,
+        slug="test-task",
+        test_target="tests/",
+    )
+    plan_content = {
+        "approach": "Do the thing.",
+        "steps": [
+            {
+                "id": 1,
+                "description": "Step one",
+                "files": ["src/theforge/foo.py"],
+                "action": "modify",
+                "details": "...",
+            },
+        ],
+        "criteria_mapping": [],
+    }
+    prompt = build_plan_review_prompt(
+        task,
+        story_content="## Spec\n- AC: something",
+        plan_content=plan_content,
+    )
+    assert "Risks Stated By The Plan" not in prompt
+
+
+def test_plan_review_prompt_rules_require_risk_reporting():
+    """The Rules section must mandate that unresolved AC-relevant risks become findings."""
+    from theforge.task.plan_prompts import build_plan_review_prompt
+    from theforge.task.story import TaskStory
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as td:
+        spec = Path(td) / "spec.md"
+        spec.write_text("# Spec\n", encoding="utf-8")
+        task = TaskStory(
+            name="Test Task",
+            story_path=spec,
+            slug="test-task",
+            test_target="tests/",
+        )
+        prompt = build_plan_review_prompt(
+            task,
+            story_content="## Spec\n- AC: something",
+            plan_content="## Plan\n- step 1",
+        )
+    assert "reported as a P1 finding" in prompt
+    assert "risk-silent" in prompt
+
+
 def test_plan_review_prompt_cli_mode_uses_yaml_block(tmp_path):
     """build_plan_review_prompt with mode='cli' includes YAML block, omits submit_plan_review."""
     from theforge.task.plan_prompts import build_plan_review_prompt

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -449,27 +449,24 @@ def test_plan_review_prompt_no_risks_omits_risk_section(tmp_path):
     assert "Risks Stated By The Plan" not in prompt
 
 
-def test_plan_review_prompt_rules_require_risk_reporting():
+def test_plan_review_prompt_rules_require_risk_reporting(tmp_path):
     """The Rules section must mandate that unresolved AC-relevant risks become findings."""
     from theforge.task.plan_prompts import build_plan_review_prompt
     from theforge.task.story import TaskStory
-    import tempfile
-    from pathlib import Path
 
-    with tempfile.TemporaryDirectory() as td:
-        spec = Path(td) / "spec.md"
-        spec.write_text("# Spec\n", encoding="utf-8")
-        task = TaskStory(
-            name="Test Task",
-            story_path=spec,
-            slug="test-task",
-            test_target="tests/",
-        )
-        prompt = build_plan_review_prompt(
-            task,
-            story_content="## Spec\n- AC: something",
-            plan_content="## Plan\n- step 1",
-        )
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n", encoding="utf-8")
+    task = TaskStory(
+        name="Test Task",
+        story_path=spec,
+        slug="test-task",
+        test_target="tests/",
+    )
+    prompt = build_plan_review_prompt(
+        task,
+        story_content="## Spec\n- AC: something",
+        plan_content="## Plan\n- step 1",
+    )
     assert "reported as a P1 finding" in prompt
     assert "risk-silent" in prompt
 


### PR DESCRIPTION
## Summary

Plan risks are now rendered into the review prompt and the reviewer is explicitly required to retire, carry, or dismiss them.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $2.62
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Plan review certifies coverage as complete on a plan whose own risk list names an unaddressed gap on the surface its criteria depend on (GitHub Issue #2371)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2371