### PR TITLE
Function tools are rejected for current-generation OpenAI reasoning models on the API transport, and the rejection is absorbed by a fallback that cannot carry the result the phase required

### DIFF
--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -96,8 +96,8 @@ def _redact_tool_call_arguments(arguments: dict) -> dict:
 
 
 # Patterns in result.output that indicate a model-preference fallback should fire.
-# Only usage-exhaustion and model-not-found errors trigger fallback; runtime errors
-# (bad code, schema violations) propagate immediately.
+# Usage-exhaustion, model-not-found, and fail-closed capability mismatches are
+# fallback-eligible; runtime errors (bad code, schema violations) are not.
 _MODEL_FALLBACK_PATTERNS = (
     "429",
     "rate limit",
@@ -117,6 +117,8 @@ _MODEL_FALLBACK_PATTERNS = (
     "model has been deprecated",
 )
 
+_MODEL_FALLBACK_FAILURE_CODES: frozenset[str] = frozenset({"capability_mismatch"})
+
 
 def _is_rate_limit_error(exc: Exception) -> bool:
     """Return True if *exc* is a provider 429 / quota-exhausted error."""
@@ -130,11 +132,14 @@ def _is_rate_limit_error(exc: Exception) -> bool:
 def _classify_api_model_fallback(result: AgentResult) -> str | None:
     """Return a reason string if *result* should trigger model-preference fallback.
 
-    Only quota-exhaustion and model-not-found errors trigger fallback.
-    Runtime errors (bad code, schema violations, timeouts) return None.
+    Quota-exhaustion, model-not-found, and fail-closed capability mismatches
+    trigger fallback. Runtime errors (bad code, schema violations, timeouts)
+    return None.
     """
     if result.success:
         return None
+    if result.failure_code in _MODEL_FALLBACK_FAILURE_CODES:
+        return f"matched failure_code {result.failure_code!r}"
     output_lower = result.output.lower()
     for pattern in _MODEL_FALLBACK_PATTERNS:
         if pattern in output_lower:
@@ -1147,10 +1152,11 @@ def run_api_agent(
     JSON output that does not match the ideation prompt.
 
     If profile.fallback_models is non-empty, forge tries each model in
-    (profile.model, *profile.fallback_models) order. Only quota-exhaustion and
-    model-not-found errors trigger fallback; runtime errors propagate immediately.
-    The model actually used is recorded in AgentResult.model_usage[*].model and,
-    when a fallback fired, in AgentResult.model_config (the full preference list).
+    (profile.model, *profile.fallback_models) order. Quota-exhaustion,
+    model-not-found, and fail-closed capability mismatches trigger fallback;
+    runtime errors propagate immediately. The model actually used is recorded in
+    AgentResult.model_usage[*].model and, when a fallback fired, in
+    AgentResult.model_config (the full preference list).
     """
     if not profile.provider:
         return AgentResult(

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -835,9 +835,7 @@ def _run_loop_openai(
                     ),
                 )
             chat_extra_kwargs = tool_shape.chat_extra_kwargs()
-        adapter = _make_openai_chat_adapter(
-            profile, secrets, extra_kwargs=chat_extra_kwargs
-        )
+        adapter = _make_openai_chat_adapter(profile, secrets, extra_kwargs=chat_extra_kwargs)
         finalizer = _make_openai_chat_finalizer(profile, secrets) if is_review else noop_finalizer
 
     manager = AgentLoopManager(

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -61,6 +61,7 @@ from theforge.runners.schema_utils import (
     _estimate_cost,
     cache_reads_are_subset_of_input,
     noop_finalizer,
+    openai_function_tool_request_shape,
     rate_card_confirmed,
     uses_openai_responses_api,
 )
@@ -761,6 +762,36 @@ def _build_registry_tools(profile: "ModelProfile") -> list[ToolDef]:
     return result
 
 
+def _capability_mismatch_result(
+    profile: "ModelProfile", provider: str, reason: str
+) -> AgentResult:
+    """Return a fail-closed runner result for a missing required capability."""
+    usage = _UsageAccumulator().to_model_usage(profile.model, provider)
+    if _is_local_endpoint(profile.base_url):
+        usage = dataclasses.replace(usage, cost_usd=0.0)
+        cost = 0.0
+    else:
+        cost = usage.cost_usd
+    return AgentResult(
+        success=False,
+        output=reason,
+        session_id=None,
+        cost_usd=cost,
+        exit_code=1,
+        raw={},
+        profile_name=profile.name,
+        model_usage=(usage,),
+        failure_code="capability_mismatch",
+    )
+
+
+def _openai_function_tools_mismatch_text(model: str, detail: str) -> str:
+    return (
+        f"CAPABILITY_MISMATCH: OpenAI model {model!r} cannot satisfy required "
+        f"function-tools on the API transport. {detail}"
+    )
+
+
 # ── Loop-mode entry points ────────────────────────────────────────────
 
 
@@ -778,6 +809,7 @@ def _run_loop_openai(
     tools = _build_registry_tools(profile)
     is_responses = uses_openai_responses_api(profile.model)
     is_review = profile.phase not in _NO_SUBMIT_PHASES
+    chat_extra_kwargs: dict[str, Any] | None = None
 
     if is_responses:
         tool_schemas = [t.to_openai_responses_function() for t in tools] + (
@@ -791,7 +823,21 @@ def _run_loop_openai(
         tool_schemas = [t.to_openai_function() for t in tools] + (
             _build_submit_tools_openai(responses_api=False) if is_review else []
         )
-        adapter = _make_openai_chat_adapter(profile, secrets)
+        if tool_schemas and not _is_local_endpoint(profile.base_url):
+            tool_shape = openai_function_tool_request_shape(profile.model)
+            if tool_shape.transport == "unsupported":
+                return _capability_mismatch_result(
+                    profile,
+                    "openai",
+                    _openai_function_tools_mismatch_text(
+                        profile.model,
+                        "No supported tool-bearing request shape is configured for this model.",
+                    ),
+                )
+            chat_extra_kwargs = tool_shape.chat_extra_kwargs()
+        adapter = _make_openai_chat_adapter(
+            profile, secrets, extra_kwargs=chat_extra_kwargs
+        )
         finalizer = _make_openai_chat_finalizer(profile, secrets) if is_review else noop_finalizer
 
     manager = AgentLoopManager(
@@ -809,23 +855,13 @@ def _run_loop_openai(
             tool_schemas=tool_schemas,
         )
     except Exception as exc:
-        if isinstance(exc, openai.BadRequestError) and "tool" in str(exc).lower():
-            # The provider's own error body names the offending parameter and
-            # the working alternative (e.g. "use /v1/responses or set
-            # reasoning_effort to 'none'"). Without it here, the fallback
-            # absorbs the rejection into an untraceable "tool-call 400" line
-            # and diagnosing the cause requires reproducing the request by
-            # hand against the live provider (#2379).
-            _log(
-                f"  ⚠ {profile.name or profile.model} tool-call 400 — "
-                f"falling back to single-shot text mode: {exc}"
+        if tool_schemas and isinstance(exc, openai.BadRequestError) and "tool" in str(exc).lower():
+            message = _openai_function_tools_mismatch_text(
+                profile.model,
+                f"Provider response: {exc}",
             )
-            fallback_prompt = (
-                prompt
-                + "\n\n[SYSTEM] Respond with a JSON object matching the review output schema. "
-                "Do not use tool calls."
-            )
-            return PROVIDER_RUNNERS["openai"](fallback_prompt, profile, secrets)
+            _log(f"  ⚠ {profile.name or profile.model} capability mismatch: {message}")
+            return _capability_mismatch_result(profile, "openai", message)
         raise
 
     if _is_local_endpoint(profile.base_url):

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -333,7 +333,8 @@ def _maybe_run_api_fallback(
     1. The legacy api_fallback profile (TransportFallbackConfig), if configured.
     2. Each entry in profile.fallback_models that resolves to an API model.
 
-    Only quota-exhaustion/capacity and model-not-found errors trigger fallback.
+    Only quota-exhaustion/capacity, model-not-found, and fail-closed API
+    capability mismatches trigger fallback.
     When a resumed CLI session hits one of those failures, the retry crosses
     transports and starts a fresh API request with the same prompt context.
     That preserves forward progress within the same dev iteration, but session

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -84,17 +84,19 @@ def uses_openai_responses_api(model: str) -> bool:
     return model in _RESPONSES_ONLY_MODELS
 
 
+# Keep this list limited to models for which issue #2377 observed the provider
+# reject tool-bearing Chat Completions requests unless reasoning_effort='none'
+# is supplied. Do not broaden it without a concrete failing probe.
 _CHAT_COMPLETIONS_TOOL_REASONING_NONE_MODELS: frozenset[str] = frozenset(
     {
-        "gpt-5.4",
-        "gpt-5.4-mini",
-        "gpt-5.4-pro",
-        "gpt-5.5",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
     }
 )
 
+# Leave empty until a shipped model is observed to lack both a supported Chat
+# Completions tool shape and a Responses path. "unsupported" is fail-closed
+# metadata, not something we should guess from a model-family prefix.
 _CHAT_COMPLETIONS_TOOL_UNSUPPORTED_MODELS: frozenset[str] = frozenset()
 
 

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import date
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from theforge.agent_types import ModelUsage
 from theforge.runners.rate_registry import (
@@ -82,6 +82,54 @@ _RESPONSES_ONLY_MODELS: set[str] = {
 def uses_openai_responses_api(model: str) -> bool:
     """Return True when this OpenAI model should be sent to /v1/responses."""
     return model in _RESPONSES_ONLY_MODELS
+
+
+_CHAT_COMPLETIONS_TOOL_REASONING_NONE_MODELS: frozenset[str] = frozenset(
+    {
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-pro",
+        "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+    }
+)
+
+_CHAT_COMPLETIONS_TOOL_UNSUPPORTED_MODELS: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class OpenAIFunctionToolRequestShape:
+    """How an OpenAI model can satisfy a required function-tools request.
+
+    ``transport`` is the request surface that can carry function tools for this
+    model. ``"responses"`` means the model should be sent to ``/v1/responses``;
+    ``"chat"`` means Chat Completions can carry the request, optionally with a
+    provider-required override such as ``reasoning_effort='none'``; and
+    ``"unsupported"`` means the shipped metadata has no supported tool-bearing
+    shape for this model, so the run must fail closed instead of discarding the
+    required capability.
+    """
+
+    transport: Literal["responses", "chat", "unsupported"]
+    chat_reasoning_effort: str | None = None
+
+    def chat_extra_kwargs(self) -> dict[str, Any]:
+        """Return Chat Completions kwargs required for a tool-bearing request."""
+        if self.chat_reasoning_effort is None:
+            return {}
+        return {"reasoning_effort": self.chat_reasoning_effort}
+
+
+def openai_function_tool_request_shape(model: str) -> OpenAIFunctionToolRequestShape:
+    """Return the supported OpenAI request shape for required function tools."""
+    if uses_openai_responses_api(model):
+        return OpenAIFunctionToolRequestShape("responses")
+    if model in _CHAT_COMPLETIONS_TOOL_UNSUPPORTED_MODELS:
+        return OpenAIFunctionToolRequestShape("unsupported")
+    if model in _CHAT_COMPLETIONS_TOOL_REASONING_NONE_MODELS:
+        return OpenAIFunctionToolRequestShape("chat", chat_reasoning_effort="none")
+    return OpenAIFunctionToolRequestShape("chat")
 
 
 def sampling_control_kwargs() -> dict[str, Any]:

--- a/tests/test_model_preference.py
+++ b/tests/test_model_preference.py
@@ -120,7 +120,10 @@ def _runtime_fail_result() -> AgentResult:
 def _capability_mismatch_result() -> AgentResult:
     return AgentResult(
         success=False,
-        output="CAPABILITY_MISMATCH: OpenAI model 'gpt-5.1' cannot satisfy required function-tools.",
+        output=(
+            "CAPABILITY_MISMATCH: OpenAI model 'gpt-5.1' cannot satisfy "
+            "required function-tools on the API transport."
+        ),
         session_id=None,
         cost_usd=None,
         exit_code=1,

--- a/tests/test_model_preference.py
+++ b/tests/test_model_preference.py
@@ -117,6 +117,19 @@ def _runtime_fail_result() -> AgentResult:
     )
 
 
+def _capability_mismatch_result() -> AgentResult:
+    return AgentResult(
+        success=False,
+        output="CAPABILITY_MISMATCH: OpenAI model 'gpt-5.1' cannot satisfy required function-tools.",
+        session_id=None,
+        cost_usd=None,
+        exit_code=1,
+        raw={},
+        profile_name="test",
+        failure_code="capability_mismatch",
+    )
+
+
 # ── Config parsing ─────────────────────────────────────────────────────
 
 
@@ -280,6 +293,10 @@ class TestClassifyApiModelFallback:
         )
         assert _classify_api_model_fallback(result) is not None
 
+    def test_capability_mismatch_failure_code_triggers_fallback(self):
+        reason = _classify_api_model_fallback(_capability_mismatch_result())
+        assert reason == "matched failure_code 'capability_mismatch'"
+
 
 class TestRunApiAgentPreferenceList:
     """run_api_agent iterates through models in preference order."""
@@ -403,6 +420,30 @@ class TestRunApiAgentPreferenceList:
         assert not result.success
         # Only first model was attempted
         assert call_log == ["gpt-4o"]
+
+    def test_capability_mismatch_triggers_fallback_to_second(self, tmp_path):
+        """Fail-closed capability mismatches still honor the configured model list."""
+        profile = _make_api_profile(model="gpt-5.1", fallback_models=("gpt-5.1-codex",))
+        capability_mismatch = _capability_mismatch_result()
+        success = _success_result("gpt-5.1-codex")
+
+        call_log: list[str] = []
+
+        def mock_runner(prompt, prof, secrets):
+            call_log.append(prof.model)
+            return capability_mismatch if prof.model == "gpt-5.1" else success
+
+        with patch.dict("theforge.runners.api.PROVIDER_RUNNERS", {"openai": mock_runner}):
+            result = run_api_agent(
+                prompt="test",
+                profile=profile,
+                working_dir=tmp_path,
+                quiet=True,
+            )
+
+        assert result.success
+        assert call_log == ["gpt-5.1", "gpt-5.1-codex"]
+        assert result.model_config == ("gpt-5.1", "gpt-5.1-codex")
 
     def test_single_model_no_model_config(self, tmp_path):
         """Scalar model (no fallbacks) does not set model_config."""

--- a/tests/test_runner_api_local.py
+++ b/tests/test_runner_api_local.py
@@ -1,4 +1,4 @@
-"""Tests for diagnostic logging, local endpoint detection, cost zeroing, and tool-calling fallback."""  # noqa: E501
+"""Tests for diagnostic logging, local endpoint detection, cost zeroing, and OpenAI tool compatibility."""  # noqa: E501
 
 from __future__ import annotations
 
@@ -31,6 +31,7 @@ def _make_profile(
     allowed_tools: tuple[str, ...] = (),
     timeout_seconds: int = 300,
     max_tool_output_bytes: int = 51200,
+    phase: str | None = None,
 ) -> ModelProfile:
     return ModelProfile(
         name=name,
@@ -41,6 +42,7 @@ def _make_profile(
         timeout_seconds=timeout_seconds,
         allowed_tools=allowed_tools,
         max_tool_output_bytes=max_tool_output_bytes,
+        phase=phase,
     )
 
 
@@ -514,20 +516,8 @@ class TestLocalEndpointCostZeroing:
         assert result.model_usage[0].cost_usd == 0.0
 
 
-class TestToolCallingFallback:
-    """When AgentLoopManager raises BadRequestError with 'tool' in the message,
-    _run_loop_openai falls back to single-shot via PROVIDER_RUNNERS["openai"]."""
-
-    def _valid_review_json(self) -> str:
-        return json.dumps(
-            {
-                "verdict": "APPROVE",
-                "summary": "ok",
-                "findings": [],
-                "story_compliance": {"matches_spec": True, "mismatches": []},
-                "test_coverage": {"adequate": True, "gaps": []},
-            }
-        )
+class TestOpenAIFunctionToolCompatibility:
+    """Tool-required OpenAI loop requests use a supported request shape or fail closed."""
 
     def _make_mock_openai_module(self):
         """Build a sys.modules-compatible mock openai with a real BadRequestError subclass."""
@@ -541,51 +531,74 @@ class TestToolCallingFallback:
         mock_httpx = MagicMock()
         return mock_openai, mock_httpx, FakeBadRequestError
 
-    def test_bad_request_with_tool_keyword_triggers_fallback(self, tmp_path):
-        """BadRequestError mentioning 'tool' triggers single-shot retry."""
+    def test_reasoning_models_send_reasoning_effort_none_with_tools(self, tmp_path):
         import sys
 
-        profile = _make_local_profile(
-            base_url="http://localhost:11434/v1", allowed_tools=("read_file",)
+        profile = _make_profile(model="gpt-5.6-sol", allowed_tools=("read_file",))
+        mock_result = AgentResult(
+            success=True,
+            output="{}",
+            session_id=None,
+            cost_usd=0.01,
+            exit_code=0,
+            raw={},
+            profile_name=profile.name,
         )
-        review_json = self._valid_review_json()
-        fallback_result = MagicMock()
-        fallback_result.success = True
-        fallback_result.cost_usd = 0.0
-        fallback_result.output = review_json
-
-        mock_openai, mock_httpx, FakeBadRequestError = self._make_mock_openai_module()
-        bad_request = FakeBadRequestError("model does not support tools")
+        mock_openai, mock_httpx, _ = self._make_mock_openai_module()
 
         with (
             patch.dict(sys.modules, {"openai": mock_openai, "httpx": mock_httpx}),
+            patch("theforge.runners.api._make_openai_chat_adapter") as make_chat,
+            patch("theforge.runners.api._make_openai_chat_finalizer") as make_chat_finalizer,
             patch("theforge.runners.api.AgentLoopManager") as MockManager,
-            patch.dict(
-                "theforge.runners.api.PROVIDER_RUNNERS",
-                {"openai": MagicMock(return_value=fallback_result)},
-            ),
         ):
-            MockManager.return_value.run.side_effect = bad_request
+            make_chat.return_value = MagicMock()
+            make_chat_finalizer.return_value = MagicMock()
+            MockManager.return_value.run.return_value = mock_result
             result = _run_loop_openai("prompt", profile, tmp_path, secrets=None)
 
-        assert result.success
-        assert result is fallback_result
+        assert result is mock_result
+        make_chat.assert_called_once()
+        assert make_chat.call_args.kwargs["extra_kwargs"] == {"reasoning_effort": "none"}
 
-    def test_bad_request_fallback_logs_provider_message(self, tmp_path):
-        """The provider's own error text (not just the fixed fallback string) is logged,
-        so the reason for the 400 is diagnosable from the run log without reproducing
-        the request against the provider by hand."""
+    def test_tool_free_requests_do_not_send_reasoning_effort_override(self, tmp_path):
+        import sys
+
+        profile = _make_profile(model="gpt-5.6-sol", phase="preflight")
+        mock_result = AgentResult(
+            success=True,
+            output="{}",
+            session_id=None,
+            cost_usd=0.01,
+            exit_code=0,
+            raw={},
+            profile_name=profile.name,
+        )
+
+        mock_openai, mock_httpx, _ = self._make_mock_openai_module()
+
+        with (
+            patch.dict(sys.modules, {"openai": mock_openai, "httpx": mock_httpx}),
+            patch("theforge.runners.api._make_openai_chat_adapter") as make_chat,
+            patch("theforge.runners.api.AgentLoopManager") as MockManager,
+        ):
+            make_chat.return_value = MagicMock()
+            MockManager.return_value.run.return_value = mock_result
+            result = _run_loop_openai("prompt", profile, tmp_path, secrets=None)
+
+        assert result is mock_result
+        make_chat.assert_called_once()
+        assert make_chat.call_args.kwargs["extra_kwargs"] is None
+
+    def test_provider_tool_rejection_becomes_capability_mismatch(self, tmp_path):
+        """A provider 400 about tools fails the phase instead of degrading to text."""
         import sys
 
         profile = _make_local_profile(
-            base_url="http://localhost:11434/v1", allowed_tools=("read_file",)
+            model="gpt-5.6-sol",
+            base_url="https://api.openai.test/v1",
+            allowed_tools=("read_file",),
         )
-        review_json = self._valid_review_json()
-        fallback_result = MagicMock()
-        fallback_result.success = True
-        fallback_result.cost_usd = 0.0
-        fallback_result.output = review_json
-
         mock_openai, mock_httpx, FakeBadRequestError = self._make_mock_openai_module()
         provider_message = (
             "Function tools with reasoning_effort are not supported for gpt-5.1 in "
@@ -599,17 +612,37 @@ class TestToolCallingFallback:
         with (
             patch.dict(sys.modules, {"openai": mock_openai, "httpx": mock_httpx}),
             patch("theforge.runners.api.AgentLoopManager") as MockManager,
-            patch.dict(
-                "theforge.runners.api.PROVIDER_RUNNERS",
-                {"openai": MagicMock(return_value=fallback_result)},
-            ),
             patch("theforge.runners.api._log") as mock_log,
         ):
             MockManager.return_value.run.side_effect = bad_request
-            _run_loop_openai("prompt", profile, tmp_path, secrets=None)
+            result = _run_loop_openai("prompt", profile, tmp_path, secrets=None)
 
         logged = "\n".join(call.args[0] for call in mock_log.call_args_list)
         assert provider_message in logged
+        assert not result.success
+        assert result.failure_code == "capability_mismatch"
+        assert "function-tools" in result.output
+        assert provider_message in result.output
+
+    def test_pre_dispatch_unsupported_tool_shape_fails_closed(self, tmp_path):
+        import sys
+
+        profile = _make_profile(model="gpt-5.6-sol", allowed_tools=("read_file",))
+        mock_openai, mock_httpx, _ = self._make_mock_openai_module()
+
+        with (
+            patch.dict(sys.modules, {"openai": mock_openai, "httpx": mock_httpx}),
+            patch("theforge.runners.api.openai_function_tool_request_shape") as tool_shape,
+            patch("theforge.runners.api.AgentLoopManager") as MockManager,
+        ):
+            tool_shape.return_value.transport = "unsupported"
+            tool_shape.return_value.chat_extra_kwargs.return_value = {}
+            result = _run_loop_openai("prompt", profile, tmp_path, secrets=None)
+
+        MockManager.return_value.run.assert_not_called()
+        assert not result.success
+        assert result.failure_code == "capability_mismatch"
+        assert "function-tools" in result.output
 
     def test_bad_request_without_tool_keyword_reraises(self, tmp_path):
         """BadRequestError without 'tool' in message propagates (not a tool-call issue)."""

--- a/tests/test_runner_api_local.py
+++ b/tests/test_runner_api_local.py
@@ -561,6 +561,36 @@ class TestOpenAIFunctionToolCompatibility:
         make_chat.assert_called_once()
         assert make_chat.call_args.kwargs["extra_kwargs"] == {"reasoning_effort": "none"}
 
+    def test_unprobed_tool_models_do_not_send_reasoning_effort_override(self, tmp_path):
+        import sys
+
+        profile = _make_profile(model="gpt-5.4", allowed_tools=("read_file",))
+        mock_result = AgentResult(
+            success=True,
+            output="{}",
+            session_id=None,
+            cost_usd=0.01,
+            exit_code=0,
+            raw={},
+            profile_name=profile.name,
+        )
+        mock_openai, mock_httpx, _ = self._make_mock_openai_module()
+
+        with (
+            patch.dict(sys.modules, {"openai": mock_openai, "httpx": mock_httpx}),
+            patch("theforge.runners.api._make_openai_chat_adapter") as make_chat,
+            patch("theforge.runners.api._make_openai_chat_finalizer") as make_chat_finalizer,
+            patch("theforge.runners.api.AgentLoopManager") as MockManager,
+        ):
+            make_chat.return_value = MagicMock()
+            make_chat_finalizer.return_value = MagicMock()
+            MockManager.return_value.run.return_value = mock_result
+            result = _run_loop_openai("prompt", profile, tmp_path, secrets=None)
+
+        assert result is mock_result
+        make_chat.assert_called_once()
+        assert make_chat.call_args.kwargs["extra_kwargs"] == {}
+
     def test_tool_free_requests_do_not_send_reasoning_effort_override(self, tmp_path):
         import sys
 

--- a/tests/test_runner_sampling_controls.py
+++ b/tests/test_runner_sampling_controls.py
@@ -18,7 +18,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from theforge.config import ModelProfile
-from theforge.runners.schema_utils import sampling_control_kwargs
+from theforge.runners.schema_utils import (
+    openai_function_tool_request_shape,
+    sampling_control_kwargs,
+)
 
 # Names deliberately chosen to span "known at authoring time" and "not yet
 # released": the policy must be identical for all of them.
@@ -79,6 +82,26 @@ class TestSamplingControlPolicy:
         assert inspect.signature(sampling_control_kwargs).parameters == {}
 
 
+class TestOpenAIFunctionToolRequestShape:
+    def test_responses_only_models_route_tools_to_responses(self):
+        shape = openai_function_tool_request_shape("gpt-5.1-codex")
+
+        assert shape.transport == "responses"
+        assert shape.chat_extra_kwargs() == {}
+
+    def test_current_reasoning_models_send_reasoning_effort_none_for_tools(self):
+        shape = openai_function_tool_request_shape("gpt-5.6-sol")
+
+        assert shape.transport == "chat"
+        assert shape.chat_extra_kwargs() == {"reasoning_effort": "none"}
+
+    def test_tool_capability_defaults_to_plain_chat_when_no_override_is_needed(self):
+        shape = openai_function_tool_request_shape("gpt-4o")
+
+        assert shape.transport == "chat"
+        assert shape.chat_extra_kwargs() == {}
+
+
 class TestOpenAICompatibleRequests:
     """Chat Completions single-shot, loop adapter, and finalizers."""
 
@@ -104,6 +127,23 @@ class TestOpenAICompatibleRequests:
 
         kwargs = client.chat.completions.create.call_args.kwargs
         assert "temperature" not in kwargs
+        assert kwargs["tools"] == [{"type": "function", "name": "read_file"}]
+
+    def test_loop_adapter_accepts_provider_specific_tool_controls(self):
+        from theforge.runners.adapters.openai import _make_openai_chat_adapter
+
+        client = _openai_chat_client()
+        adapter = _make_openai_chat_adapter(
+            _profile(model="gpt-5.6-sol"),
+            None,
+            client=client,
+            extra_kwargs={"reasoning_effort": "none"},
+        )
+        adapter([{"role": "user", "content": "go"}], [{"type": "function", "name": "read_file"}])
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["reasoning_effort"] == "none"
         assert kwargs["tools"] == [{"type": "function", "name": "read_file"}]
 
     @pytest.mark.parametrize("model", FUTURE_AND_CURRENT_MODELS)

--- a/tests/test_runner_sampling_controls.py
+++ b/tests/test_runner_sampling_controls.py
@@ -89,14 +89,21 @@ class TestOpenAIFunctionToolRequestShape:
         assert shape.transport == "responses"
         assert shape.chat_extra_kwargs() == {}
 
-    def test_current_reasoning_models_send_reasoning_effort_none_for_tools(self):
-        shape = openai_function_tool_request_shape("gpt-5.6-sol")
+    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra"])
+    def test_observed_reasoning_models_send_reasoning_effort_none_for_tools(self, model):
+        shape = openai_function_tool_request_shape(model)
 
         assert shape.transport == "chat"
         assert shape.chat_extra_kwargs() == {"reasoning_effort": "none"}
 
     def test_tool_capability_defaults_to_plain_chat_when_no_override_is_needed(self):
         shape = openai_function_tool_request_shape("gpt-4o")
+
+        assert shape.transport == "chat"
+        assert shape.chat_extra_kwargs() == {}
+
+    def test_unprobed_gpt5_chat_models_keep_default_reasoning_for_tools(self):
+        shape = openai_function_tool_request_shape("gpt-5.4")
 
         assert shape.transport == "chat"
         assert shape.chat_extra_kwargs() == {}


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The OpenAI tool-bearing API path now sends the observed provider-required request shape and fails closed on unsupported tool capability instead of degrading to text. | [google-gemini-3.5-flash-api] The implementation successfully eliminates text fallback for OpenAI tool rejections and addresses compatibility for reasoning models. | [anthropic-claude-haiku-4-5-cli] Implementation successfully addresses all spec acceptance criteria with comprehensive test coverage and proper fail-closed behavior.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $4.69
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Function tools are rejected for current-generation OpenAI reasoning models on the API transport, and the rejection is absorbed by a fallback that cannot carry the result the phase required (GitHub Issue #2377)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2377