### PR TITLE
Advisory P2 cleanup may consume the final dev iteration, so a gate failure it introduces has nothing left to repair it

### DIFF
--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -857,7 +857,8 @@ def _maybe_enter_p2_cleanup(
     Returns False when:
       - the feature is disabled,
       - no carried P2 findings remain (or none existed),
-      - the dev iteration budget for this cycle is exhausted, or
+      - the dev iteration budget for this cycle is exhausted,
+      - entering cleanup would consume the final iteration reserved for repair, or
       - the configured cleanup-iteration cap has been reached.
     """
     current_p2s = _open_p2_findings(parsed_review)
@@ -890,6 +891,10 @@ def _maybe_enter_p2_cleanup(
         return False
     if state.budget.remaining() <= 0:
         state.p2_cleanup_audit.append({"action": "skip_budget", **audit_base})
+        _clear_p2_cleanup_state(state)
+        return False
+    if state.budget.remaining() < 2:
+        state.p2_cleanup_audit.append({"action": "skip_budget_reserve", **audit_base})
         _clear_p2_cleanup_state(state)
         return False
     cap = config.retry.p2_cleanup_max_iterations

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -1087,8 +1087,9 @@ class CoordinatorState:
     # Audit trail for cleanup decisions: one entry per cleanup transition with
     # action ("enter" | "continue" | "exit_clean" | "exit_budget" | "exit_cap"
     # | "exit_regression" | "skip_disabled" | "skip_no_p2" | "skip_budget"
-    # | "skip_cap"), pre-pass P2 count, post-pass P2 count, budget remaining,
-    # review_cycle, and dev_iteration at the decision point.
+    # | "skip_budget_reserve" | "skip_cap"), pre-pass P2 count, post-pass P2
+    # count, budget remaining, review_cycle, and dev_iteration at the decision
+    # point.
     p2_cleanup_audit: list[dict] = field(default_factory=list)
     # ── Symptom-verification test escalations (#1560) ─────────────────────────
     # One entry per P2→P1 escalation applied because a bug-fix PR's reviewer

--- a/tests/test_coord_review_p2_cleanup.py
+++ b/tests/test_coord_review_p2_cleanup.py
@@ -23,6 +23,7 @@ from theforge.config import load_config
 from theforge.coordinator.engine import run_from_review
 from theforge.coordinator.review_phase import _maybe_enter_p2_cleanup
 from theforge.coordinator.state import CoordinatorState, Phase, RetryReason
+from theforge.coordinator.validate_phase import _ValidateOutcome
 from theforge.review import ReviewFinding, ReviewResult
 
 APPROVE_WITH_P2 = """\
@@ -466,3 +467,54 @@ class TestP2CleanupLoop:
         assert mock_dev.call_count == 0
         actions = [entry["action"] for entry in result.state.p2_cleanup_audit]
         assert actions == ["skip_budget_reserve"]
+
+    @patch("theforge.coordinator.engine._run_validate_phase")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_cleanup_breakage_uses_reserved_repair_iteration_before_rereview(
+        self, mock_shell, mock_dev, mock_pool, mock_validate, tmp_path
+    ):
+        """A cleanup regression spends the reserved repair attempt instead of escalating."""
+        config = _make_config(tmp_path)
+        config = dataclasses.replace(
+            config,
+            retry=dataclasses.replace(
+                config.retry,
+                max_dev_iterations=3,
+            ),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_dev.return_value = _make_agent_result(success=True, output="Polished.")
+        mock_validate.side_effect = [
+            (_ValidateOutcome.RETRY_DEV, None),
+            (_ValidateOutcome.PASS, None),
+        ]
+
+        pool_calls = {"n": 0}
+
+        def pool_side_effect(**kwargs):
+            pool_calls["n"] += 1
+            if pool_calls["n"] == 1:
+                return [
+                    _make_agent_result(success=True, output=APPROVE_WITH_P2, profile_name="review")
+                ]
+            return [_make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")]
+
+        mock_pool.side_effect = pool_side_effect
+
+        result = run_from_review(config, task, workspace)
+
+        assert result.success is True
+        assert result.phase == Phase.DONE
+        assert result.state.p2_cleanup_iterations == 1
+        assert result.state.p2_cleanup_active is False
+        assert mock_dev.call_count == 2
+        assert mock_validate.call_count == 2
+        assert pool_calls["n"] == 2
+        actions = [entry["action"] for entry in result.state.p2_cleanup_audit]
+        assert actions == ["enter", "exit_clean"]

--- a/tests/test_coord_review_p2_cleanup.py
+++ b/tests/test_coord_review_p2_cleanup.py
@@ -100,8 +100,9 @@ class TestMaybeEnterP2Cleanup:
     def test_enters_cleanup_when_p2s_present_and_budget_remains(self, tmp_path):
         config = _make_config(tmp_path)  # max_dev_iterations=2
         state = CoordinatorState()
-        state.budget.max_iterations = config.retry.max_dev_iterations
-        # cycle_count=0 → remaining=2
+        state.budget.max_iterations = 3
+        state.budget.cycle_count = 1
+        # remaining=2: one iteration for cleanup, one reserved for repair
 
         entered = _maybe_enter_p2_cleanup(state, config, _approve_with_p2_review())
 
@@ -138,6 +139,20 @@ class TestMaybeEnterP2Cleanup:
         assert entered is False
         assert state.p2_cleanup_active is False
         assert state.p2_cleanup_audit[-1]["action"] == "skip_budget"
+
+    def test_does_not_enter_when_only_repair_reserve_remains(self, tmp_path):
+        """Cleanup must not spend the final iteration reserved for repair."""
+        config = _make_config(tmp_path)
+        state = CoordinatorState()
+        state.budget.max_iterations = 2
+        state.budget.cycle_count = 1
+        # remaining()==1: enough for one more dev call, but not for cleanup plus repair.
+
+        entered = _maybe_enter_p2_cleanup(state, config, _approve_with_p2_review())
+
+        assert entered is False
+        assert state.p2_cleanup_active is False
+        assert state.p2_cleanup_audit[-1]["action"] == "skip_budget_reserve"
 
     def test_does_not_enter_when_disabled(self, tmp_path):
         """AC: operator may disable cleanup via config."""
@@ -419,22 +434,16 @@ class TestP2CleanupLoop:
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch_gate_shell()
-    def test_cleanup_budget_exhaustion_exits_done_not_escalate(
+    def test_cleanup_reserve_decline_exits_done_not_escalate(
         self, mock_shell, mock_dev, mock_pool, tmp_path
     ):
-        """AC: budget exhaustion with P2s still open exits DONE, not ESCALATE.
-
-        max_dev_iterations=1 + cleanup cap=1: after one cleanup pass that still
-        leaves P2s open, the next review pass cannot start another cleanup
-        iteration; the run must terminate as DONE.
-        """
+        """AC: reserve protection declines cleanup and exits DONE, not ESCALATE."""
         config = _make_config(tmp_path)
         config = dataclasses.replace(
             config,
             retry=dataclasses.replace(
                 config.retry,
                 max_dev_iterations=1,
-                p2_cleanup_max_iterations=1,
             ),
         )
         task = _make_task(tmp_path)
@@ -453,9 +462,7 @@ class TestP2CleanupLoop:
 
         assert result.success is True
         assert result.phase == Phase.DONE
-        assert result.state.p2_cleanup_iterations == 1
-        # Audit shows the second pass refused another cleanup iteration.
+        assert result.state.p2_cleanup_iterations == 0
+        assert mock_dev.call_count == 0
         actions = [entry["action"] for entry in result.state.p2_cleanup_audit]
-        assert "enter" in actions
-        # Either cap or budget exhaustion blocked the second pass.
-        assert any(a in {"skip_cap", "skip_budget"} for a in actions)
+        assert actions == ["skip_budget_reserve"]

--- a/tests/test_coord_review_p2_cleanup.py
+++ b/tests/test_coord_review_p2_cleanup.py
@@ -23,7 +23,7 @@ from theforge.config import load_config
 from theforge.coordinator.engine import run_from_review
 from theforge.coordinator.review_phase import _maybe_enter_p2_cleanup
 from theforge.coordinator.state import CoordinatorState, Phase, RetryReason
-from theforge.coordinator.validate_phase import _ValidateOutcome, _blocking_finding_route
+from theforge.coordinator.validate_phase import _blocking_finding_route, _ValidateOutcome
 from theforge.review import ReviewFinding, ReviewResult
 
 APPROVE_WITH_P2 = """\
@@ -502,12 +502,11 @@ class TestP2CleanupLoop:
         actions = [entry["action"] for entry in result.state.p2_cleanup_audit]
         assert actions == ["skip_budget_reserve"]
 
-    @patch("theforge.coordinator.engine._run_validate_phase")
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.dev_phase.run_agent")
     @patch_gate_shell()
     def test_cleanup_breakage_uses_reserved_repair_iteration_before_rereview(
-        self, mock_shell, mock_dev, mock_pool, mock_validate, tmp_path
+        self, mock_shell, mock_dev, mock_pool, tmp_path
     ):
         """A cleanup regression spends the reserved repair attempt instead of escalating."""
         config = _make_config(tmp_path)
@@ -522,12 +521,8 @@ class TestP2CleanupLoop:
         workspace = tmp_path / "test-task"
         workspace.mkdir()
 
-        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "PASS"])
         mock_dev.return_value = _make_agent_result(success=True, output="Polished.")
-        mock_validate.side_effect = [
-            (_ValidateOutcome.RETRY_DEV, None),
-            (_ValidateOutcome.PASS, None),
-        ]
 
         pool_calls = {"n": 0}
 
@@ -548,7 +543,8 @@ class TestP2CleanupLoop:
         assert result.state.p2_cleanup_iterations == 1
         assert result.state.p2_cleanup_active is False
         assert mock_dev.call_count == 2
-        assert mock_validate.call_count == 2
         assert pool_calls["n"] == 2
+        assert result.state.gate_decisions[-2:] == ["FAIL", "PASS"]
+        assert result.state.validate_blocks == []
         actions = [entry["action"] for entry in result.state.p2_cleanup_audit]
         assert actions == ["enter", "exit_clean"]

--- a/tests/test_coord_review_p2_cleanup.py
+++ b/tests/test_coord_review_p2_cleanup.py
@@ -23,7 +23,7 @@ from theforge.config import load_config
 from theforge.coordinator.engine import run_from_review
 from theforge.coordinator.review_phase import _maybe_enter_p2_cleanup
 from theforge.coordinator.state import CoordinatorState, Phase, RetryReason
-from theforge.coordinator.validate_phase import _ValidateOutcome
+from theforge.coordinator.validate_phase import _ValidateOutcome, _blocking_finding_route
 from theforge.review import ReviewFinding, ReviewResult
 
 APPROVE_WITH_P2 = """\
@@ -307,6 +307,40 @@ class TestP2CleanupConfigLoading:
         with patch("importlib.import_module"):
             cfg = load_config(config_path)
         assert cfg.retry.p2_cleanup_max_iterations == 3
+
+
+class TestValidateCleanupRouting:
+    """Validate-phase seam tests for cleanup reserve and repair routing."""
+
+    def test_cleanup_breakage_uses_reserved_repair_iteration_when_budget_remains(
+        self, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        state = CoordinatorState()
+        state.p2_cleanup_active = True
+        state.budget.max_iterations = 3
+        state.budget.cycle_count = 2
+        # remaining()==1: cleanup is active, but one in-cycle repair attempt remains.
+
+        route = _blocking_finding_route(state, config)
+
+        assert route.outcome == _ValidateOutcome.RETRY_DEV
+        assert route.reason == "dev_budget_remains"
+
+    def test_cleanup_breakage_escalates_when_reserved_repair_iteration_is_spent(
+        self, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        state = CoordinatorState()
+        state.p2_cleanup_active = True
+        state.budget.max_iterations = 3
+        state.budget.cycle_count = 3
+        # remaining()==0: cleanup may not buy a new cycle once the reserved repair is gone.
+
+        route = _blocking_finding_route(state, config)
+
+        assert route.outcome == _ValidateOutcome.ESCALATE
+        assert route.reason == "p2_cleanup"
 
 
 class TestP2CleanupLoop:

--- a/tests/test_coord_review_p2_cleanup.py
+++ b/tests/test_coord_review_p2_cleanup.py
@@ -312,9 +312,7 @@ class TestP2CleanupConfigLoading:
 class TestValidateCleanupRouting:
     """Validate-phase seam tests for cleanup reserve and repair routing."""
 
-    def test_cleanup_breakage_uses_reserved_repair_iteration_when_budget_remains(
-        self, tmp_path
-    ):
+    def test_cleanup_breakage_uses_reserved_repair_iteration_when_budget_remains(self, tmp_path):
         config = _make_config(tmp_path)
         state = CoordinatorState()
         state.p2_cleanup_active = True
@@ -327,9 +325,7 @@ class TestValidateCleanupRouting:
         assert route.outcome == _ValidateOutcome.RETRY_DEV
         assert route.reason == "dev_budget_remains"
 
-    def test_cleanup_breakage_escalates_when_reserved_repair_iteration_is_spent(
-        self, tmp_path
-    ):
+    def test_cleanup_breakage_escalates_when_reserved_repair_iteration_is_spent(self, tmp_path):
         config = _make_config(tmp_path)
         state = CoordinatorState()
         state.p2_cleanup_active = True

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -1849,9 +1849,7 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         assert sb.remaining_reserved_review_usd(reservation, 2.02) == 0.0
         assert state.adaptive_limits_audit["review_funding_reservation"]["release_count"] == 2
 
-    def test_a_rereleased_retained_cycle_funds_the_next_dev_dispatch(
-        self, tmp_path: Path
-    ) -> None:
+    def test_a_rereleased_retained_cycle_funds_the_next_dev_dispatch(self, tmp_path: Path) -> None:
         """The retained re-review dollar is returned in time to fund the repair attempt."""
         state, result, dev_calls = self._run_loop(
             tmp_path,

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -1216,7 +1216,7 @@ class TestTheSeatedReviewReservationIsHeldAcrossPhases:
     later dev attempt is refused once the rest of the allocation is gone.
     """
 
-    def _config(self, tmp_path: Path):
+    def _config(self, tmp_path: Path, *, max_dev_iterations: int = 3):
         from coord_test_helpers import _make_config, _make_review_profile
 
         from theforge.config.types import AssignmentConfig, RetryPolicy
@@ -1231,7 +1231,7 @@ class TestTheSeatedReviewReservationIsHeldAcrossPhases:
             review_pool=[_make_review_profile("openai-gpt-5.5-cli", budget_usd=1.01)],
             synthesis_profile=None,
             retry=RetryPolicy(
-                max_dev_iterations=3,
+                max_dev_iterations=max_dev_iterations,
                 max_review_cycles=5,
                 max_dev_iterations_cap=6,
                 max_review_cycles_cap=5,
@@ -1584,7 +1584,7 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
     stay protected, and the run audit shows what was let go.
     """
 
-    def _config(self, tmp_path: Path):
+    def _config(self, tmp_path: Path, *, max_dev_iterations: int = 3):
         from coord_test_helpers import _make_config, _make_review_profile
 
         from theforge.config.types import AssignmentConfig, RetryPolicy
@@ -1596,7 +1596,7 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
             review_pool=[_make_review_profile("openai-gpt-5.5-cli", budget_usd=1.01)],
             synthesis_profile=None,
             retry=RetryPolicy(
-                max_dev_iterations=3,
+                max_dev_iterations=max_dev_iterations,
                 max_review_cycles=5,
                 max_dev_iterations_cap=6,
                 max_review_cycles_cap=5,
@@ -1638,6 +1638,7 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         review_output: str | None = None,
         human_decision: tuple[str, str | None] | None = None,
         zero_findings_stop: int = 0,
+        max_dev_iterations: int = 3,
     ):
         """Drive DEV → VALIDATE → REVIEW round the loop the review verdict picks.
 
@@ -1660,7 +1661,7 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         from theforge.coordinator.validate_phase import _ValidateOutcome
 
         review_output = APPROVE_WITH_P2 if review_output is None else review_output
-        config = self._config(tmp_path)
+        config = self._config(tmp_path, max_dev_iterations=max_dev_iterations)
         if zero_findings_stop:
             config = dataclasses.replace(
                 config,
@@ -1818,37 +1819,34 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         assert state.allocation_exhausted["reserved_review_remaining_usd"] == 1.01
         assert state.allocation_exhausted["reserved_review_released"] is True
 
-    def test_a_retained_cycle_that_runs_funds_the_next_cleanup_attempt(
+    def test_a_retained_cycle_that_runs_releases_the_reserve_when_cleanup_is_declined(
         self, tmp_path: Path
     ) -> None:
-        """The retained cycle is protected until it runs — and not one dollar longer.
+        """Once the retained review runs, the reserve is settled if cleanup stops.
 
-        Two cleanup passes: the first release retains one $1.01 cycle, that cycle
-        then actually runs, and the dev attempt after it must be funded from the
-        allocation the retained cycle no longer needs. Holding the retained
-        figure flat refuses this attempt against money already spent.
+        Under the reserve rule, the first cleanup pass may consume the second of
+        three dev iterations, leaving one repair iteration. The re-review spends
+        the retained $1.01 cycle, and the next APPROVE+P2 declines cleanup on
+        reserve grounds rather than spending the last repair iteration. That
+        decline must still re-release the reservation to zero instead of
+        continuing to withhold the already-spent retained cycle.
         """
         state, result, dev_calls = self._run_loop(tmp_path, dev_costs=[6.95, 2.53])
 
-        # Three dev dispatches: the seated one and two cleanup passes.
-        assert len(dev_calls) == 3
-        assert result is None
+        assert len(dev_calls) == 2
+        assert result is not None
+        assert result.phase == Phase.DONE
         assert state.allocation_exhausted is None
         assert state.review_cycle == 2
         assert state.total_review_cost_measured == 2.02
-        # Total spend at this dispatch is $11.50 of a $12.00 allocation, so the
-        # story genuinely has money left — but only once the retained cycle's
-        # $1.01 stops being withheld: holding it flat leaves $12.00 - $11.50 -
-        # $1.01 = -$0.51 and refuses the attempt.
-        assert dev_calls[2] == 11.50
-        assert dev_calls[2] < 12.00
+        assert state.p2_cleanup_audit[-1]["action"] == "skip_budget_reserve"
 
         reservation = state.review_funding_reservation
         assert reservation["release_count"] == 2
+        assert reservation["release_reason"] == "approve_final"
         assert reservation["retained_review_usd"] == 0.0
         assert reservation["review_observed_at_release_usd"] == 2.02
         assert sb.remaining_reserved_review_usd(reservation, 2.02) == 0.0
-        # The audit shows the re-release, not the first one.
         assert state.adaptive_limits_audit["review_funding_reservation"]["release_count"] == 2
 
     def test_a_finalized_approval_releases_the_whole_reserve(self, tmp_path: Path) -> None:
@@ -1935,7 +1933,10 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         # Identical APPROVE+P2 cycles: cycles 2 and 3 bring zero new findings,
         # so the run converges and finalizes through early termination.
         state, result, dev_calls = self._run_loop(
-            tmp_path, dev_costs=[1.00, 0.50, 0.50], zero_findings_stop=2
+            tmp_path,
+            dev_costs=[1.00, 0.50, 0.50],
+            zero_findings_stop=2,
+            max_dev_iterations=4,
         )
 
         assert result is not None

--- a/tests/test_story_budget_seam.py
+++ b/tests/test_story_budget_seam.py
@@ -1849,6 +1849,26 @@ class TestTheReservationIsReleasedOnceReviewCanNoLongerRun:
         assert sb.remaining_reserved_review_usd(reservation, 2.02) == 0.0
         assert state.adaptive_limits_audit["review_funding_reservation"]["release_count"] == 2
 
+    def test_a_rereleased_retained_cycle_funds_the_next_dev_dispatch(
+        self, tmp_path: Path
+    ) -> None:
+        """The retained re-review dollar is returned in time to fund the repair attempt."""
+        state, result, dev_calls = self._run_loop(
+            tmp_path,
+            dev_costs=[6.95, 2.53],
+            max_dev_iterations=4,
+        )
+
+        assert result is None
+        assert len(dev_calls) == 3
+        assert dev_calls[-1] == 11.50
+        assert state.p2_cleanup_active is True
+        assert state.p2_cleanup_iterations == 2
+        reservation = state.review_funding_reservation
+        assert reservation["release_count"] == 2
+        assert reservation["release_reason"] == "approve_p2_cleanup"
+        assert reservation["retained_review_usd"] == 0.0
+
     def test_a_finalized_approval_releases_the_whole_reserve(self, tmp_path: Path) -> None:
         """The approve_final path, end to end: nothing is reachable, nothing is held.
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The cleanup reserve guard, distinct audit reason, and reserved repair routing are implemented and covered; no P1 regressions were found. | [anthropic-opus-cli] The repair-path test now drives a real gate FAIL then PASS through the unmocked validate phase and is joined by direct _blocking_finding_route cases for cleanup-active with and without a remaining iteration, closing the prior cycle's coverage gap; 118 tests in the touched suites pass, ruff check and format are clean, and the BLOCKED gate is the same 17 environment-bound failures in test_sprint_lock, test_cut_rc_isolation and test_sprint_reexec_collision that reproduce standalone here and touch no code in this diff.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $5.53
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

Advisory P2 cleanup may consume the final dev iteration, so a gate failure it introduces has nothing left to repair it (GitHub Issue #2423)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2423