### PR TITLE
A gate failure on an auto-fixable formatting rule survives every retry unchanged, so dev iterations are spent without the failure ever being addressed

### DIFF
--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -1513,12 +1513,19 @@ def _run_dev_phase(
                         "pressure and narrower scope instead of repeating unchanged "
                         "conditions."
                     )
-            state.human_feedback = (
+            _submit_pressure_feedback = (
                 "The previous dev iteration exhausted its iteration budget without calling the "
                 "submit tool, so there is no structured handoff to continue from. Do not repeat "
                 "the same exploratory loop. Narrow scope, stabilize the worktree, and submit a "
                 "structured result promptly."
             )
+            if state.human_feedback:
+                state.human_feedback = (
+                    f"{state.human_feedback}\n\n"
+                    f"Additional retry guidance:\n{_submit_pressure_feedback}"
+                )
+            else:
+                state.human_feedback = _submit_pressure_feedback
             # Preserve any partial edits before retrying (#1746). Like the
             # timeout resume below, this is another retry-with-possibly-dirty-
             # worktree case: the agent burned its internal iteration budget

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -415,6 +415,16 @@ def _describe_dev_failure(result: object, *, is_timeout: bool) -> str:
     return exit_detail
 
 
+def _append_retry_guidance(existing_feedback: str | None, guidance: str) -> str:
+    """Preserve prior feedback while appending a retry note only once."""
+    if not existing_feedback:
+        return guidance
+    appended_block = f"Additional retry guidance:\n{guidance}"
+    if existing_feedback.endswith(appended_block):
+        return existing_feedback
+    return f"{existing_feedback}\n\n{appended_block}"
+
+
 def _dev_transport_retry_backoff_seconds(retry_count: int) -> int:
     """Return the backoff delay before the next transient dev retry."""
     return _DEV_TRANSPORT_RETRY_BACKOFF_BASE_SECONDS * (2 ** max(retry_count - 1, 0))
@@ -1519,13 +1529,9 @@ def _run_dev_phase(
                 "the same exploratory loop. Narrow scope, stabilize the worktree, and submit a "
                 "structured result promptly."
             )
-            if state.human_feedback:
-                state.human_feedback = (
-                    f"{state.human_feedback}\n\n"
-                    f"Additional retry guidance:\n{_submit_pressure_feedback}"
-                )
-            else:
-                state.human_feedback = _submit_pressure_feedback
+            state.human_feedback = _append_retry_guidance(
+                state.human_feedback, _submit_pressure_feedback
+            )
             # Preserve any partial edits before retrying (#1746). Like the
             # timeout resume below, this is another retry-with-possibly-dirty-
             # worktree case: the agent burned its internal iteration budget
@@ -1709,12 +1715,13 @@ def _run_dev_phase(
         # applies equally to the dev phase.
         if _is_timeout and not state.budget.is_exhausted():
             state.retry_reason = RetryReason.TIMEOUT_RESUME
-            state.human_feedback = (
+            state.human_feedback = _append_retry_guidance(
+                state.human_feedback,
                 f"Your previous dev iteration was cut off by a timeout: {_failure_detail}. "
                 "Any work you had already produced was checkpoint-committed for you, so "
                 "the branch already contains it — continue from that committed state rather "
                 "than redoing it. Narrow the remaining scope so you finish within the time "
-                "limit."
+                "limit.",
             )
             record_dev_iteration_telemetry(
                 state,

--- a/tests/test_coord_dev_timeout_retry.py
+++ b/tests/test_coord_dev_timeout_retry.py
@@ -169,6 +169,23 @@ def test_timeout_with_iterations_remaining_retries_not_escalates(tmp_path: Path)
     assert state.dev_iteration_telemetry[-1].is_timeout is True
 
 
+def test_timeout_retry_preserves_existing_gate_feedback(tmp_path: Path) -> None:
+    """A timeout retry keeps prior gate feedback and appends timeout guidance once."""
+    config, task, state = _setup(tmp_path)
+    state.budget.max_iterations = 3
+    state.budget.consume(review_cycle=0)
+    state.human_feedback = "Gate output:\nFAIL\nFix formatting before retrying."
+
+    result = _run_dev(config, task, state, tmp_path, _timeout_agent_result())
+
+    assert result is None
+    assert state.retry_reason == RetryReason.TIMEOUT_RESUME
+    assert state.human_feedback is not None
+    assert "Gate output:\nFAIL" in state.human_feedback
+    assert "cut off by a timeout" in state.human_feedback
+    assert state.human_feedback.count("Additional retry guidance:") == 1
+
+
 def test_timeout_kill_sets_sticky_state_flag_on_retry_path(tmp_path: Path) -> None:
     """A dev wall-clock timeout sets state.dev_process_timeout_killed at kill time,
     independent of which downstream branch (retry here) runs. This is the signal

--- a/tests/test_coord_max_iterations_no_submit.py
+++ b/tests/test_coord_max_iterations_no_submit.py
@@ -115,9 +115,10 @@ def test_audit_records_distinct_code_for_max_iterations_without_submit(
 @patch("theforge.coordinator.review_pool.run_agent_pool")
 @patch("theforge.coordinator.preflight_flow.run_agent")
 @patch("theforge.coordinator.dev_phase.run_agent")
+@patch("theforge.coordinator.dev_phase.build_dev_prompt")
 @patch_gate_shell()
-def test_followup_after_max_iterations_no_submit_does_not_retry_unchanged_conditions(
-    mock_shell, mock_dev, mock_preflight, mock_pool, tmp_path
+def test_followup_after_max_iterations_no_submit_preserves_gate_failure_feedback(
+    mock_shell, mock_build_dev_prompt, mock_dev, mock_preflight, mock_pool, tmp_path
 ):
     config = _make_config(tmp_path)
     config = config.__class__(
@@ -126,22 +127,23 @@ def test_followup_after_max_iterations_no_submit_does_not_retry_unchanged_condit
             "dev_profile": config.dev_profile.__class__(
                 **{**config.dev_profile.__dict__, "budget_usd": 10.0}
             ),
+            "retry": config.retry.__class__(max_dev_iterations=3, max_review_cycles=2),
         }
     )
     task = _make_task(tmp_path)
     workspace = tmp_path / task.slug
     workspace.mkdir()
 
-    mock_shell.side_effect = _shell_pass(workspace, ["PASS"])
+    mock_shell.side_effect = _shell_pass(workspace, ["FAIL", "PASS"])
     mock_preflight.return_value = _make_agent_result(
         success=True, output=PREFLIGHT_PROCEED, profile_name="preflight"
     )
-
-    seen_prompts: list[str] = []
+    mock_build_dev_prompt.return_value = "dev prompt"
 
     def dev_side_effect(**kwargs):
-        seen_prompts.append(kwargs["prompt"])
-        if len(seen_prompts) == 1:
+        if mock_dev.call_count == 1:
+            return _make_agent_result(profile_name="dev")
+        if mock_dev.call_count == 2:
             return _max_iter_no_submit_result(profile_name="dev")
         return _make_agent_result(profile_name="dev")
 
@@ -153,11 +155,14 @@ def test_followup_after_max_iterations_no_submit_does_not_retry_unchanged_condit
     result = run_task(config, task)
 
     assert result.success is True
-    assert len(seen_prompts) == 2
-    assert seen_prompts[1] != seen_prompts[0]
-    assert "submit tool" not in seen_prompts[0]
-    assert "submit tool" in seen_prompts[1]
-    assert result.state.gate_decisions == ["PASS"]
+    assert mock_build_dev_prompt.call_count == 3
+    retry_feedback = mock_build_dev_prompt.call_args_list[2].kwargs["human_feedback"]
+    assert retry_feedback is not None
+    assert "Gate output" in retry_feedback
+    assert "FAIL" in retry_feedback
+    assert "submit tool" in retry_feedback
+    assert "Additional retry guidance:" in retry_feedback
+    assert result.state.gate_decisions == ["FAIL", "PASS"]
 
 
 def test_sprint_audit_records_stable_outcome_code(tmp_path):

--- a/tests/test_coord_max_iterations_no_submit.py
+++ b/tests/test_coord_max_iterations_no_submit.py
@@ -165,6 +165,56 @@ def test_followup_after_max_iterations_no_submit_preserves_gate_failure_feedback
     assert result.state.gate_decisions == ["FAIL", "PASS"]
 
 
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.dev_phase.run_agent")
+@patch("theforge.coordinator.dev_phase.build_dev_prompt")
+@patch_gate_shell()
+def test_repeated_no_submit_retries_do_not_duplicate_guidance_block(
+    mock_shell, mock_build_dev_prompt, mock_dev, mock_preflight, mock_pool, tmp_path
+):
+    config = _make_config(tmp_path)
+    config = config.__class__(
+        **{
+            **config.__dict__,
+            "dev_profile": config.dev_profile.__class__(
+                **{**config.dev_profile.__dict__, "budget_usd": 10.0}
+            ),
+            "retry": config.retry.__class__(max_dev_iterations=4, max_review_cycles=2),
+        }
+    )
+    task = _make_task(tmp_path)
+    workspace = tmp_path / task.slug
+    workspace.mkdir()
+
+    mock_shell.side_effect = _shell_pass(workspace, ["FAIL", "FAIL", "PASS"])
+    mock_preflight.return_value = _make_agent_result(
+        success=True, output=PREFLIGHT_PROCEED, profile_name="preflight"
+    )
+    mock_build_dev_prompt.return_value = "dev prompt"
+    mock_dev.side_effect = [
+        _make_agent_result(profile_name="dev"),
+        _max_iter_no_submit_result(profile_name="dev"),
+        _make_agent_result(profile_name="dev"),
+        _max_iter_no_submit_result(profile_name="dev"),
+        _make_agent_result(profile_name="dev"),
+    ]
+    mock_pool.return_value = [
+        _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+    ]
+
+    result = run_task(config, task)
+
+    assert result.success is True
+    assert mock_build_dev_prompt.call_count == 5
+    retry_feedback = mock_build_dev_prompt.call_args_list[4].kwargs["human_feedback"]
+    assert retry_feedback is not None
+    assert retry_feedback.count("Additional retry guidance:") == 1
+    assert retry_feedback.count("submit tool") == 1
+    assert "Gate output" in retry_feedback
+    assert result.state.gate_decisions == ["FAIL", "FAIL", "PASS"]
+
+
 def test_sprint_audit_records_stable_outcome_code(tmp_path):
     task = _make_task(tmp_path)
     state_result = type("R", (), {})()


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The no-submit retry path now preserves prior gate feedback and appends retry guidance; focused coordinator tests pass. | [anthropic-opus-cli] Cycle-1 P2s were both addressed: gate feedback now survives the no-submit retry and the timeout retry via the shared _append_retry_guidance helper, with seam-level and engine-level tests; 1794 coordinator/timeout tests pass and ruff is clean. One residual P2 remains in the dedupe guard's first-append case.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $3.66
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/dev_phase.py:418`** When a dev iteration ends without a submit while no earlier feedback is stored, the retry note is recorded bare, and a second consecutive no-submit iteration then appends the same note again under an 'Additional retry guidance:' heading, so the next dev prompt carries the identical paragraph twice; the same doubling occurs for two consecutive dev timeouts.

## Story

A gate failure on an auto-fixable formatting rule survives every retry unchanged, so dev iterations are spent without the failure ever being addressed (GitHub Issue #2428)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2428