### PR TITLE
Spend carried from a previous attempt is charged against the ceiling supplied for a later run without being disclosed, so a ready story is refused for headroom the operator was never shown

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -11,6 +11,7 @@ from theforge.config import load_config
 from theforge.coordinator.util import set_log_level as coordinator_set_log_level
 from theforge.runners import LogLevel
 from theforge.runners import set_log_level as runner_set_log_level
+from theforge.sprint.budget import evaluate_budget
 from theforge.sprint import SprintRunContext, run_sprint
 from theforge.sprint.launch_guard import acquire_launch_story_locks
 from theforge.sprint.live_stories import LivenessResolution
@@ -1195,8 +1196,18 @@ def _run_query_mode(
             if carry_snapshot.headroom_is_lower_bound:
                 budget_line += " (lower bound; carried unmeasured spend remains)"
             print(budget_line)
-            if carry_snapshot.verification_spend_usd >= resolved.budget_usd:
-                print("  cannot dispatch under the supplied ceiling")
+            carry_budget_decision = evaluate_budget(
+                accumulated_cost=0.0,
+                prior_cost=carry_snapshot.carried_cost_usd,
+                budget_usd=resolved.budget_usd,
+                unmeasured_spend=carry_snapshot.unresolved_unmeasured_sources,
+                accepted_unmeasured_ceiling_usd=carry_snapshot.accepted_unmeasured_ceiling_usd,
+            )
+            if carry_budget_decision is not None:
+                print(
+                    "  cannot dispatch under the supplied ceiling: "
+                    f"{carry_budget_decision.detail}"
+                )
         for task, _src, _ref in resolved.stories:
             deps = ", ".join(task.depends_on) if task.depends_on else "-"
             if task.slug in batch_plan.blocked:

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -1182,9 +1182,8 @@ def _run_query_mode(
                 selected_slugs=[task.slug for task in tasks],
             )
             headroom = carry_snapshot.remaining_headroom_usd(resolved.budget_usd)
-            budget_line = (
-                f"  budget=${resolved.budget_usd:.2f} carried=${carry_snapshot.carried_cost_usd:.2f}"
-            )
+            budget_line = f"  budget=${resolved.budget_usd:.2f}"
+            budget_line += f" carried=${carry_snapshot.carried_cost_usd:.2f}"
             if carry_snapshot.accepted_unmeasured_ceiling_usd > 0.0:
                 budget_line += (
                     " accepted_unmeasured_ceiling="

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -11,8 +11,8 @@ from theforge.config import load_config
 from theforge.coordinator.util import set_log_level as coordinator_set_log_level
 from theforge.runners import LogLevel
 from theforge.runners import set_log_level as runner_set_log_level
-from theforge.sprint.budget import evaluate_budget
 from theforge.sprint import SprintRunContext, run_sprint
+from theforge.sprint.budget import evaluate_budget
 from theforge.sprint.launch_guard import acquire_launch_story_locks
 from theforge.sprint.live_stories import LivenessResolution
 from theforge.sprint.lock import release_story_locks

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -1205,8 +1205,7 @@ def _run_query_mode(
             )
             if carry_budget_decision is not None:
                 print(
-                    "  cannot dispatch under the supplied ceiling: "
-                    f"{carry_budget_decision.detail}"
+                    f"  cannot dispatch under the supplied ceiling: {carry_budget_decision.detail}"
                 )
         for task, _src, _ref in resolved.stories:
             deps = ", ".join(task.depends_on) if task.depends_on else "-"

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -1180,7 +1180,6 @@ def _run_query_mode(
             carry_snapshot = load_sprint_carry_budget_snapshot(
                 project_root=config.project_root,
                 sprint_name=sprint_name,
-                selected_slugs=[task.slug for task in tasks],
                 resume=resume,
                 reexec=reexec,
             )

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -13,11 +13,11 @@ from theforge.runners import LogLevel
 from theforge.runners import set_log_level as runner_set_log_level
 from theforge.sprint import SprintRunContext, run_sprint
 from theforge.sprint.budget import evaluate_budget
+from theforge.sprint.carry import load_sprint_carry_budget_snapshot
 from theforge.sprint.launch_guard import acquire_launch_story_locks
 from theforge.sprint.live_stories import LivenessResolution
 from theforge.sprint.lock import release_story_locks
 from theforge.sprint.preflight import reacquire_story_locks_in_daemon
-from theforge.sprint.query import load_sprint_carry_budget_snapshot
 from theforge.sprint.runner import parse_manifest_slugs
 
 # A run's reported disposition must be derived from how it actually ended, not

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -16,6 +16,7 @@ from theforge.sprint.launch_guard import acquire_launch_story_locks
 from theforge.sprint.live_stories import LivenessResolution
 from theforge.sprint.lock import release_story_locks
 from theforge.sprint.preflight import reacquire_story_locks_in_daemon
+from theforge.sprint.query import load_sprint_carry_budget_snapshot
 from theforge.sprint.runner import parse_manifest_slugs
 
 # A run's reported disposition must be derived from how it actually ended, not
@@ -1174,6 +1175,27 @@ def _run_query_mode(
             satisfied=satisfied,
         )
         print(f"[dry-run] {query_desc}  {len(tasks)} issue(s)  sprint='{sprint_name}'")
+        if resolved.budget_usd > 0.0:
+            carry_snapshot = load_sprint_carry_budget_snapshot(
+                project_root=config.project_root,
+                sprint_name=sprint_name,
+                selected_slugs=[task.slug for task in tasks],
+            )
+            headroom = carry_snapshot.remaining_headroom_usd(resolved.budget_usd)
+            budget_line = (
+                f"  budget=${resolved.budget_usd:.2f} carried=${carry_snapshot.carried_cost_usd:.2f}"
+            )
+            if carry_snapshot.accepted_unmeasured_ceiling_usd > 0.0:
+                budget_line += (
+                    " accepted_unmeasured_ceiling="
+                    f"${carry_snapshot.accepted_unmeasured_ceiling_usd:.2f}"
+                )
+            budget_line += f" usable_headroom=${max(headroom, 0.0):.2f}"
+            if carry_snapshot.headroom_is_lower_bound:
+                budget_line += " (lower bound; carried unmeasured spend remains)"
+            print(budget_line)
+            if carry_snapshot.verification_spend_usd >= resolved.budget_usd:
+                print("  cannot dispatch under the supplied ceiling")
         for task, _src, _ref in resolved.stories:
             deps = ", ".join(task.depends_on) if task.depends_on else "-"
             if task.slug in batch_plan.blocked:

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -1180,6 +1180,8 @@ def _run_query_mode(
                 project_root=config.project_root,
                 sprint_name=sprint_name,
                 selected_slugs=[task.slug for task in tasks],
+                resume=resume,
+                reexec=reexec,
             )
             headroom = carry_snapshot.remaining_headroom_usd(resolved.budget_usd)
             budget_line = f"  budget=${resolved.budget_usd:.2f}"

--- a/src/theforge/runners/runner_ghaw.py
+++ b/src/theforge/runners/runner_ghaw.py
@@ -208,7 +208,9 @@ def _discover_run_id(
 ) -> str | None:
     """Poll `gh run list` until the run carrying our dispatch id appears."""
     discovery_deadline = min(deadline, time.monotonic() + _RUN_DISCOVERY_TIMEOUT_SECONDS)
-    while time.monotonic() < discovery_deadline:
+    attempted = False
+    while not attempted or time.monotonic() < discovery_deadline:
+        attempted = True
         proc = _gh(
             build_run_list_argv(workflow=workflow, ref=ref),
             working_dir=working_dir,
@@ -222,6 +224,8 @@ def _discover_run_id(
             for run in runs:
                 if dispatch_id in (run.get("displayTitle") or ""):
                     return str(run.get("databaseId"))
+        if time.monotonic() >= discovery_deadline:
+            break
         time.sleep(_poll_seconds())
     return None
 

--- a/src/theforge/runners/runner_ghaw.py
+++ b/src/theforge/runners/runner_ghaw.py
@@ -208,6 +208,8 @@ def _discover_run_id(
 ) -> str | None:
     """Poll `gh run list` until the run carrying our dispatch id appears."""
     discovery_deadline = min(deadline, time.monotonic() + _RUN_DISCOVERY_TIMEOUT_SECONDS)
+    if time.monotonic() >= discovery_deadline:
+        return None
     attempted = False
     while not attempted or time.monotonic() < discovery_deadline:
         attempted = True

--- a/src/theforge/sprint/carry.py
+++ b/src/theforge/sprint/carry.py
@@ -76,7 +76,7 @@ def _prior_sprint_block(project_root: Path, sprint_id: str | None) -> dict:
         if sprint_block.get("sprint_id") != sprint_id:
             return {}
         return sprint_block
-    except Exception:
+    except (OSError, yaml.YAMLError, AttributeError):
         return {}
 
 
@@ -164,7 +164,6 @@ def load_sprint_carry_budget_snapshot(
     *,
     project_root: Path,
     sprint_name: str,
-    selected_slugs: list[str],
     sprint_id: str | None = None,
     resume: bool = False,
     reexec: bool = False,
@@ -172,10 +171,6 @@ def load_sprint_carry_budget_snapshot(
     has_previous_run_marker: bool | None = None,
 ) -> SprintCarryBudgetSnapshot:
     """Return the carried budget state the next dispatch will inherit."""
-    # The enforcing ledger seeds prior cost from the whole logical sprint, not
-    # from just the stories selected for the next invocation, so disclosure must
-    # report the same carried total even when only a subset is about to run.
-    del selected_slugs
     resolved_sprint_id = sprint_id or _existing_sprint_id(sprint_name, project_root)
     carries_prior_spend = sprint_invocation_carries_prior_spend(resume=resume, reexec=reexec)
     if has_previous_run_marker is None:

--- a/src/theforge/sprint/carry.py
+++ b/src/theforge/sprint/carry.py
@@ -172,6 +172,9 @@ def load_sprint_carry_budget_snapshot(
     has_previous_run_marker: bool | None = None,
 ) -> SprintCarryBudgetSnapshot:
     """Return the carried budget state the next dispatch will inherit."""
+    # The enforcing ledger seeds prior cost from the whole logical sprint, not
+    # from just the stories selected for the next invocation, so disclosure must
+    # report the same carried total even when only a subset is about to run.
     del selected_slugs
     resolved_sprint_id = sprint_id or _existing_sprint_id(sprint_name, project_root)
     carries_prior_spend = sprint_invocation_carries_prior_spend(resume=resume, reexec=reexec)

--- a/src/theforge/sprint/carry.py
+++ b/src/theforge/sprint/carry.py
@@ -1,0 +1,246 @@
+"""Sprint carry-accounting helpers shared by query, CLI, and runner paths."""
+
+from __future__ import annotations
+
+import datetime
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from . import unmeasured as unmeasured_spend_policy
+from .budget import budget_verification_spend
+
+if TYPE_CHECKING:
+    from .unmeasured import AcceptedUnmeasuredSpend
+
+
+@dataclass(frozen=True)
+class SprintCarryBudgetSnapshot:
+    """Budget-relevant spend already attached to a logical sprint before dispatch."""
+
+    sprint_id: str | None
+    carried_cost_usd: float
+    unresolved_unmeasured_sources: tuple[str, ...]
+    accepted_unmeasured_spend: tuple["AcceptedUnmeasuredSpend", ...]
+    accepted_unmeasured_ceiling_usd: float
+    verification_spend_usd: float
+
+    @property
+    def headroom_is_lower_bound(self) -> bool:
+        return bool(self.unresolved_unmeasured_sources)
+
+    def remaining_headroom_usd(self, budget_usd: float) -> float:
+        return round(float(budget_usd) - self.verification_spend_usd, 4)
+
+
+def _existing_sprint_id(sprint_name: str, project_root: Path) -> str | None:
+    """Return the stable sprint id when one already exists, else ``None``."""
+    sprint_id_path = project_root / ".forge" / "logs" / sprint_name / ".sprint_id"
+    try:
+        if sprint_id_path.exists():
+            sprint_id = sprint_id_path.read_text(encoding="utf-8").strip()
+            return sprint_id or None
+    except OSError:
+        return None
+    return None
+
+
+def sprint_invocation_carries_prior_spend(*, resume: bool, reexec: bool) -> bool:
+    """Whether this invocation should inherit prior same-sprint spend."""
+    return bool(resume or reexec)
+
+
+def previous_run_marker_present(environ: Mapping[str, str] | None = None) -> bool:
+    """Whether the process is continuing from an earlier detached sprint run."""
+    env = os.environ if environ is None else environ
+    return bool(env.get("FORGE_PREV_RUN_ID"))
+
+
+def _prior_sprint_block(project_root: Path, sprint_id: str | None) -> dict:
+    """Return this sprint's block from sprint-audit.yaml, or ``{}``."""
+    if not sprint_id:
+        return {}
+    audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
+    if not audit_path.exists():
+        return {}
+    try:
+        import yaml  # noqa: PLC0415
+
+        with open(audit_path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        sprint_block = data.get("sprint", {})
+        if not isinstance(sprint_block, dict):
+            return {}
+        if sprint_block.get("sprint_id") != sprint_id:
+            return {}
+        return sprint_block
+    except Exception:
+        return {}
+
+
+def prior_unmeasured_spend_sources(project_root: Path, sprint_id: str | None) -> list[str]:
+    """The sources the prior generation recorded as unmeasured, if any."""
+    recorded = _prior_sprint_block(project_root, sprint_id).get("unmeasured_spend_sources") or []
+    return [str(source) for source in recorded if source] if isinstance(recorded, list) else []
+
+
+def prior_sprint_cost_incomplete(
+    project_root: Path,
+    sprint_id: str | None,
+    accepted: Mapping[str, "AcceptedUnmeasuredSpend"] | None = None,
+) -> bool:
+    """Return True when the prior generation recorded an incomplete sprint cost."""
+    sprint_block = _prior_sprint_block(project_root, sprint_id)
+    if sprint_block.get("cost_complete") is not False:
+        return False
+    if accepted:
+        recorded = sprint_block.get("unmeasured_spend_sources") or []
+        if isinstance(recorded, list) and unmeasured_spend_policy.all_sources_accepted(
+            [str(source) for source in recorded if source], accepted
+        ):
+            return False
+    return True
+
+
+def _parse_accumulated_story_timestamp(value: object) -> datetime.datetime | None:
+    """Parse timestamps persisted in accumulated sprint story state."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def read_prior_sprint_accounting(
+    project_root: Path,
+    sprint_id: str | None,
+) -> tuple[float, datetime.datetime | None, dict[str, dict]]:
+    """Recover prior same-sprint cost/timing from progressive story state."""
+    if not sprint_id:
+        return 0.0, None, {}
+
+    from .audit import _load_accumulated_stories  # noqa: PLC0415
+
+    recovered_entries: dict[str, dict] = {}
+    recovered_cost = 0.0
+    earliest_started_at: datetime.datetime | None = None
+    for raw_entry in _load_accumulated_stories(sprint_id, project_root):
+        if not isinstance(raw_entry, dict):
+            continue
+        canonical_ref = raw_entry.get("canonical_ref")
+        if not isinstance(canonical_ref, str) or not canonical_ref:
+            continue
+        entry = dict(raw_entry)
+        recovered_entries[canonical_ref] = entry
+        try:
+            recovered_cost += float(entry.get("cost_usd", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            pass
+        started_at = _parse_accumulated_story_timestamp(entry.get("started_at"))
+        if started_at is not None and (
+            earliest_started_at is None or started_at < earliest_started_at
+        ):
+            earliest_started_at = started_at
+
+    return round(recovered_cost, 4), earliest_started_at, recovered_entries
+
+
+def read_prior_sprint_audit_cost(project_root: Path, sprint_id: str | None) -> float:
+    """Read carry-forward cost for a same-sprint resume/re-exec from sprint-audit.yaml."""
+    sprint_block = _prior_sprint_block(project_root, sprint_id)
+    total = sprint_block.get("total_cost_usd")
+    if total is None:
+        total = sprint_block.get("total_cost_measured_usd", 0.0)
+    try:
+        return float(total or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def load_sprint_carry_budget_snapshot(
+    *,
+    project_root: Path,
+    sprint_name: str,
+    selected_slugs: list[str],
+    sprint_id: str | None = None,
+    resume: bool = False,
+    reexec: bool = False,
+    accepted_unmeasured: Mapping[str, "AcceptedUnmeasuredSpend"] | None = None,
+    has_previous_run_marker: bool | None = None,
+) -> SprintCarryBudgetSnapshot:
+    """Return the carried budget state the next dispatch will inherit."""
+    del selected_slugs
+    resolved_sprint_id = sprint_id or _existing_sprint_id(sprint_name, project_root)
+    carries_prior_spend = sprint_invocation_carries_prior_spend(resume=resume, reexec=reexec)
+    if has_previous_run_marker is None:
+        has_previous_run_marker = previous_run_marker_present()
+    if not resolved_sprint_id:
+        return SprintCarryBudgetSnapshot(
+            sprint_id=None,
+            carried_cost_usd=0.0,
+            unresolved_unmeasured_sources=(),
+            accepted_unmeasured_spend=(),
+            accepted_unmeasured_ceiling_usd=0.0,
+            verification_spend_usd=0.0,
+        )
+
+    recovered_cost_usd, _started_at, entries_by_ref = read_prior_sprint_accounting(
+        project_root, resolved_sprint_id
+    )
+    carried_cost_usd = 0.0
+    if carries_prior_spend:
+        if entries_by_ref:
+            carried_cost_usd = recovered_cost_usd
+        elif has_previous_run_marker:
+            carried_cost_usd = read_prior_sprint_audit_cost(project_root, resolved_sprint_id)
+
+    occurrence_ids: dict[str, str | None] = {}
+    raw_unmeasured_sources: list[str] = []
+    for entry in entries_by_ref.values():
+        slug = entry.get("slug")
+        if not isinstance(slug, str) or not slug:
+            continue
+        if "cost_usd" in entry and entry.get("cost_usd") is None:
+            raw_source = f"carried:{slug}"
+            raw_unmeasured_sources.append(raw_source)
+            origin = unmeasured_spend_policy.build_source(
+                raw_source,
+                unmeasured_spend_policy.read_story_audit(project_root, sprint_name, slug),
+            ).origin
+            occurrence_ids[raw_source] = origin.get("run_id")
+
+    if accepted_unmeasured is not None:
+        accepted_index = dict(accepted_unmeasured)
+    else:
+        from .audit import _load_accepted_unmeasured_spend  # noqa: PLC0415
+
+        accepted_index = unmeasured_spend_policy.accepted_by_source(
+            _load_accepted_unmeasured_spend(resolved_sprint_id, project_root)
+        )
+    if carries_prior_spend and prior_sprint_cost_incomplete(
+        project_root, resolved_sprint_id, accepted_index
+    ):
+        raw_unmeasured_sources.append("carried:prior-generation")
+    unresolved, applied = unmeasured_spend_policy.partition(
+        raw_unmeasured_sources,
+        accepted_index,
+        current_generation=set(),
+        occurrence_ids=occurrence_ids,
+    )
+    accepted_ceiling_usd = unmeasured_spend_policy.accepted_ceiling_total(applied)
+    verification_spend_usd = budget_verification_spend(
+        accumulated_cost=0.0,
+        prior_cost=carried_cost_usd,
+        accepted_unmeasured_ceiling_usd=accepted_ceiling_usd,
+    )
+    return SprintCarryBudgetSnapshot(
+        sprint_id=resolved_sprint_id,
+        carried_cost_usd=carried_cost_usd,
+        unresolved_unmeasured_sources=tuple(unresolved),
+        accepted_unmeasured_spend=tuple(applied),
+        accepted_unmeasured_ceiling_usd=accepted_ceiling_usd,
+        verification_spend_usd=verification_spend_usd,
+    )

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -16,18 +16,12 @@ from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 from ..log_util import _log_line
-from . import carry
 
 if TYPE_CHECKING:
     from ..task import TaskStory
     from .manifest import ResolvedSprint
 
 logger = logging.getLogger(__name__)
-
-# Backward-compatible query surface for tests/callers that imported the helper
-# from this module before it moved to sprint/carry.py.
-load_sprint_carry_budget_snapshot = carry.load_sprint_carry_budget_snapshot
-
 
 class MilestoneNotFoundError(RuntimeError):
     """Raised when a milestone title is absent from the repository."""

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -6,6 +6,7 @@ and to assemble a ResolvedSprint from the resulting issue list.
 
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 import re
@@ -18,8 +19,11 @@ from urllib.parse import quote
 if TYPE_CHECKING:
     from ..task import TaskStory
     from .manifest import ResolvedSprint
+    from .unmeasured import AcceptedUnmeasuredSpend
 
 from ..log_util import _log_line
+from . import unmeasured as unmeasured_spend_policy
+from .budget import budget_verification_spend
 
 logger = logging.getLogger(__name__)
 
@@ -44,12 +48,214 @@ class NormalizedDependencyPlan:
     blocked: dict[str, list[str]]
 
 
+@dataclass(frozen=True)
+class SprintCarryBudgetSnapshot:
+    """Budget-relevant spend already attached to a logical sprint before dispatch."""
+
+    sprint_id: str | None
+    carried_cost_usd: float
+    selected_cost_by_slug: dict[str, float]
+    unresolved_unmeasured_sources: tuple[str, ...]
+    accepted_unmeasured_spend: tuple["AcceptedUnmeasuredSpend", ...]
+    accepted_unmeasured_ceiling_usd: float
+    verification_spend_usd: float
+
+    @property
+    def headroom_is_lower_bound(self) -> bool:
+        return bool(self.unresolved_unmeasured_sources)
+
+    def remaining_headroom_usd(self, budget_usd: float) -> float:
+        return round(float(budget_usd) - self.verification_spend_usd, 4)
+
+
 def _log(msg: str) -> None:
     _log_line("[sprint]", msg)
 
 
 def _is_issue_slug(slug: str) -> bool:
     return re.fullmatch(r"issue-\d+", slug) is not None
+
+
+def _existing_sprint_id(sprint_name: str, project_root: Path) -> str | None:
+    """Return the stable sprint id when one already exists, else ``None``."""
+    sprint_id_path = project_root / ".forge" / "logs" / sprint_name / ".sprint_id"
+    try:
+        if sprint_id_path.exists():
+            sprint_id = sprint_id_path.read_text(encoding="utf-8").strip()
+            return sprint_id or None
+    except OSError:
+        return None
+    return None
+
+
+def _prior_sprint_block(project_root: Path, sprint_id: str | None) -> dict:
+    """Return this sprint's block from sprint-audit.yaml, or ``{}``."""
+    if not sprint_id:
+        return {}
+    audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
+    if not audit_path.exists():
+        return {}
+    try:
+        import yaml  # noqa: PLC0415
+
+        with open(audit_path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        sprint_block = data.get("sprint", {})
+        if not isinstance(sprint_block, dict):
+            return {}
+        if sprint_block.get("sprint_id") != sprint_id:
+            return {}
+        return sprint_block
+    except Exception:
+        return {}
+
+
+def prior_unmeasured_spend_sources(project_root: Path, sprint_id: str | None) -> list[str]:
+    """The sources the prior generation recorded as unmeasured, if any."""
+    recorded = _prior_sprint_block(project_root, sprint_id).get("unmeasured_spend_sources") or []
+    return [str(source) for source in recorded if source] if isinstance(recorded, list) else []
+
+
+def prior_sprint_cost_incomplete(
+    project_root: Path,
+    sprint_id: str | None,
+    accepted: Mapping[str, "AcceptedUnmeasuredSpend"] | None = None,
+) -> bool:
+    """Return True when the prior generation recorded an incomplete sprint cost."""
+    sprint_block = _prior_sprint_block(project_root, sprint_id)
+    if sprint_block.get("cost_complete") is not False:
+        return False
+    if accepted:
+        recorded = sprint_block.get("unmeasured_spend_sources") or []
+        if isinstance(recorded, list) and unmeasured_spend_policy.all_sources_accepted(
+            [str(source) for source in recorded if source], accepted
+        ):
+            return False
+    return True
+
+
+def _parse_accumulated_story_timestamp(value: object) -> datetime.datetime | None:
+    """Parse timestamps persisted in accumulated sprint story state."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def read_prior_sprint_accounting(
+    project_root: Path,
+    sprint_id: str | None,
+) -> tuple[float, datetime.datetime | None, dict[str, dict]]:
+    """Recover prior same-sprint cost/timing from progressive story state."""
+    if not sprint_id:
+        return 0.0, None, {}
+
+    from .audit import _load_accumulated_stories  # noqa: PLC0415
+
+    recovered_entries: dict[str, dict] = {}
+    recovered_cost = 0.0
+    earliest_started_at: datetime.datetime | None = None
+    for raw_entry in _load_accumulated_stories(sprint_id, project_root):
+        if not isinstance(raw_entry, dict):
+            continue
+        canonical_ref = raw_entry.get("canonical_ref")
+        if not isinstance(canonical_ref, str) or not canonical_ref:
+            continue
+        entry = dict(raw_entry)
+        recovered_entries[canonical_ref] = entry
+        try:
+            recovered_cost += float(entry.get("cost_usd", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            pass
+        started_at = _parse_accumulated_story_timestamp(entry.get("started_at"))
+        if started_at is not None and (
+            earliest_started_at is None or started_at < earliest_started_at
+        ):
+            earliest_started_at = started_at
+
+    return round(recovered_cost, 4), earliest_started_at, recovered_entries
+
+
+def load_sprint_carry_budget_snapshot(
+    *,
+    project_root: Path,
+    sprint_name: str,
+    selected_slugs: list[str],
+    sprint_id: str | None = None,
+    accepted_unmeasured: Mapping[str, "AcceptedUnmeasuredSpend"] | None = None,
+) -> SprintCarryBudgetSnapshot:
+    """Return the carried budget state the next dispatch will inherit."""
+    resolved_sprint_id = sprint_id or _existing_sprint_id(sprint_name, project_root)
+    if not resolved_sprint_id:
+        return SprintCarryBudgetSnapshot(
+            sprint_id=None,
+            carried_cost_usd=0.0,
+            selected_cost_by_slug={},
+            unresolved_unmeasured_sources=(),
+            accepted_unmeasured_spend=(),
+            accepted_unmeasured_ceiling_usd=0.0,
+            verification_spend_usd=0.0,
+        )
+
+    carried_cost_usd, _started_at, entries_by_ref = read_prior_sprint_accounting(
+        project_root, resolved_sprint_id
+    )
+    selected = set(selected_slugs)
+    selected_cost_by_slug: dict[str, float] = {}
+    occurrence_ids: dict[str, str | None] = {}
+    raw_unmeasured_sources: list[str] = []
+    for entry in entries_by_ref.values():
+        slug = entry.get("slug")
+        if not isinstance(slug, str) or not slug:
+            continue
+        try:
+            cost_usd = float(entry.get("cost_usd", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            cost_usd = 0.0
+        if slug in selected and cost_usd > 0.0:
+            selected_cost_by_slug[slug] = selected_cost_by_slug.get(slug, 0.0) + cost_usd
+        if "cost_usd" in entry and entry.get("cost_usd") is None:
+            raw_source = f"carried:{slug}"
+            raw_unmeasured_sources.append(raw_source)
+            origin = unmeasured_spend_policy.build_source(
+                raw_source,
+                unmeasured_spend_policy.read_story_audit(project_root, sprint_name, slug),
+            ).origin
+            occurrence_ids[raw_source] = origin.get("run_id")
+
+    if accepted_unmeasured is not None:
+        accepted_index = dict(accepted_unmeasured)
+    else:
+        from .audit import _load_accepted_unmeasured_spend  # noqa: PLC0415
+
+        accepted_index = unmeasured_spend_policy.accepted_by_source(
+            _load_accepted_unmeasured_spend(resolved_sprint_id, project_root)
+        )
+    if prior_sprint_cost_incomplete(project_root, resolved_sprint_id, accepted_index):
+        raw_unmeasured_sources.append("carried:prior-generation")
+    unresolved, applied = unmeasured_spend_policy.partition(
+        raw_unmeasured_sources,
+        accepted_index,
+        current_generation=set(),
+        occurrence_ids=occurrence_ids,
+    )
+    accepted_ceiling_usd = unmeasured_spend_policy.accepted_ceiling_total(applied)
+    verification_spend_usd = budget_verification_spend(
+        accumulated_cost=0.0,
+        prior_cost=carried_cost_usd,
+        accepted_unmeasured_ceiling_usd=accepted_ceiling_usd,
+    )
+    return SprintCarryBudgetSnapshot(
+        sprint_id=resolved_sprint_id,
+        carried_cost_usd=carried_cost_usd,
+        selected_cost_by_slug=dict(sorted(selected_cost_by_slug.items())),
+        unresolved_unmeasured_sources=tuple(unresolved),
+        accepted_unmeasured_spend=tuple(applied),
+        accepted_unmeasured_ceiling_usd=accepted_ceiling_usd,
+        verification_spend_usd=verification_spend_usd,
+    )
 
 
 def _gh_api_paginate_issues(

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 class MilestoneNotFoundError(RuntimeError):
     """Raised when a milestone title is absent from the repository."""
 

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -6,12 +6,10 @@ and to assemble a ResolvedSprint from the resulting issue list.
 
 from __future__ import annotations
 
-import datetime
 import json
 import logging
 import re
 import subprocess
-from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -20,11 +18,16 @@ from urllib.parse import quote
 if TYPE_CHECKING:
     from ..task import TaskStory
     from .manifest import ResolvedSprint
-    from .unmeasured import AcceptedUnmeasuredSpend
 
+from .carry import (
+    SprintCarryBudgetSnapshot,
+    load_sprint_carry_budget_snapshot,
+    prior_sprint_cost_incomplete,
+    prior_unmeasured_spend_sources,
+    read_prior_sprint_accounting,
+    read_prior_sprint_audit_cost,
+)
 from ..log_util import _log_line
-from . import unmeasured as unmeasured_spend_policy
-from .budget import budget_verification_spend
 
 logger = logging.getLogger(__name__)
 
@@ -49,234 +52,12 @@ class NormalizedDependencyPlan:
     blocked: dict[str, list[str]]
 
 
-@dataclass(frozen=True)
-class SprintCarryBudgetSnapshot:
-    """Budget-relevant spend already attached to a logical sprint before dispatch."""
-
-    sprint_id: str | None
-    carried_cost_usd: float
-    unresolved_unmeasured_sources: tuple[str, ...]
-    accepted_unmeasured_spend: tuple["AcceptedUnmeasuredSpend", ...]
-    accepted_unmeasured_ceiling_usd: float
-    verification_spend_usd: float
-
-    @property
-    def headroom_is_lower_bound(self) -> bool:
-        return bool(self.unresolved_unmeasured_sources)
-
-    def remaining_headroom_usd(self, budget_usd: float) -> float:
-        return round(float(budget_usd) - self.verification_spend_usd, 4)
-
-
 def _log(msg: str) -> None:
     _log_line("[sprint]", msg)
 
 
 def _is_issue_slug(slug: str) -> bool:
     return re.fullmatch(r"issue-\d+", slug) is not None
-
-
-def _existing_sprint_id(sprint_name: str, project_root: Path) -> str | None:
-    """Return the stable sprint id when one already exists, else ``None``."""
-    sprint_id_path = project_root / ".forge" / "logs" / sprint_name / ".sprint_id"
-    try:
-        if sprint_id_path.exists():
-            sprint_id = sprint_id_path.read_text(encoding="utf-8").strip()
-            return sprint_id or None
-    except OSError:
-        return None
-    return None
-
-
-def sprint_invocation_carries_prior_spend(*, resume: bool, reexec: bool) -> bool:
-    """Whether this invocation should inherit prior same-sprint spend."""
-    return bool(resume or reexec)
-
-
-def _prior_sprint_block(project_root: Path, sprint_id: str | None) -> dict:
-    """Return this sprint's block from sprint-audit.yaml, or ``{}``."""
-    if not sprint_id:
-        return {}
-    audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
-    if not audit_path.exists():
-        return {}
-    try:
-        import yaml  # noqa: PLC0415
-
-        with open(audit_path, encoding="utf-8") as handle:
-            data = yaml.safe_load(handle) or {}
-        sprint_block = data.get("sprint", {})
-        if not isinstance(sprint_block, dict):
-            return {}
-        if sprint_block.get("sprint_id") != sprint_id:
-            return {}
-        return sprint_block
-    except Exception:
-        return {}
-
-
-def prior_unmeasured_spend_sources(project_root: Path, sprint_id: str | None) -> list[str]:
-    """The sources the prior generation recorded as unmeasured, if any."""
-    recorded = _prior_sprint_block(project_root, sprint_id).get("unmeasured_spend_sources") or []
-    return [str(source) for source in recorded if source] if isinstance(recorded, list) else []
-
-
-def prior_sprint_cost_incomplete(
-    project_root: Path,
-    sprint_id: str | None,
-    accepted: Mapping[str, "AcceptedUnmeasuredSpend"] | None = None,
-) -> bool:
-    """Return True when the prior generation recorded an incomplete sprint cost."""
-    sprint_block = _prior_sprint_block(project_root, sprint_id)
-    if sprint_block.get("cost_complete") is not False:
-        return False
-    if accepted:
-        recorded = sprint_block.get("unmeasured_spend_sources") or []
-        if isinstance(recorded, list) and unmeasured_spend_policy.all_sources_accepted(
-            [str(source) for source in recorded if source], accepted
-        ):
-            return False
-    return True
-
-
-def _parse_accumulated_story_timestamp(value: object) -> datetime.datetime | None:
-    """Parse timestamps persisted in accumulated sprint story state."""
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
-def read_prior_sprint_accounting(
-    project_root: Path,
-    sprint_id: str | None,
-) -> tuple[float, datetime.datetime | None, dict[str, dict]]:
-    """Recover prior same-sprint cost/timing from progressive story state."""
-    if not sprint_id:
-        return 0.0, None, {}
-
-    from .audit import _load_accumulated_stories  # noqa: PLC0415
-
-    recovered_entries: dict[str, dict] = {}
-    recovered_cost = 0.0
-    earliest_started_at: datetime.datetime | None = None
-    for raw_entry in _load_accumulated_stories(sprint_id, project_root):
-        if not isinstance(raw_entry, dict):
-            continue
-        canonical_ref = raw_entry.get("canonical_ref")
-        if not isinstance(canonical_ref, str) or not canonical_ref:
-            continue
-        entry = dict(raw_entry)
-        recovered_entries[canonical_ref] = entry
-        try:
-            recovered_cost += float(entry.get("cost_usd", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            pass
-        started_at = _parse_accumulated_story_timestamp(entry.get("started_at"))
-        if started_at is not None and (
-            earliest_started_at is None or started_at < earliest_started_at
-        ):
-            earliest_started_at = started_at
-
-    return round(recovered_cost, 4), earliest_started_at, recovered_entries
-
-
-def read_prior_sprint_audit_cost(project_root: Path, sprint_id: str | None) -> float:
-    """Read carry-forward cost for a same-sprint resume/re-exec from sprint-audit.yaml."""
-    sprint_block = _prior_sprint_block(project_root, sprint_id)
-    total = sprint_block.get("total_cost_usd")
-    if total is None:
-        total = sprint_block.get("total_cost_measured_usd", 0.0)
-    try:
-        return float(total or 0.0)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def load_sprint_carry_budget_snapshot(
-    *,
-    project_root: Path,
-    sprint_name: str,
-    selected_slugs: list[str],
-    sprint_id: str | None = None,
-    resume: bool = False,
-    reexec: bool = False,
-    accepted_unmeasured: Mapping[str, "AcceptedUnmeasuredSpend"] | None = None,
-) -> SprintCarryBudgetSnapshot:
-    """Return the carried budget state the next dispatch will inherit."""
-    resolved_sprint_id = sprint_id or _existing_sprint_id(sprint_name, project_root)
-    carries_prior_spend = sprint_invocation_carries_prior_spend(resume=resume, reexec=reexec)
-    if not resolved_sprint_id:
-        return SprintCarryBudgetSnapshot(
-            sprint_id=None,
-            carried_cost_usd=0.0,
-            unresolved_unmeasured_sources=(),
-            accepted_unmeasured_spend=(),
-            accepted_unmeasured_ceiling_usd=0.0,
-            verification_spend_usd=0.0,
-        )
-    if not carries_prior_spend:
-        return SprintCarryBudgetSnapshot(
-            sprint_id=resolved_sprint_id,
-            carried_cost_usd=0.0,
-            unresolved_unmeasured_sources=(),
-            accepted_unmeasured_spend=(),
-            accepted_unmeasured_ceiling_usd=0.0,
-            verification_spend_usd=0.0,
-        )
-
-    carried_cost_usd, _started_at, entries_by_ref = read_prior_sprint_accounting(
-        project_root, resolved_sprint_id
-    )
-    if not entries_by_ref:
-        carried_cost_usd = read_prior_sprint_audit_cost(project_root, resolved_sprint_id)
-    occurrence_ids: dict[str, str | None] = {}
-    raw_unmeasured_sources: list[str] = []
-    for entry in entries_by_ref.values():
-        slug = entry.get("slug")
-        if not isinstance(slug, str) or not slug:
-            continue
-        if "cost_usd" in entry and entry.get("cost_usd") is None:
-            raw_source = f"carried:{slug}"
-            raw_unmeasured_sources.append(raw_source)
-            origin = unmeasured_spend_policy.build_source(
-                raw_source,
-                unmeasured_spend_policy.read_story_audit(project_root, sprint_name, slug),
-            ).origin
-            occurrence_ids[raw_source] = origin.get("run_id")
-
-    if accepted_unmeasured is not None:
-        accepted_index = dict(accepted_unmeasured)
-    else:
-        from .audit import _load_accepted_unmeasured_spend  # noqa: PLC0415
-
-        accepted_index = unmeasured_spend_policy.accepted_by_source(
-            _load_accepted_unmeasured_spend(resolved_sprint_id, project_root)
-        )
-    if prior_sprint_cost_incomplete(project_root, resolved_sprint_id, accepted_index):
-        raw_unmeasured_sources.append("carried:prior-generation")
-    unresolved, applied = unmeasured_spend_policy.partition(
-        raw_unmeasured_sources,
-        accepted_index,
-        current_generation=set(),
-        occurrence_ids=occurrence_ids,
-    )
-    accepted_ceiling_usd = unmeasured_spend_policy.accepted_ceiling_total(applied)
-    verification_spend_usd = budget_verification_spend(
-        accumulated_cost=0.0,
-        prior_cost=carried_cost_usd,
-        accepted_unmeasured_ceiling_usd=accepted_ceiling_usd,
-    )
-    return SprintCarryBudgetSnapshot(
-        sprint_id=resolved_sprint_id,
-        carried_cost_usd=carried_cost_usd,
-        unresolved_unmeasured_sources=tuple(unresolved),
-        accepted_unmeasured_spend=tuple(applied),
-        accepted_unmeasured_ceiling_usd=accepted_ceiling_usd,
-        verification_spend_usd=verification_spend_usd,
-    )
 
 
 def _gh_api_paginate_issues(

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -15,9 +15,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
-from . import carry
-
 from ..log_util import _log_line
+from . import carry
 
 if TYPE_CHECKING:
     from ..task import TaskStory

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -15,19 +15,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
+from ..log_util import _log_line
+
 if TYPE_CHECKING:
     from ..task import TaskStory
     from .manifest import ResolvedSprint
-
-from .carry import (
-    SprintCarryBudgetSnapshot,
-    load_sprint_carry_budget_snapshot,
-    prior_sprint_cost_incomplete,
-    prior_unmeasured_spend_sources,
-    read_prior_sprint_accounting,
-    read_prior_sprint_audit_cost,
-)
-from ..log_util import _log_line
 
 logger = logging.getLogger(__name__)
 

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
-from .carry import load_sprint_carry_budget_snapshot
+from . import carry
 
 from ..log_util import _log_line
 
@@ -24,6 +24,10 @@ if TYPE_CHECKING:
     from .manifest import ResolvedSprint
 
 logger = logging.getLogger(__name__)
+
+# Backward-compatible query surface for tests/callers that imported the helper
+# from this module before it moved to sprint/carry.py.
+load_sprint_carry_budget_snapshot = carry.load_sprint_carry_budget_snapshot
 
 
 class MilestoneNotFoundError(RuntimeError):

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
+from .carry import load_sprint_carry_budget_snapshot
+
 from ..log_util import _log_line
 
 if TYPE_CHECKING:

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -11,6 +11,7 @@ import json
 import logging
 import re
 import subprocess
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/src/theforge/sprint/query.py
+++ b/src/theforge/sprint/query.py
@@ -55,7 +55,6 @@ class SprintCarryBudgetSnapshot:
 
     sprint_id: str | None
     carried_cost_usd: float
-    selected_cost_by_slug: dict[str, float]
     unresolved_unmeasured_sources: tuple[str, ...]
     accepted_unmeasured_spend: tuple["AcceptedUnmeasuredSpend", ...]
     accepted_unmeasured_ceiling_usd: float
@@ -87,6 +86,11 @@ def _existing_sprint_id(sprint_name: str, project_root: Path) -> str | None:
     except OSError:
         return None
     return None
+
+
+def sprint_invocation_carries_prior_spend(*, resume: bool, reexec: bool) -> bool:
+    """Whether this invocation should inherit prior same-sprint spend."""
+    return bool(resume or reexec)
 
 
 def _prior_sprint_block(project_root: Path, sprint_id: str | None) -> dict:
@@ -179,21 +183,44 @@ def read_prior_sprint_accounting(
     return round(recovered_cost, 4), earliest_started_at, recovered_entries
 
 
+def read_prior_sprint_audit_cost(project_root: Path, sprint_id: str | None) -> float:
+    """Read carry-forward cost for a same-sprint resume/re-exec from sprint-audit.yaml."""
+    sprint_block = _prior_sprint_block(project_root, sprint_id)
+    total = sprint_block.get("total_cost_usd")
+    if total is None:
+        total = sprint_block.get("total_cost_measured_usd", 0.0)
+    try:
+        return float(total or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def load_sprint_carry_budget_snapshot(
     *,
     project_root: Path,
     sprint_name: str,
     selected_slugs: list[str],
     sprint_id: str | None = None,
+    resume: bool = False,
+    reexec: bool = False,
     accepted_unmeasured: Mapping[str, "AcceptedUnmeasuredSpend"] | None = None,
 ) -> SprintCarryBudgetSnapshot:
     """Return the carried budget state the next dispatch will inherit."""
     resolved_sprint_id = sprint_id or _existing_sprint_id(sprint_name, project_root)
+    carries_prior_spend = sprint_invocation_carries_prior_spend(resume=resume, reexec=reexec)
     if not resolved_sprint_id:
         return SprintCarryBudgetSnapshot(
             sprint_id=None,
             carried_cost_usd=0.0,
-            selected_cost_by_slug={},
+            unresolved_unmeasured_sources=(),
+            accepted_unmeasured_spend=(),
+            accepted_unmeasured_ceiling_usd=0.0,
+            verification_spend_usd=0.0,
+        )
+    if not carries_prior_spend:
+        return SprintCarryBudgetSnapshot(
+            sprint_id=resolved_sprint_id,
+            carried_cost_usd=0.0,
             unresolved_unmeasured_sources=(),
             accepted_unmeasured_spend=(),
             accepted_unmeasured_ceiling_usd=0.0,
@@ -203,20 +230,14 @@ def load_sprint_carry_budget_snapshot(
     carried_cost_usd, _started_at, entries_by_ref = read_prior_sprint_accounting(
         project_root, resolved_sprint_id
     )
-    selected = set(selected_slugs)
-    selected_cost_by_slug: dict[str, float] = {}
+    if not entries_by_ref:
+        carried_cost_usd = read_prior_sprint_audit_cost(project_root, resolved_sprint_id)
     occurrence_ids: dict[str, str | None] = {}
     raw_unmeasured_sources: list[str] = []
     for entry in entries_by_ref.values():
         slug = entry.get("slug")
         if not isinstance(slug, str) or not slug:
             continue
-        try:
-            cost_usd = float(entry.get("cost_usd", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            cost_usd = 0.0
-        if slug in selected and cost_usd > 0.0:
-            selected_cost_by_slug[slug] = selected_cost_by_slug.get(slug, 0.0) + cost_usd
         if "cost_usd" in entry and entry.get("cost_usd") is None:
             raw_source = f"carried:{slug}"
             raw_unmeasured_sources.append(raw_source)
@@ -251,7 +272,6 @@ def load_sprint_carry_budget_snapshot(
     return SprintCarryBudgetSnapshot(
         sprint_id=resolved_sprint_id,
         carried_cost_usd=carried_cost_usd,
-        selected_cost_by_slug=dict(sorted(selected_cost_by_slug.items())),
         unresolved_unmeasured_sources=tuple(unresolved),
         accepted_unmeasured_spend=tuple(applied),
         accepted_unmeasured_ceiling_usd=accepted_ceiling_usd,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -125,6 +125,7 @@ from .query import (
     load_sprint_carry_budget_snapshot,
     normalize_dependency_plan,
 )
+from .query import read_prior_sprint_audit_cost as _query_read_prior_sprint_audit_cost
 from .query import prior_sprint_cost_incomplete as _query_prior_sprint_cost_incomplete
 from .query import prior_unmeasured_spend_sources as _query_prior_unmeasured_spend_sources
 from .query import read_prior_sprint_accounting as _query_read_prior_sprint_accounting
@@ -942,41 +943,7 @@ def _read_prior_sprint_cost(project_root: Path, sprint_id: str | None) -> float:
     """
     if not sprint_id or not os.environ.get("FORGE_PREV_RUN_ID"):
         return 0.0
-    audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
-    if not audit_path.exists():
-        return 0.0
-    try:
-        with open(audit_path, encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
-        sprint_block = data.get("sprint", {})
-        if sprint_block.get("sprint_id") != sprint_id:
-            return 0.0
-        total = sprint_block.get("total_cost_usd")
-        if total is None:
-            total = sprint_block.get("total_cost_measured_usd", 0.0)
-        return float(total or 0.0)
-    except (OSError, ValueError, TypeError):
-        return 0.0
-
-
-def _prior_sprint_block(project_root: Path, sprint_id: str | None) -> dict:
-    """Return this sprint's block from sprint-audit.yaml, or ``{}``."""
-    if not sprint_id:
-        return {}
-    audit_path = project_root / ".forge" / "audits" / "sprint-audit.yaml"
-    if not audit_path.exists():
-        return {}
-    try:
-        with open(audit_path, encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
-        sprint_block = data.get("sprint", {})
-        if not isinstance(sprint_block, dict):
-            return {}
-        if sprint_block.get("sprint_id") != sprint_id:
-            return {}
-        return sprint_block
-    except (OSError, yaml.YAMLError, AttributeError):
-        return {}
+    return _query_read_prior_sprint_audit_cost(project_root, sprint_id)
 
 
 def _prior_unmeasured_spend_sources(project_root: Path, sprint_id: str | None) -> list[str]:
@@ -5170,6 +5137,8 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
             sprint_name=_ctx.resolved.name,
             selected_slugs=list(_ctx.slug_to_context.keys()),
             sprint_id=_ctx.sprint_id,
+            resume=_ctx.resume,
+            reexec=_ctx.reexec,
             accepted_unmeasured=dict(accepted_unmeasured),
         )
         _headroom = _carry_snapshot.remaining_headroom_usd(_ctx.resolved.budget_usd)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -987,9 +987,12 @@ def _prior_sprint_cost_incomplete(
 
 def _parse_accumulated_story_timestamp(value: object) -> datetime.datetime | None:
     """Parse timestamps persisted in accumulated sprint story state."""
-    from .query import _parse_accumulated_story_timestamp as _query_parse  # noqa: PLC0415
-
-    return _query_parse(value)
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def _read_prior_sprint_accounting(

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -121,6 +121,12 @@ from .manifest import (
 )
 from .prior_landing import landing_settled
 from .query import NormalizedDependencyPlan, normalize_dependency_plan
+from .query import (
+    load_sprint_carry_budget_snapshot,
+    prior_sprint_cost_incomplete as _query_prior_sprint_cost_incomplete,
+    prior_unmeasured_spend_sources as _query_prior_unmeasured_spend_sources,
+    read_prior_sprint_accounting as _query_read_prior_sprint_accounting,
+)
 from .sources import StorySource
 from .state_writer import (
     SPRINT_PHASE_DONE,
@@ -974,8 +980,7 @@ def _prior_sprint_block(project_root: Path, sprint_id: str | None) -> dict:
 
 def _prior_unmeasured_spend_sources(project_root: Path, sprint_id: str | None) -> list[str]:
     """The sources the prior generation recorded as unmeasured, if any."""
-    recorded = _prior_sprint_block(project_root, sprint_id).get("unmeasured_spend_sources") or []
-    return [str(s) for s in recorded if s] if isinstance(recorded, list) else []
+    return _query_prior_unmeasured_spend_sources(project_root, sprint_id)
 
 
 def _prior_sprint_cost_incomplete(
@@ -996,26 +1001,14 @@ def _prior_sprint_cost_incomplete(
     the flag: there is no source there for an operator to have resolved, so the
     whole-generation carry remains the honest statement.
     """
-    sprint_block = _prior_sprint_block(project_root, sprint_id)
-    if sprint_block.get("cost_complete") is not False:
-        return False
-    if accepted:
-        recorded = sprint_block.get("unmeasured_spend_sources") or []
-        if isinstance(recorded, list) and unmeasured_spend_policy.all_sources_accepted(
-            [str(s) for s in recorded if s], accepted
-        ):
-            return False
-    return True
+    return _query_prior_sprint_cost_incomplete(project_root, sprint_id, dict(accepted or {}))
 
 
 def _parse_accumulated_story_timestamp(value: object) -> datetime.datetime | None:
     """Parse timestamps persisted in accumulated sprint story state."""
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
+    from .query import _parse_accumulated_story_timestamp as _query_parse  # noqa: PLC0415
+
+    return _query_parse(value)
 
 
 def _read_prior_sprint_accounting(
@@ -1023,34 +1016,11 @@ def _read_prior_sprint_accounting(
     sprint_id: str | None,
 ) -> tuple[float, datetime.datetime | None, dict[str, dict]]:
     """Recover prior same-sprint cost/timing from progressive story state."""
-    if not sprint_id:
-        return 0.0, None, {}
-
-    from .audit import _load_accumulated_stories  # noqa: PLC0415
-
-    recovered_entries: dict[str, dict] = {}
-    recovered_cost = 0.0
-    earliest_started_at: datetime.datetime | None = None
-    for raw_entry in _load_accumulated_stories(sprint_id, project_root):
-        if not isinstance(raw_entry, dict):
-            continue
-        canonical_ref = raw_entry.get("canonical_ref")
-        if not isinstance(canonical_ref, str) or not canonical_ref:
-            continue
-        entry = dict(raw_entry)
-        recovered_entries[canonical_ref] = entry
-        try:
-            recovered_cost += float(entry.get("cost_usd", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            pass
-        started_at = _parse_accumulated_story_timestamp(entry.get("started_at"))
-        if started_at is not None and (
-            earliest_started_at is None or started_at < earliest_started_at
-        ):
-            earliest_started_at = started_at
-
+    recovered_cost, earliest_started_at, recovered_entries = _query_read_prior_sprint_accounting(
+        project_root, sprint_id
+    )
     if recovered_entries:
-        return round(recovered_cost, 4), earliest_started_at, recovered_entries
+        return recovered_cost, earliest_started_at, recovered_entries
 
     if os.environ.get("FORGE_PREV_RUN_ID"):
         return _read_prior_sprint_cost(project_root, sprint_id), None, {}
@@ -5192,6 +5162,34 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
             _carried_raw, occurrence=_OCCURRENCE_CARRIED
         ).origin
         carried_occurrence_ids[_carried_raw] = _carried_origin.get("run_id")
+
+    if _ctx.resolved.budget_usd > 0.0:
+        _carry_snapshot = load_sprint_carry_budget_snapshot(
+            project_root=_ctx.config.project_root,
+            sprint_name=_ctx.resolved.name,
+            selected_slugs=list(_ctx.slug_to_context.keys()),
+            sprint_id=_ctx.sprint_id,
+            accepted_unmeasured=dict(accepted_unmeasured),
+        )
+        _headroom = _carry_snapshot.remaining_headroom_usd(_ctx.resolved.budget_usd)
+        _budget_line = (
+            f"Budget ${_ctx.resolved.budget_usd:.2f} · carried ${_carry_snapshot.carried_cost_usd:.2f}"
+        )
+        if _carry_snapshot.accepted_unmeasured_ceiling_usd > 0.0:
+            _budget_line += (
+                " · accepted unmeasured ceiling "
+                f"${_carry_snapshot.accepted_unmeasured_ceiling_usd:.2f}"
+            )
+        _budget_line += f" · usable headroom ${max(_headroom, 0.0):.2f}"
+        if _carry_snapshot.headroom_is_lower_bound:
+            _budget_line += " lower bound"
+        _log(_budget_line)
+        if _carry_snapshot.verification_spend_usd >= _ctx.resolved.budget_usd:
+            _log(
+                "Selected run cannot dispatch under the supplied ceiling: "
+                f"carried verification ${_carry_snapshot.verification_spend_usd:.2f} "
+                f">= budget ${_ctx.resolved.budget_usd:.2f}"
+            )
 
     def _recorded_prior_done(slug: str, canonical_ref: str | None = None) -> bool:
         """True when this sprint already recorded the story as run-to-DONE.

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -125,10 +125,10 @@ from .query import (
     load_sprint_carry_budget_snapshot,
     normalize_dependency_plan,
 )
-from .query import read_prior_sprint_audit_cost as _query_read_prior_sprint_audit_cost
 from .query import prior_sprint_cost_incomplete as _query_prior_sprint_cost_incomplete
 from .query import prior_unmeasured_spend_sources as _query_prior_unmeasured_spend_sources
 from .query import read_prior_sprint_accounting as _query_read_prior_sprint_accounting
+from .query import read_prior_sprint_audit_cost as _query_read_prior_sprint_audit_cost
 from .sources import StorySource
 from .state_writer import (
     SPRINT_PHASE_DONE,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -86,6 +86,14 @@ from .audit import (
 )
 from .auth_gate import enforce_sprint_auth_readiness
 from .budget import budget_verification_spend, evaluate_budget
+from .carry import (
+    load_sprint_carry_budget_snapshot,
+    previous_run_marker_present as _previous_run_marker_present,
+)
+from .carry import prior_sprint_cost_incomplete as _query_prior_sprint_cost_incomplete
+from .carry import prior_unmeasured_spend_sources as _query_prior_unmeasured_spend_sources
+from .carry import read_prior_sprint_accounting as _query_read_prior_sprint_accounting
+from .carry import read_prior_sprint_audit_cost as _query_read_prior_sprint_audit_cost
 from .ci_checks import PrCheckState, poll_required_checks, required_pr_check_state
 from .collision import (
     batch_group_id,
@@ -122,13 +130,8 @@ from .manifest import (
 from .prior_landing import landing_settled
 from .query import (
     NormalizedDependencyPlan,
-    load_sprint_carry_budget_snapshot,
     normalize_dependency_plan,
 )
-from .query import prior_sprint_cost_incomplete as _query_prior_sprint_cost_incomplete
-from .query import prior_unmeasured_spend_sources as _query_prior_unmeasured_spend_sources
-from .query import read_prior_sprint_accounting as _query_read_prior_sprint_accounting
-from .query import read_prior_sprint_audit_cost as _query_read_prior_sprint_audit_cost
 from .sources import StorySource
 from .state_writer import (
     SPRINT_PHASE_DONE,
@@ -941,7 +944,7 @@ def _read_prior_sprint_cost(project_root: Path, sprint_id: str | None) -> float:
     measured lower bound rather than dropping the prior spend entirely — the
     cost-unknown signal itself is carried by the per-story entries.
     """
-    if not sprint_id or not os.environ.get("FORGE_PREV_RUN_ID"):
+    if not sprint_id or not _previous_run_marker_present():
         return 0.0
     return _query_read_prior_sprint_audit_cost(project_root, sprint_id)
 
@@ -990,7 +993,7 @@ def _read_prior_sprint_accounting(
     if recovered_entries:
         return recovered_cost, earliest_started_at, recovered_entries
 
-    if os.environ.get("FORGE_PREV_RUN_ID"):
+    if _previous_run_marker_present():
         return _read_prior_sprint_cost(project_root, sprint_id), None, {}
 
     return 0.0, None, {}

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -5131,6 +5131,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
         ).origin
         carried_occurrence_ids[_carried_raw] = _carried_origin.get("run_id")
 
+    _startup_budget_decision = None
     if _ctx.resolved.budget_usd > 0.0:
         _carry_snapshot = load_sprint_carry_budget_snapshot(
             project_root=_ctx.config.project_root,
@@ -5153,11 +5154,26 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
         if _carry_snapshot.headroom_is_lower_bound:
             _budget_line += " lower bound"
         _log(_budget_line)
-        if _carry_snapshot.verification_spend_usd >= _ctx.resolved.budget_usd:
+        _startup_budget_details = (
+            {
+                raw: _describe_unmeasured_source(raw, occurrence=_OCCURRENCE_CARRIED).describe()
+                for raw in _carry_snapshot.unresolved_unmeasured_sources
+            }
+            if _carry_snapshot.unresolved_unmeasured_sources
+            else None
+        )
+        _startup_budget_decision = evaluate_budget(
+            accumulated_cost=0.0,
+            prior_cost=_carry_snapshot.carried_cost_usd,
+            budget_usd=_ctx.resolved.budget_usd,
+            unmeasured_spend=_carry_snapshot.unresolved_unmeasured_sources,
+            accepted_unmeasured_ceiling_usd=_carry_snapshot.accepted_unmeasured_ceiling_usd,
+            source_details=_startup_budget_details,
+        )
+        if _startup_budget_decision is not None:
             _log(
                 "Selected run cannot dispatch under the supplied ceiling: "
-                f"carried verification ${_carry_snapshot.verification_spend_usd:.2f} "
-                f">= budget ${_ctx.resolved.budget_usd:.2f}"
+                f"{_startup_budget_decision.detail}"
             )
 
     def _recorded_prior_done(slug: str, canonical_ref: str | None = None) -> bool:
@@ -5388,6 +5404,24 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
         )
         _sprint_state.current_story_entries_by_ref[canonical_ref] = entry
         _persist_accumulated_story_entries(_sprint_state)
+
+    def _skip_story_for_budget(slug: str, decision) -> None:
+        _sprint_state.dag.mark_skipped(slug)
+        _budget_reason = decision.story_reason
+        _set_outcome(_sprint_state, slug, StoryOutcome.SKIPPED, reason=_budget_reason)
+        if _sprint_state.stop.stop_if_unset(decision.stopped_reason):
+            if _ctx.notify and _ctx.config.notifications.backend not in ("ntfy", "none"):
+                from ..notify_backends import send_notifications
+
+                send_notifications(
+                    _ctx.config,
+                    decision.notification_title(_ctx.resolved.name),
+                    f"{decision.detail} — remaining stories skipped",
+                )
+        _log(f"SKIPPED {slug} ({_budget_reason})")
+        _record_current_story_entry(slug, "SKIPPED", error=_budget_reason)
+        if _sprint_state.state_writer is not None:
+            _sprint_state.state_writer.update(slug, status="skipped")
 
     # Intake remediation gate: between dependency normalization and the
     # batch preflight spend, run the shared shape + grooming check on the
@@ -6355,6 +6389,17 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 detail=_sk_detail,
             )
 
+    def _skip_remaining_stories_for_budget(decision) -> None:
+        while not _sprint_state.dag.is_done():
+            _ready_now = list(_sprint_state.dag.ready())
+            if not _ready_now:
+                break
+            for _ready_task in _ready_now:
+                _skip_story_for_budget(_ready_task.slug, decision)
+
+    if _startup_budget_decision is not None:
+        _skip_remaining_stories_for_budget(_startup_budget_decision)
+
     # Parallel scheduling state
     story_deadlines: dict[str, float] = {}
     story_wait_started: set[str] = set()
@@ -6522,27 +6567,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                     source_details=_budget_details,
                 )
                 if _budget_decision is not None:
-                    _sprint_state.dag.mark_skipped(task.slug)
-                    _budget_reason = _budget_decision.story_reason
-                    _set_outcome(
-                        _sprint_state, task.slug, StoryOutcome.SKIPPED, reason=_budget_reason
-                    )
-                    if _sprint_state.stop.stop_if_unset(_budget_decision.stopped_reason):
-                        if _ctx.notify and _ctx.config.notifications.backend not in (
-                            "ntfy",
-                            "none",
-                        ):
-                            from ..notify_backends import send_notifications
-
-                            send_notifications(
-                                _ctx.config,
-                                _budget_decision.notification_title(_ctx.resolved.name),
-                                f"{_budget_decision.detail} \u2014 remaining stories skipped",
-                            )
-                    _log(f"SKIPPED {task.slug} ({_budget_reason})")
-                    _record_current_story_entry(task.slug, "SKIPPED", error=_budget_reason)
-                    if _sprint_state.state_writer is not None:
-                        _sprint_state.state_writer.update(task.slug, status="skipped")
+                    _skip_story_for_budget(task.slug, _budget_decision)
                     continue
 
                 # Eager merge for sequential mode; disabled in parallel mode

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -120,13 +120,14 @@ from .manifest import (
     resolve_from_manifest,
 )
 from .prior_landing import landing_settled
-from .query import NormalizedDependencyPlan, normalize_dependency_plan
 from .query import (
+    NormalizedDependencyPlan,
     load_sprint_carry_budget_snapshot,
-    prior_sprint_cost_incomplete as _query_prior_sprint_cost_incomplete,
-    prior_unmeasured_spend_sources as _query_prior_unmeasured_spend_sources,
-    read_prior_sprint_accounting as _query_read_prior_sprint_accounting,
+    normalize_dependency_plan,
 )
+from .query import prior_sprint_cost_incomplete as _query_prior_sprint_cost_incomplete
+from .query import prior_unmeasured_spend_sources as _query_prior_unmeasured_spend_sources
+from .query import read_prior_sprint_accounting as _query_read_prior_sprint_accounting
 from .sources import StorySource
 from .state_writer import (
     SPRINT_PHASE_DONE,
@@ -5172,9 +5173,8 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
             accepted_unmeasured=dict(accepted_unmeasured),
         )
         _headroom = _carry_snapshot.remaining_headroom_usd(_ctx.resolved.budget_usd)
-        _budget_line = (
-            f"Budget ${_ctx.resolved.budget_usd:.2f} · carried ${_carry_snapshot.carried_cost_usd:.2f}"
-        )
+        _budget_line = f"Budget ${_ctx.resolved.budget_usd:.2f}"
+        _budget_line += f" · carried ${_carry_snapshot.carried_cost_usd:.2f}"
         if _carry_snapshot.accepted_unmeasured_ceiling_usd > 0.0:
             _budget_line += (
                 " · accepted unmeasured ceiling "

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -6405,12 +6405,12 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
             )
 
     def _skip_remaining_stories_for_budget(decision) -> None:
-        while not _sprint_state.dag.is_done():
-            _ready_now = list(_sprint_state.dag.ready())
-            if not _ready_now:
-                break
-            for _ready_task in _ready_now:
-                _skip_story_for_budget(_ready_task.slug, decision)
+        # A startup headroom refusal is global to the selected run: nothing has
+        # dispatched yet, so every remaining selected story is refused for the
+        # same reason rather than letting downstream dependents later degrade
+        # into "dependency failed" during the deadlock sweep.
+        for _remaining_task in list(_sprint_state.dag.remaining()):
+            _skip_story_for_budget(_remaining_task.slug, decision)
 
     if _startup_budget_decision is not None:
         _skip_remaining_stories_for_budget(_startup_budget_decision)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -5152,7 +5152,6 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
         _carry_snapshot = load_sprint_carry_budget_snapshot(
             project_root=_ctx.config.project_root,
             sprint_name=_ctx.resolved.name,
-            selected_slugs=list(_ctx.slug_to_context.keys()),
             sprint_id=_ctx.sprint_id,
             resume=_ctx.resume,
             reexec=_ctx.reexec,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -88,12 +88,22 @@ from .auth_gate import enforce_sprint_auth_readiness
 from .budget import budget_verification_spend, evaluate_budget
 from .carry import (
     load_sprint_carry_budget_snapshot,
+)
+from .carry import (
     previous_run_marker_present as _previous_run_marker_present,
 )
-from .carry import prior_sprint_cost_incomplete as _query_prior_sprint_cost_incomplete
-from .carry import prior_unmeasured_spend_sources as _query_prior_unmeasured_spend_sources
-from .carry import read_prior_sprint_accounting as _query_read_prior_sprint_accounting
-from .carry import read_prior_sprint_audit_cost as _query_read_prior_sprint_audit_cost
+from .carry import (
+    prior_sprint_cost_incomplete as _query_prior_sprint_cost_incomplete,
+)
+from .carry import (
+    prior_unmeasured_spend_sources as _query_prior_unmeasured_spend_sources,
+)
+from .carry import (
+    read_prior_sprint_accounting as _query_read_prior_sprint_accounting,
+)
+from .carry import (
+    read_prior_sprint_audit_cost as _query_read_prior_sprint_audit_cost,
+)
 from .ci_checks import PrCheckState, poll_required_checks, required_pr_check_state
 from .collision import (
     batch_group_id,

--- a/tests/test_cli_sprint_query.py
+++ b/tests/test_cli_sprint_query.py
@@ -17,6 +17,7 @@ from theforge.config import (
     WorkspaceConfig,
 )
 from theforge.sprint.manifest import ResolvedSprint
+from theforge.sprint.query import SprintCarryBudgetSnapshot
 from theforge.sprint.sources import GitHubIssueSource
 from theforge.task import TaskStory
 
@@ -232,3 +233,95 @@ class TestCmdSprintDryRunQuery:
         assert "blocked=[issue-9]" in out
         assert "issue-3" in out
         assert "blocked=[issue-1]" in out
+
+    def test_query_mode_dry_run_prints_budget_carry_and_headroom(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        config = _make_forge_config(tmp_path)
+        args = _make_query_args(tmp_path, parallel=2)
+
+        resolved = ResolvedSprint(
+            name="v0.5.0",
+            budget_usd=150.0,
+            stories=[
+                (
+                    TaskStory(name="A", slug="issue-1", github_issue=1),
+                    GitHubIssueSource(),
+                    "issue:1",
+                )
+            ],
+            max_parallel=2,
+        )
+
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=config),
+            patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+            patch(
+                "theforge.sprint.query.fetch_issues_for_milestone",
+                return_value=[{"number": 1, "title": "A"}],
+            ),
+            patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
+            patch(
+                "theforge.cli.sprint.load_sprint_carry_budget_snapshot",
+                return_value=SprintCarryBudgetSnapshot(
+                    sprint_id="sid",
+                    carried_cost_usd=64.56,
+                    selected_cost_by_slug={"issue-1": 64.56},
+                    unresolved_unmeasured_sources=(),
+                    accepted_unmeasured_spend=(),
+                    accepted_unmeasured_ceiling_usd=0.0,
+                    verification_spend_usd=64.56,
+                ),
+            ),
+        ):
+            rc = cmd_sprint(args)
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "budget=$150.00 carried=$64.56 usable_headroom=$85.44" in out
+
+    def test_query_mode_dry_run_warns_when_carried_spend_consumes_budget(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        config = _make_forge_config(tmp_path)
+        args = _make_query_args(tmp_path, parallel=2)
+
+        resolved = ResolvedSprint(
+            name="v0.5.0",
+            budget_usd=50.0,
+            stories=[
+                (
+                    TaskStory(name="A", slug="issue-1", github_issue=1),
+                    GitHubIssueSource(),
+                    "issue:1",
+                )
+            ],
+            max_parallel=2,
+        )
+
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=config),
+            patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+            patch(
+                "theforge.sprint.query.fetch_issues_for_milestone",
+                return_value=[{"number": 1, "title": "A"}],
+            ),
+            patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
+            patch(
+                "theforge.cli.sprint.load_sprint_carry_budget_snapshot",
+                return_value=SprintCarryBudgetSnapshot(
+                    sprint_id="sid",
+                    carried_cost_usd=64.56,
+                    selected_cost_by_slug={"issue-1": 64.56},
+                    unresolved_unmeasured_sources=(),
+                    accepted_unmeasured_spend=(),
+                    accepted_unmeasured_ceiling_usd=0.0,
+                    verification_spend_usd=64.56,
+                ),
+            ),
+        ):
+            rc = cmd_sprint(args)
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "cannot dispatch under the supplied ceiling" in out

--- a/tests/test_cli_sprint_query.py
+++ b/tests/test_cli_sprint_query.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -315,6 +316,7 @@ class TestCmdSprintDryRunQuery:
         )
 
         with (
+            patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False),
             patch("theforge.cli.sprint.load_config", return_value=config),
             patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
             patch(
@@ -328,6 +330,45 @@ class TestCmdSprintDryRunQuery:
         out = capsys.readouterr().out
         assert rc == 0
         assert "budget=$150.00 carried=$64.56 usable_headroom=$85.44" in out
+
+    def test_query_mode_dry_run_without_previous_run_marker_does_not_fallback_to_audit_cost(
+        self, tmp_path: Path, capsys, monkeypatch
+    ) -> None:
+        config = _make_forge_config(tmp_path)
+        args = _make_query_args(tmp_path, parallel=2)
+        args.resume = True
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 64.56)
+        monkeypatch.delenv("FORGE_PREV_RUN_ID", raising=False)
+
+        resolved = ResolvedSprint(
+            name="v0.5.0",
+            budget_usd=150.0,
+            stories=[
+                (
+                    TaskStory(name="A", slug="issue-1", github_issue=1),
+                    GitHubIssueSource(),
+                    "issue:1",
+                )
+            ],
+            max_parallel=2,
+        )
+
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=config),
+            patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+            patch(
+                "theforge.sprint.query.fetch_issues_for_milestone",
+                return_value=[{"number": 1, "title": "A"}],
+            ),
+            patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
+        ):
+            rc = cmd_sprint(args)
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "budget=$150.00 carried=$0.00 usable_headroom=$150.00" in out
+        assert "cannot dispatch under the supplied ceiling" not in out
 
     def test_query_mode_dry_run_ignores_existing_spend_without_resume(
         self, tmp_path: Path, capsys
@@ -526,5 +567,57 @@ class TestCmdSprintDryRunQuery:
         out = capsys.readouterr().out
         assert rc == 0
         assert "usable_headroom=$14.00" in out
+        assert "(lower bound; carried unmeasured spend remains)" in out
+        assert "cannot dispatch under the supplied ceiling" in out
+
+    def test_query_mode_dry_run_non_resume_reports_carried_unmeasured_progressive_state(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        config = _make_forge_config(tmp_path)
+        args = _make_query_args(tmp_path, parallel=2)
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "v0.5.0",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue:2",
+                    "slug": "issue-2",
+                    "path": "issue-2.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                    "story_run_id": "run-prev",
+                }
+            ],
+        )
+
+        resolved = ResolvedSprint(
+            name="v0.5.0",
+            budget_usd=20.0,
+            stories=[
+                (
+                    TaskStory(name="A", slug="issue-1", github_issue=1),
+                    GitHubIssueSource(),
+                    "issue:1",
+                )
+            ],
+            max_parallel=2,
+        )
+
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=config),
+            patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+            patch(
+                "theforge.sprint.query.fetch_issues_for_milestone",
+                return_value=[{"number": 1, "title": "A"}],
+            ),
+            patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
+        ):
+            rc = cmd_sprint(args)
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "budget=$20.00 carried=$0.00 usable_headroom=$20.00" in out
         assert "(lower bound; carried unmeasured spend remains)" in out
         assert "cannot dispatch under the supplied ceiling" in out

--- a/tests/test_cli_sprint_query.py
+++ b/tests/test_cli_sprint_query.py
@@ -18,7 +18,10 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
-from theforge.sprint.audit import persist_accumulated_story_state
+from theforge.sprint.audit import (
+    persist_accumulated_story_state,
+    persist_accepted_unmeasured_spend,
+)
 from theforge.sprint.manifest import ResolvedSprint
 from theforge.sprint.sources import GitHubIssueSource
 from theforge.task import TaskStory
@@ -116,6 +119,31 @@ def _write_prior_sprint_audit(tmp_path: Path, sprint_id: str, total_cost_usd: fl
                     "sprint_id": sprint_id,
                     "total_cost_usd": total_cost_usd,
                     "cost_complete": True,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_incomplete_prior_sprint_audit(
+    tmp_path: Path,
+    sprint_id: str,
+    *,
+    total_cost_measured_usd: float,
+    unmeasured_spend_sources: list[str],
+) -> None:
+    audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text(
+        yaml.safe_dump(
+            {
+                "sprint": {
+                    "sprint_id": sprint_id,
+                    "total_cost_usd": None,
+                    "total_cost_measured_usd": total_cost_measured_usd,
+                    "cost_complete": False,
+                    "unmeasured_spend_sources": unmeasured_spend_sources,
                 }
             }
         ),
@@ -351,3 +379,152 @@ class TestCmdSprintDryRunQuery:
         assert rc == 0
         assert "budget=$50.00 carried=$0.00 usable_headroom=$50.00" in out
         assert "cannot dispatch under the supplied ceiling" not in out
+
+    def test_query_mode_dry_run_reports_accepted_unmeasured_ceiling(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        config = _make_forge_config(tmp_path)
+        args = _make_query_args(tmp_path, parallel=2)
+        args.resume = True
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "v0.5.0",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue:2",
+                    "slug": "issue-2",
+                    "path": "issue-2.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                },
+                {
+                    "canonical_ref": "issue:1",
+                    "slug": "issue-1",
+                    "path": "issue-1.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                    "story_run_id": "run-prev",
+                },
+            ],
+        )
+        _write_incomplete_prior_sprint_audit(
+            tmp_path,
+            sprint_id,
+            total_cost_measured_usd=6.0,
+            unmeasured_spend_sources=["carried:issue-1"],
+        )
+        assert (
+            persist_accepted_unmeasured_spend(
+                sprint_id,
+                "v0.5.0",
+                tmp_path,
+                [
+                    {
+                        "source": "issue-1",
+                        "accepted_ceiling_usd": 4.5,
+                        "accepted_at": "2026-08-08T00:00:00+00:00",
+                    }
+                ],
+            )
+            is True
+        )
+
+        resolved = ResolvedSprint(
+            name="v0.5.0",
+            budget_usd=20.0,
+            stories=[
+                (
+                    TaskStory(name="A", slug="issue-1", github_issue=1),
+                    GitHubIssueSource(),
+                    "issue:1",
+                )
+            ],
+            max_parallel=2,
+        )
+
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=config),
+            patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+            patch(
+                "theforge.sprint.query.fetch_issues_for_milestone",
+                return_value=[{"number": 1, "title": "A"}],
+            ),
+            patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
+        ):
+            rc = cmd_sprint(args)
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "accepted_unmeasured_ceiling=$4.50" in out
+        assert "usable_headroom=$9.50" in out
+        assert "lower bound" not in out
+
+    def test_query_mode_dry_run_marks_headroom_as_lower_bound_for_incomplete_prior_cost(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        config = _make_forge_config(tmp_path)
+        args = _make_query_args(tmp_path, parallel=2)
+        args.resume = True
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "v0.5.0",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue:2",
+                    "slug": "issue-2",
+                    "path": "issue-2.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                },
+                {
+                    "canonical_ref": "issue:1",
+                    "slug": "issue-1",
+                    "path": "issue-1.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                    "story_run_id": "run-prev",
+                },
+            ],
+        )
+        _write_incomplete_prior_sprint_audit(
+            tmp_path,
+            sprint_id,
+            total_cost_measured_usd=6.0,
+            unmeasured_spend_sources=["carried:issue-1"],
+        )
+
+        resolved = ResolvedSprint(
+            name="v0.5.0",
+            budget_usd=20.0,
+            stories=[
+                (
+                    TaskStory(name="A", slug="issue-1", github_issue=1),
+                    GitHubIssueSource(),
+                    "issue:1",
+                )
+            ],
+            max_parallel=2,
+        )
+
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=config),
+            patch("theforge.cli.sprint._find_config", return_value=tmp_path / "forge.yaml"),
+            patch(
+                "theforge.sprint.query.fetch_issues_for_milestone",
+                return_value=[{"number": 1, "title": "A"}],
+            ),
+            patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
+        ):
+            rc = cmd_sprint(args)
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "usable_headroom=$14.00" in out
+        assert "(lower bound; carried unmeasured spend remains)" in out
+        assert "cannot dispatch under the supplied ceiling" in out

--- a/tests/test_cli_sprint_query.py
+++ b/tests/test_cli_sprint_query.py
@@ -19,8 +19,8 @@ from theforge.config import (
     WorkspaceConfig,
 )
 from theforge.sprint.audit import (
-    persist_accumulated_story_state,
     persist_accepted_unmeasured_spend,
+    persist_accumulated_story_state,
 )
 from theforge.sprint.manifest import ResolvedSprint
 from theforge.sprint.sources import GitHubIssueSource

--- a/tests/test_cli_sprint_query.py
+++ b/tests/test_cli_sprint_query.py
@@ -6,6 +6,8 @@ import argparse
 from pathlib import Path
 from unittest.mock import patch
 
+import yaml
+
 from theforge.cli import cmd_sprint
 from theforge.config import (
     DEFAULT_VALIDATION,
@@ -16,8 +18,8 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.sprint.audit import persist_accumulated_story_state
 from theforge.sprint.manifest import ResolvedSprint
-from theforge.sprint.query import SprintCarryBudgetSnapshot
 from theforge.sprint.sources import GitHubIssueSource
 from theforge.task import TaskStory
 
@@ -90,6 +92,34 @@ def _make_query_args(tmp_path: Path, *, parallel: int) -> argparse.Namespace:
         verbose=False,
         no_notify=True,
         no_pull=False,
+    )
+
+
+def _set_existing_sprint_id(
+    tmp_path: Path,
+    sprint_name: str = "v0.5.0",
+    sprint_id: str = "sprint-123",
+) -> str:
+    sprint_dir = tmp_path / ".forge" / "logs" / sprint_name
+    sprint_dir.mkdir(parents=True, exist_ok=True)
+    (sprint_dir / ".sprint_id").write_text(sprint_id, encoding="utf-8")
+    return sprint_id
+
+
+def _write_prior_sprint_audit(tmp_path: Path, sprint_id: str, total_cost_usd: float) -> None:
+    audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text(
+        yaml.safe_dump(
+            {
+                "sprint": {
+                    "sprint_id": sprint_id,
+                    "total_cost_usd": total_cost_usd,
+                    "cost_complete": True,
+                }
+            }
+        ),
+        encoding="utf-8",
     )
 
 
@@ -239,6 +269,9 @@ class TestCmdSprintDryRunQuery:
     ) -> None:
         config = _make_forge_config(tmp_path)
         args = _make_query_args(tmp_path, parallel=2)
+        args.resume = True
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 64.56)
 
         resolved = ResolvedSprint(
             name="v0.5.0",
@@ -261,18 +294,6 @@ class TestCmdSprintDryRunQuery:
                 return_value=[{"number": 1, "title": "A"}],
             ),
             patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
-            patch(
-                "theforge.cli.sprint.load_sprint_carry_budget_snapshot",
-                return_value=SprintCarryBudgetSnapshot(
-                    sprint_id="sid",
-                    carried_cost_usd=64.56,
-                    selected_cost_by_slug={"issue-1": 64.56},
-                    unresolved_unmeasured_sources=(),
-                    accepted_unmeasured_spend=(),
-                    accepted_unmeasured_ceiling_usd=0.0,
-                    verification_spend_usd=64.56,
-                ),
-            ),
         ):
             rc = cmd_sprint(args)
 
@@ -280,11 +301,27 @@ class TestCmdSprintDryRunQuery:
         assert rc == 0
         assert "budget=$150.00 carried=$64.56 usable_headroom=$85.44" in out
 
-    def test_query_mode_dry_run_warns_when_carried_spend_consumes_budget(
+    def test_query_mode_dry_run_ignores_existing_spend_without_resume(
         self, tmp_path: Path, capsys
     ) -> None:
         config = _make_forge_config(tmp_path)
         args = _make_query_args(tmp_path, parallel=2)
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "v0.5.0",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue:1",
+                    "slug": "issue-1",
+                    "path": "issue-1.md",
+                    "outcome": "DONE",
+                    "cost_usd": 64.56,
+                    "story_run_id": "run-prev",
+                }
+            ],
+        )
 
         resolved = ResolvedSprint(
             name="v0.5.0",
@@ -307,21 +344,10 @@ class TestCmdSprintDryRunQuery:
                 return_value=[{"number": 1, "title": "A"}],
             ),
             patch("theforge.sprint.query.build_resolved_sprint", return_value=resolved),
-            patch(
-                "theforge.cli.sprint.load_sprint_carry_budget_snapshot",
-                return_value=SprintCarryBudgetSnapshot(
-                    sprint_id="sid",
-                    carried_cost_usd=64.56,
-                    selected_cost_by_slug={"issue-1": 64.56},
-                    unresolved_unmeasured_sources=(),
-                    accepted_unmeasured_spend=(),
-                    accepted_unmeasured_ceiling_usd=0.0,
-                    verification_spend_usd=64.56,
-                ),
-            ),
         ):
             rc = cmd_sprint(args)
 
         out = capsys.readouterr().out
         assert rc == 0
-        assert "cannot dispatch under the supplied ceiling" in out
+        assert "budget=$50.00 carried=$0.00 usable_headroom=$50.00" in out
+        assert "cannot dispatch under the supplied ceiling" not in out

--- a/tests/test_runner_ghaw.py
+++ b/tests/test_runner_ghaw.py
@@ -20,6 +20,7 @@ from theforge.config import ModelProfile
 from theforge.runners import runner_ghaw
 from theforge.runners.cli import run_agent
 from theforge.runners.runner_ghaw import (
+    _discover_run_id,
     _run_ghaw,
     build_argv,
     build_run_download_argv,
@@ -144,6 +145,25 @@ class TestGhawLifecycle:
 
 
 class TestGhawGuards:
+    def test_discover_run_id_skips_run_list_when_deadline_already_elapsed(
+        self, tmp_path: Path
+    ) -> None:
+        with (
+            patch("theforge.runners.runner_ghaw.time.monotonic", return_value=123.0),
+            patch("theforge.runners.runner_ghaw._gh") as mock_gh,
+        ):
+            run_id = _discover_run_id(
+                workflow="forge-dev-ghaw.lock.yml",
+                ref="main",
+                dispatch_id="abc123",
+                working_dir=tmp_path,
+                env={},
+                deadline=122.0,
+            )
+
+        assert run_id is None
+        mock_gh.assert_not_called()
+
     def test_oversized_prompt_refused_before_dispatch(self, tmp_path: Path) -> None:
         result = _run_ghaw(
             prompt="x" * 70_000,

--- a/tests/test_sprint_query.py
+++ b/tests/test_sprint_query.py
@@ -9,14 +9,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-from theforge.sprint.audit import persist_accumulated_story_state
+from theforge.sprint.audit import (
+    persist_accumulated_story_state,
+    persist_accepted_unmeasured_spend,
+)
 from theforge.sprint.query import (
     MilestoneNotFoundError,
     _get_milestone_number,
     _gh_api_paginate_issues,
-    load_sprint_carry_budget_snapshot,
     fetch_issues_for_label,
     fetch_issues_for_milestone,
+    load_sprint_carry_budget_snapshot,
 )
 
 
@@ -258,8 +261,35 @@ def _write_prior_sprint_audit(tmp_path: Path, sprint_id: str, total_cost_usd: fl
     )
 
 
+def _write_incomplete_prior_sprint_audit(
+    tmp_path: Path,
+    sprint_id: str,
+    *,
+    total_cost_measured_usd: float,
+    unmeasured_spend_sources: list[str],
+) -> None:
+    audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text(
+        yaml.safe_dump(
+            {
+                "sprint": {
+                    "sprint_id": sprint_id,
+                    "total_cost_usd": None,
+                    "total_cost_measured_usd": total_cost_measured_usd,
+                    "cost_complete": False,
+                    "unmeasured_spend_sources": unmeasured_spend_sources,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 class TestLoadSprintCarryBudgetSnapshot:
-    def test_resume_uses_sprint_audit_when_progressive_state_is_absent(self, tmp_path: Path) -> None:
+    def test_resume_uses_sprint_audit_when_progressive_state_is_absent(
+        self, tmp_path: Path
+    ) -> None:
         sprint_id = _set_existing_sprint_id(tmp_path)
         _write_prior_sprint_audit(tmp_path, sprint_id, 6.0)
 
@@ -272,6 +302,116 @@ class TestLoadSprintCarryBudgetSnapshot:
 
         assert snapshot.sprint_id == sprint_id
         assert snapshot.carried_cost_usd == pytest.approx(6.0)
+        assert snapshot.verification_spend_usd == pytest.approx(6.0)
+
+    def test_resume_loads_accepted_unmeasured_ceiling_from_persisted_audit(
+        self, tmp_path: Path
+    ) -> None:
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue:2",
+                    "slug": "issue-2",
+                    "path": "issue-2.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                },
+                {
+                    "canonical_ref": "issue:1",
+                    "slug": "issue-1",
+                    "path": "issue-1.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                    "story_run_id": "run-prev",
+                },
+            ],
+        )
+        _write_incomplete_prior_sprint_audit(
+            tmp_path,
+            sprint_id,
+            total_cost_measured_usd=6.0,
+            unmeasured_spend_sources=["carried:issue-1"],
+        )
+        assert (
+            persist_accepted_unmeasured_spend(
+                sprint_id,
+                "Test Sprint",
+                tmp_path,
+                [
+                    {
+                        "source": "issue-1",
+                        "accepted_ceiling_usd": 4.5,
+                        "accepted_at": "2026-08-08T00:00:00+00:00",
+                    }
+                ],
+            )
+            is True
+        )
+
+        snapshot = load_sprint_carry_budget_snapshot(
+            project_root=tmp_path,
+            sprint_name="Test Sprint",
+            selected_slugs=["issue-1"],
+            resume=True,
+        )
+
+        assert snapshot.carried_cost_usd == pytest.approx(6.0)
+        assert snapshot.accepted_unmeasured_ceiling_usd == pytest.approx(4.5)
+        assert snapshot.unresolved_unmeasured_sources == ()
+        assert snapshot.headroom_is_lower_bound is False
+        assert snapshot.verification_spend_usd == pytest.approx(10.5)
+
+    def test_resume_marks_incomplete_prior_cost_as_lower_bound(self, tmp_path: Path) -> None:
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue:2",
+                    "slug": "issue-2",
+                    "path": "issue-2.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                },
+                {
+                    "canonical_ref": "issue:1",
+                    "slug": "issue-1",
+                    "path": "issue-1.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                    "story_run_id": "run-prev",
+                },
+            ],
+        )
+        _write_incomplete_prior_sprint_audit(
+            tmp_path,
+            sprint_id,
+            total_cost_measured_usd=6.0,
+            unmeasured_spend_sources=["carried:issue-1"],
+        )
+
+        snapshot = load_sprint_carry_budget_snapshot(
+            project_root=tmp_path,
+            sprint_name="Test Sprint",
+            selected_slugs=["issue-1"],
+            resume=True,
+        )
+
+        assert snapshot.carried_cost_usd == pytest.approx(6.0)
+        assert snapshot.accepted_unmeasured_ceiling_usd == 0.0
+        assert snapshot.unresolved_unmeasured_sources == (
+            "carried:issue-1",
+            "carried:prior-generation",
+        )
+        assert snapshot.headroom_is_lower_bound is True
         assert snapshot.verification_spend_usd == pytest.approx(6.0)
 
     def test_non_resume_ignores_existing_prior_spend(self, tmp_path: Path) -> None:

--- a/tests/test_sprint_query.py
+++ b/tests/test_sprint_query.py
@@ -7,11 +7,14 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
+from theforge.sprint.audit import persist_accumulated_story_state
 from theforge.sprint.query import (
     MilestoneNotFoundError,
     _get_milestone_number,
     _gh_api_paginate_issues,
+    load_sprint_carry_budget_snapshot,
     fetch_issues_for_label,
     fetch_issues_for_milestone,
 )
@@ -225,3 +228,78 @@ class TestFetchIssuesForLabel:
             fetch_issues_for_label("sprint", tmp_path)
         cmd = mock_run.call_args[0][0]
         assert "--paginate" in cmd
+
+
+def _set_existing_sprint_id(
+    tmp_path: Path,
+    sprint_name: str = "Test Sprint",
+    sprint_id: str = "sprint-123",
+) -> str:
+    sprint_dir = tmp_path / ".forge" / "logs" / sprint_name
+    sprint_dir.mkdir(parents=True, exist_ok=True)
+    (sprint_dir / ".sprint_id").write_text(sprint_id, encoding="utf-8")
+    return sprint_id
+
+
+def _write_prior_sprint_audit(tmp_path: Path, sprint_id: str, total_cost_usd: float) -> None:
+    audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text(
+        yaml.safe_dump(
+            {
+                "sprint": {
+                    "sprint_id": sprint_id,
+                    "total_cost_usd": total_cost_usd,
+                    "cost_complete": True,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestLoadSprintCarryBudgetSnapshot:
+    def test_resume_uses_sprint_audit_when_progressive_state_is_absent(self, tmp_path: Path) -> None:
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 6.0)
+
+        snapshot = load_sprint_carry_budget_snapshot(
+            project_root=tmp_path,
+            sprint_name="Test Sprint",
+            selected_slugs=["issue-1"],
+            resume=True,
+        )
+
+        assert snapshot.sprint_id == sprint_id
+        assert snapshot.carried_cost_usd == pytest.approx(6.0)
+        assert snapshot.verification_spend_usd == pytest.approx(6.0)
+
+    def test_non_resume_ignores_existing_prior_spend(self, tmp_path: Path) -> None:
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue:1",
+                    "slug": "issue-1",
+                    "path": "issue-1.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                }
+            ],
+        )
+
+        snapshot = load_sprint_carry_budget_snapshot(
+            project_root=tmp_path,
+            sprint_name="Test Sprint",
+            selected_slugs=["issue-1"],
+            resume=False,
+            reexec=False,
+        )
+
+        assert snapshot.sprint_id == sprint_id
+        assert snapshot.carried_cost_usd == 0.0
+        assert snapshot.verification_spend_usd == 0.0

--- a/tests/test_sprint_query.py
+++ b/tests/test_sprint_query.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -293,6 +294,25 @@ class TestLoadSprintCarryBudgetSnapshot:
         sprint_id = _set_existing_sprint_id(tmp_path)
         _write_prior_sprint_audit(tmp_path, sprint_id, 6.0)
 
+        with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+            snapshot = load_sprint_carry_budget_snapshot(
+                project_root=tmp_path,
+                sprint_name="Test Sprint",
+                selected_slugs=["issue-1"],
+                resume=True,
+            )
+
+        assert snapshot.sprint_id == sprint_id
+        assert snapshot.carried_cost_usd == pytest.approx(6.0)
+        assert snapshot.verification_spend_usd == pytest.approx(6.0)
+
+    def test_resume_without_previous_run_marker_does_not_fallback_to_sprint_audit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 6.0)
+        monkeypatch.delenv("FORGE_PREV_RUN_ID", raising=False)
+
         snapshot = load_sprint_carry_budget_snapshot(
             project_root=tmp_path,
             sprint_name="Test Sprint",
@@ -301,8 +321,8 @@ class TestLoadSprintCarryBudgetSnapshot:
         )
 
         assert snapshot.sprint_id == sprint_id
-        assert snapshot.carried_cost_usd == pytest.approx(6.0)
-        assert snapshot.verification_spend_usd == pytest.approx(6.0)
+        assert snapshot.carried_cost_usd == 0.0
+        assert snapshot.verification_spend_usd == 0.0
 
     def test_resume_loads_accepted_unmeasured_ceiling_from_persisted_audit(
         self, tmp_path: Path
@@ -442,4 +462,38 @@ class TestLoadSprintCarryBudgetSnapshot:
 
         assert snapshot.sprint_id == sprint_id
         assert snapshot.carried_cost_usd == 0.0
+        assert snapshot.verification_spend_usd == 0.0
+
+    def test_non_resume_still_surfaces_carried_unmeasured_progressive_state(
+        self, tmp_path: Path
+    ) -> None:
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "issue:2",
+                    "slug": "issue-2",
+                    "path": "issue-2.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                    "story_run_id": "run-prev",
+                }
+            ],
+        )
+
+        snapshot = load_sprint_carry_budget_snapshot(
+            project_root=tmp_path,
+            sprint_name="Test Sprint",
+            selected_slugs=["issue-1"],
+            resume=False,
+            reexec=False,
+        )
+
+        assert snapshot.sprint_id == sprint_id
+        assert snapshot.carried_cost_usd == 0.0
+        assert snapshot.unresolved_unmeasured_sources == ("carried:issue-2",)
+        assert snapshot.headroom_is_lower_bound is True
         assert snapshot.verification_spend_usd == 0.0

--- a/tests/test_sprint_query.py
+++ b/tests/test_sprint_query.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from theforge.sprint.carry import load_sprint_carry_budget_snapshot
 from theforge.sprint.audit import (
     persist_accepted_unmeasured_spend,
     persist_accumulated_story_state,
@@ -20,7 +21,6 @@ from theforge.sprint.query import (
     _gh_api_paginate_issues,
     fetch_issues_for_label,
     fetch_issues_for_milestone,
-    load_sprint_carry_budget_snapshot,
 )
 
 
@@ -288,6 +288,20 @@ def _write_incomplete_prior_sprint_audit(
 
 
 class TestLoadSprintCarryBudgetSnapshot:
+    def test_programming_errors_in_prior_sprint_block_are_not_suppressed(
+        self, tmp_path: Path
+    ) -> None:
+        sprint_id = _set_existing_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 6.0)
+
+        with patch("yaml.safe_load", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                load_sprint_carry_budget_snapshot(
+                    project_root=tmp_path,
+                    sprint_name="Test Sprint",
+                    resume=True,
+                )
+
     def test_resume_uses_sprint_audit_when_progressive_state_is_absent(
         self, tmp_path: Path
     ) -> None:
@@ -298,7 +312,6 @@ class TestLoadSprintCarryBudgetSnapshot:
             snapshot = load_sprint_carry_budget_snapshot(
                 project_root=tmp_path,
                 sprint_name="Test Sprint",
-                selected_slugs=["issue-1"],
                 resume=True,
             )
 
@@ -316,7 +329,6 @@ class TestLoadSprintCarryBudgetSnapshot:
         snapshot = load_sprint_carry_budget_snapshot(
             project_root=tmp_path,
             sprint_name="Test Sprint",
-            selected_slugs=["issue-1"],
             resume=True,
         )
 
@@ -376,7 +388,6 @@ class TestLoadSprintCarryBudgetSnapshot:
         snapshot = load_sprint_carry_budget_snapshot(
             project_root=tmp_path,
             sprint_name="Test Sprint",
-            selected_slugs=["issue-1"],
             resume=True,
         )
 
@@ -421,7 +432,6 @@ class TestLoadSprintCarryBudgetSnapshot:
         snapshot = load_sprint_carry_budget_snapshot(
             project_root=tmp_path,
             sprint_name="Test Sprint",
-            selected_slugs=["issue-1"],
             resume=True,
         )
 
@@ -455,7 +465,6 @@ class TestLoadSprintCarryBudgetSnapshot:
         snapshot = load_sprint_carry_budget_snapshot(
             project_root=tmp_path,
             sprint_name="Test Sprint",
-            selected_slugs=["issue-1"],
             resume=False,
             reexec=False,
         )
@@ -487,7 +496,6 @@ class TestLoadSprintCarryBudgetSnapshot:
         snapshot = load_sprint_carry_budget_snapshot(
             project_root=tmp_path,
             sprint_name="Test Sprint",
-            selected_slugs=["issue-1"],
             resume=False,
             reexec=False,
         )

--- a/tests/test_sprint_query.py
+++ b/tests/test_sprint_query.py
@@ -10,8 +10,8 @@ import pytest
 import yaml
 
 from theforge.sprint.audit import (
-    persist_accumulated_story_state,
     persist_accepted_unmeasured_spend,
+    persist_accumulated_story_state,
 )
 from theforge.sprint.query import (
     MilestoneNotFoundError,

--- a/tests/test_sprint_query.py
+++ b/tests/test_sprint_query.py
@@ -10,11 +10,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-from theforge.sprint.carry import load_sprint_carry_budget_snapshot
 from theforge.sprint.audit import (
     persist_accepted_unmeasured_spend,
     persist_accumulated_story_state,
 )
+from theforge.sprint.carry import load_sprint_carry_budget_snapshot
 from theforge.sprint.query import (
     MilestoneNotFoundError,
     _get_milestone_number,

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -1068,6 +1068,34 @@ class TestResumeSprintIntegration:
             "budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
         )
 
+    def test_resume_without_previous_run_marker_does_not_refuse_from_audit_fallback(
+        self, tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=5.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+        _write_prior_sprint_audit(tmp_path, sprint_id, 6.0)
+        coord_result = _make_coordinator_result(success=True, cost=1.0)
+        full_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="full",
+            reason="no worktree found",
+            worktree_path=None,
+        )
+        monkeypatch.delenv("FORGE_PREV_RUN_ID", raising=False)
+
+        with patch("theforge.sprint.runner._triage_spec", return_value=full_triage):
+            with patch("theforge.sprint.runner.run_task", return_value=coord_result) as mock_run:
+                result = run_sprint_ctx(config, manifest_path, resume=True)
+
+        err = capsys.readouterr().err
+        mock_run.assert_called_once()
+        assert result.specs_succeeded == 1
+        assert result.stopped_reason is None
+        assert "Budget $5.00 · carried $0.00 · usable headroom $5.00" in err
+        assert "Selected run cannot dispatch under the supplied ceiling" not in err
+
     def test_resume_prior_state_cost_exceeds_budget_without_sprint_audit(
         self, tmp_path: Path, capsys
     ) -> None:
@@ -1692,6 +1720,41 @@ class TestResumeSprintIntegration:
         assert result.stopped_reason.startswith("Budget unverifiable")
         assert "Budget $20.00 · carried $6.00 · usable headroom $14.00 lower bound" in err
         assert "Selected run cannot dispatch under the supplied ceiling" in err
+
+    def test_no_resume_startup_discloses_carried_unmeasured_and_refuses_pre_dispatch(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=20.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-b.md",
+                    "slug": "feature-b",
+                    "path": "feature-b.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                    "story_run_id": "run-prev",
+                }
+            ],
+        )
+
+        with patch("theforge.sprint.runner.run_task") as mock_task:
+            result = run_sprint_ctx(config, manifest_path, resume=False)
+
+        err = capsys.readouterr().err
+        mock_task.assert_not_called()
+        assert result.specs_skipped == 1
+        assert result.stopped_reason is not None
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        assert "Budget $20.00 · carried $0.00 · usable headroom $20.00 lower bound" in err
+        assert "Selected run cannot dispatch under the supplied ceiling" in err
+        assert "carried:feature-b" in err
 
 
 # ── _build_task_from_story depends_on parsing ─────────────────────────

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -23,7 +23,10 @@ from theforge.config import (
 )
 from theforge.coordinator import audit_substrate
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
-from theforge.sprint.audit import persist_accumulated_story_state
+from theforge.sprint.audit import (
+    persist_accumulated_story_state,
+    persist_accepted_unmeasured_spend,
+)
 from theforge.sprint.dag import StoryTriage, _triage_spec
 from theforge.sprint.lock import acquire_story_locks, release_story_locks
 from theforge.sprint.manifest import ResolvedSprint, _build_task_from_story
@@ -127,6 +130,30 @@ def _write_prior_sprint_audit(tmp_path: Path, sprint_id: str, total_cost_usd: fl
     audits_dir.mkdir(parents=True, exist_ok=True)
     with open(audits_dir / "sprint-audit.yaml", "w", encoding="utf-8") as f:
         yaml.dump({"sprint": {"sprint_id": sprint_id, "total_cost_usd": total_cost_usd}}, f)
+
+
+def _write_incomplete_prior_sprint_audit(
+    tmp_path: Path,
+    sprint_id: str,
+    *,
+    total_cost_measured_usd: float,
+    unmeasured_spend_sources: list[str],
+) -> None:
+    audits_dir = tmp_path / ".forge" / "audits"
+    audits_dir.mkdir(parents=True, exist_ok=True)
+    with open(audits_dir / "sprint-audit.yaml", "w", encoding="utf-8") as f:
+        yaml.dump(
+            {
+                "sprint": {
+                    "sprint_id": sprint_id,
+                    "total_cost_usd": None,
+                    "total_cost_measured_usd": total_cost_measured_usd,
+                    "cost_complete": False,
+                    "unmeasured_spend_sources": unmeasured_spend_sources,
+                }
+            },
+            f,
+        )
 
 
 def _make_coordinator_result(
@@ -1532,6 +1559,139 @@ class TestResumeSprintIntegration:
         assert result.specs_succeeded == 1
         assert "Budget $5.00 · carried $0.00 · usable headroom $5.00" in err
         assert "Selected run cannot dispatch under the supplied ceiling" not in err
+
+    def test_resume_startup_discloses_accepted_unmeasured_ceiling(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=20.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-b.md",
+                    "slug": "feature-b",
+                    "path": "feature-b.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                },
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                    "story_run_id": "run-prev",
+                },
+            ],
+        )
+        _write_incomplete_prior_sprint_audit(
+            tmp_path,
+            sprint_id,
+            total_cost_measured_usd=6.0,
+            unmeasured_spend_sources=["carried:feature-a"],
+        )
+        assert (
+            persist_accepted_unmeasured_spend(
+                sprint_id,
+                "Test Sprint",
+                tmp_path,
+                [
+                    {
+                        "source": "feature-a",
+                        "accepted_ceiling_usd": 4.5,
+                        "accepted_at": "2026-08-08T00:00:00+00:00",
+                    }
+                ],
+            )
+            is True
+        )
+        coord_result = _make_coordinator_result(success=True, cost=1.0)
+        full_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="full",
+            reason="no worktree found",
+            worktree_path=None,
+            slug="feature-a",
+        )
+
+        with patch("theforge.sprint.runner._triage_spec", return_value=full_triage) as mock_triage:
+            with patch("theforge.sprint.runner.run_task", return_value=coord_result) as mock_task:
+                with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+                    result = run_sprint_ctx(config, manifest_path, resume=True)
+
+        err = capsys.readouterr().err
+        mock_triage.assert_called_once()
+        mock_task.assert_called_once()
+        assert result.specs_succeeded == 2
+        assert result.stopped_reason is None
+        assert "Budget $20.00 · carried $6.00 · accepted unmeasured ceiling $4.50" in err
+        assert "usable headroom $9.50" in err
+        assert "lower bound" not in err
+
+    def test_resume_startup_marks_headroom_as_lower_bound_for_incomplete_prior_cost(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=20.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-b.md",
+                    "slug": "feature-b",
+                    "path": "feature-b.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                },
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "FAILED",
+                    "cost_usd": None,
+                    "story_run_id": "run-prev",
+                },
+            ],
+        )
+        _write_incomplete_prior_sprint_audit(
+            tmp_path,
+            sprint_id,
+            total_cost_measured_usd=6.0,
+            unmeasured_spend_sources=["carried:feature-a"],
+        )
+        coord_result = _make_coordinator_result(success=True, cost=1.0)
+        full_triage = StoryTriage(
+            story_path="feature-a.md",
+            action="full",
+            reason="no worktree found",
+            worktree_path=None,
+            slug="feature-a",
+        )
+
+        with patch("theforge.sprint.runner._triage_spec", return_value=full_triage) as mock_triage:
+            with patch("theforge.sprint.runner.run_task", return_value=coord_result) as mock_task:
+                with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+                    result = run_sprint_ctx(config, manifest_path, resume=True)
+
+        err = capsys.readouterr().err
+        mock_triage.assert_called_once()
+        mock_task.assert_not_called()
+        assert result.specs_skipped == 1
+        assert result.stopped_reason is not None
+        assert result.stopped_reason.startswith("Budget unverifiable")
+        assert "Budget $20.00 · carried $6.00 · usable headroom $14.00 lower bound" in err
+        assert "Selected run cannot dispatch under the supplied ceiling" in err
 
 
 # ── _build_task_from_story depends_on parsing ─────────────────────────

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -1039,7 +1039,7 @@ class TestResumeSprintIntegration:
         )
 
     def test_resume_prior_state_cost_exceeds_budget_without_sprint_audit(
-        self, tmp_path: Path
+        self, tmp_path: Path, capsys
     ) -> None:
         """Budget checks use progressive prior story state during re-exec."""
         _make_spec_file(tmp_path, "Feature A", "feature-a")
@@ -1077,12 +1077,15 @@ class TestResumeSprintIntegration:
                 with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
                     result = run_sprint_ctx(config, manifest_path, resume=True)
 
+        err = capsys.readouterr().err
         mock_run.assert_not_called()
         assert result.specs_skipped == 1
         assert (
             result.stopped_reason
             == "Budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
         )
+        assert "Budget $5.00 · carried $6.00 · usable headroom $0.00" in err
+        assert "Selected run cannot dispatch under the supplied ceiling" in err
         audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
         audit_data = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
         assert audit_data["specs"][0]["error"] == (

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -1003,7 +1003,7 @@ class TestResumeSprintIntegration:
         assert result.total_cost_usd == pytest.approx(1.0)
         assert result.stopped_reason is None
 
-    def test_resume_prior_cost_exceeds_budget(self, tmp_path: Path) -> None:
+    def test_resume_prior_cost_exceeds_budget(self, tmp_path: Path, capsys) -> None:
         """When prior cost already meets/exceeds budget, first spec is skipped."""
         _make_spec_file(tmp_path, "Feature A", "feature-a")
         manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=5.0)
@@ -1025,6 +1025,7 @@ class TestResumeSprintIntegration:
                 with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
                     result = run_sprint_ctx(config, manifest_path, resume=True)
 
+        err = capsys.readouterr().err
         # Spec should be skipped — prior cost alone exceeds budget
         mock_run.assert_not_called()
         assert result.specs_skipped == 1
@@ -1032,6 +1033,8 @@ class TestResumeSprintIntegration:
             result.stopped_reason
             == "Budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
         )
+        assert "Budget $5.00 · carried $6.00 · usable headroom $0.00" in err
+        assert "Selected run cannot dispatch under the supplied ceiling" in err
         audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
         audit_data = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
         assert audit_data["specs"][0]["error"] == (
@@ -1494,6 +1497,41 @@ class TestResumeSprintIntegration:
         mock_triage.assert_not_called()
         mock_task.assert_called_once()
         assert result.specs_succeeded == 1
+
+    def test_no_resume_existing_sprint_does_not_disclose_or_charge_carried_spend(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"], budget=5.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+        persist_accumulated_story_state(
+            sprint_id,
+            "Test Sprint",
+            tmp_path,
+            [
+                {
+                    "canonical_ref": "feature-a.md",
+                    "slug": "feature-a",
+                    "path": "feature-a.md",
+                    "outcome": "DONE",
+                    "cost_usd": 6.0,
+                    "story_run_id": "run-prev",
+                }
+            ],
+        )
+        coord_result = _make_coordinator_result(success=True, cost=1.0)
+
+        with patch("theforge.sprint.runner._triage_spec") as mock_triage:
+            with patch("theforge.sprint.runner.run_task", return_value=coord_result) as mock_task:
+                result = run_sprint_ctx(config, manifest_path, resume=False)
+
+        err = capsys.readouterr().err
+        mock_triage.assert_not_called()
+        mock_task.assert_called_once()
+        assert result.specs_succeeded == 1
+        assert "Budget $5.00 · carried $0.00 · usable headroom $5.00" in err
+        assert "Selected run cannot dispatch under the supplied ceiling" not in err
 
 
 # ── _build_task_from_story depends_on parsing ─────────────────────────

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -24,8 +24,8 @@ from theforge.config import (
 from theforge.coordinator import audit_substrate
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
 from theforge.sprint.audit import (
-    persist_accumulated_story_state,
     persist_accepted_unmeasured_spend,
+    persist_accumulated_story_state,
 )
 from theforge.sprint.dag import StoryTriage, _triage_spec
 from theforge.sprint.lock import acquire_story_locks, release_story_locks

--- a/tests/test_sprint_resume.py
+++ b/tests/test_sprint_resume.py
@@ -1068,6 +1068,58 @@ class TestResumeSprintIntegration:
             "budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
         )
 
+    def test_resume_prior_cost_exceeds_budget_skips_dependency_chain_for_budget(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Startup headroom refusal applies to downstream selected dependencies too."""
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        _make_spec_file(tmp_path, "Feature B", "feature-b", depends_on=["feature-a"])
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"], budget=5.0)
+        config = _make_config(tmp_path)
+        sprint_id = _set_sprint_id(tmp_path)
+
+        _write_prior_sprint_audit(tmp_path, sprint_id, 6.0)
+
+        triages = {
+            "feature-a.md": StoryTriage(
+                story_path="feature-a.md",
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+                slug="feature-a",
+            ),
+            "feature-b.md": StoryTriage(
+                story_path="feature-b.md",
+                action="full",
+                reason="no worktree found",
+                worktree_path=None,
+                slug="feature-b",
+            ),
+        }
+
+        def triage_side_effect(spec_path, config, project_root, *, task=None, **_progress):
+            return triages[Path(spec_path).name]
+
+        with patch("theforge.sprint.runner._triage_spec", side_effect=triage_side_effect):
+            with patch("theforge.sprint.runner.run_task") as mock_run:
+                with patch.dict(os.environ, {"FORGE_PREV_RUN_ID": "run-prev-123"}, clear=False):
+                    result = run_sprint_ctx(config, manifest_path, resume=True)
+
+        err = capsys.readouterr().err
+        mock_run.assert_not_called()
+        assert result.specs_skipped == 2
+        assert (
+            result.stopped_reason
+            == "Budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
+        )
+        assert "Budget $5.00 · carried $6.00 · usable headroom $0.00" in err
+        audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+        audit_data = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
+        errors_by_slug = {spec["slug"]: spec["error"] for spec in audit_data["specs"]}
+        expected = "budget exhausted (sprint $0.00 + carried $6.00 = $6.00 >= $5.00)"
+        assert errors_by_slug == {"feature-a": expected, "feature-b": expected}
+        assert "dependency failed" not in err
+
     def test_resume_without_previous_run_marker_does_not_refuse_from_audit_fallback(
         self, tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior dependency-chain budget-refusal bug is covered; no blocking issues found. | [anthropic-opus-cli] The prior P1 is fixed — the startup headroom refusal now sweeps StoryDAG.remaining() rather than only the initially-ready set, so a dependent story is recorded as skipped-for-budget instead of degrading into a dependency failure, and a new two-story integration test pins that; I verified remaining() returns unfinished TaskStory objects and that reconcile-skipped/already-merged slugs are already marked finished before the sweep, so they are not relabelled. Affected suites (110 tests), ruff check and ruff format all pass.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $13.60
- **Dev iterations:** 4
- **Tests:** N/A

## Findings

_No findings._

## Story

Spend carried from a previous attempt is charged against the ceiling supplied for a later run without being disclosed, so a ready story is refused for headroom the operator was never shown (GitHub Issue #2344)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2344