### PR TITLE
A reviewer is told its approval depends on a gate result it is never given, so it runs the authoritative gate again itself moments after the coordinator already did

### DIFF
--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -2421,6 +2421,8 @@ def _run_review_only_phase(
         assembled_context=review_context,
         sandboxed=state.sandboxed,
         containment=state.dev_containment,
+        authoritative_gate_decision=state.last_gate_decision,
+        authoritative_gate_commit=state.last_gate_commit,
         p2_policy=config.dev.p2_policy,
     )
 

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -779,6 +779,8 @@ def _run_review_pool(
                     assembled_context=review_context,
                     sandboxed=state.sandboxed,
                     containment=state.dev_containment,
+                    authoritative_gate_decision=state.last_gate_decision,
+                    authoritative_gate_commit=state.last_gate_commit,
                     fix_claim_flags=fix_claim_flags,
                     p2_policy=config.dev.p2_policy,
                 )
@@ -804,6 +806,8 @@ def _run_review_pool(
                 assembled_context=review_context,
                 sandboxed=state.sandboxed,
                 containment=state.dev_containment,
+                authoritative_gate_decision=state.last_gate_decision,
+                authoritative_gate_commit=state.last_gate_commit,
                 fix_claim_flags=fix_claim_flags,
                 p2_policy=config.dev.p2_policy,
             )

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -515,6 +515,11 @@ def build_review_prompt(
         - **Full-gate ownership is coordinator-only.** Do NOT run the full
           authoritative gate yourself when the supplied `Authoritative gate commit`
           still matches the HEAD you are reviewing; rely on the supplied verdict.
+        - When the supplied gate evidence is current for the reviewed HEAD but
+          the authoritative verdict is a non-`PASS` value such as `FAIL`,
+          `ERROR`, or `SKIPPED`, do NOT rerun the full gate. Review the diff on
+          its merits, and if your conclusion depends on the non-`PASS` gate
+          state, say so explicitly in `summary`.
         - You MAY run the full authoritative gate only when the supplied gate
           evidence is missing or stale for the current HEAD — for example, if
           `Authoritative gate commit` is `UNAVAILABLE` or no longer matches

--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -171,6 +171,8 @@ def build_review_prompt(
     assembled_context: ContextPack | None = None,
     sandboxed: bool = True,
     containment: str | None = None,
+    authoritative_gate_decision: str | None = None,
+    authoritative_gate_commit: str | None = None,
     fix_claim_flags: list[str] | None = None,
     p2_policy: str = "in_scope",
 ) -> str:
@@ -417,6 +419,8 @@ def build_review_prompt(
         )
     else:
         sandbox_label = "enabled" if sandboxed else _containment_labels["none"]
+    gate_decision_label = authoritative_gate_decision or "UNAVAILABLE"
+    gate_commit_label = authoritative_gate_commit or "UNAVAILABLE"
     _hard_block = render_hard_conventions_block(
         stack=stack,
         allowed_root_files=allowed_root_files,
@@ -440,6 +444,8 @@ def build_review_prompt(
         Treat it as authoritative over any self-reported handoff claims.
 
         Sandbox isolation: {sandbox_label}
+        Authoritative gate verdict: {gate_decision_label}
+        Authoritative gate commit: {gate_commit_label}
 
         Verified commit log (`git log --oneline main..HEAD`):
         ```
@@ -502,9 +508,18 @@ def build_review_prompt(
         ## Rules
 
         - **Default to APPROVE.** If the code satisfies every acceptance criterion
-          and the gate passes, it should be approved even if you'd do it differently.
+          and the coordinator's authoritative gate verdict for the reviewed HEAD is
+          `PASS`, it should be approved even if you'd do it differently.
         - verdict MUST be `APPROVE` if there are zero P1 findings
         - verdict MUST be `REQUEST_CHANGES` if any P1 finding exists
+        - **Full-gate ownership is coordinator-only.** Do NOT run the full
+          authoritative gate yourself when the supplied `Authoritative gate commit`
+          still matches the HEAD you are reviewing; rely on the supplied verdict.
+        - You MAY run the full authoritative gate only when the supplied gate
+          evidence is missing or stale for the current HEAD — for example, if
+          `Authoritative gate commit` is `UNAVAILABLE` or no longer matches
+          `git rev-parse HEAD`. When that happens, note the mismatch in `summary`
+          so the coordinator can refresh the authoritative result.
         - A P1 must cite a concrete failure: file + line + what breaks. "Could be
           improved" or "might cause issues" is P2, not P1.
         - **Verify before asserting.** Before filing a P1 about a runtime behavior,

--- a/tests/test_coord_review_phase_cycle.py
+++ b/tests/test_coord_review_phase_cycle.py
@@ -32,7 +32,7 @@ from theforge.config import (
 )
 from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.engine import run_from_review, run_review_only, run_task
-from theforge.coordinator.state import Phase
+from theforge.coordinator.state import CoordinatorState, Phase
 
 
 class TestReviewOnly:
@@ -158,6 +158,39 @@ class TestReviewOnly:
             result = run_review_only(config, task, workspace)
             assert result.state.dev_iteration == 0
             assert len(result.state.dev_results) == 0
+
+    @patch("theforge.coordinator.review_phase.build_review_prompt")
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.engine._fresh_run_state")
+    @patch_gate_shell()
+    def test_review_only_prompt_builder_receives_authoritative_gate_evidence(
+        self, mock_shell, mock_fresh_state, mock_pool, mock_prompt_builder, tmp_path
+    ):
+        """Review-only prompt construction keeps coordinator-owned gate evidence."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.return_value = (True, "", 0, False)
+        seeded_state = CoordinatorState()
+        seeded_state.last_gate_decision = "PASS"
+        seeded_state.last_gate_commit = "abc1234deadbeef"
+        mock_fresh_state.return_value = seeded_state
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+        mock_prompt_builder.return_value = "review prompt"
+
+        result = run_review_only(config, task, workspace)
+
+        assert result.success is True
+        mock_prompt_builder.assert_called_once()
+        call_args = mock_prompt_builder.call_args
+        assert call_args.kwargs["mode"] == config.review_pool[0].mode
+        assert call_args.kwargs["p2_policy"] == "in_scope"
+        assert call_args.kwargs["authoritative_gate_decision"] == "PASS"
+        assert call_args.kwargs["authoritative_gate_commit"] == "abc1234deadbeef"
 
 
 class TestRunFromReview:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -281,6 +281,8 @@ class TestCoordinatorHybridRunner:
         call_args = mock_prompt_builder.call_args_list[0]
         assert call_args.kwargs["mode"] == "api"
         assert call_args.kwargs["p2_policy"] == "in_scope"
+        assert call_args.kwargs["authoritative_gate_decision"] == "PASS"
+        assert call_args.kwargs["authoritative_gate_commit"]
 
     @patch("theforge.coordinator.review_pool.build_review_prompt")
     @patch("theforge.coordinator.review_pool.run_agent_pool")

--- a/tests/test_task_review.py
+++ b/tests/test_task_review.py
@@ -652,6 +652,26 @@ class TestReviewPromptGateEvidence:
         assert "`git rev-parse HEAD`" in prompt
         assert "note the mismatch in `summary`" in prompt
 
+    def test_review_prompt_handles_current_non_pass_gate_without_rerunning(
+        self, review_task: TaskStory
+    ) -> None:
+        prompt = build_review_prompt(
+            review_task,
+            **_REVIEW_COMMON_KWARGS,
+            authoritative_gate_decision="SKIPPED",
+            authoritative_gate_commit="abc1234deadbeef",
+        )
+
+        assert "authoritative verdict is a non-`PASS` value such as `FAIL`," in prompt
+        assert "`ERROR`, or `SKIPPED`" in prompt
+        assert "do NOT rerun the full gate" in prompt
+        review_on_merits = (
+            "Review the diff on\n          its merits" in prompt
+            or "Review the diff on its merits" in prompt
+        )
+        assert review_on_merits
+        assert "say so explicitly in `summary`" in prompt
+
 
 class TestNotesConventionInReviewPrompt:
     """Verify review prompt includes Notes guidance."""

--- a/tests/test_task_review.py
+++ b/tests/test_task_review.py
@@ -616,6 +616,43 @@ class TestReviewPromptEvidenceRules:
         assert "active P2 policy (`in_scope`)" in prompt
 
 
+class TestReviewPromptGateEvidence:
+    def test_review_prompt_surfaces_authoritative_gate_verdict_and_commit(
+        self, review_task: TaskStory
+    ) -> None:
+        prompt = build_review_prompt(
+            review_task,
+            **_REVIEW_COMMON_KWARGS,
+            authoritative_gate_decision="PASS",
+            authoritative_gate_commit="abc1234deadbeef",
+        )
+
+        assert "Authoritative gate verdict: PASS" in prompt
+        assert "Authoritative gate commit: abc1234deadbeef" in prompt
+        assert "coordinator's authoritative gate verdict for the reviewed HEAD" in prompt
+
+    def test_review_prompt_forbids_redundant_full_gate_when_evidence_matches(
+        self, review_task: TaskStory
+    ) -> None:
+        prompt = build_review_prompt(review_task, **_REVIEW_COMMON_KWARGS)
+
+        assert "Full-gate ownership is coordinator-only" in prompt
+        assert "Do NOT run the full" in prompt
+        assert "authoritative gate yourself" in prompt
+        assert "supplied `Authoritative gate commit`" in prompt
+        assert "still matches the HEAD you are reviewing" in prompt
+
+    def test_review_prompt_allows_refresh_only_when_gate_evidence_missing_or_stale(
+        self, review_task: TaskStory
+    ) -> None:
+        prompt = build_review_prompt(review_task, **_REVIEW_COMMON_KWARGS)
+
+        assert "You MAY run the full authoritative gate only when the supplied gate" in prompt
+        assert "`Authoritative gate commit` is `UNAVAILABLE`" in prompt
+        assert "`git rev-parse HEAD`" in prompt
+        assert "note the mismatch in `summary`" in prompt
+
+
 class TestNotesConventionInReviewPrompt:
     """Verify review prompt includes Notes guidance."""
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The prior review-only coverage gap is fixed, and the reviewer prompt now receives and renders coordinator-owned gate evidence with clear full-gate ownership rules. | [anthropic-opus-cli] Cycle-1 P1 (untested review-only call site) is fixed by a passing seam test in tests/test_coord_review_phase_cycle.py, and the non-PASS gate-state gap is now covered by an explicit prompt rule plus a test; iteration 2 adds only prompt text and tests, no regressions, full test_task_review.py (53) and test_coord_review_phase_cycle.py (26) pass and ruff is clean.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $3.58
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

A reviewer is told its approval depends on a gate result it is never given, so it runs the authoritative gate again itself moments after the coordinator already did (GitHub Issue #2437)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2437