### PR TITLE
A story's allocation band is fed by the story's own failed attempts, so each allocation-exhausted escalation raises the ceiling for the next re-entry

### DIFF
--- a/src/theforge/coordinator/audit_substrate.py
+++ b/src/theforge/coordinator/audit_substrate.py
@@ -2535,8 +2535,12 @@ def derive_cost_samples_by_score(
     projected into columns at upsert time — and routes admissibility through the
     same centralized taint gate every other history consumer uses (ADR-0006
     clause 4): a run that failed its own trust checks does not teach what a
-    story of its kind costs. When ``stats`` is provided its
-    ``"excluded_for_taint"`` key is incremented by the number of rows set aside.
+    story of its kind costs. Runs that did not end successfully are excluded
+    before the taint gate: an unsuccessful spend observation is a lower bound
+    on what the work needed, not a measurement of what the work costs. When
+    ``stats`` is provided its ``"excluded_for_taint"`` and
+    ``"excluded_for_unsuccessful_outcome"`` keys are incremented by the number
+    of rows set aside for those reasons.
 
     Rows with a null score, a null cost (cost-unknown runs, which are a lower
     bound rather than a measurement), or a non-positive cost are skipped: none
@@ -2545,15 +2549,19 @@ def derive_cost_samples_by_score(
     from .trust_status import filter_tainted_records  # noqa: PLC0415
 
     rows = conn.execute(
-        "SELECT complexity_score, total_cost_usd, raw_json FROM audit_records "
+        "SELECT complexity_score, total_cost_usd, outcome_success, raw_json FROM audit_records "
         "WHERE complexity_score IS NOT NULL AND total_cost_usd IS NOT NULL"
     ).fetchall()
     candidates: list[dict] = []
+    excluded_for_unsuccessful_outcome = 0
     for row in rows:
         if isinstance(row, sqlite3.Row):
-            score, cost, raw = row["complexity_score"], row["total_cost_usd"], row["raw_json"]
+            score = row["complexity_score"]
+            cost = row["total_cost_usd"]
+            outcome_success = row["outcome_success"]
+            raw = row["raw_json"]
         else:
-            score, cost, raw = row[0], row[1], row[2]
+            score, cost, outcome_success, raw = row[0], row[1], row[2], row[3]
         try:
             cost_value = float(cost)
         except (TypeError, ValueError):
@@ -2562,6 +2570,9 @@ def derive_cost_samples_by_score(
             continue
         score_value = _coerce_complexity_score(score)
         if score_value is None:
+            continue
+        if outcome_success != 1:
+            excluded_for_unsuccessful_outcome += 1
             continue
         trust: str | None = None
         try:
@@ -2578,6 +2589,10 @@ def derive_cost_samples_by_score(
     admissible, excluded = filter_tainted_records(candidates)
     if stats is not None:
         stats["excluded_for_taint"] = int(stats.get("excluded_for_taint", 0)) + excluded
+        stats["excluded_for_unsuccessful_outcome"] = (
+            int(stats.get("excluded_for_unsuccessful_outcome", 0))
+            + excluded_for_unsuccessful_outcome
+        )
     out: dict[int, list[float]] = {}
     for entry in admissible:
         out.setdefault(int(entry["complexity_score"]), []).append(float(entry["total_cost_usd"]))

--- a/src/theforge/coordinator/story_budget.py
+++ b/src/theforge/coordinator/story_budget.py
@@ -96,6 +96,7 @@ class StoryAllocation:
     max_usd: float | None = None
     reason: str = ""
     excluded_for_taint: int = 0
+    excluded_for_unsuccessful_outcome: int = 0
     scaled_profiles: dict = field(default_factory=dict)
 
     @property
@@ -115,6 +116,7 @@ class StoryAllocation:
             "fallback_configured_usd": round(self.fallback_configured_usd, 2),
             "reason": self.reason,
             "excluded_for_taint": self.excluded_for_taint,
+            "excluded_for_unsuccessful_outcome": self.excluded_for_unsuccessful_outcome,
             **({"scaled_profiles": dict(self.scaled_profiles)} if self.scaled_profiles else {}),
         }
 
@@ -206,6 +208,7 @@ def allocation_from_samples(
     configured_usd: float,
     *,
     excluded_for_taint: int = 0,
+    excluded_for_unsuccessful_outcome: int = 0,
     min_samples: int = MIN_BAND_SAMPLES,
 ) -> StoryAllocation:
     """Return the allocation for ``complexity_score`` given its cost ``samples``.
@@ -223,6 +226,7 @@ def allocation_from_samples(
             sample_count=len(samples),
             reason="no preflight complexity score for this story",
             excluded_for_taint=excluded_for_taint,
+            excluded_for_unsuccessful_outcome=excluded_for_unsuccessful_outcome,
         )
     usable = [float(s) for s in samples if s is not None and float(s) > 0.0]
     if len(usable) < min_samples:
@@ -237,6 +241,7 @@ def allocation_from_samples(
                 f"run(s), below the {min_samples}-run floor"
             ),
             excluded_for_taint=excluded_for_taint,
+            excluded_for_unsuccessful_outcome=excluded_for_unsuccessful_outcome,
         )
     median = percentile(usable, 0.5)
     p90 = percentile(usable, 0.9)
@@ -256,6 +261,7 @@ def allocation_from_samples(
             f"{complexity_score} (max ${observed_max:.2f} x {BAND_HEADROOM})"
         ),
         excluded_for_taint=excluded_for_taint,
+        excluded_for_unsuccessful_outcome=excluded_for_unsuccessful_outcome,
     )
 
 
@@ -279,6 +285,7 @@ def derive_story_allocation(
 
     samples: list[float] = []
     excluded = 0
+    excluded_for_unsuccessful_outcome = 0
     reason_prefix = ""
     substrate = audit_substrate.substrate_path(project_root)
     if not substrate.exists() and not audit_substrate.has_audit_inputs(project_root):
@@ -293,6 +300,9 @@ def derive_story_allocation(
                 stats: dict = {}
                 by_score = audit_substrate.derive_cost_samples_by_score(conn, stats=stats)
                 excluded = int(stats.get("excluded_for_taint", 0))
+                excluded_for_unsuccessful_outcome = int(
+                    stats.get("excluded_for_unsuccessful_outcome", 0)
+                )
                 if complexity_score is not None:
                     samples = list(by_score.get(int(complexity_score), []))
             finally:
@@ -303,6 +313,7 @@ def derive_story_allocation(
         samples,
         configured_usd,
         excluded_for_taint=excluded,
+        excluded_for_unsuccessful_outcome=excluded_for_unsuccessful_outcome,
         min_samples=min_samples,
     )
     if reason_prefix:

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -276,7 +276,13 @@ class TestSubstrateCostSamples:
                     outcome_success=False,
                     error_type="allocation_exhausted",
                 ),
-                _record(run_id="r3", score=5, cost=77.0, outcome_success=None, error_type="timeout"),
+                _record(
+                    run_id="r3",
+                    score=5,
+                    cost=77.0,
+                    outcome_success=None,
+                    error_type="timeout",
+                ),
             ],
         )
         conn = sub.require_substrate(tmp_path)
@@ -323,7 +329,9 @@ class TestDeriveStoryAllocation:
         assert allocation.allocation_usd == 50.0
         assert allocation.reason.startswith("no audit substrate; ")
 
-    def test_unsuccessful_reentry_history_does_not_raise_the_next_ceiling(self, tmp_path: Path) -> None:
+    def test_unsuccessful_reentry_history_does_not_raise_the_next_ceiling(
+        self, tmp_path: Path
+    ) -> None:
         successful_band = [10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 24.0, 30.0]
         _seed_substrate(
             tmp_path,

--- a/tests/test_story_budget_allocation.py
+++ b/tests/test_story_budget_allocation.py
@@ -75,13 +75,15 @@ def _record(
     score: int | None,
     cost: float | None,
     trust_status: str | None = None,
+    outcome_success: bool | None = True,
+    error_type: str | None = None,
     review_cycle_costs: list[float | None] | None = None,
     review_pools: list[list[str] | None] | None = None,
 ) -> dict:
     rec: dict = {
         "run_id": run_id,
         "task": {"slug": f"story-{run_id}", "name": run_id},
-        "outcome": {"success": True, "final_phase": "DONE"},
+        "outcome": {"success": outcome_success, "final_phase": "DONE", "error_type": error_type},
         "timing": {"started_at": "2026-03-01T10:00:00+00:00", "duration_seconds": 60.0},
         "cost": {"total_usd": cost},
         "totals": {"cost_usd": cost, "duration_s": 60.0},
@@ -262,6 +264,31 @@ class TestSubstrateCostSamples:
         assert samples[5] == [2.0]
         assert stats["excluded_for_taint"] == 1
 
+    def test_unsuccessful_runs_are_lower_bounds_not_measurements(self, tmp_path: Path) -> None:
+        _seed_substrate(
+            tmp_path,
+            [
+                _record(run_id="r1", score=5, cost=2.0),
+                _record(
+                    run_id="r2",
+                    score=5,
+                    cost=99.0,
+                    outcome_success=False,
+                    error_type="allocation_exhausted",
+                ),
+                _record(run_id="r3", score=5, cost=77.0, outcome_success=None, error_type="timeout"),
+            ],
+        )
+        conn = sub.require_substrate(tmp_path)
+        try:
+            stats: dict = {}
+            samples = sub.derive_cost_samples_by_score(conn, stats=stats)
+        finally:
+            conn.close()
+
+        assert samples[5] == [2.0]
+        assert stats["excluded_for_unsuccessful_outcome"] == 2
+
 
 class TestDeriveStoryAllocation:
     def test_derives_from_the_substrate_for_the_story_score(self, tmp_path: Path) -> None:
@@ -295,6 +322,36 @@ class TestDeriveStoryAllocation:
         assert allocation.basis == sb.BASIS_CONFIGURED_FALLBACK
         assert allocation.allocation_usd == 50.0
         assert allocation.reason.startswith("no audit substrate; ")
+
+    def test_unsuccessful_reentry_history_does_not_raise_the_next_ceiling(self, tmp_path: Path) -> None:
+        successful_band = [10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 24.0, 30.0]
+        _seed_substrate(
+            tmp_path,
+            [_record(run_id=f"s{i}", score=8, cost=cost) for i, cost in enumerate(successful_band)]
+            + [
+                _record(
+                    run_id="fail-1",
+                    score=8,
+                    cost=64.56,
+                    outcome_success=False,
+                    error_type="allocation_exhausted",
+                ),
+                _record(
+                    run_id="fail-2",
+                    score=8,
+                    cost=105.38,
+                    outcome_success=False,
+                    error_type="allocation_exhausted",
+                ),
+            ],
+        )
+
+        allocation = sb.derive_story_allocation(tmp_path, complexity_score=8, configured_usd=50.0)
+
+        assert allocation.basis == sb.BASIS_SUBSTRATE_BAND
+        assert allocation.max_usd == 30.0
+        assert allocation.allocation_usd == round(30.0 * sb.BAND_HEADROOM, 2)
+        assert allocation.excluded_for_unsuccessful_outcome == 2
 
 
 class TestReviewCyclePlanningPrice:
@@ -670,6 +727,14 @@ class TestScaleRoleBudgets:
 
         assert scaled["dev"] == 20.0
         assert scaled["review_pool[0]"] > 0
+
+    def test_locked_roles_preserve_an_operator_raised_budget(self) -> None:
+        current = {"preflight": 1.0, "dev": 20.0, "review_pool[0]": 4.0, "review_pool[1]": 4.0}
+        scaled = sb.scale_role_budgets(current, 12.0, locked={"dev"})
+
+        assert scaled["dev"] == 20.0
+        assert scaled["preflight"] < current["preflight"]
+        assert scaled["review_pool[0]"] < current["review_pool[0]"]
 
 
 class TestPhaseFundingShortfall:

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -254,9 +254,7 @@ class TestPreflightInstallsTheAllocation:
                     "preflight": {"complexity": "large", "complexity_score": 8},
                     "reviews": [],
                 }
-                for index, cost in enumerate(
-                    [10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 24.0, 30.0]
-                )
+                for index, cost in enumerate([10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 24.0, 30.0])
             ]
             + [
                 {

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -237,6 +237,7 @@ class TestPreflightInstallsTheAllocation:
     def test_unsuccessful_reentries_do_not_raise_the_installed_allocation(
         self, tmp_path: Path
     ) -> None:
+        started_at = "2026-03-01T10:00:00+00:00"
         _seed_story_runs(
             tmp_path,
             [
@@ -244,13 +245,18 @@ class TestPreflightInstallsTheAllocation:
                     "run_id": f"seed-8-{index}",
                     "task": {"slug": f"seed-8-{index}", "name": "seed"},
                     "outcome": {"success": True, "final_phase": "DONE"},
-                    "timing": {"started_at": "2026-03-01T10:00:00+00:00", "duration_seconds": 60.0},
+                    "timing": {
+                        "started_at": started_at,
+                        "duration_seconds": 60.0,
+                    },
                     "cost": {"total_usd": cost},
                     "totals": {"cost_usd": cost, "duration_s": 60.0},
                     "preflight": {"complexity": "large", "complexity_score": 8},
                     "reviews": [],
                 }
-                for index, cost in enumerate([10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 24.0, 30.0])
+                for index, cost in enumerate(
+                    [10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 24.0, 30.0]
+                )
             ]
             + [
                 {
@@ -261,7 +267,10 @@ class TestPreflightInstallsTheAllocation:
                         "final_phase": "ESCALATE",
                         "error_type": "allocation_exhausted",
                     },
-                    "timing": {"started_at": "2026-03-01T10:00:00+00:00", "duration_seconds": 60.0},
+                    "timing": {
+                        "started_at": started_at,
+                        "duration_seconds": 60.0,
+                    },
                     "cost": {"total_usd": 64.56},
                     "totals": {"cost_usd": 64.56, "duration_s": 60.0},
                     "preflight": {"complexity": "large", "complexity_score": 8},
@@ -275,7 +284,10 @@ class TestPreflightInstallsTheAllocation:
                         "final_phase": "ESCALATE",
                         "error_type": "allocation_exhausted",
                     },
-                    "timing": {"started_at": "2026-03-01T10:00:00+00:00", "duration_seconds": 60.0},
+                    "timing": {
+                        "started_at": started_at,
+                        "duration_seconds": 60.0,
+                    },
                     "cost": {"total_usd": 105.38},
                     "totals": {"cost_usd": 105.38, "duration_s": 60.0},
                     "preflight": {"complexity": "large", "complexity_score": 8},

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -61,6 +61,20 @@ def _seed_band(project_root: Path, score: int, costs: list[float]) -> None:
         conn.close()
 
 
+def _seed_story_runs(project_root: Path, records: list[dict]) -> None:
+    runs = sub.runs_dir(project_root)
+    runs.mkdir(parents=True, exist_ok=True)
+    for rec in records:
+        (runs / f"{rec['run_id']}.json").write_text(json.dumps(rec), encoding="utf-8")
+    conn = sub.create_or_open(project_root)
+    try:
+        for rec in records:
+            sub.upsert_run_record(conn, rec, provenance="native")
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def _seed_review_cycle_history(
     project_root: Path, cycle_costs: list[float], *, complexity_score: int = 5
 ) -> None:
@@ -219,6 +233,83 @@ class TestPreflightInstallsTheAllocation:
 
         assert state.story_allocation["allocation_usd"] == round(40.64 * 1.25, 2)
         assert state.story_allocation["allocation_usd"] > 20.0
+
+    def test_unsuccessful_reentries_do_not_raise_the_installed_allocation(
+        self, tmp_path: Path
+    ) -> None:
+        _seed_story_runs(
+            tmp_path,
+            [
+                {
+                    "run_id": f"seed-8-{index}",
+                    "task": {"slug": f"seed-8-{index}", "name": "seed"},
+                    "outcome": {"success": True, "final_phase": "DONE"},
+                    "timing": {"started_at": "2026-03-01T10:00:00+00:00", "duration_seconds": 60.0},
+                    "cost": {"total_usd": cost},
+                    "totals": {"cost_usd": cost, "duration_s": 60.0},
+                    "preflight": {"complexity": "large", "complexity_score": 8},
+                    "reviews": [],
+                }
+                for index, cost in enumerate([10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 24.0, 30.0])
+            ]
+            + [
+                {
+                    "run_id": "failed-reentry-1",
+                    "task": {"slug": "issue-2309", "name": "issue-2309"},
+                    "outcome": {
+                        "success": False,
+                        "final_phase": "ESCALATE",
+                        "error_type": "allocation_exhausted",
+                    },
+                    "timing": {"started_at": "2026-03-01T10:00:00+00:00", "duration_seconds": 60.0},
+                    "cost": {"total_usd": 64.56},
+                    "totals": {"cost_usd": 64.56, "duration_s": 60.0},
+                    "preflight": {"complexity": "large", "complexity_score": 8},
+                    "reviews": [],
+                },
+                {
+                    "run_id": "failed-reentry-2",
+                    "task": {"slug": "issue-2309", "name": "issue-2309"},
+                    "outcome": {
+                        "success": False,
+                        "final_phase": "ESCALATE",
+                        "error_type": "allocation_exhausted",
+                    },
+                    "timing": {"started_at": "2026-03-01T10:00:00+00:00", "duration_seconds": 60.0},
+                    "cost": {"total_usd": 105.38},
+                    "totals": {"cost_usd": 105.38, "duration_s": 60.0},
+                    "preflight": {"complexity": "large", "complexity_score": 8},
+                    "reviews": [],
+                },
+            ],
+        )
+        config = _config(tmp_path)
+        state = CoordinatorState()
+        state.preflight_complexity = "large"
+        state.preflight_complexity_score = 8
+
+        _apply_preflight_config(config, state)
+
+        assert state.story_allocation["allocation_usd"] == round(30.0 * sb.BAND_HEADROOM, 2)
+        assert state.story_allocation["max_usd"] == 30.0
+        assert state.story_allocation["excluded_for_unsuccessful_outcome"] == 2
+
+    def test_explicit_override_budgets_stay_locked_when_allocation_is_derived(
+        self, tmp_path: Path
+    ) -> None:
+        _seed_band(tmp_path, 2, _SCORE_2_COSTS)
+        config = _config(tmp_path)
+        original_dev_budget = config.dev_profile.budget_usd
+        state = CoordinatorState()
+        state.preflight_complexity = "small"
+        state.preflight_complexity_score = 2
+        state._explicit_roles = {"dev"}
+
+        updated = _apply_preflight_config(config, state)
+
+        assert updated.dev_profile.budget_usd == original_dev_budget
+        assert state.story_allocation["allocation_usd"] == 1.69
+        assert state.story_allocation["scaled_profiles"]["dev"] == original_dev_budget
 
 
 class TestAllocationExhaustionIsReported:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] No blocking defects found; the failed-run filter is consumed by the allocation path and focused tests plus Ruff pass. | [anthropic-opus-cli] Allocator now excludes unsuccessful runs from complexity-score cost bands, killing the re-entry ratchet; unit + seam tests reproduce the #2309 history and pass, ruff clean, 361 related tests green.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $3.24
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/model_profiles.py:2423`** The dev cost projection read at the story's complexity score still aggregates every recorded run at that score, including runs that ended unsuccessfully, while the per-story allocation it is compared against is now derived only from successful runs, so the two figures no longer describe the same population even though the function documents itself as doing exactly that.
- **[P2] `src/theforge/coordinator/story_budget.py:300`** The excluded_for_unsuccessful_outcome value installed on a story's allocation is a substrate-wide count of every unsuccessful run at any complexity score, not the count for the score the allocation was derived from, so an operator reading the allocation record cannot tell how much evidence was set aside for this particular band.

## Story

A story's allocation band is fed by the story's own failed attempts, so each allocation-exhausted escalation raises the ceiling for the next re-entry (GitHub Issue #2406)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2406