### PR TITLE
The provider readiness check exercises a request shape no phase uses, so a model that fails every tool-bearing invocation is reported ready

### DIFF
--- a/src/theforge/cli/provider_readiness.py
+++ b/src/theforge/cli/provider_readiness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +16,7 @@ from theforge.config import (
     DEFAULT_PREFLIGHT_PROFILE,
     DEFAULT_REVIEW_PROFILE,
     ForgeConfig,
+    resolve_preflight_tools,
 )
 from theforge.config.profiles import iter_config_profiles, iter_plan_phase_profiles
 from theforge.config.types import ModelProfile
@@ -138,13 +140,14 @@ def run_readiness_probe(
 
     t0 = time.perf_counter()
     try:
-        result = run_api_agent(
-            prompt=_READINESS_PROMPT,
-            profile=profile,
-            working_dir=working_dir,
-            quiet=True,
-            secrets=secrets,
-        )
+        with tempfile.TemporaryDirectory(prefix="forge-check-providers-") as probe_dir:
+            result = run_api_agent(
+                prompt=_READINESS_PROMPT,
+                profile=profile,
+                working_dir=Path(probe_dir),
+                quiet=True,
+                secrets=secrets,
+            )
     except Exception as exc:
         return ReadinessResult(
             probe=probe,
@@ -165,15 +168,16 @@ def run_readiness_probe(
             outcome=result,
         )
 
-    payload = _structured_payload(result)
-    if payload is None or "verdict" not in payload:
-        return ReadinessResult(
-            probe=probe,
-            elapsed=elapsed,
-            status=READINESS_STATUS_FAILED,
-            detail="no valid verdict in structured output",
-            outcome=result,
-        )
+    if _requires_structured_verdict(probe):
+        payload = _structured_payload(result)
+        if payload is None or "verdict" not in payload:
+            return ReadinessResult(
+                probe=probe,
+                elapsed=elapsed,
+                status=READINESS_STATUS_FAILED,
+                detail="no valid verdict in structured output",
+                outcome=result,
+            )
 
     if not _is_local_endpoint(getattr(profile, "base_url", None)) and result.cost_usd is None:
         return ReadinessResult(
@@ -194,6 +198,7 @@ def run_readiness_probe(
 
 
 def _probe_for_profile(role: str, profile: ModelProfile) -> ReadinessProbe:
+    profile = _project_probe_profile(role, profile)
     allowed_tools = tuple(profile.allowed_tools or ())
     capability = (
         READINESS_CAPABILITY_TOOL_STRUCTURED
@@ -240,6 +245,19 @@ def _agent_role_probes(agent: object) -> list[ReadinessProbe]:
             _agent_to_profile(agent, role="review", allowed_tools=review_tools),
         ),
     ]
+
+
+def _project_probe_profile(role: str, profile: ModelProfile) -> ModelProfile:
+    if role != "agent-dev":
+        return profile
+    return dataclasses.replace(
+        profile,
+        allowed_tools=resolve_preflight_tools(profile.allowed_tools),
+    )
+
+
+def _requires_structured_verdict(probe: ReadinessProbe) -> bool:
+    return probe.profile.phase not in {"dev", "preflight"}
 
 
 def _structured_payload(result: AgentResult) -> dict | None:

--- a/src/theforge/cli/provider_readiness.py
+++ b/src/theforge/cli/provider_readiness.py
@@ -75,7 +75,6 @@ def build_readiness_probes(config: ForgeConfig) -> list[ReadinessProbe]:
     advisor_profile = dataclasses.replace(
         config.preflight_profile,
         allowed_tools=DEFAULT_INVESTIGATION_TOOLS,
-        phase="advisor",
     )
     probes.append(_probe_for_profile("advisor", advisor_profile))
 

--- a/src/theforge/cli/provider_readiness.py
+++ b/src/theforge/cli/provider_readiness.py
@@ -10,19 +10,27 @@ from pathlib import Path
 
 from theforge.agent_types import AgentResult
 from theforge.assignment import _agent_to_profile
-from theforge.config import DEFAULT_INVESTIGATION_TOOLS, DEFAULT_PREFLIGHT_PROFILE, ForgeConfig
+from theforge.config import (
+    DEFAULT_INVESTIGATION_TOOLS,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    ForgeConfig,
+)
 from theforge.config.profiles import iter_config_profiles, iter_plan_phase_profiles
+from theforge.config.types import ModelProfile
 from theforge.runners.api import run_api_agent
 from theforge.runners.schema_utils import openai_function_tool_request_shape
 
 READINESS_STATUS_READY = "ready"
 READINESS_STATUS_FAILED = "failed"
+READINESS_STATUS_UNTESTED = "untested"
 READINESS_STATUS_UNSUPPORTED = "unsupported"
 READINESS_STATUS_COST_UNAVAILABLE = "cost-unavailable"
 
 READINESS_STATUSES: tuple[str, ...] = (
     READINESS_STATUS_READY,
     READINESS_STATUS_FAILED,
+    READINESS_STATUS_UNTESTED,
     READINESS_STATUS_UNSUPPORTED,
     READINESS_STATUS_COST_UNAVAILABLE,
 )
@@ -43,7 +51,7 @@ class ReadinessProbe:
 
     role: str
     capability: str
-    profile: object
+    profile: ModelProfile
 
 
 @dataclass(frozen=True)
@@ -70,7 +78,7 @@ def build_readiness_probes(config: ForgeConfig) -> list[ReadinessProbe]:
             continue
         probes.append(_probe_for_profile(role, profile))
     for role, profile in iter_plan_phase_profiles(config):
-        probes.append(_probe_for_profile(role, profile))
+        probes.append(_probe_for_profile(role, _stamp_phase(profile, role)))
 
     advisor_profile = dataclasses.replace(
         config.preflight_profile,
@@ -79,30 +87,23 @@ def build_readiness_probes(config: ForgeConfig) -> list[ReadinessProbe]:
     probes.append(_probe_for_profile("advisor", advisor_profile))
 
     for agent in config.agents:
-        probes.extend(
-            [
-                _probe_for_profile("agent-dev", _agent_to_profile(agent, role="dev")),
-                _probe_for_profile(
-                    "agent-preflight",
-                    _agent_to_profile(
-                        agent,
-                        role="preflight",
-                        allowed_tools=DEFAULT_PREFLIGHT_PROFILE.allowed_tools,
-                    ),
-                ),
-                _probe_for_profile("agent-planner", _agent_to_profile(agent, role="review")),
-                _probe_for_profile("agent-plan-review", _agent_to_profile(agent, role="review")),
-                _probe_for_profile("agent-code-review", _agent_to_profile(agent, role="review")),
-            ]
-        )
+        probes.extend(_agent_role_probes(agent))
 
     deduped: list[ReadinessProbe] = []
-    seen: set[tuple[str, str, object]] = set()
+    seen: set[tuple[str, str, str, str, str | None, tuple[str, ...], str | None]] = set()
     for probe in probes:
         profile = probe.profile
-        if getattr(profile, "mode", None) != "api":
+        if profile.mode != "api":
             continue
-        key = (probe.role, probe.capability, profile)
+        key = (
+            probe.role,
+            probe.capability,
+            profile.name,
+            profile.model,
+            profile.provider,
+            profile.allowed_tools,
+            profile.phase,
+        )
         if key in seen:
             continue
         seen.add(key)
@@ -120,8 +121,8 @@ def run_readiness_probe(
     profile = probe.profile
     if (
         probe.capability == READINESS_CAPABILITY_TOOL_STRUCTURED
-        and getattr(profile, "provider", None) == "openai"
-        and not _is_local_endpoint(getattr(profile, "base_url", None))
+        and profile.provider == "openai"
+        and not _is_local_endpoint(profile.base_url)
     ):
         tool_shape = openai_function_tool_request_shape(profile.model)
         if tool_shape.transport == "unsupported":
@@ -192,14 +193,53 @@ def run_readiness_probe(
     )
 
 
-def _probe_for_profile(role: str, profile: object) -> ReadinessProbe:
-    allowed_tools = tuple(getattr(profile, "allowed_tools", ()) or ())
+def _probe_for_profile(role: str, profile: ModelProfile) -> ReadinessProbe:
+    allowed_tools = tuple(profile.allowed_tools or ())
     capability = (
         READINESS_CAPABILITY_TOOL_STRUCTURED
         if allowed_tools
         else READINESS_CAPABILITY_PLAIN_STRUCTURED
     )
     return ReadinessProbe(role=role, capability=capability, profile=profile)
+
+
+def _stamp_phase(profile: ModelProfile, role: str) -> ModelProfile:
+    phase = profile.phase
+    if role == "plan":
+        phase = "plan"
+    elif role == "plan-review":
+        phase = "plan_review"
+    return dataclasses.replace(profile, phase=phase)
+
+
+def _agent_role_probes(agent: object) -> list[ReadinessProbe]:
+    planner_profile = _agent_to_profile(
+        agent,
+        role="plan",
+        allowed_tools=DEFAULT_INVESTIGATION_TOOLS,
+    )
+    review_tools = DEFAULT_REVIEW_PROFILE.allowed_tools
+    plan_review_profile = dataclasses.replace(
+        _agent_to_profile(agent, role="review", allowed_tools=review_tools),
+        phase="plan_review",
+    )
+    return [
+        _probe_for_profile("agent-dev", _agent_to_profile(agent, role="dev")),
+        _probe_for_profile(
+            "agent-preflight",
+            _agent_to_profile(
+                agent,
+                role="preflight",
+                allowed_tools=DEFAULT_PREFLIGHT_PROFILE.allowed_tools,
+            ),
+        ),
+        _probe_for_profile("agent-planner", planner_profile),
+        _probe_for_profile("agent-plan-review", plan_review_profile),
+        _probe_for_profile(
+            "agent-code-review",
+            _agent_to_profile(agent, role="review", allowed_tools=review_tools),
+        ),
+    ]
 
 
 def _structured_payload(result: AgentResult) -> dict | None:
@@ -216,10 +256,10 @@ def _is_local_endpoint(base_url: str | None) -> bool:
     return bool(base_url and ("localhost" in base_url or "127.0.0.1" in base_url))
 
 
-def _success_suffix(*, profile: object, result: AgentResult, elapsed: float) -> str:
-    if _is_local_endpoint(getattr(profile, "base_url", None)) or result.cost_usd == 0.0:
+def _success_suffix(*, profile: ModelProfile, result: AgentResult, elapsed: float) -> str:
+    if _is_local_endpoint(profile.base_url) or result.cost_usd == 0.0:
         cost_str = "$0.000"
     else:
         cost_str = f"${result.cost_usd:.3f}"
-    local_tag = " [local]" if _is_local_endpoint(getattr(profile, "base_url", None)) else ""
+    local_tag = " [local]" if _is_local_endpoint(profile.base_url) else ""
     return f"{elapsed:.1f}s  {cost_str}{local_tag}"

--- a/src/theforge/cli/provider_readiness.py
+++ b/src/theforge/cli/provider_readiness.py
@@ -1,0 +1,226 @@
+"""Capability-level readiness probes for ``forge check-providers``."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from theforge.agent_types import AgentResult
+from theforge.assignment import _agent_to_profile
+from theforge.config import DEFAULT_INVESTIGATION_TOOLS, DEFAULT_PREFLIGHT_PROFILE, ForgeConfig
+from theforge.config.profiles import iter_config_profiles, iter_plan_phase_profiles
+from theforge.runners.api import run_api_agent
+from theforge.runners.schema_utils import openai_function_tool_request_shape
+
+READINESS_STATUS_READY = "ready"
+READINESS_STATUS_FAILED = "failed"
+READINESS_STATUS_UNSUPPORTED = "unsupported"
+READINESS_STATUS_COST_UNAVAILABLE = "cost-unavailable"
+
+READINESS_STATUSES: tuple[str, ...] = (
+    READINESS_STATUS_READY,
+    READINESS_STATUS_FAILED,
+    READINESS_STATUS_UNSUPPORTED,
+    READINESS_STATUS_COST_UNAVAILABLE,
+)
+
+READINESS_CAPABILITY_PLAIN_STRUCTURED = "plain-structured"
+READINESS_CAPABILITY_TOOL_STRUCTURED = "tool-structured"
+
+_READINESS_PROMPT = (
+    "Review this diff: -    x = 1\n+    x = 2\n\n"
+    "Respond with JSON containing a 'verdict' field set to APPROVE or REQUEST_CHANGES, "
+    "and a 'summary' field with a one-line explanation."
+)
+
+
+@dataclass(frozen=True)
+class ReadinessProbe:
+    """One capability the provider check should exercise."""
+
+    role: str
+    capability: str
+    profile: object
+
+
+@dataclass(frozen=True)
+class ReadinessResult:
+    """Outcome of one readiness probe."""
+
+    probe: ReadinessProbe
+    elapsed: float
+    status: str
+    detail: str
+    outcome: AgentResult | Exception | None = None
+
+    @property
+    def ready(self) -> bool:
+        return self.status == READINESS_STATUS_READY
+
+
+def build_readiness_probes(config: ForgeConfig) -> list[ReadinessProbe]:
+    """Derive the API capability probes production can actually dispatch."""
+    probes: list[ReadinessProbe] = []
+
+    for role, profile in iter_config_profiles(config):
+        if role == "agent-pool":
+            continue
+        probes.append(_probe_for_profile(role, profile))
+    for role, profile in iter_plan_phase_profiles(config):
+        probes.append(_probe_for_profile(role, profile))
+
+    advisor_profile = dataclasses.replace(
+        config.preflight_profile,
+        allowed_tools=DEFAULT_INVESTIGATION_TOOLS,
+        phase="advisor",
+    )
+    probes.append(_probe_for_profile("advisor", advisor_profile))
+
+    for agent in config.agents:
+        probes.extend(
+            [
+                _probe_for_profile("agent-dev", _agent_to_profile(agent, role="dev")),
+                _probe_for_profile(
+                    "agent-preflight",
+                    _agent_to_profile(
+                        agent,
+                        role="preflight",
+                        allowed_tools=DEFAULT_PREFLIGHT_PROFILE.allowed_tools,
+                    ),
+                ),
+                _probe_for_profile("agent-planner", _agent_to_profile(agent, role="review")),
+                _probe_for_profile("agent-plan-review", _agent_to_profile(agent, role="review")),
+                _probe_for_profile("agent-code-review", _agent_to_profile(agent, role="review")),
+            ]
+        )
+
+    deduped: list[ReadinessProbe] = []
+    seen: set[tuple[str, str, object]] = set()
+    for probe in probes:
+        profile = probe.profile
+        if getattr(profile, "mode", None) != "api":
+            continue
+        key = (probe.role, probe.capability, profile)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(probe)
+    return deduped
+
+
+def run_readiness_probe(
+    probe: ReadinessProbe,
+    *,
+    working_dir: Path,
+    secrets: dict[str, str] | None,
+) -> ReadinessResult:
+    """Exercise one capability probe and classify the outcome."""
+    profile = probe.profile
+    if (
+        probe.capability == READINESS_CAPABILITY_TOOL_STRUCTURED
+        and getattr(profile, "provider", None) == "openai"
+        and not _is_local_endpoint(getattr(profile, "base_url", None))
+    ):
+        tool_shape = openai_function_tool_request_shape(profile.model)
+        if tool_shape.transport == "unsupported":
+            return ReadinessResult(
+                probe=probe,
+                elapsed=0.0,
+                status=READINESS_STATUS_UNSUPPORTED,
+                detail=(
+                    "not exercised: no supported OpenAI tool-bearing request shape "
+                    "is configured for this model"
+                ),
+            )
+
+    t0 = time.perf_counter()
+    try:
+        result = run_api_agent(
+            prompt=_READINESS_PROMPT,
+            profile=profile,
+            working_dir=working_dir,
+            quiet=True,
+            secrets=secrets,
+        )
+    except Exception as exc:
+        return ReadinessResult(
+            probe=probe,
+            elapsed=time.perf_counter() - t0,
+            status=READINESS_STATUS_FAILED,
+            detail=f"{type(exc).__name__}: {exc}",
+            outcome=exc,
+        )
+
+    elapsed = time.perf_counter() - t0
+    if not result.success:
+        short_err = (result.output or "unknown error")[:120]
+        return ReadinessResult(
+            probe=probe,
+            elapsed=elapsed,
+            status=READINESS_STATUS_FAILED,
+            detail=short_err,
+            outcome=result,
+        )
+
+    payload = _structured_payload(result)
+    if payload is None or "verdict" not in payload:
+        return ReadinessResult(
+            probe=probe,
+            elapsed=elapsed,
+            status=READINESS_STATUS_FAILED,
+            detail="no valid verdict in structured output",
+            outcome=result,
+        )
+
+    if not _is_local_endpoint(getattr(profile, "base_url", None)) and result.cost_usd is None:
+        return ReadinessResult(
+            probe=probe,
+            elapsed=elapsed,
+            status=READINESS_STATUS_COST_UNAVAILABLE,
+            detail="structured result returned but cost is unavailable",
+            outcome=result,
+        )
+
+    return ReadinessResult(
+        probe=probe,
+        elapsed=elapsed,
+        status=READINESS_STATUS_READY,
+        detail=_success_suffix(profile=profile, result=result, elapsed=elapsed),
+        outcome=result,
+    )
+
+
+def _probe_for_profile(role: str, profile: object) -> ReadinessProbe:
+    allowed_tools = tuple(getattr(profile, "allowed_tools", ()) or ())
+    capability = (
+        READINESS_CAPABILITY_TOOL_STRUCTURED
+        if allowed_tools
+        else READINESS_CAPABILITY_PLAIN_STRUCTURED
+    )
+    return ReadinessProbe(role=role, capability=capability, profile=profile)
+
+
+def _structured_payload(result: AgentResult) -> dict | None:
+    if isinstance(result.structured_data, dict):
+        return result.structured_data
+    try:
+        payload = json.loads(result.output)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _is_local_endpoint(base_url: str | None) -> bool:
+    return bool(base_url and ("localhost" in base_url or "127.0.0.1" in base_url))
+
+
+def _success_suffix(*, profile: object, result: AgentResult, elapsed: float) -> str:
+    if _is_local_endpoint(getattr(profile, "base_url", None)) or result.cost_usd == 0.0:
+        cost_str = "$0.000"
+    else:
+        cost_str = f"${result.cost_usd:.3f}"
+    local_tag = " [local]" if _is_local_endpoint(getattr(profile, "base_url", None)) else ""
+    return f"{elapsed:.1f}s  {cost_str}{local_tag}"

--- a/src/theforge/cli/provider_readiness.py
+++ b/src/theforge/cli/provider_readiness.py
@@ -25,14 +25,12 @@ from theforge.runners.schema_utils import openai_function_tool_request_shape
 
 READINESS_STATUS_READY = "ready"
 READINESS_STATUS_FAILED = "failed"
-READINESS_STATUS_UNTESTED = "untested"
 READINESS_STATUS_UNSUPPORTED = "unsupported"
 READINESS_STATUS_COST_UNAVAILABLE = "cost-unavailable"
 
 READINESS_STATUSES: tuple[str, ...] = (
     READINESS_STATUS_READY,
     READINESS_STATUS_FAILED,
-    READINESS_STATUS_UNTESTED,
     READINESS_STATUS_UNSUPPORTED,
     READINESS_STATUS_COST_UNAVAILABLE,
 )
@@ -116,7 +114,6 @@ def build_readiness_probes(config: ForgeConfig) -> list[ReadinessProbe]:
 def run_readiness_probe(
     probe: ReadinessProbe,
     *,
-    working_dir: Path,
     secrets: dict[str, str] | None,
 ) -> ReadinessResult:
     """Exercise one capability probe and classify the outcome."""
@@ -198,7 +195,7 @@ def run_readiness_probe(
 
 
 def _probe_for_profile(role: str, profile: ModelProfile) -> ReadinessProbe:
-    profile = _project_probe_profile(role, profile)
+    profile = _project_probe_profile(_stamp_phase(profile, role))
     allowed_tools = tuple(profile.allowed_tools or ())
     capability = (
         READINESS_CAPABILITY_TOOL_STRUCTURED
@@ -209,11 +206,22 @@ def _probe_for_profile(role: str, profile: ModelProfile) -> ReadinessProbe:
 
 
 def _stamp_phase(profile: ModelProfile, role: str) -> ModelProfile:
-    phase = profile.phase
-    if role == "plan":
-        phase = "plan"
-    elif role == "plan-review":
-        phase = "plan_review"
+    phase_by_role = {
+        "dev": "dev",
+        "preflight": "preflight",
+        "preflight-fallback": "preflight",
+        "review": "review",
+        "synthesis": "synthesis",
+        "plan": "plan",
+        "plan-review": "plan_review",
+        "advisor": "preflight",
+        "agent-dev": "dev",
+        "agent-preflight": "preflight",
+        "agent-planner": "plan",
+        "agent-plan-review": "plan_review",
+        "agent-code-review": "review",
+    }
+    phase = phase_by_role.get(role, profile.phase)
     return dataclasses.replace(profile, phase=phase)
 
 
@@ -247,8 +255,8 @@ def _agent_role_probes(agent: object) -> list[ReadinessProbe]:
     ]
 
 
-def _project_probe_profile(role: str, profile: ModelProfile) -> ModelProfile:
-    if role != "agent-dev":
+def _project_probe_profile(profile: ModelProfile) -> ModelProfile:
+    if profile.phase != "dev":
         return profile
     return dataclasses.replace(
         profile,

--- a/src/theforge/cli/providers.py
+++ b/src/theforge/cli/providers.py
@@ -13,6 +13,7 @@ from theforge.cli.provider_readiness import (
 )
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
+from theforge.runners.api import run_api_agent as run_api_agent
 
 
 def cmd_check_providers(args: object) -> int:

--- a/src/theforge/cli/providers.py
+++ b/src/theforge/cli/providers.py
@@ -13,7 +13,8 @@ from theforge.cli.provider_readiness import (
 )
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
-from theforge.runners.api import run_api_agent as run_api_agent
+
+_MAX_READINESS_WORKERS = 4
 
 
 def cmd_check_providers(args: object) -> int:
@@ -41,12 +42,18 @@ def cmd_check_providers(args: object) -> int:
             )
             return 1
 
-    print(f"[check-providers] forge.yaml: {len(probes)} capability probe(s) found\n")
+    max_workers = min(len(probes), _MAX_READINESS_WORKERS) or 1
+    print(
+        "[check-providers] "
+        "forge.yaml: "
+        f"{len(probes)} capability probe(s) found; "
+        f"running up to {max_workers} at a time\n"
+    )
 
     working_dir = config_path.parent
 
     results = []
-    with ThreadPoolExecutor(max_workers=len(probes) or 1) as pool:
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
         futures = {
             pool.submit(
                 run_readiness_probe,

--- a/src/theforge/cli/providers.py
+++ b/src/theforge/cli/providers.py
@@ -13,7 +13,6 @@ from theforge.cli.provider_readiness import (
 )
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
-from theforge.runners.api import run_api_agent as run_api_agent
 
 
 def cmd_check_providers(args: object) -> int:

--- a/src/theforge/cli/providers.py
+++ b/src/theforge/cli/providers.py
@@ -50,15 +50,12 @@ def cmd_check_providers(args: object) -> int:
         f"running up to {max_workers} at a time\n"
     )
 
-    working_dir = config_path.parent
-
     results = []
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         futures = {
             pool.submit(
                 run_readiness_probe,
                 probe,
-                working_dir=working_dir,
                 secrets=config.secrets,
             ): probe
             for probe in probes

--- a/src/theforge/cli/providers.py
+++ b/src/theforge/cli/providers.py
@@ -1,27 +1,23 @@
-"""forge check-providers subcommand — smoke-test all API-mode profiles."""
+"""forge check-providers subcommand — exercise API provider capabilities."""
 
 from __future__ import annotations
 
-import dataclasses
 import sys
-import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from theforge.agent_types import AgentResult
+from theforge.cli.provider_readiness import (
+    READINESS_STATUS_READY,
+    build_readiness_probes,
+    run_readiness_probe,
+)
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
-from theforge.runners.api import run_api_agent
-
-_CHECK_PROVIDERS_PROMPT = (
-    "Review this diff: -    x = 1\n+    x = 2\n\n"
-    "Respond with JSON containing a 'verdict' field set to APPROVE or REQUEST_CHANGES, "
-    "and a 'summary' field with a one-line explanation."
-)
+from theforge.runners.api import run_api_agent as run_api_agent
 
 
 def cmd_check_providers(args: object) -> int:
-    """Smoke-test all API-mode profiles in forge.yaml."""
+    """Exercise every API capability forge can dispatch from forge.yaml."""
     config_path = getattr(args, "config", None)
     if config_path:
         config_path = Path(config_path)
@@ -32,112 +28,72 @@ def cmd_check_providers(args: object) -> int:
         return 1
 
     config = load_config(config_path)
-
-    # Collect all unique API profiles (by name) across all config slots.
-    seen: dict[str, object] = {}
-    candidates = [
-        config.dev_profile,
-        config.preflight_profile,
-        *config.review_pool,
-    ]
-    if config.synthesis_profile is not None:
-        candidates.append(config.synthesis_profile)
-    if config.plan_agent_review.enabled:
-        candidates.extend(config.plan_agent_review.profiles)
-
-    api_profiles = []
-    for p in candidates:
-        if p.mode == "api" and p.name not in seen:
-            seen[p.name] = p
-            api_profiles.append(p)
+    probes = build_readiness_probes(config)
 
     # Optional single-profile filter.
     profile_filter = getattr(args, "profile", None)
     if profile_filter:
-        api_profiles = [p for p in api_profiles if p.name == profile_filter]
-        if not api_profiles:
+        probes = [probe for probe in probes if probe.profile.name == profile_filter]
+        if not probes:
             print(
                 f"[check-providers] No API profile named '{profile_filter}' found in forge.yaml",
                 file=sys.stderr,
             )
             return 1
 
-    print(f"[check-providers] forge.yaml: {len(api_profiles)} API profile(s) found\n")
+    print(f"[check-providers] forge.yaml: {len(probes)} capability probe(s) found\n")
 
     working_dir = config_path.parent
 
-    def _run_one(profile: object) -> tuple:
-        # Use single-shot mode by ensuring allowed_tools is empty.
-        single_shot = dataclasses.replace(profile, allowed_tools=())
-        t0 = time.perf_counter()
-        try:
-            result: AgentResult = run_api_agent(
-                prompt=_CHECK_PROVIDERS_PROMPT,
-                profile=single_shot,
-                working_dir=working_dir,
-                quiet=True,
-                secrets=config.secrets,
-            )
-            elapsed = time.perf_counter() - t0
-            return (profile, elapsed, result)
-        except Exception as exc:
-            elapsed = time.perf_counter() - t0
-            return (profile, elapsed, exc)
-
     results = []
-    with ThreadPoolExecutor(max_workers=len(api_profiles) or 1) as pool:
-        futures = {pool.submit(_run_one, p): p for p in api_profiles}
+    with ThreadPoolExecutor(max_workers=len(probes) or 1) as pool:
+        futures = {
+            pool.submit(
+                run_readiness_probe,
+                probe,
+                working_dir=working_dir,
+                secrets=config.secrets,
+            ): probe
+            for probe in probes
+        }
         for fut in as_completed(futures):
             results.append(fut.result())
 
-    # Sort results to match original profile order.
-    order = {p.name: i for i, p in enumerate(api_profiles)}
-    results.sort(key=lambda t: order.get(t[0].name, 999))
+    order = {
+        (probe.role, probe.capability, probe.profile.name, probe.profile.model): i
+        for i, probe in enumerate(probes)
+    }
+    results.sort(
+        key=lambda result: order.get(
+            (
+                result.probe.role,
+                result.probe.capability,
+                result.probe.profile.name,
+                result.probe.profile.model,
+            ),
+            999,
+        )
+    )
 
     any_failed = False
-    for profile, elapsed, outcome in results:
+    for result in results:
+        profile = result.probe.profile
         provider = profile.provider or "?"
         model = profile.model
         name_col = f"{profile.name:<22}"
+        role_col = f"{result.probe.role:<18}"
+        capability_col = f"{result.probe.capability:<16}"
         prov_col = f"{provider:<10}"
         model_col = f"{model:<28}"
-
-        is_local = profile.base_url and (
-            "localhost" in profile.base_url or "127.0.0.1" in profile.base_url
+        if not result.ready:
+            any_failed = True
+        marker = "\u2713" if result.status == READINESS_STATUS_READY else "\u2717"
+        print(
+            f"  {name_col} {role_col} {capability_col} {prov_col} {model_col} "
+            f"{marker}  {result.status}: {result.detail}"
         )
-        local_tag = " [local]" if is_local else ""
 
-        if isinstance(outcome, Exception):
-            any_failed = True
-            print(
-                f"  {name_col} {prov_col} {model_col} \u2717  {type(outcome).__name__}: {outcome}"
-            )
-        elif not outcome.success:
-            any_failed = True
-            short_err = (outcome.output or "unknown error")[:120]
-            print(f"  {name_col} {prov_col} {model_col} \u2717  {short_err}")
-        elif outcome.structured_data is None or "verdict" not in outcome.structured_data:
-            any_failed = True
-            msg = "no valid verdict in structured output"
-            print(f"  {name_col} {prov_col} {model_col} \u2717  {msg}")
-        else:
-            if is_local or outcome.cost_usd == 0.0:
-                cost_str = "$0.000"
-            elif outcome.cost_usd is not None:
-                cost_str = f"${outcome.cost_usd:.3f}"
-            else:
-                cost_str = "$?.???"
-            suffix = f"{elapsed:.1f}s  {cost_str}{local_tag}"
-            print(f"  {name_col} {prov_col} {model_col} \u2713  {suffix}")
-
-    passed = sum(
-        1
-        for _, _, o in results
-        if not isinstance(o, Exception)
-        and o.success
-        and o.structured_data is not None
-        and "verdict" in o.structured_data
-    )
+    passed = sum(1 for result in results if result.status == READINESS_STATUS_READY)
     total = len(results)
     print(f"\n[check-providers] {passed}/{total} passed")
     return 1 if any_failed else 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -423,8 +423,8 @@ def _block_real_coordinator_runners():
             side_effect=_unexpected_call("theforge.ideate.run_agent_pool"),
         ),
         patch(
-            "theforge.cli.providers.run_api_agent",
-            side_effect=_unexpected_call("theforge.cli.providers.run_api_agent"),
+            "theforge.cli.provider_readiness.run_api_agent",
+            side_effect=_unexpected_call("theforge.cli.provider_readiness.run_api_agent"),
         ),
         patch(
             "theforge.runners.run_agent",

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -29,13 +29,13 @@ from theforge.cli import (
     cmd_init_hooks,
     cmd_secrets_init,
 )
-from theforge.cli.provider_readiness import READINESS_STATUS_COST_UNAVAILABLE
 from theforge.cli import hooks as hooks_module
 from theforge.cli.hooks import created_labels, static_issue_labels
 from theforge.cli.init_commands import _extract_forge_block
+from theforge.cli.provider_readiness import READINESS_STATUS_COST_UNAVAILABLE
 from theforge.config import (
-    AgentDef,
     DEFAULT_VALIDATION,
+    AgentDef,
     ForgeConfig,
     LogConfig,
     ModelProfile,
@@ -584,9 +584,7 @@ class TestCmdCheckProviders:
             _make_pass_result("codex-reviewer"),
         ]
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch(
-                "theforge.cli.provider_readiness.run_api_agent", side_effect=side_effects
-            ):
+            with patch("theforge.cli.provider_readiness.run_api_agent", side_effect=side_effects):
                 rc = cmd_check_providers(args)
 
         assert rc == 0
@@ -604,9 +602,7 @@ class TestCmdCheckProviders:
             _make_fail_result("codex-reviewer"),
         ]
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch(
-                "theforge.cli.provider_readiness.run_api_agent", side_effect=side_effects
-            ):
+            with patch("theforge.cli.provider_readiness.run_api_agent", side_effect=side_effects):
                 rc = cmd_check_providers(args)
 
         assert rc == 1
@@ -676,9 +672,7 @@ class TestCmdCheckProviders:
             structured_data={"summary": "no verdict here"},
         )
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch(
-                "theforge.cli.provider_readiness.run_api_agent", return_value=bad_result
-            ):
+            with patch("theforge.cli.provider_readiness.run_api_agent", return_value=bad_result):
                 rc = cmd_check_providers(args)
 
         assert rc == 1
@@ -752,7 +746,9 @@ class TestCmdCheckProviders:
         assert rc == 0
         assert mock_api.call_args.kwargs["profile"].allowed_tools == ("Read", "Grep")
 
-    def test_tool_bearing_agent_pool_failure_cannot_hide_behind_plain_probe(self, tmp_path, capsys):
+    def test_tool_bearing_agent_pool_failure_cannot_hide_behind_plain_probe(
+        self, tmp_path, capsys
+    ):
         cfg = _make_forge_config(tmp_path, review_pool=[])
         cfg = ForgeConfig(
             **{
@@ -779,9 +775,7 @@ class TestCmdCheckProviders:
             return _make_pass_result(profile.name)
 
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch(
-                "theforge.cli.provider_readiness.run_api_agent", side_effect=_side_effect
-            ):
+            with patch("theforge.cli.provider_readiness.run_api_agent", side_effect=_side_effect):
                 rc = cmd_check_providers(args)
 
         assert rc == 1
@@ -828,9 +822,7 @@ class TestCmdCheckProviders:
         )
 
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch(
-                "theforge.cli.provider_readiness.run_api_agent", return_value=unknown_cost
-            ):
+            with patch("theforge.cli.provider_readiness.run_api_agent", return_value=unknown_cost):
                 rc = cmd_check_providers(args)
 
         assert rc == 1

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -29,10 +29,12 @@ from theforge.cli import (
     cmd_init_hooks,
     cmd_secrets_init,
 )
+from theforge.cli.provider_readiness import READINESS_STATUS_COST_UNAVAILABLE
 from theforge.cli import hooks as hooks_module
 from theforge.cli.hooks import created_labels, static_issue_labels
 from theforge.cli.init_commands import _extract_forge_block
 from theforge.config import (
+    AgentDef,
     DEFAULT_VALIDATION,
     ForgeConfig,
     LogConfig,
@@ -41,6 +43,7 @@ from theforge.config import (
     PlanConfig,
     RetryPolicy,
     WorkspaceConfig,
+    transport_for,
 )
 from theforge.runners import AgentResult
 
@@ -581,7 +584,9 @@ class TestCmdCheckProviders:
             _make_pass_result("codex-reviewer"),
         ]
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch("theforge.cli.providers.run_api_agent", side_effect=side_effects):
+            with patch(
+                "theforge.cli.provider_readiness.run_api_agent", side_effect=side_effects
+            ):
                 rc = cmd_check_providers(args)
 
         assert rc == 0
@@ -599,7 +604,9 @@ class TestCmdCheckProviders:
             _make_fail_result("codex-reviewer"),
         ]
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch("theforge.cli.providers.run_api_agent", side_effect=side_effects):
+            with patch(
+                "theforge.cli.provider_readiness.run_api_agent", side_effect=side_effects
+            ):
                 rc = cmd_check_providers(args)
 
         assert rc == 1
@@ -616,7 +623,7 @@ class TestCmdCheckProviders:
             raise RuntimeError("connection refused")
 
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch("theforge.cli.providers.run_api_agent", side_effect=_boom):
+            with patch("theforge.cli.provider_readiness.run_api_agent", side_effect=_boom):
                 rc = cmd_check_providers(args)
 
         assert rc == 1
@@ -631,7 +638,7 @@ class TestCmdCheckProviders:
 
         with patch("theforge.cli.providers.load_config", return_value=cfg):
             with patch(
-                "theforge.cli.providers.run_api_agent",
+                "theforge.cli.provider_readiness.run_api_agent",
                 return_value=_make_pass_result("claude-reviewer"),
             ) as mock_api:
                 rc = cmd_check_providers(args)
@@ -647,7 +654,7 @@ class TestCmdCheckProviders:
         args = _make_args(profile="nonexistent", config=str(tmp_path / "forge.yaml"))
 
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch("theforge.cli.providers.run_api_agent") as mock_api:
+            with patch("theforge.cli.provider_readiness.run_api_agent") as mock_api:
                 rc = cmd_check_providers(args)
 
         assert rc == 1
@@ -669,7 +676,9 @@ class TestCmdCheckProviders:
             structured_data={"summary": "no verdict here"},
         )
         with patch("theforge.cli.providers.load_config", return_value=cfg):
-            with patch("theforge.cli.providers.run_api_agent", return_value=bad_result):
+            with patch(
+                "theforge.cli.provider_readiness.run_api_agent", return_value=bad_result
+            ):
                 rc = cmd_check_providers(args)
 
         assert rc == 1
@@ -684,9 +693,8 @@ class TestCmdCheckProviders:
         assert rc == 1
 
     def test_deduplication(self, tmp_path, capsys):
-        """Same profile name appearing in multiple config slots is tested only once."""
+        """Exact duplicate probes in the same role collapse to one run."""
         shared = _api_profile("shared-reviewer")
-        # Place same profile in review_pool and also as synthesis_profile
         cfg = ForgeConfig(
             project="test",
             project_root=tmp_path,
@@ -712,8 +720,8 @@ class TestCmdCheckProviders:
                 timeout_seconds=120,
                 allowed_tools=("Read",),
             ),
-            review_pool=[shared],
-            synthesis_profile=shared,  # same object → same name → should be deduped
+            review_pool=[shared, shared],
+            synthesis_profile=None,
             retry=RetryPolicy(),
             plan_agent_review=PlanAgentReviewConfig.of(enabled=False),
             log=LogConfig(enabled=False),
@@ -722,13 +730,113 @@ class TestCmdCheckProviders:
 
         with patch("theforge.cli.providers.load_config", return_value=cfg):
             with patch(
-                "theforge.cli.providers.run_api_agent",
+                "theforge.cli.provider_readiness.run_api_agent",
                 return_value=_make_pass_result("shared-reviewer"),
             ) as mock_api:
                 rc = cmd_check_providers(args)
 
         assert rc == 0
         assert mock_api.call_count == 1
+
+    def test_tool_bearing_profile_is_probed_with_original_allowlist(self, tmp_path):
+        cfg = _make_forge_config(tmp_path, review_pool=[_api_profile("reviewer")])
+        args = _make_args(config=str(tmp_path / "forge.yaml"))
+
+        with patch("theforge.cli.providers.load_config", return_value=cfg):
+            with patch(
+                "theforge.cli.provider_readiness.run_api_agent",
+                return_value=_make_pass_result("reviewer"),
+            ) as mock_api:
+                rc = cmd_check_providers(args)
+
+        assert rc == 0
+        assert mock_api.call_args.kwargs["profile"].allowed_tools == ("Read", "Grep")
+
+    def test_tool_bearing_agent_pool_failure_cannot_hide_behind_plain_probe(self, tmp_path, capsys):
+        cfg = _make_forge_config(tmp_path, review_pool=[])
+        cfg = ForgeConfig(
+            **{
+                **cfg.__dict__,
+                "agents": [
+                    AgentDef(
+                        name="agent-api",
+                        provider="openai",
+                        model="gpt-5.4",
+                        budget_usd=1.0,
+                        timeout_seconds=120,
+                        tier="mid",
+                        transport=transport_for("openai", "api"),
+                    )
+                ],
+            }
+        )
+        args = _make_args(config=str(tmp_path / "forge.yaml"))
+
+        def _side_effect(*_, **kwargs):
+            profile = kwargs["profile"]
+            if profile.allowed_tools:
+                return _make_fail_result(profile.name)
+            return _make_pass_result(profile.name)
+
+        with patch("theforge.cli.providers.load_config", return_value=cfg):
+            with patch(
+                "theforge.cli.provider_readiness.run_api_agent", side_effect=_side_effect
+            ):
+                rc = cmd_check_providers(args)
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "agent-dev" in captured.out
+        assert "0/5 passed" in captured.out
+
+    def test_same_profile_can_render_distinct_role_rows(self, tmp_path, capsys):
+        shared = _api_profile("shared")
+        cfg = _make_forge_config(tmp_path, review_pool=[shared])
+        cfg = ForgeConfig(
+            **{
+                **cfg.__dict__,
+                "plan_agent_review": PlanAgentReviewConfig(enabled=True, pool=[shared]),
+            }
+        )
+        args = _make_args(config=str(tmp_path / "forge.yaml"))
+
+        with patch("theforge.cli.providers.load_config", return_value=cfg):
+            with patch(
+                "theforge.cli.provider_readiness.run_api_agent",
+                side_effect=[_make_pass_result("shared"), _make_pass_result("shared")],
+            ):
+                rc = cmd_check_providers(args)
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "review" in captured.out
+        assert "plan-review" in captured.out
+        assert "2/2 passed" in captured.out
+
+    def test_cost_unavailable_is_reported_and_fails(self, tmp_path, capsys):
+        cfg = _make_forge_config(tmp_path, review_pool=[_api_profile("reviewer")])
+        args = _make_args(config=str(tmp_path / "forge.yaml"))
+        unknown_cost = AgentResult(
+            success=True,
+            output='{"verdict":"APPROVE","summary":"ok"}',
+            session_id=None,
+            cost_usd=None,
+            exit_code=0,
+            raw={},
+            profile_name="reviewer",
+            structured_data={"verdict": "APPROVE", "summary": "ok"},
+        )
+
+        with patch("theforge.cli.providers.load_config", return_value=cfg):
+            with patch(
+                "theforge.cli.provider_readiness.run_api_agent", return_value=unknown_cost
+            ):
+                rc = cmd_check_providers(args)
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert READINESS_STATUS_COST_UNAVAILABLE in captured.out
+        assert "0/1 passed" in captured.out
 
 
 # ── TestCmdInitHooks ──────────────────────────────────────────────────

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -173,6 +173,25 @@ def test_build_readiness_probes_projects_agent_pool_roles_with_tools(tmp_path):
     assert agent_probes["agent-planner"].profile != agent_probes["agent-code-review"].profile
 
 
+def test_build_readiness_probes_narrows_configured_dev_api_tools_by_phase(tmp_path):
+    config = _config(tmp_path)
+    config = ForgeConfig(
+        **{
+            **config.__dict__,
+            "dev_profile": _api_profile(
+                "dev-api",
+                allowed_tools=("Read", "Write", "Bash", "Glob", "Grep"),
+            ),
+        }
+    )
+
+    probes = build_readiness_probes(config)
+    dev_probe = next(probe for probe in probes if probe.role == "dev")
+
+    assert dev_probe.profile.phase == "dev"
+    assert dev_probe.profile.allowed_tools == ("Read", "Glob", "Grep")
+
+
 def test_run_readiness_probe_marks_openai_unsupported_shape_not_ready(tmp_path):
     probe = next(
         probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "review"
@@ -183,7 +202,7 @@ def test_run_readiness_probe_marks_openai_unsupported_shape_not_ready(tmp_path):
         return_value=OpenAIFunctionToolRequestShape("unsupported"),
     ):
         with patch("theforge.cli.provider_readiness.run_api_agent") as mock_api:
-            result = run_readiness_probe(probe, working_dir=tmp_path, secrets={})
+            result = run_readiness_probe(probe, secrets={})
 
     assert result.status == READINESS_STATUS_UNSUPPORTED
     assert not result.ready
@@ -196,7 +215,7 @@ def test_run_readiness_probe_marks_successful_probe_ready(tmp_path):
     )
 
     with patch("theforge.cli.provider_readiness.run_api_agent", return_value=_pass_result()):
-        result = run_readiness_probe(probe, working_dir=tmp_path, secrets={})
+        result = run_readiness_probe(probe, secrets={})
 
     assert result.status == READINESS_STATUS_READY
     assert result.ready is True
@@ -211,7 +230,7 @@ def test_run_readiness_probe_uses_throwaway_working_dir(tmp_path):
         "theforge.cli.provider_readiness.run_api_agent",
         return_value=_pass_result(),
     ) as mock_api:
-        result = run_readiness_probe(probe, working_dir=tmp_path, secrets={})
+        result = run_readiness_probe(probe, secrets={})
 
     assert result.status == READINESS_STATUS_READY
     called_dir = mock_api.call_args.kwargs["working_dir"]
@@ -235,7 +254,7 @@ def test_run_readiness_probe_no_submit_phase_accepts_unstructured_success(tmp_pa
     )
 
     with patch("theforge.cli.provider_readiness.run_api_agent", return_value=unstructured):
-        result = run_readiness_probe(probe, working_dir=tmp_path, secrets={})
+        result = run_readiness_probe(probe, secrets={})
 
     assert result.status == READINESS_STATUS_READY
     assert result.ready is True

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -165,6 +165,7 @@ def test_build_readiness_probes_projects_agent_pool_roles_with_tools(tmp_path):
         "agent-code-review",
     }
     assert all(agent_probes[role].profile.allowed_tools for role in agent_probes)
+    assert agent_probes["agent-dev"].profile.allowed_tools == ("Read", "Glob", "Grep")
     assert agent_probes["agent-dev"].capability == READINESS_CAPABILITY_TOOL_STRUCTURED
     assert agent_probes["agent-planner"].profile.phase == "plan"
     assert agent_probes["agent-plan-review"].profile.phase == "plan_review"
@@ -195,6 +196,45 @@ def test_run_readiness_probe_marks_successful_probe_ready(tmp_path):
     )
 
     with patch("theforge.cli.provider_readiness.run_api_agent", return_value=_pass_result()):
+        result = run_readiness_probe(probe, working_dir=tmp_path, secrets={})
+
+    assert result.status == READINESS_STATUS_READY
+    assert result.ready is True
+
+
+def test_run_readiness_probe_uses_throwaway_working_dir(tmp_path):
+    probe = next(
+        probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "review"
+    )
+
+    with patch(
+        "theforge.cli.provider_readiness.run_api_agent",
+        return_value=_pass_result(),
+    ) as mock_api:
+        result = run_readiness_probe(probe, working_dir=tmp_path, secrets={})
+
+    assert result.status == READINESS_STATUS_READY
+    called_dir = mock_api.call_args.kwargs["working_dir"]
+    assert called_dir != tmp_path
+    assert called_dir.name.startswith("forge-check-providers-")
+
+
+def test_run_readiness_probe_no_submit_phase_accepts_unstructured_success(tmp_path):
+    probe = next(
+        probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "preflight"
+    )
+    unstructured = AgentResult(
+        success=True,
+        output="Capability probe completed successfully.",
+        session_id=None,
+        cost_usd=0.002,
+        exit_code=0,
+        raw={},
+        profile_name=probe.profile.name,
+        structured_data=None,
+    )
+
+    with patch("theforge.cli.provider_readiness.run_api_agent", return_value=unstructured):
         result = run_readiness_probe(probe, working_dir=tmp_path, secrets={})
 
     assert result.status == READINESS_STATUS_READY

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
+from theforge.cli.provider_readiness import (
+    READINESS_CAPABILITY_TOOL_STRUCTURED,
+    READINESS_STATUS_READY,
+    READINESS_STATUS_UNSUPPORTED,
+    build_readiness_probes,
+    run_readiness_probe,
+)
 from theforge.config import (
-    AgentDef,
     DEFAULT_VALIDATION,
+    AgentDef,
     ForgeConfig,
     LogConfig,
     ModelProfile,
@@ -14,13 +21,6 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
     transport_for,
-)
-from theforge.cli.provider_readiness import (
-    READINESS_CAPABILITY_TOOL_STRUCTURED,
-    READINESS_STATUS_READY,
-    READINESS_STATUS_UNSUPPORTED,
-    build_readiness_probes,
-    run_readiness_probe,
 )
 from theforge.runners import AgentResult
 from theforge.runners.schema_utils import OpenAIFunctionToolRequestShape
@@ -111,7 +111,7 @@ def test_build_readiness_probes_includes_config_plan_and_advisor_shapes(tmp_path
 
     assert ("preflight", "preflight", "preflight") in labels
     assert ("review", "reviewer", "review") in labels
-    assert ("plan", "plan", None) in labels
+    assert ("plan", "plan", "plan") in labels
     assert ("plan-review", "plan-reviewer", "plan_review") in labels
     assert ("advisor", "preflight", "preflight") in labels
 
@@ -166,13 +166,15 @@ def test_build_readiness_probes_projects_agent_pool_roles_with_tools(tmp_path):
     }
     assert all(agent_probes[role].profile.allowed_tools for role in agent_probes)
     assert agent_probes["agent-dev"].capability == READINESS_CAPABILITY_TOOL_STRUCTURED
+    assert agent_probes["agent-planner"].profile.phase == "plan"
+    assert agent_probes["agent-plan-review"].profile.phase == "plan_review"
+    assert agent_probes["agent-code-review"].profile.phase == "review"
+    assert agent_probes["agent-planner"].profile != agent_probes["agent-code-review"].profile
 
 
 def test_run_readiness_probe_marks_openai_unsupported_shape_not_ready(tmp_path):
     probe = next(
-        probe
-        for probe in build_readiness_probes(_config(tmp_path))
-        if probe.role == "review"
+        probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "review"
     )
 
     with patch(
@@ -189,9 +191,7 @@ def test_run_readiness_probe_marks_openai_unsupported_shape_not_ready(tmp_path):
 
 def test_run_readiness_probe_marks_successful_probe_ready(tmp_path):
     probe = next(
-        probe
-        for probe in build_readiness_probes(_config(tmp_path))
-        if probe.role == "review"
+        probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "review"
     )
 
     with patch("theforge.cli.provider_readiness.run_api_agent", return_value=_pass_result()):

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -113,7 +113,7 @@ def test_build_readiness_probes_includes_config_plan_and_advisor_shapes(tmp_path
     assert ("review", "reviewer", "review") in labels
     assert ("plan", "plan", None) in labels
     assert ("plan-review", "plan-reviewer", "plan_review") in labels
-    assert ("advisor", "preflight", "advisor") in labels
+    assert ("advisor", "preflight", "preflight") in labels
 
 
 def test_build_readiness_probes_dedupes_exact_duplicates_but_not_roles(tmp_path):

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from theforge.config import (
+    AgentDef,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    LogConfig,
+    ModelProfile,
+    PlanAgentReviewConfig,
+    PlanConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+    transport_for,
+)
+from theforge.cli.provider_readiness import (
+    READINESS_CAPABILITY_TOOL_STRUCTURED,
+    READINESS_STATUS_READY,
+    READINESS_STATUS_UNSUPPORTED,
+    build_readiness_probes,
+    run_readiness_probe,
+)
+from theforge.runners import AgentResult
+from theforge.runners.schema_utils import OpenAIFunctionToolRequestShape
+
+
+def _api_profile(
+    name: str,
+    *,
+    provider: str = "openai",
+    model: str = "gpt-5.4",
+    allowed_tools: tuple[str, ...] = ("Read", "Grep"),
+    phase: str | None = None,
+) -> ModelProfile:
+    return ModelProfile(
+        name=name,
+        provider=provider,
+        model=model,
+        budget_usd=1.0,
+        timeout_seconds=120,
+        allowed_tools=allowed_tools,
+        phase=phase,
+    )
+
+
+def _config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=300,
+            allowed_tools=("Read",),
+        ),
+        preflight_profile=_api_profile(
+            "preflight",
+            provider="openai",
+            model="gpt-5.4",
+            allowed_tools=("Read", "Glob", "Grep"),
+            phase="preflight",
+        ),
+        review_pool=[_api_profile("reviewer", phase="review")],
+        synthesis_profile=None,
+        retry=RetryPolicy(),
+        plan=PlanConfig.of(
+            enabled=True,
+            cli=None,
+            provider="openai",
+            model="gpt-5.4",
+            budget_usd=0.5,
+            timeout=300,
+            transport=transport_for("openai", "api"),
+        ),
+        plan_agent_review=PlanAgentReviewConfig(
+            enabled=True,
+            pool=[_api_profile("plan-reviewer", phase="plan_review")],
+        ),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _pass_result(profile_name: str = "test", *, cost_usd: float | None = 0.003) -> AgentResult:
+    return AgentResult(
+        success=True,
+        output='{"verdict":"APPROVE","summary":"ok"}',
+        session_id=None,
+        cost_usd=cost_usd,
+        exit_code=0,
+        raw={},
+        profile_name=profile_name,
+        structured_data={"verdict": "APPROVE", "summary": "ok"},
+    )
+
+
+def test_build_readiness_probes_includes_config_plan_and_advisor_shapes(tmp_path):
+    config = _config(tmp_path)
+
+    probes = build_readiness_probes(config)
+    labels = {(probe.role, probe.profile.name, probe.profile.phase) for probe in probes}
+
+    assert ("preflight", "preflight", "preflight") in labels
+    assert ("review", "reviewer", "review") in labels
+    assert ("plan", "plan", None) in labels
+    assert ("plan-review", "plan-reviewer", "plan_review") in labels
+    assert ("advisor", "preflight", "advisor") in labels
+
+
+def test_build_readiness_probes_dedupes_exact_duplicates_but_not_roles(tmp_path):
+    shared = _api_profile("shared")
+    config = _config(tmp_path)
+    config = ForgeConfig(
+        **{
+            **config.__dict__,
+            "review_pool": [shared, shared],
+            "plan_agent_review": PlanAgentReviewConfig(enabled=True, pool=[shared]),
+        }
+    )
+
+    probes = build_readiness_probes(config)
+    shared_rows = [probe for probe in probes if probe.profile.name == "shared"]
+
+    assert len([probe for probe in shared_rows if probe.role == "review"]) == 1
+    assert len([probe for probe in shared_rows if probe.role == "plan-review"]) == 1
+
+
+def test_build_readiness_probes_projects_agent_pool_roles_with_tools(tmp_path):
+    config = _config(tmp_path)
+    config = ForgeConfig(
+        **{
+            **config.__dict__,
+            "review_pool": [],
+            "agents": [
+                AgentDef(
+                    name="pool-openai",
+                    provider="openai",
+                    model="gpt-5.4",
+                    budget_usd=1.0,
+                    timeout_seconds=120,
+                    tier="mid",
+                    transport=transport_for("openai", "api"),
+                )
+            ],
+        }
+    )
+
+    probes = build_readiness_probes(config)
+    agent_probes = {probe.role: probe for probe in probes if probe.profile.name == "pool-openai"}
+
+    assert set(agent_probes) == {
+        "agent-dev",
+        "agent-preflight",
+        "agent-planner",
+        "agent-plan-review",
+        "agent-code-review",
+    }
+    assert all(agent_probes[role].profile.allowed_tools for role in agent_probes)
+    assert agent_probes["agent-dev"].capability == READINESS_CAPABILITY_TOOL_STRUCTURED
+
+
+def test_run_readiness_probe_marks_openai_unsupported_shape_not_ready(tmp_path):
+    probe = next(
+        probe
+        for probe in build_readiness_probes(_config(tmp_path))
+        if probe.role == "review"
+    )
+
+    with patch(
+        "theforge.cli.provider_readiness.openai_function_tool_request_shape",
+        return_value=OpenAIFunctionToolRequestShape("unsupported"),
+    ):
+        with patch("theforge.cli.provider_readiness.run_api_agent") as mock_api:
+            result = run_readiness_probe(probe, working_dir=tmp_path, secrets={})
+
+    assert result.status == READINESS_STATUS_UNSUPPORTED
+    assert not result.ready
+    mock_api.assert_not_called()
+
+
+def test_run_readiness_probe_marks_successful_probe_ready(tmp_path):
+    probe = next(
+        probe
+        for probe in build_readiness_probes(_config(tmp_path))
+        if probe.role == "review"
+    )
+
+    with patch("theforge.cli.provider_readiness.run_api_agent", return_value=_pass_result()):
+        result = run_readiness_probe(probe, working_dir=tmp_path, secrets={})
+
+    assert result.status == READINESS_STATUS_READY
+    assert result.ready is True


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The prior P1 is resolved: check-providers now probes tool-bearing capability shapes without granting dev Write/Edit/Bash, and I found no blocking regressions. | [anthropic-opus-cli] All prior findings are resolved — probes run in a throwaway temp directory, the dev-role tool narrowing is now keyed on the resolved phase so both the configured and pool-derived dev probes are read-only, the dead working_dir parameter and the unreachable untested constant are gone, and the conftest network guard points at the real call site; no regressions found in dda217ef and the gate is PASS at the reviewed HEAD.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $9.95
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

The provider readiness check exercises a request shape no phase uses, so a model that fails every tool-bearing invocation is reported ready (GitHub Issue #2378)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2378