### PR TITLE
A gate verdict that does not reproduce aborts a sprint before any work begins, and the same gate passes on the next run with nothing changed

### DIFF
--- a/docs/flake-register.md
+++ b/docs/flake-register.md
@@ -24,6 +24,14 @@ for the rules that govern entries here.
 - **A green-on-re-run after a same-SHA red is a flake signal, not a pass.** When
   a gate goes red and a plain re-run of the same commit goes green, the test that
   flipped is a flake candidate — add it here rather than merging on the green.
+- **The sprint baseline gate confirms a failure before refusing work, and says
+  so.** A failing baseline gate is re-run once against the same worktree and
+  commit; only a failure that reproduces halts the sprint (#2434). This is not
+  retry-until-green — the first run's full output is written to
+  `.forge/logs/<sprint>/…-unreproduced-failure.txt`, the sprint log records
+  `baseline_gate_failure_not_reproduced`, and the audit's `baseline_check`
+  carries `failure_reproduced: false`. Each of those is a flake candidate for
+  this register, not a pass to be forgotten.
 
 ## Status legend
 

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1055,6 +1055,12 @@ def _refuse_dirty_root_before_spend(
 #: ``GateLabel.purpose`` for the pre-sprint merge-base gate.
 BASELINE_GATE_PURPOSE = "baseline gate"
 
+#: ``GateLabel.purpose`` for the immediate re-run that decides whether a failing
+#: baseline gate is evidence about the merge base or about one noisy invocation
+#: (#2434). A distinct purpose keeps the two runs distinguishable in the log,
+#: where the resolved command is identical.
+BASELINE_GATE_CONFIRM_PURPOSE = "baseline gate confirmation"
+
 #: Top-level ``sprint_phase`` values for the pre-story window. Both gates below
 #: can run for many minutes; without their own phases the whole window reports
 #: as ``starting`` with every story ``waiting`` (#2014).
@@ -1271,6 +1277,7 @@ def _run_baseline_gate(
     resolved: ResolvedSprint,
     *,
     run_id: str | None = None,
+    on_confirmation_start: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     """Run the configured gate on the sprint merge base before any agent work starts.
 
@@ -1281,6 +1288,15 @@ def _run_baseline_gate(
     worktree the gate ran in, which is the only environment the failure can be
     reproduced in. Cleanup of the worktree happens after that capture, never
     before, and only on outcomes that did not halt the sprint (#2160).
+
+    A gate that fails is re-run once against the same worktree and commit before
+    its FAIL is treated as the baseline's verdict; only a failure that reproduces
+    halts the sprint (#2434). Every record produced by an executed gate carries
+    ``confirmation_attempted`` and ``failure_reproduced`` so a reader — and the
+    audit — can tell a confirmed broken baseline from a failure that vanished on
+    re-run. ``on_confirmation_start``, when given, is called just before that
+    second run so a caller can say so on its live progress surface: the re-run
+    doubles the gate's wall time and would otherwise look like a stuck sprint.
     """
 
     # Declared before the first return so *every* baseline record carries the
@@ -1514,15 +1530,136 @@ def _run_baseline_gate(
                 "process_teardowns": [t.to_audit_dict() for t in gate_teardowns],
                 "decision": decision,
                 "output_tail": output_tail,
+                # Nothing failed, so nothing needed confirming; the keys are
+                # present on every executed-gate record so a reader never has to
+                # ask whether this is one of the kinds that says.
+                "confirmation_attempted": False,
+                "failure_reproduced": None,
                 "message": (
                     "Baseline gate passed on sprint merge base "
                     f"{merge_base_ref} before dev iterations started"
                 ),
             }
 
+        # A verdict that decides whether work may begin is evidence about the
+        # merge base only if it reproduces. Process-teardown and sandbox flakes
+        # fail one invocation and pass the next against the identical tree, and
+        # this gate's FAIL ends the sprint before any story starts — so the
+        # failure is re-run once, immediately, in the same worktree at the same
+        # commit, and only a failure that repeats is treated as the baseline's
+        # answer (#2434). The re-run happens *before* the evidence capture and
+        # worktree preservation below: a first run that does not reproduce
+        # returns through the ordinary cleanup path and leaves nothing behind.
+        initial_result = {
+            "decision": decision,
+            "error": error,
+            "exit_code": exit_code,
+            "output_tail": output_tail,
+            "duration_seconds": round(duration, 2),
+        }
+        if on_confirmation_start is not None:
+            on_confirmation_start()
+        _log(
+            f"Baseline gate failed on merge base {merge_base_ref}; re-running the identical "
+            "gate once to confirm the failure reproduces before refusing the sprint"
+        )
+        confirm_full_output: list[str] = []
+        (
+            confirm_decision,
+            confirm_error,
+            confirm_tail,
+            confirm_cmd,
+            confirm_exit,
+        ) = run_gate_full(
+            config,
+            baseline_worktree,
+            full_output=confirm_full_output,
+            process_teardowns=gate_teardowns,
+            label=GateLabel(
+                purpose=BASELINE_GATE_CONFIRM_PURPOSE,
+                target="merge base",
+                commit=merge_base_ref,
+                worktree_path=str(baseline_worktree),
+            ),
+        )
+        duration = time.monotonic() - started_monotonic
+        finished_at = datetime.datetime.now(datetime.timezone.utc)
+        confirmation_passed = confirm_decision == "PASS" and confirm_error is None
+        confirm_exit_code = (
+            confirm_exit if confirm_exit is not None else (0 if confirmation_passed else 1)
+        )
+        confirmation_result = {
+            "decision": confirm_decision,
+            "error": confirm_error,
+            "exit_code": confirm_exit_code,
+            "output_tail": confirm_tail,
+        }
+        if confirmation_passed:
+            # The first run's output is still the only record of what failed, and
+            # the operator has no other way to see it — the sprint is about to
+            # proceed as though the failure never happened. Written under its own
+            # filename so it can never be mistaken for a halting verdict's
+            # evidence, and the worktree is *not* preserved: nothing halted.
+            unreproduced_filename = (
+                f"{evidence_filename.removesuffix('.txt')}-unreproduced-failure.txt"
+            )
+            evidence_path, evidence_unavailable = _write_baseline_gate_evidence(
+                log_dir=sprint_log_dir,
+                filename=unreproduced_filename,
+                header_lines=[
+                    f"# baseline gate {decision or 'ERROR'} on merge base {merge_base_ref}",
+                    "# NOT REPRODUCED: an immediate re-run of the identical gate passed",
+                    f"# gate command: {resolved_gate_cmd}",
+                    f"# exit code: {exit_code}",
+                    f"# worktree: {baseline_worktree}",
+                ],
+                full_output=gate_full_output[0] if gate_full_output else None,
+            )
+            message = (
+                "Baseline gate failed and then passed on an immediate re-run of the identical "
+                f"gate against merge base {merge_base_ref}; the failure did not reproduce, so "
+                "it is not treated as evidence about the merge base and the sprint proceeds "
+                f"(first run exit {exit_code}: {error or 'Gate returned FAIL'})"
+            )
+            message += _baseline_evidence_footer(
+                worktree=None,
+                evidence_path=evidence_path,
+                evidence_unavailable=evidence_unavailable,
+            )
+            return {
+                "status": "pass_unreproduced_failure",
+                "passed": True,
+                "exit_code": confirm_exit_code,
+                "duration_seconds": round(duration, 2),
+                "started_at": baseline_started_at,
+                "finished_at": finished_at,
+                "merge_base": merge_base_ref,
+                "command": confirm_cmd,
+                "process_teardowns": [t.to_audit_dict() for t in gate_teardowns],
+                "decision": confirm_decision,
+                "output_tail": confirm_tail,
+                "confirmation_attempted": True,
+                "failure_reproduced": False,
+                "initial_result": initial_result,
+                "confirmation_result": confirmation_result,
+                "evidence_path": evidence_path,
+                "evidence_unavailable": evidence_unavailable,
+                "message": message,
+            }
+
+        # Reproduced: the confirmation run is the verdict, and its output is what
+        # the operator investigates.
+        decision = confirm_decision
+        error = confirm_error
+        output_tail = confirm_tail
+        resolved_gate_cmd = confirm_cmd
+        exit_code = confirm_exit_code
+        if confirm_full_output:
+            gate_full_output = confirm_full_output
         message = (
             "Broken baseline: configured gate failed on sprint merge base "
             f"{merge_base_ref} before any dev work started ({error or 'Gate returned FAIL'})"
+            " (failure reproduced on an immediate re-run of the identical gate)"
         )
         try:
             local_sha = subprocess.check_output(
@@ -1585,6 +1722,10 @@ def _run_baseline_gate(
             "process_teardowns": [t.to_audit_dict() for t in gate_teardowns],
             "decision": decision,
             "output_tail": output_tail,
+            "confirmation_attempted": True,
+            "failure_reproduced": True,
+            "initial_result": initial_result,
+            "confirmation_result": confirmation_result,
             "worktree": preserved_worktree,
             "evidence_path": evidence_path,
             "evidence_unavailable": evidence_unavailable,
@@ -4350,6 +4491,32 @@ def _attempt_integration(
     return True
 
 
+def _fold_entry_intake_cost(
+    context: SprintRunContext,
+    state: SprintExecutionState,
+    log: Callable[[str], None],
+) -> None:
+    """Roll pre-``run_sprint`` intake remediation spend into the sprint ledger.
+
+    Entry-level intake remediation runs in the CLI before the sprint starts and
+    spends the same sprint-authorized budget, so the sprint total is wrong
+    without it. Called once, before the baseline-gate abort branch, because an
+    abort before any story starts has still spent this money and an operator
+    deciding whether to retry needs the figure (#2434).
+    """
+    if not context.entry_intake_outcomes:
+        return
+    for issue_num, outcome in context.entry_intake_outcomes.items():
+        if _intake_outcome_cost_measured(outcome) is None:
+            state.cost.flag_unmeasured_here(f"entry-intake:issue-{issue_num}")
+    entry_intake_cost = sum(
+        _intake_outcome_cost(o) for o in context.entry_intake_outcomes.values()
+    )
+    if entry_intake_cost > 0.0:
+        state.cost.add(entry_intake_cost)
+        log(f"Entry-intake remediation cost: ${entry_intake_cost:.4f} (rolled into sprint total)")
+
+
 def run_sprint(context: SprintRunContext) -> SprintResult:
     """Run all stories in a sprint with optional concurrency.
 
@@ -4745,11 +4912,45 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
             started_at=baseline_started_at.isoformat(),
         )
         try:
-            baseline_gate = _run_baseline_gate(_ctx.config, _ctx.resolved, run_id=_ctx.run_id)
+            baseline_gate = _run_baseline_gate(
+                _ctx.config,
+                _ctx.resolved,
+                run_id=_ctx.run_id,
+                # The confirmation re-run doubles the gate's wall time, and the
+                # phase started when the *first* run did — without this the
+                # second half of the window reads as a stuck gate (#2434).
+                on_confirmation_start=lambda: _publish_sprint_phase(
+                    SPRINT_PHASE_BASELINE_GATE,
+                    detail=(
+                        f"re-running gate to confirm failure on merge base of "
+                        f"{_ctx.config.workspace.base_branch}"
+                    ),
+                    started_at=baseline_started_at.isoformat(),
+                ),
+            )
         finally:
             _publish_sprint_phase(SPRINT_PHASE_STARTING)
     _ctx.resolved.baseline_gate = baseline_gate
     _log(str(baseline_gate.get("message", "Baseline gate check completed")))
+    if baseline_gate.get("failure_reproduced") is False:
+        # The sprint is about to proceed past a gate that said FAIL. That is the
+        # right call — the failure was not reproducible against the same commit —
+        # but it is an ambiguity an operator should be able to see without
+        # reading the audit JSON afterwards.
+        _initial = baseline_gate.get("initial_result")
+        _sprint_logger.emit(
+            "baseline_gate_failure_not_reproduced",
+            merge_base=baseline_gate.get("merge_base"),
+            initial_exit_code=_initial.get("exit_code") if isinstance(_initial, dict) else None,
+            evidence_path=baseline_gate.get("evidence_path"),
+        )
+    # Entry-level intake remediation runs in the CLI before run_sprint and
+    # spends the same sprint-authorized budget. The fold happens here, ahead of
+    # the baseline-gate abort below, because an abort before any story starts
+    # has still spent that money and an operator deciding whether to retry needs
+    # the figure (#2434). Folding once, on every path, is what keeps the abort's
+    # audit and the completed sprint's total the same number.
+    _fold_entry_intake_cost(_ctx, _sprint_state, _log)
     if not bool(baseline_gate.get("passed", False)):
         _write_sprint_audit(
             manifest=_ctx.resolved,
@@ -4759,7 +4960,10 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 specs_succeeded=0,
                 specs_failed=total,
                 specs_skipped=0,
-                total_cost_usd=0.0,
+                # Spend reaching the abort, not a placeholder: the pre-gate
+                # entry-intake remediation folded above is real money and the
+                # operator sees it here or nowhere (#2434).
+                total_cost_usd=_sprint_state.cost.spent,
                 budget_usd=_ctx.resolved.budget_usd,
                 results=[],
                 stopped_reason="broken_baseline",
@@ -4789,22 +4993,8 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
     # inheriting under a ``carried:`` prefix, so an operator acceptance made for
     # an earlier occurrence never absorbs a new unknown nobody has bounded
     # (#2310).
-    # Entry-level intake remediation runs in the CLI before run_sprint and
-    # spends the same sprint-authorized budget; fold its agent cost into
-    # the sprint total so operator-visible accounting matches actual spend.
-    if _ctx.entry_intake_outcomes:
-        for _issue_num, _entry_outcome in _ctx.entry_intake_outcomes.items():
-            if _intake_outcome_cost_measured(_entry_outcome) is None:
-                _sprint_state.cost.flag_unmeasured_here(f"entry-intake:issue-{_issue_num}")
-        _entry_intake_cost = sum(
-            _intake_outcome_cost(o) for o in _ctx.entry_intake_outcomes.values()
-        )
-        if _entry_intake_cost > 0.0:
-            _sprint_state.cost.add(_entry_intake_cost)
-            _log(
-                f"Entry-intake remediation cost: ${_entry_intake_cost:.4f} "
-                "(rolled into sprint total)"
-            )
+    # Entry-intake remediation spend is folded in above, before the baseline-gate
+    # abort, so an abort reports it too (#2434).
     if _ctx.notify and _ctx.config.notifications.backend not in ("ntfy", "none"):
         from ..notify_backends import send_notifications
 

--- a/tests/test_sprint_baseline_gate.py
+++ b/tests/test_sprint_baseline_gate.py
@@ -589,3 +589,193 @@ def test_every_baseline_record_answers_whether_it_left_processes(tmp_path: Path)
     early = _run_baseline_gate(replace(config, project_root=not_a_checkout), resolved)
     assert early["passed"] is False
     assert early["process_teardowns"] == []
+
+
+# --- confirmation of a failing baseline gate (#2434) -------------------------
+
+
+def _flaky_gate_command(marker: Path) -> str:
+    """A gate that fails its first invocation and passes every one after.
+
+    Stands in for the process-teardown/sandbox flakes that fail one run of an
+    8,000-test suite and pass the next against the identical commit.
+    """
+    return (
+        'python -c "import pathlib, sys; '
+        f"m = pathlib.Path(r'{marker}'); first = not m.exists(); m.write_text('ran'); "
+        "print('FLAKE-FAILURE' if first else 'CLEAN-RERUN'); "
+        'sys.exit(1 if first else 0)"'
+    )
+
+
+def _counting_gate_command(counter: Path, *, exit_code: int) -> str:
+    return (
+        'python -c "import pathlib, sys; '
+        f"c = pathlib.Path(r'{counter}'); "
+        "c.write_text(str(int(c.read_text() or 0) + 1) if c.exists() else '1'); "
+        "print('GATE-RAN'); "
+        f'sys.exit({exit_code})"'
+    )
+
+
+def test_baseline_gate_failure_that_does_not_reproduce_does_not_break_the_baseline(
+    tmp_path: Path,
+) -> None:
+    """One failing invocation is not evidence about the merge base (#2434).
+
+    The gate fails, an immediate re-run of the identical command against the
+    identical worktree passes, and the sprint is allowed to start — the verdict
+    that decides whether work may begin is the one that reproduced.
+    """
+    config, resolved, base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command=_flaky_gate_command(tmp_path / "flake.marker"),
+        ),
+    )
+
+    baseline = _run_baseline_gate(config, resolved, run_id="abc123")
+
+    assert baseline["passed"] is True
+    assert baseline["status"] == "pass_unreproduced_failure"
+    assert baseline["merge_base"] == base_commit
+    # The ambiguity is on the record, not smoothed away into a plain pass.
+    assert baseline["confirmation_attempted"] is True
+    assert baseline["failure_reproduced"] is False
+    assert baseline["initial_result"]["exit_code"] == 1
+    assert baseline["confirmation_result"]["decision"] == "PASS"
+    assert "did not reproduce" in str(baseline["message"])
+
+
+def test_an_unreproduced_baseline_failure_leaves_no_preserved_worktree(
+    tmp_path: Path,
+) -> None:
+    """Nothing halted, so nothing is preserved — but the failure is still recorded.
+
+    Preservation exists so a halting failure can be reproduced in the workspace
+    that produced it. A first run that vanished on re-run halts nothing; leaking
+    a worktree per flake would spend disk on every one of them. Its output is
+    still written, under a filename that cannot be read as a halting verdict's
+    evidence.
+    """
+    config, resolved, _base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command=_flaky_gate_command(tmp_path / "flake.marker"),
+        ),
+    )
+
+    baseline = _run_baseline_gate(config, resolved, run_id="abc123")
+
+    assert baseline.get("worktree") is None
+    assert _preserved_temp_roots(tmp_path) == []
+    assert "forge-baseline-" not in _git(tmp_path, "worktree", "list")
+
+    evidence_path = Path(str(baseline["evidence_path"]))
+    assert evidence_path.name == "run-abc123-baseline-gate-unreproduced-failure.txt"
+    evidence = evidence_path.read_text(encoding="utf-8")
+    assert "FLAKE-FAILURE" in evidence
+    assert "NOT REPRODUCED" in evidence
+
+
+def test_a_baseline_failure_is_re_run_once_before_it_is_believed(tmp_path: Path) -> None:
+    """Exactly two runs on a failure, exactly one on a pass.
+
+    The confirmation doubles a many-minute gate's wall time, so it is spent only
+    where the answer could change the sprint's fate.
+    """
+    config, resolved, _base_commit = _init_repo(tmp_path)
+    failing_counter = tmp_path / "failing.count"
+    config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command=_counting_gate_command(failing_counter, exit_code=1),
+        ),
+    )
+
+    baseline = _run_baseline_gate(config, resolved)
+
+    assert baseline["passed"] is False
+    assert failing_counter.read_text(encoding="utf-8") == "2"
+
+    passing_counter = tmp_path / "passing.count"
+    passing_config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command=_counting_gate_command(passing_counter, exit_code=0),
+        ),
+    )
+
+    passing = _run_baseline_gate(passing_config, resolved)
+
+    assert passing["passed"] is True
+    assert passing["confirmation_attempted"] is False
+    assert passing["failure_reproduced"] is None
+    assert passing_counter.read_text(encoding="utf-8") == "1"
+
+
+def test_a_reproduced_baseline_failure_still_breaks_the_baseline(tmp_path: Path) -> None:
+    """A failure that repeats is the merge base's verdict and halts the sprint."""
+    config, resolved, _base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(config.validation, gate_command=_LONG_FAILING_GATE),
+    )
+
+    baseline = _run_baseline_gate(config, resolved, run_id="abc123")
+
+    assert baseline["passed"] is False
+    assert baseline["status"] == "fail"
+    assert baseline["confirmation_attempted"] is True
+    assert baseline["failure_reproduced"] is True
+    assert baseline["initial_result"]["exit_code"] == 1
+    assert baseline["confirmation_result"]["decision"] == "FAIL"
+    assert "reproduced" in str(baseline["message"])
+    # The halting outcome keeps everything it kept before the re-run existed.
+    assert Path(str(baseline["worktree"])).is_dir()
+    assert _EARLY_MARKER in Path(str(baseline["evidence_path"])).read_text(encoding="utf-8")
+
+
+def test_an_unreproduced_baseline_failure_lets_the_sprint_run_its_stories(
+    tmp_path: Path,
+) -> None:
+    """Seam test: the sprint that would have aborted now starts its work.
+
+    Exercises the whole path — gate, confirmation, run_sprint's abort branch —
+    rather than _run_baseline_gate's return value alone, because the abort is
+    what cost the overnight window in the reported occurrence.
+    """
+    config, resolved, _base_commit = _init_repo(tmp_path)
+    config = replace(
+        config,
+        validation=replace(
+            config.validation,
+            gate_command=_flaky_gate_command(tmp_path / "flake.marker"),
+        ),
+    )
+
+    with (
+        patch("theforge.coordinator.workspace.assert_base_branch_checked_out"),
+        patch("theforge.sprint.runner.run_task", return_value=_fake_result()) as mock_run_task,
+        patch("theforge.sprint.runner._write_sprint_summary"),
+        # The fixture repo sits on the feature branch, which the audit publish
+        # refuses; unrelated to what this test pins.
+        patch("theforge.sprint.runner._commit_story_run_audits"),
+    ):
+        result = run_sprint_ctx(config, resolved, no_pull=True, run_id="abc123")
+
+    assert mock_run_task.called
+    assert result.specs_succeeded == 1
+
+    audit_path = tmp_path / ".forge" / "audits" / "sprint-audit.yaml"
+    audit = yaml.safe_load(audit_path.read_text(encoding="utf-8"))
+    baseline_check = audit["baseline_check"]
+    assert baseline_check["passed"] is True
+    assert baseline_check["failure_reproduced"] is False
+    assert baseline_check["initial_result"]["exit_code"] == 1

--- a/tests/test_sprint_intake_remediation_cost.py
+++ b/tests/test_sprint_intake_remediation_cost.py
@@ -354,6 +354,64 @@ class TestResumeReloadsIntakeCost:
         assert sprint_result.specs_succeeded == 2
 
 
+class TestBrokenBaselineAbortCost:
+    """An abort before any story starts has still spent money (#2434).
+
+    Entry-level intake remediation runs before the baseline gate does. When the
+    gate then refuses the sprint, the audit is the only place that spend is ever
+    reported — an operator deciding whether to retry reads it there or nowhere.
+    """
+
+    def test_broken_baseline_audit_reports_pre_gate_remediation_spend(
+        self, tmp_path: Path
+    ) -> None:
+        import yaml
+
+        _make_spec_file(tmp_path, "Feature A", "feature-a")
+        manifest_path = _make_manifest(tmp_path, ["feature-a.md"])
+        config = _make_config(tmp_path)
+
+        broken_baseline = {
+            "passed": False,
+            "status": "fail",
+            "exit_code": 1,
+            "duration_seconds": 2.5,
+            "confirmation_attempted": True,
+            "failure_reproduced": True,
+            "message": "Broken baseline: configured gate failed on sprint merge base abc123",
+        }
+        entry_outcomes = {
+            12345: _passed_outcome_with_cost("issue-12345", INTAKE_REMEDIATION_COST_USD)
+        }
+
+        with (
+            patch(
+                "theforge.sprint.runner._run_baseline_gate",
+                return_value=broken_baseline,
+            ),
+            patch("theforge.sprint.runner.run_batch_preflight") as mock_preflight,
+            patch("theforge.sprint.runner.run_task") as mock_run_task,
+            pytest.raises(RuntimeError, match="Broken baseline"),
+        ):
+            run_sprint_ctx(
+                config,
+                manifest_path,
+                no_pull=True,
+                entry_intake_outcomes=entry_outcomes,
+            )
+
+        assert not mock_preflight.called
+        assert not mock_run_task.called
+
+        audit = yaml.safe_load(
+            (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text(encoding="utf-8")
+        )
+        assert audit["sprint"]["stopped_reason"] == "broken_baseline"
+        assert audit["sprint"]["total_cost_usd"] == pytest.approx(
+            INTAKE_REMEDIATION_COST_USD, abs=1e-6
+        ), "a broken-baseline abort must report what reaching it cost, not 0.0"
+
+
 class TestAllSkippedQueryModeIntakeCost:
     """Query-mode all-skipped path bypasses run_sprint and writes the audit
     via _emit_all_skipped_audit. Entry intake remediation may have spent


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The implementation satisfies the sprint baseline rerun and abort-cost requirements; focused regression tests pass. | [google-gemini-3.5-flash-api] The sprint baseline gate successfully confirms failures with an immediate re-run and accurately records costs upon aborts.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $7.47
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A gate verdict that does not reproduce aborts a sprint before any work begins, and the same gate passes on the next run with nothing changed (GitHub Issue #2434)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2434