### PR TITLE
Nothing verifies that a declared transport can serve the model declared on it, so a wrong choice is accepted, certified, and only visible as failures several layers downstream

### DIFF
--- a/src/theforge/cli/provider_readiness.py
+++ b/src/theforge/cli/provider_readiness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 import tempfile
 import time
 from dataclasses import dataclass
@@ -51,17 +52,29 @@ _READINESS_PROMPT = (
     "and a 'summary' field with a one-line explanation."
 )
 
-_AUTH_FAILURE_HINTS: tuple[str, ...] = (
+_AUTH_FAILURE_PATTERNS: tuple[str, ...] = (
+    "failed to authenticate",
+    "oauth access token has been revoked",
+    "authentication_error",
     "authenticationerror",
-    "unauthorized",
-    "invalid key",
     "invalid api key",
-    "api key",
+    "invalid_api_key",
+    "invalid x-api-key",
+    "unauthorized",
     "not logged in",
     "login required",
-    "credentials",
-    "oauth",
-    "401",
+    "bad credentials",
+    "permission_error",
+)
+_AUTH_STATUS_CODE_CONTEXT = (
+    r"\b(?:http|https|status|statuscode|status[ _-]code|error|errors|err|code|response)\b"
+    r"[^0-9a-z]{0,8}"
+)
+_AUTH_STATUS_CODES = r"401|403"
+_AUTH_STATUS_REASONS = r"unauthorized|forbidden|permission denied"
+_AUTH_CODE_RE = re.compile(
+    rf"{_AUTH_STATUS_CODE_CONTEXT}(?:{_AUTH_STATUS_CODES})\b"
+    rf"|\b(?:{_AUTH_STATUS_CODES})\s+(?:{_AUTH_STATUS_REASONS})\b"
 )
 
 
@@ -187,10 +200,14 @@ def run_readiness_probe(
     probe: ReadinessProbe,
     *,
     secrets: dict[str, str] | None,
+    include_alternate_transports: bool = True,
 ) -> ReadinessResult:
     """Exercise one capability probe on its declared and alternate transports."""
     attempts: list[ReadinessAttempt] = []
-    for transport_attempt in _transport_attempts_for_probe(probe):
+    for transport_attempt in _transport_attempts_for_probe(
+        probe,
+        include_alternate_transports=include_alternate_transports,
+    ):
         if isinstance(transport_attempt, ReadinessAttempt):
             attempts.append(transport_attempt)
             continue
@@ -204,7 +221,11 @@ def run_readiness_probe(
     return ReadinessResult(probe=probe, attempts=tuple(attempts))
 
 
-def _transport_attempts_for_probe(probe: ReadinessProbe) -> list[TransportSpec | ReadinessAttempt]:
+def _transport_attempts_for_probe(
+    probe: ReadinessProbe,
+    *,
+    include_alternate_transports: bool,
+) -> list[TransportSpec | ReadinessAttempt]:
     provider = probe.profile.provider_family
     if not provider:
         return [
@@ -215,19 +236,33 @@ def _transport_attempts_for_probe(probe: ReadinessProbe) -> list[TransportSpec |
             )
         ]
 
-    attempts: list[TransportSpec | ReadinessAttempt] = []
-    for transport_kind in (probe.declared_transport_kind, _alternate_transport_kind(probe)):
-        try:
-            attempts.append(transport_for(provider, transport_kind))
-        except ValueError as exc:
-            attempts.append(
-                _unverified_attempt(
-                    probe,
-                    attempted_transport_kind=transport_kind,
-                    detail=f"not exercised: {exc}",
-                )
-            )
+    attempts = [_transport_attempt_for_probe(probe, probe.declared_transport_kind)]
+    if include_alternate_transports:
+        attempts.append(_transport_attempt_for_probe(probe, _alternate_transport_kind(probe)))
     return attempts
+
+
+def _transport_attempt_for_probe(
+    probe: ReadinessProbe,
+    transport_kind: str,
+) -> TransportSpec | ReadinessAttempt:
+    provider = probe.profile.provider_family
+    if transport_kind == probe.declared_transport_kind and probe.profile.transport is not None:
+        return probe.profile.transport
+    if not provider:
+        return _unverified_attempt(
+            probe,
+            attempted_transport_kind=transport_kind,
+            detail="not exercised: provider identity is unavailable for this profile",
+        )
+    try:
+        return transport_for(provider, transport_kind)
+    except ValueError as exc:
+        return _unverified_attempt(
+            probe,
+            attempted_transport_kind=transport_kind,
+            detail=f"not exercised: {exc}",
+        )
 
 
 def _alternate_transport_kind(probe: ReadinessProbe) -> str:
@@ -447,7 +482,7 @@ def _runtime_unverified_reason(
             return message
 
     lowered = message.lower()
-    if any(hint in lowered for hint in _AUTH_FAILURE_HINTS):
+    if _looks_like_auth_failure(lowered):
         return message[:120]
     return None
 
@@ -465,6 +500,12 @@ def _safe_auth_check(
         )
     except ValueError as exc:
         return (False, str(exc))
+
+
+def _looks_like_auth_failure(message: str) -> bool:
+    return any(pattern in message for pattern in _AUTH_FAILURE_PATTERNS) or bool(
+        _AUTH_CODE_RE.search(message)
+    )
 
 
 def _identity_mismatch_reason(profile: ModelProfile, result: AgentResult) -> str | None:

--- a/src/theforge/cli/provider_readiness.py
+++ b/src/theforge/cli/provider_readiness.py
@@ -16,22 +16,29 @@ from theforge.config import (
     DEFAULT_PREFLIGHT_PROFILE,
     DEFAULT_REVIEW_PROFILE,
     ForgeConfig,
+    TransportSpec,
     resolve_preflight_tools,
+    transport_for,
 )
+from theforge.config.auth import check_agent_auth
+from theforge.config.models import mirror_fields_for_transport
 from theforge.config.profiles import iter_config_profiles, iter_plan_phase_profiles
 from theforge.config.types import ModelProfile
 from theforge.runners.api import run_api_agent
+from theforge.runners.cli import run_agent
 from theforge.runners.schema_utils import openai_function_tool_request_shape
 
 READINESS_STATUS_READY = "ready"
 READINESS_STATUS_FAILED = "failed"
 READINESS_STATUS_UNSUPPORTED = "unsupported"
+READINESS_STATUS_UNVERIFIED = "unverified"
 READINESS_STATUS_COST_UNAVAILABLE = "cost-unavailable"
 
 READINESS_STATUSES: tuple[str, ...] = (
     READINESS_STATUS_READY,
     READINESS_STATUS_FAILED,
     READINESS_STATUS_UNSUPPORTED,
+    READINESS_STATUS_UNVERIFIED,
     READINESS_STATUS_COST_UNAVAILABLE,
 )
 
@@ -44,6 +51,19 @@ _READINESS_PROMPT = (
     "and a 'summary' field with a one-line explanation."
 )
 
+_AUTH_FAILURE_HINTS: tuple[str, ...] = (
+    "authenticationerror",
+    "unauthorized",
+    "invalid key",
+    "invalid api key",
+    "api key",
+    "not logged in",
+    "login required",
+    "credentials",
+    "oauth",
+    "401",
+)
+
 
 @dataclass(frozen=True)
 class ReadinessProbe:
@@ -53,12 +73,18 @@ class ReadinessProbe:
     capability: str
     profile: ModelProfile
 
+    @property
+    def declared_transport_kind(self) -> str:
+        return self.profile.mode
+
 
 @dataclass(frozen=True)
-class ReadinessResult:
-    """Outcome of one readiness probe."""
+class ReadinessAttempt:
+    """Outcome of exercising one transport for a readiness probe."""
 
     probe: ReadinessProbe
+    attempted_transport_kind: str
+    declared_transport_kind: str
     elapsed: float
     status: str
     detail: str
@@ -68,9 +94,56 @@ class ReadinessResult:
     def ready(self) -> bool:
         return self.status == READINESS_STATUS_READY
 
+    @property
+    def is_declared_transport(self) -> bool:
+        return self.attempted_transport_kind == self.declared_transport_kind
+
+
+@dataclass(frozen=True)
+class ReadinessResult:
+    """Grouped readiness evidence for one declared profile/capability probe."""
+
+    probe: ReadinessProbe
+    attempts: tuple[ReadinessAttempt, ...]
+
+    @property
+    def declared_attempt(self) -> ReadinessAttempt:
+        for attempt in self.attempts:
+            if attempt.is_declared_transport:
+                return attempt
+        raise ValueError("readiness result is missing the declared transport attempt")
+
+    @property
+    def elapsed(self) -> float:
+        return self.declared_attempt.elapsed
+
+    @property
+    def status(self) -> str:
+        return self.declared_attempt.status
+
+    @property
+    def detail(self) -> str:
+        return self.declared_attempt.detail
+
+    @property
+    def outcome(self) -> AgentResult | Exception | None:
+        return self.declared_attempt.outcome
+
+    @property
+    def ready(self) -> bool:
+        return self.declared_attempt.ready
+
+    @property
+    def ready_alternate_transport_kinds(self) -> tuple[str, ...]:
+        return tuple(
+            attempt.attempted_transport_kind
+            for attempt in self.attempts
+            if not attempt.is_declared_transport and attempt.ready
+        )
+
 
 def build_readiness_probes(config: ForgeConfig) -> list[ReadinessProbe]:
-    """Derive the API capability probes production can actually dispatch."""
+    """Derive the capability probes production can actually dispatch."""
     probes: list[ReadinessProbe] = []
 
     for role, profile in iter_config_profiles(config):
@@ -90,17 +163,16 @@ def build_readiness_probes(config: ForgeConfig) -> list[ReadinessProbe]:
         probes.extend(_agent_role_probes(agent))
 
     deduped: list[ReadinessProbe] = []
-    seen: set[tuple[str, str, str, str, str | None, tuple[str, ...], str | None]] = set()
+    seen: set[tuple[str, str, str, str | None, str, str, tuple[str, ...], str | None]] = set()
     for probe in probes:
         profile = probe.profile
-        if profile.mode != "api":
-            continue
         key = (
             probe.role,
             probe.capability,
             profile.name,
+            profile.provider_family,
+            probe.declared_transport_kind,
             profile.model,
-            profile.provider,
             profile.allowed_tools,
             profile.phase,
         )
@@ -116,8 +188,67 @@ def run_readiness_probe(
     *,
     secrets: dict[str, str] | None,
 ) -> ReadinessResult:
-    """Exercise one capability probe and classify the outcome."""
-    profile = probe.profile
+    """Exercise one capability probe on its declared and alternate transports."""
+    attempts: list[ReadinessAttempt] = []
+    for transport_attempt in _transport_attempts_for_probe(probe):
+        if isinstance(transport_attempt, ReadinessAttempt):
+            attempts.append(transport_attempt)
+            continue
+        attempts.append(
+            _run_transport_attempt(
+                probe,
+                transport=transport_attempt,
+                secrets=secrets,
+            )
+        )
+    return ReadinessResult(probe=probe, attempts=tuple(attempts))
+
+
+def _transport_attempts_for_probe(probe: ReadinessProbe) -> list[TransportSpec | ReadinessAttempt]:
+    provider = probe.profile.provider_family
+    if not provider:
+        return [
+            _unverified_attempt(
+                probe,
+                attempted_transport_kind=probe.declared_transport_kind,
+                detail="not exercised: provider identity is unavailable for this profile",
+            )
+        ]
+
+    attempts: list[TransportSpec | ReadinessAttempt] = []
+    for transport_kind in (probe.declared_transport_kind, _alternate_transport_kind(probe)):
+        try:
+            attempts.append(transport_for(provider, transport_kind))
+        except ValueError as exc:
+            attempts.append(
+                _unverified_attempt(
+                    probe,
+                    attempted_transport_kind=transport_kind,
+                    detail=f"not exercised: {exc}",
+                )
+            )
+    return attempts
+
+
+def _alternate_transport_kind(probe: ReadinessProbe) -> str:
+    return "cli" if probe.declared_transport_kind == "api" else "api"
+
+
+def _run_transport_attempt(
+    probe: ReadinessProbe,
+    *,
+    transport: TransportSpec,
+    secrets: dict[str, str] | None,
+) -> ReadinessAttempt:
+    profile = _profile_for_transport(probe.profile, transport)
+    unavailable = _preflight_unverified_reason(profile, secrets)
+    if unavailable is not None:
+        return _unverified_attempt(
+            probe,
+            attempted_transport_kind=transport.kind,
+            detail=f"not exercised: {unavailable}",
+        )
+
     if (
         probe.capability == READINESS_CAPABILITY_TOOL_STRUCTURED
         and profile.provider == "openai"
@@ -125,8 +256,10 @@ def run_readiness_probe(
     ):
         tool_shape = openai_function_tool_request_shape(profile.model)
         if tool_shape.transport == "unsupported":
-            return ReadinessResult(
+            return ReadinessAttempt(
                 probe=probe,
+                attempted_transport_kind=transport.kind,
+                declared_transport_kind=probe.declared_transport_kind,
                 elapsed=0.0,
                 status=READINESS_STATUS_UNSUPPORTED,
                 detail=(
@@ -138,59 +271,234 @@ def run_readiness_probe(
     t0 = time.perf_counter()
     try:
         with tempfile.TemporaryDirectory(prefix="forge-check-providers-") as probe_dir:
-            result = run_api_agent(
+            result = _dispatch_probe_attempt(
                 prompt=_READINESS_PROMPT,
                 profile=profile,
                 working_dir=Path(probe_dir),
-                quiet=True,
                 secrets=secrets,
             )
     except Exception as exc:
-        return ReadinessResult(
+        elapsed = time.perf_counter() - t0
+        detail = _runtime_unverified_reason(profile, secrets=secrets, exc=exc)
+        if detail is not None:
+            return _unverified_attempt(
+                probe,
+                attempted_transport_kind=transport.kind,
+                detail=f"not exercised: {detail}",
+                elapsed=elapsed,
+                outcome=exc,
+            )
+        return ReadinessAttempt(
             probe=probe,
-            elapsed=time.perf_counter() - t0,
+            attempted_transport_kind=transport.kind,
+            declared_transport_kind=probe.declared_transport_kind,
+            elapsed=elapsed,
             status=READINESS_STATUS_FAILED,
             detail=f"{type(exc).__name__}: {exc}",
             outcome=exc,
         )
 
     elapsed = time.perf_counter() - t0
-    if not result.success:
-        short_err = (result.output or "unknown error")[:120]
-        return ReadinessResult(
-            probe=probe,
+
+    identity_mismatch = _identity_mismatch_reason(profile, result)
+    if identity_mismatch is not None:
+        return _unverified_attempt(
+            probe,
+            attempted_transport_kind=transport.kind,
+            detail=f"not exercised: {identity_mismatch}",
             elapsed=elapsed,
-            status=READINESS_STATUS_FAILED,
-            detail=short_err,
+            outcome=result,
+        )
+
+    if not result.success:
+        unverified_reason = _runtime_unverified_reason(profile, secrets=secrets, result=result)
+        short_err = (result.output or "unknown error")[:120]
+        return ReadinessAttempt(
+            probe=probe,
+            attempted_transport_kind=transport.kind,
+            declared_transport_kind=probe.declared_transport_kind,
+            elapsed=elapsed,
+            status=(
+                READINESS_STATUS_UNVERIFIED
+                if unverified_reason is not None
+                else READINESS_STATUS_FAILED
+            ),
+            detail=unverified_reason or short_err,
             outcome=result,
         )
 
     if _requires_structured_verdict(probe):
         payload = _structured_payload(result)
         if payload is None or "verdict" not in payload:
-            return ReadinessResult(
+            return ReadinessAttempt(
                 probe=probe,
+                attempted_transport_kind=transport.kind,
+                declared_transport_kind=probe.declared_transport_kind,
                 elapsed=elapsed,
                 status=READINESS_STATUS_FAILED,
                 detail="no valid verdict in structured output",
                 outcome=result,
             )
 
-    if not _is_local_endpoint(getattr(profile, "base_url", None)) and result.cost_usd is None:
-        return ReadinessResult(
-            probe=probe,
-            elapsed=elapsed,
-            status=READINESS_STATUS_COST_UNAVAILABLE,
-            detail="structured result returned but cost is unavailable",
-            outcome=result,
-        )
+    if result.cost_usd is None:
+        if transport.kind == "cli":
+            return _unverified_attempt(
+                probe,
+                attempted_transport_kind=transport.kind,
+                detail="not exercised: structured result returned but CLI cost is unavailable",
+                elapsed=elapsed,
+                outcome=result,
+            )
+        if not _is_local_endpoint(getattr(profile, "base_url", None)):
+            return ReadinessAttempt(
+                probe=probe,
+                attempted_transport_kind=transport.kind,
+                declared_transport_kind=probe.declared_transport_kind,
+                elapsed=elapsed,
+                status=READINESS_STATUS_COST_UNAVAILABLE,
+                detail="structured result returned but cost is unavailable",
+                outcome=result,
+            )
 
-    return ReadinessResult(
+    return ReadinessAttempt(
         probe=probe,
+        attempted_transport_kind=transport.kind,
+        declared_transport_kind=probe.declared_transport_kind,
         elapsed=elapsed,
         status=READINESS_STATUS_READY,
         detail=_success_suffix(profile=profile, result=result, elapsed=elapsed),
         outcome=result,
+    )
+
+
+def _dispatch_probe_attempt(
+    *,
+    prompt: str,
+    profile: ModelProfile,
+    working_dir: Path,
+    secrets: dict[str, str] | None,
+) -> AgentResult:
+    if profile.mode == "api":
+        return run_api_agent(
+            prompt=prompt,
+            profile=profile,
+            working_dir=working_dir,
+            quiet=True,
+            secrets=secrets,
+        )
+    return run_agent(
+        prompt=prompt,
+        profile=profile,
+        working_dir=working_dir,
+        quiet=True,
+        secrets=secrets,
+    )
+
+
+def _profile_for_transport(profile: ModelProfile, transport: TransportSpec) -> ModelProfile:
+    cli, provider = mirror_fields_for_transport(transport, profile.cli, profile.provider)
+    return dataclasses.replace(
+        profile,
+        transport=transport,
+        cli=cli,
+        provider=provider,
+        api_fallback=None,
+        fallback_models=(),
+    )
+
+
+def _preflight_unverified_reason(
+    profile: ModelProfile,
+    secrets: dict[str, str] | None,
+) -> str | None:
+    if profile.mode != "cli":
+        return None
+    ready, reason = check_agent_auth(
+        profile,
+        secrets,
+        include_sandbox_readiness=False,
+        include_credential_probe=True,
+    )
+    if ready:
+        return None
+    return reason
+
+
+def _runtime_unverified_reason(
+    profile: ModelProfile,
+    *,
+    secrets: dict[str, str] | None,
+    result: AgentResult | None = None,
+    exc: Exception | None = None,
+) -> str | None:
+    ready, reason = _safe_auth_check(profile, secrets)
+    if not ready:
+        return reason
+
+    if result is not None and result.startup_failure:
+        return (result.output or "startup failure")[:120]
+
+    message = ""
+    if result is not None:
+        message = result.output or ""
+    if exc is not None:
+        message = f"{type(exc).__name__}: {exc}"
+        if isinstance(exc, (ImportError, ModuleNotFoundError, FileNotFoundError)):
+            return message
+
+    lowered = message.lower()
+    if any(hint in lowered for hint in _AUTH_FAILURE_HINTS):
+        return message[:120]
+    return None
+
+
+def _safe_auth_check(
+    profile: ModelProfile,
+    secrets: dict[str, str] | None,
+) -> tuple[bool, str]:
+    try:
+        return check_agent_auth(
+            profile,
+            secrets,
+            include_sandbox_readiness=False,
+            include_credential_probe=True,
+        )
+    except ValueError as exc:
+        return (False, str(exc))
+
+
+def _identity_mismatch_reason(profile: ModelProfile, result: AgentResult) -> str | None:
+    expected_transport = profile.mode
+    observed_transport = result.transport_used or expected_transport
+    if observed_transport != expected_transport:
+        return (
+            "requested transport "
+            f"{expected_transport!r} but runner reported {observed_transport!r}"
+        )
+
+    expected_model = profile.model
+    observed_model = result.model_used or expected_model
+    if observed_model != expected_model:
+        return f"requested model {expected_model!r} but runner reported {observed_model!r}"
+    return None
+
+
+def _unverified_attempt(
+    probe: ReadinessProbe,
+    *,
+    attempted_transport_kind: str,
+    detail: str,
+    elapsed: float = 0.0,
+    outcome: AgentResult | Exception | None = None,
+) -> ReadinessAttempt:
+    return ReadinessAttempt(
+        probe=probe,
+        attempted_transport_kind=attempted_transport_kind,
+        declared_transport_kind=probe.declared_transport_kind,
+        elapsed=elapsed,
+        status=READINESS_STATUS_UNVERIFIED,
+        detail=detail,
+        outcome=outcome,
     )
 
 

--- a/src/theforge/cli/providers.py
+++ b/src/theforge/cli/providers.py
@@ -1,4 +1,4 @@
-"""forge check-providers subcommand — exercise API provider capabilities."""
+"""forge check-providers subcommand — exercise provider capabilities."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from theforge.cli.provider_readiness import (
     READINESS_STATUS_READY,
+    ReadinessResult,
     build_readiness_probes,
     run_readiness_probe,
 )
@@ -18,7 +19,7 @@ _MAX_READINESS_WORKERS = 4
 
 
 def cmd_check_providers(args: object) -> int:
-    """Exercise every API capability forge can dispatch from forge.yaml."""
+    """Exercise every configured provider capability forge can dispatch."""
     config_path = getattr(args, "config", None)
     if config_path:
         config_path = Path(config_path)
@@ -37,7 +38,8 @@ def cmd_check_providers(args: object) -> int:
         probes = [probe for probe in probes if probe.profile.name == profile_filter]
         if not probes:
             print(
-                f"[check-providers] No API profile named '{profile_filter}' found in forge.yaml",
+                "[check-providers] "
+                f"No provider capability probe named '{profile_filter}' found in forge.yaml",
                 file=sys.stderr,
             )
             return 1
@@ -64,7 +66,13 @@ def cmd_check_providers(args: object) -> int:
             results.append(fut.result())
 
     order = {
-        (probe.role, probe.capability, probe.profile.name, probe.profile.model): i
+        (
+            probe.role,
+            probe.capability,
+            probe.profile.name,
+            probe.profile.model,
+            probe.declared_transport_kind,
+        ): i
         for i, probe in enumerate(probes)
     }
     results.sort(
@@ -74,6 +82,7 @@ def cmd_check_providers(args: object) -> int:
                 result.probe.capability,
                 result.probe.profile.name,
                 result.probe.profile.model,
+                result.probe.declared_transport_kind,
             ),
             999,
         )
@@ -82,7 +91,7 @@ def cmd_check_providers(args: object) -> int:
     any_failed = False
     for result in results:
         profile = result.probe.profile
-        provider = profile.provider or "?"
+        provider = profile.provider_family or "?"
         model = profile.model
         name_col = f"{profile.name:<22}"
         role_col = f"{result.probe.role:<18}"
@@ -96,6 +105,8 @@ def cmd_check_providers(args: object) -> int:
             f"  {name_col} {role_col} {capability_col} {prov_col} {model_col} "
             f"{marker}  {result.status}: {result.detail}"
         )
+        for detail_line in _expanded_detail_lines(result):
+            print(detail_line)
 
     passed = sum(1 for result in results if result.status == READINESS_STATUS_READY)
     total = len(results)
@@ -107,14 +118,32 @@ def register_parser(subparsers: object) -> None:
     """Register the 'check-providers' subcommand parser."""
     check_providers_parser = subparsers.add_parser(
         "check-providers",
-        help="Smoke-test all API-mode profiles in forge.yaml",
+        help="Verify configured provider capability probes in forge.yaml",
     )
     check_providers_parser.add_argument(
         "--profile",
         metavar="NAME",
-        help="Test only the named profile (default: all API profiles)",
+        help="Test only the named provider capability probe (default: all probes)",
     )
     check_providers_parser.add_argument(
         "--config",
         help="Path to forge.yaml (default: auto-detect)",
     )
+
+
+def _expanded_detail_lines(result: ReadinessResult) -> list[str]:
+    if result.ready:
+        return []
+
+    lines = [f"    declared transport: {result.probe.declared_transport_kind}"]
+    for attempt in result.attempts:
+        lines.append(
+            "    "
+            f"{attempt.attempted_transport_kind:<8} "
+            f"{result.probe.capability:<16} "
+            f"{attempt.status}: {attempt.detail}"
+        )
+    if result.ready_alternate_transport_kinds:
+        alternates = ", ".join(result.ready_alternate_transport_kinds)
+        lines.append(f"    ready alternate transport: {alternates}")
+    return lines

--- a/src/theforge/cli/providers.py
+++ b/src/theforge/cli/providers.py
@@ -59,6 +59,7 @@ def cmd_check_providers(args: object) -> int:
                 run_readiness_probe,
                 probe,
                 secrets=config.secrets,
+                include_alternate_transports=not getattr(args, "declared_only", False),
             ): probe
             for probe in probes
         }
@@ -124,6 +125,11 @@ def register_parser(subparsers: object) -> None:
         "--profile",
         metavar="NAME",
         help="Test only the named provider capability probe (default: all probes)",
+    )
+    check_providers_parser.add_argument(
+        "--declared-only",
+        action="store_true",
+        help="Exercise only each probe's declared transport and skip alternate transport checks",
     )
     check_providers_parser.add_argument(
         "--config",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -427,6 +427,10 @@ def _block_real_coordinator_runners():
             side_effect=_unexpected_call("theforge.cli.provider_readiness.run_api_agent"),
         ),
         patch(
+            "theforge.cli.provider_readiness.run_agent",
+            side_effect=_unexpected_call("theforge.cli.provider_readiness.run_agent"),
+        ),
+        patch(
             "theforge.runners.run_agent",
             side_effect=_unexpected_call("theforge.runners.run_agent"),
         ),

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -66,6 +66,17 @@ def _api_profile(
     )
 
 
+def _cli_profile(name: str, cli: str = "claude", model: str = "sonnet") -> ModelProfile:
+    return ModelProfile(
+        name=name,
+        cli=cli,
+        model=model,
+        budget_usd=1.0,
+        timeout_seconds=120,
+        allowed_tools=("Read", "Grep"),
+    )
+
+
 def _make_forge_config(
     tmp_path: Path,
     review_pool: list[ModelProfile] | None = None,
@@ -134,8 +145,13 @@ def _make_fail_result(profile_name: str = "test") -> AgentResult:
     )
 
 
-def _make_args(profile: str | None = None, config: str | None = None) -> argparse.Namespace:
-    return argparse.Namespace(profile=profile, config=config)
+def _make_args(
+    profile: str | None = None,
+    config: str | None = None,
+    *,
+    declared_only: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(profile=profile, config=config, declared_only=declared_only)
 
 
 # ── TestParseFrontmatter ──────────────────────────────────────────────
@@ -671,6 +687,24 @@ class TestCmdCheckProviders:
         assert rc == 1
         mock_api.assert_not_called()
 
+    def test_declared_only_skips_alternate_transport_probe(self, tmp_path):
+        cfg = _make_forge_config(tmp_path, include_test_secrets=True)
+        args = _make_args(config=str(tmp_path / "forge.yaml"), declared_only=True)
+
+        with (
+            patch("theforge.cli.providers.load_config", return_value=cfg),
+            patch(
+                "theforge.cli.provider_readiness.run_api_agent",
+                return_value=_make_pass_result("declared-only"),
+            ) as mock_api,
+            patch("theforge.cli.provider_readiness.run_agent") as mock_cli,
+        ):
+            rc = cmd_check_providers(args)
+
+        assert rc == 0
+        assert mock_api.call_count == 5
+        mock_cli.assert_not_called()
+
     def test_no_verdict_in_structured_data_counts_as_failure(self, tmp_path, capsys):
         """structured_data without 'verdict' key → failure."""
         cfg = _make_forge_config(tmp_path, include_test_secrets=True)
@@ -911,6 +945,54 @@ class TestCmdCheckProviders:
         captured = capsys.readouterr()
         assert READINESS_STATUS_UNVERIFIED in captured.out
         assert "No CLI runner for provider 'deepseek'" in captured.out
+
+    def test_declared_explicit_cli_runner_is_exercised(self, tmp_path):
+        cfg = _make_forge_config(
+            tmp_path,
+            review_pool=[_cli_profile("review-ghaw", cli="ghaw", model="sonnet")],
+            include_test_secrets=True,
+        )
+        args = _make_args(profile="review-ghaw", config=str(tmp_path / "forge.yaml"))
+
+        with (
+            patch("theforge.cli.providers.load_config", return_value=cfg),
+            patch(
+                "theforge.cli.provider_readiness.run_agent",
+                return_value=AgentResult(
+                    success=True,
+                    output='{"verdict":"APPROVE","summary":"ok"}',
+                    session_id=None,
+                    cost_usd=0.003,
+                    exit_code=0,
+                    raw={},
+                    profile_name="review-ghaw",
+                    structured_data={"verdict": "APPROVE", "summary": "ok"},
+                    transport_used="cli",
+                ),
+            ) as mock_cli,
+            patch(
+                "theforge.cli.provider_readiness.run_api_agent",
+                return_value=AgentResult(
+                    success=True,
+                    output='{"verdict":"APPROVE","summary":"ok"}',
+                    session_id=None,
+                    cost_usd=0.003,
+                    exit_code=0,
+                    raw={},
+                    profile_name="review-ghaw",
+                    structured_data={"verdict": "APPROVE", "summary": "ok"},
+                    transport_used="api",
+                ),
+            ),
+            patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+        ):
+            rc = cmd_check_providers(args)
+
+        assert rc == 0
+        declared_profile = mock_cli.call_args.kwargs["profile"]
+        assert declared_profile.cli == "ghaw"
+        assert declared_profile.transport is not None
+        assert declared_profile.transport.runner == "ghaw"
 
 
 # ── TestCmdInitHooks ──────────────────────────────────────────────────

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -32,7 +32,10 @@ from theforge.cli import (
 from theforge.cli import hooks as hooks_module
 from theforge.cli.hooks import created_labels, static_issue_labels
 from theforge.cli.init_commands import _extract_forge_block
-from theforge.cli.provider_readiness import READINESS_STATUS_COST_UNAVAILABLE
+from theforge.cli.provider_readiness import (
+    READINESS_STATUS_COST_UNAVAILABLE,
+    READINESS_STATUS_UNVERIFIED,
+)
 from theforge.config import (
     DEFAULT_VALIDATION,
     AgentDef,
@@ -66,9 +69,14 @@ def _api_profile(
 def _make_forge_config(
     tmp_path: Path,
     review_pool: list[ModelProfile] | None = None,
+    *,
+    include_test_secrets: bool = False,
 ) -> ForgeConfig:
     if review_pool is None:
-        review_pool = [_api_profile("claude-reviewer"), _api_profile("codex-reviewer", "openai")]
+        review_pool = [
+            _api_profile("claude-reviewer"),
+            _api_profile("deepseek-reviewer", "deepseek", "deepseek-chat"),
+        ]
     return ForgeConfig(
         project="test",
         project_root=tmp_path,
@@ -78,27 +86,26 @@ def _make_forge_config(
             branch_pattern="feat/{slug}",
         ),
         validation=DEFAULT_VALIDATION,
-        dev_profile=ModelProfile(
-            name="dev",
-            cli="claude",
-            model="sonnet",
-            budget_usd=2.0,
-            timeout_seconds=300,
-            allowed_tools=("Read",),
-        ),
-        preflight_profile=ModelProfile(
-            name="preflight",
-            cli="claude",
-            model="sonnet",
-            budget_usd=0.5,
-            timeout_seconds=120,
-            allowed_tools=("Read",),
+        dev_profile=_api_profile("dev", provider="anthropic", model="claude-sonnet-4-6"),
+        preflight_profile=_api_profile(
+            "preflight",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
         ),
         review_pool=review_pool,
         synthesis_profile=None,
         retry=RetryPolicy(),
         plan_agent_review=PlanAgentReviewConfig.of(enabled=False),
         log=LogConfig(enabled=False),
+        secrets=(
+            {
+                "ANTHROPIC_API_KEY": "test-key",
+                "DEEPSEEK_API_KEY": "test-key",
+                "OPENAI_API_KEY": "test-key",
+            }
+            if include_test_secrets
+            else {}
+        ),
     )
 
 
@@ -118,7 +125,7 @@ def _make_pass_result(profile_name: str = "test") -> AgentResult:
 def _make_fail_result(profile_name: str = "test") -> AgentResult:
     return AgentResult(
         success=False,
-        output="AuthenticationError: invalid key",
+        output="provider returned malformed tool response",
         session_id=None,
         cost_usd=None,
         exit_code=1,
@@ -576,12 +583,15 @@ class TestCmdCheckProviders:
 
     def test_all_pass_exits_zero(self, tmp_path, capsys):
         """All profiles passing → exit code 0, table shows checkmarks."""
-        cfg = _make_forge_config(tmp_path)
+        cfg = _make_forge_config(tmp_path, include_test_secrets=True)
         args = _make_args(config=str(tmp_path / "forge.yaml"))
 
         side_effects = [
+            _make_pass_result("dev"),
+            _make_pass_result("preflight"),
             _make_pass_result("claude-reviewer"),
-            _make_pass_result("codex-reviewer"),
+            _make_pass_result("deepseek-reviewer"),
+            _make_pass_result("preflight"),
         ]
         with patch("theforge.cli.providers.load_config", return_value=cfg):
             with patch("theforge.cli.provider_readiness.run_api_agent", side_effect=side_effects):
@@ -590,16 +600,20 @@ class TestCmdCheckProviders:
         assert rc == 0
         captured = capsys.readouterr()
         assert "✓" in captured.out
-        assert "2/2 passed" in captured.out
+        assert "5/5 passed" in captured.out
+        assert "declared transport:" not in captured.out
 
     def test_partial_fail_exits_one(self, tmp_path, capsys):
         """One profile failing → exit code 1, failure shown inline."""
-        cfg = _make_forge_config(tmp_path)
+        cfg = _make_forge_config(tmp_path, include_test_secrets=True)
         args = _make_args(config=str(tmp_path / "forge.yaml"))
 
         side_effects = [
+            _make_pass_result("dev"),
+            _make_pass_result("preflight"),
             _make_pass_result("claude-reviewer"),
-            _make_fail_result("codex-reviewer"),
+            _make_fail_result("deepseek-reviewer"),
+            _make_pass_result("preflight"),
         ]
         with patch("theforge.cli.providers.load_config", return_value=cfg):
             with patch("theforge.cli.provider_readiness.run_api_agent", side_effect=side_effects):
@@ -608,11 +622,12 @@ class TestCmdCheckProviders:
         assert rc == 1
         captured = capsys.readouterr()
         assert "✗" in captured.out
-        assert "1/2 passed" in captured.out
+        assert "4/5 passed" in captured.out
+        assert "declared transport:" in captured.out
 
     def test_exception_counts_as_failure(self, tmp_path, capsys):
         """run_api_agent raising an exception → exit code 1, error shown inline."""
-        cfg = _make_forge_config(tmp_path)
+        cfg = _make_forge_config(tmp_path, include_test_secrets=True)
         args = _make_args(config=str(tmp_path / "forge.yaml"))
 
         def _boom(*_, **__):
@@ -629,7 +644,7 @@ class TestCmdCheckProviders:
 
     def test_profile_filter(self, tmp_path, capsys):
         """--profile <name> tests only the named profile."""
-        cfg = _make_forge_config(tmp_path)
+        cfg = _make_forge_config(tmp_path, include_test_secrets=True)
         args = _make_args(profile="claude-reviewer", config=str(tmp_path / "forge.yaml"))
 
         with patch("theforge.cli.providers.load_config", return_value=cfg):
@@ -646,7 +661,7 @@ class TestCmdCheckProviders:
 
     def test_profile_filter_unknown_exits_one(self, tmp_path):
         """--profile with unknown name → exit code 1, no API calls."""
-        cfg = _make_forge_config(tmp_path)
+        cfg = _make_forge_config(tmp_path, include_test_secrets=True)
         args = _make_args(profile="nonexistent", config=str(tmp_path / "forge.yaml"))
 
         with patch("theforge.cli.providers.load_config", return_value=cfg):
@@ -658,7 +673,7 @@ class TestCmdCheckProviders:
 
     def test_no_verdict_in_structured_data_counts_as_failure(self, tmp_path, capsys):
         """structured_data without 'verdict' key → failure."""
-        cfg = _make_forge_config(tmp_path)
+        cfg = _make_forge_config(tmp_path, include_test_secrets=True)
         args = _make_args(config=str(tmp_path / "forge.yaml"))
 
         bad_result = AgentResult(
@@ -698,27 +713,18 @@ class TestCmdCheckProviders:
                 branch_pattern="feat/{slug}",
             ),
             validation=DEFAULT_VALIDATION,
-            dev_profile=ModelProfile(
-                name="dev",
-                cli="claude",
-                model="sonnet",
-                budget_usd=2.0,
-                timeout_seconds=300,
-                allowed_tools=("Read",),
-            ),
-            preflight_profile=ModelProfile(
-                name="preflight",
-                cli="claude",
-                model="sonnet",
-                budget_usd=0.5,
-                timeout_seconds=120,
-                allowed_tools=("Read",),
+            dev_profile=_api_profile("dev", provider="anthropic", model="claude-sonnet-4-6"),
+            preflight_profile=_api_profile(
+                "preflight",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
             ),
             review_pool=[shared, shared],
             synthesis_profile=None,
             retry=RetryPolicy(),
             plan_agent_review=PlanAgentReviewConfig.of(enabled=False),
             log=LogConfig(enabled=False),
+            secrets={"ANTHROPIC_API_KEY": "test-key"},
         )
         args = _make_args(config=str(tmp_path / "forge.yaml"))
 
@@ -730,10 +736,14 @@ class TestCmdCheckProviders:
                 rc = cmd_check_providers(args)
 
         assert rc == 0
-        assert mock_api.call_count == 1
+        assert mock_api.call_count == 4
 
     def test_tool_bearing_profile_is_probed_with_original_allowlist(self, tmp_path):
-        cfg = _make_forge_config(tmp_path, review_pool=[_api_profile("reviewer")])
+        cfg = _make_forge_config(
+            tmp_path,
+            review_pool=[_api_profile("reviewer")],
+            include_test_secrets=True,
+        )
         args = _make_args(config=str(tmp_path / "forge.yaml"))
 
         with patch("theforge.cli.providers.load_config", return_value=cfg):
@@ -744,12 +754,15 @@ class TestCmdCheckProviders:
                 rc = cmd_check_providers(args)
 
         assert rc == 0
-        assert mock_api.call_args.kwargs["profile"].allowed_tools == ("Read", "Grep")
+        reviewer_call = next(
+            call for call in mock_api.call_args_list if call.kwargs["profile"].name == "reviewer"
+        )
+        assert reviewer_call.kwargs["profile"].allowed_tools == ("Read", "Grep")
 
     def test_tool_bearing_agent_pool_failure_cannot_hide_behind_plain_probe(
         self, tmp_path, capsys
     ):
-        cfg = _make_forge_config(tmp_path, review_pool=[])
+        cfg = _make_forge_config(tmp_path, review_pool=[], include_test_secrets=True)
         cfg = ForgeConfig(
             **{
                 **cfg.__dict__,
@@ -781,11 +794,11 @@ class TestCmdCheckProviders:
         assert rc == 1
         captured = capsys.readouterr()
         assert "agent-dev" in captured.out
-        assert "0/5 passed" in captured.out
+        assert "0/8 passed" in captured.out
 
     def test_same_profile_can_render_distinct_role_rows(self, tmp_path, capsys):
         shared = _api_profile("shared")
-        cfg = _make_forge_config(tmp_path, review_pool=[shared])
+        cfg = _make_forge_config(tmp_path, review_pool=[shared], include_test_secrets=True)
         cfg = ForgeConfig(
             **{
                 **cfg.__dict__,
@@ -797,7 +810,13 @@ class TestCmdCheckProviders:
         with patch("theforge.cli.providers.load_config", return_value=cfg):
             with patch(
                 "theforge.cli.provider_readiness.run_api_agent",
-                side_effect=[_make_pass_result("shared"), _make_pass_result("shared")],
+                side_effect=[
+                    _make_pass_result("dev"),
+                    _make_pass_result("preflight"),
+                    _make_pass_result("shared"),
+                    _make_pass_result("shared"),
+                    _make_pass_result("preflight"),
+                ],
             ):
                 rc = cmd_check_providers(args)
 
@@ -805,10 +824,14 @@ class TestCmdCheckProviders:
         captured = capsys.readouterr()
         assert "review" in captured.out
         assert "plan-review" in captured.out
-        assert "2/2 passed" in captured.out
+        assert "5/5 passed" in captured.out
 
     def test_cost_unavailable_is_reported_and_fails(self, tmp_path, capsys):
-        cfg = _make_forge_config(tmp_path, review_pool=[_api_profile("reviewer")])
+        cfg = _make_forge_config(
+            tmp_path,
+            review_pool=[_api_profile("reviewer")],
+            include_test_secrets=True,
+        )
         args = _make_args(config=str(tmp_path / "forge.yaml"))
         unknown_cost = AgentResult(
             success=True,
@@ -828,7 +851,66 @@ class TestCmdCheckProviders:
         assert rc == 1
         captured = capsys.readouterr()
         assert READINESS_STATUS_COST_UNAVAILABLE in captured.out
-        assert "0/1 passed" in captured.out
+        assert "0/4 passed" in captured.out
+
+    def test_declared_api_failure_names_ready_cli_alternate(self, tmp_path, capsys):
+        cfg = _make_forge_config(
+            tmp_path,
+            review_pool=[_api_profile("openai-reviewer", "openai", "gpt-5.4")],
+            include_test_secrets=True,
+        )
+        args = _make_args(profile="openai-reviewer", config=str(tmp_path / "forge.yaml"))
+
+        with (
+            patch("theforge.cli.providers.load_config", return_value=cfg),
+            patch(
+                "theforge.cli.provider_readiness.run_api_agent",
+                return_value=_make_fail_result("openai-reviewer"),
+            ),
+            patch(
+                "theforge.cli.provider_readiness.run_agent",
+                return_value=AgentResult(
+                    success=True,
+                    output='{"verdict":"APPROVE","summary":"ok"}',
+                    session_id=None,
+                    cost_usd=0.003,
+                    exit_code=0,
+                    raw={},
+                    profile_name="openai-reviewer",
+                    structured_data={"verdict": "APPROVE", "summary": "ok"},
+                    transport_used="cli",
+                ),
+            ),
+            patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+        ):
+            rc = cmd_check_providers(args)
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "declared transport: api" in captured.out
+        assert "api      tool-structured" in captured.out
+        assert "cli      tool-structured" in captured.out
+        assert "ready alternate transport: cli" in captured.out
+
+    def test_unverified_alternate_transport_reason_is_rendered(self, tmp_path, capsys):
+        cfg = _make_forge_config(
+            tmp_path,
+            review_pool=[_api_profile("deepseek-reviewer", "deepseek", "deepseek-chat")],
+            include_test_secrets=True,
+        )
+        args = _make_args(profile="deepseek-reviewer", config=str(tmp_path / "forge.yaml"))
+
+        with patch("theforge.cli.providers.load_config", return_value=cfg):
+            with patch(
+                "theforge.cli.provider_readiness.run_api_agent",
+                return_value=_make_fail_result("deepseek-reviewer"),
+            ):
+                rc = cmd_check_providers(args)
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert READINESS_STATUS_UNVERIFIED in captured.out
+        assert "No CLI runner for provider 'deepseek'" in captured.out
 
 
 # ── TestCmdInitHooks ──────────────────────────────────────────────────

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -705,6 +705,43 @@ class TestCmdCheckProviders:
         assert mock_api.call_count == 5
         mock_cli.assert_not_called()
 
+    def test_declared_only_skips_alternate_api_probe_for_cli_declared_profile(self, tmp_path):
+        cfg = _make_forge_config(
+            tmp_path,
+            review_pool=[_cli_profile("review-ghaw", cli="ghaw", model="sonnet")],
+            include_test_secrets=True,
+        )
+        args = _make_args(
+            profile="review-ghaw",
+            config=str(tmp_path / "forge.yaml"),
+            declared_only=True,
+        )
+
+        with (
+            patch("theforge.cli.providers.load_config", return_value=cfg),
+            patch(
+                "theforge.cli.provider_readiness.run_agent",
+                return_value=AgentResult(
+                    success=True,
+                    output='{"verdict":"APPROVE","summary":"ok"}',
+                    session_id=None,
+                    cost_usd=0.003,
+                    exit_code=0,
+                    raw={},
+                    profile_name="review-ghaw",
+                    structured_data={"verdict": "APPROVE", "summary": "ok"},
+                    transport_used="cli",
+                ),
+            ) as mock_cli,
+            patch("theforge.cli.provider_readiness.run_api_agent") as mock_api,
+            patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+        ):
+            rc = cmd_check_providers(args)
+
+        assert rc == 0
+        assert mock_cli.call_count == 1
+        mock_api.assert_not_called()
+
     def test_no_verdict_in_structured_data_counts_as_failure(self, tmp_path, capsys):
         """structured_data without 'verdict' key → failure."""
         cfg = _make_forge_config(tmp_path, include_test_secrets=True)

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -7,6 +7,7 @@ from theforge.cli.provider_readiness import (
     READINESS_CAPABILITY_TOOL_STRUCTURED,
     READINESS_STATUS_READY,
     READINESS_STATUS_UNSUPPORTED,
+    READINESS_STATUS_UNVERIFIED,
     build_readiness_probes,
     run_readiness_probe,
 )
@@ -42,6 +43,27 @@ def _api_profile(
         timeout_seconds=120,
         allowed_tools=allowed_tools,
         phase=phase,
+    )
+
+
+def _cli_profile(
+    name: str,
+    *,
+    cli: str = "claude",
+    model: str = "sonnet",
+    allowed_tools: tuple[str, ...] = ("Read", "Grep"),
+    phase: str | None = None,
+    fallback_models: tuple[str, ...] = (),
+) -> ModelProfile:
+    return ModelProfile(
+        name=name,
+        cli=cli,
+        model=model,
+        budget_usd=1.0,
+        timeout_seconds=120,
+        allowed_tools=allowed_tools,
+        phase=phase,
+        fallback_models=fallback_models,
     )
 
 
@@ -90,16 +112,35 @@ def _config(tmp_path: Path) -> ForgeConfig:
     )
 
 
-def _pass_result(profile_name: str = "test", *, cost_usd: float | None = 0.003) -> AgentResult:
+def _pass_result(
+    profile_name: str = "test",
+    *,
+    cost_usd: float | None = 0.003,
+    structured: bool = True,
+    transport_used: str | None = None,
+    model_used: str | None = None,
+) -> AgentResult:
+    structured_data = {"verdict": "APPROVE", "summary": "ok"} if structured else None
+    output = '{"verdict":"APPROVE","summary":"ok"}' if structured else "Capability probe complete."
     return AgentResult(
         success=True,
-        output='{"verdict":"APPROVE","summary":"ok"}',
+        output=output,
         session_id=None,
         cost_usd=cost_usd,
         exit_code=0,
         raw={},
         profile_name=profile_name,
-        structured_data={"verdict": "APPROVE", "summary": "ok"},
+        structured_data=structured_data,
+        transport_used=transport_used,
+        model_used=model_used,
+    )
+
+
+def _attempt(result, transport_kind: str):
+    return next(
+        attempt
+        for attempt in result.attempts
+        if attempt.attempted_transport_kind == transport_kind
     )
 
 
@@ -109,6 +150,7 @@ def test_build_readiness_probes_includes_config_plan_and_advisor_shapes(tmp_path
     probes = build_readiness_probes(config)
     labels = {(probe.role, probe.profile.name, probe.profile.phase) for probe in probes}
 
+    assert ("dev", "dev", "dev") in labels
     assert ("preflight", "preflight", "preflight") in labels
     assert ("review", "reviewer", "review") in labels
     assert ("plan", "plan", "plan") in labels
@@ -197,16 +239,23 @@ def test_run_readiness_probe_marks_openai_unsupported_shape_not_ready(tmp_path):
         probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "review"
     )
 
-    with patch(
-        "theforge.cli.provider_readiness.openai_function_tool_request_shape",
-        return_value=OpenAIFunctionToolRequestShape("unsupported"),
+    with (
+        patch(
+            "theforge.cli.provider_readiness.openai_function_tool_request_shape",
+            return_value=OpenAIFunctionToolRequestShape("unsupported"),
+        ),
+        patch("theforge.cli.provider_readiness.run_api_agent") as mock_api,
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_pass_result(transport_used="cli"),
+        ),
     ):
-        with patch("theforge.cli.provider_readiness.run_api_agent") as mock_api:
-            result = run_readiness_probe(probe, secrets={})
+        result = run_readiness_probe(probe, secrets={})
 
     assert result.status == READINESS_STATUS_UNSUPPORTED
     assert not result.ready
     mock_api.assert_not_called()
+    assert _attempt(result, "api").status == READINESS_STATUS_UNSUPPORTED
 
 
 def test_run_readiness_probe_marks_successful_probe_ready(tmp_path):
@@ -214,11 +263,18 @@ def test_run_readiness_probe_marks_successful_probe_ready(tmp_path):
         probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "review"
     )
 
-    with patch("theforge.cli.provider_readiness.run_api_agent", return_value=_pass_result()):
+    with (
+        patch("theforge.cli.provider_readiness.run_api_agent", return_value=_pass_result()),
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_pass_result(transport_used="cli"),
+        ),
+    ):
         result = run_readiness_probe(probe, secrets={})
 
     assert result.status == READINESS_STATUS_READY
     assert result.ready is True
+    assert {attempt.attempted_transport_kind for attempt in result.attempts} == {"api", "cli"}
 
 
 def test_run_readiness_probe_uses_throwaway_working_dir(tmp_path):
@@ -226,10 +282,16 @@ def test_run_readiness_probe_uses_throwaway_working_dir(tmp_path):
         probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "review"
     )
 
-    with patch(
-        "theforge.cli.provider_readiness.run_api_agent",
-        return_value=_pass_result(),
-    ) as mock_api:
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            return_value=_pass_result(),
+        ) as mock_api,
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_pass_result(transport_used="cli"),
+        ),
+    ):
         result = run_readiness_probe(probe, secrets={})
 
     assert result.status == READINESS_STATUS_READY
@@ -242,19 +304,137 @@ def test_run_readiness_probe_no_submit_phase_accepts_unstructured_success(tmp_pa
     probe = next(
         probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "preflight"
     )
-    unstructured = AgentResult(
-        success=True,
-        output="Capability probe completed successfully.",
-        session_id=None,
-        cost_usd=0.002,
-        exit_code=0,
-        raw={},
-        profile_name=probe.profile.name,
-        structured_data=None,
-    )
 
-    with patch("theforge.cli.provider_readiness.run_api_agent", return_value=unstructured):
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            side_effect=[
+                _pass_result(structured=False),
+                _pass_result(transport_used="api"),
+            ],
+        ),
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_pass_result(structured=False, transport_used="cli"),
+        ),
+    ):
         result = run_readiness_probe(probe, secrets={})
 
     assert result.status == READINESS_STATUS_READY
     assert result.ready is True
+
+
+def test_run_readiness_probe_exercises_declared_cli_profile_and_api_alternate(tmp_path):
+    probe = next(
+        probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "dev"
+    )
+
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_pass_result(structured=False, transport_used="cli"),
+        ) as mock_cli,
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            return_value=_pass_result(structured=False, transport_used="api"),
+        ) as mock_api,
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    assert result.status == READINESS_STATUS_READY
+    assert {attempt.attempted_transport_kind for attempt in result.attempts} == {"cli", "api"}
+    assert mock_cli.call_args.kwargs["profile"].mode == "cli"
+    assert mock_cli.call_args.kwargs["profile"].api_fallback is None
+    assert mock_cli.call_args.kwargs["profile"].fallback_models == ()
+    assert mock_api.call_args.kwargs["profile"].mode == "api"
+    assert mock_api.call_args.kwargs["profile"].api_fallback is None
+    assert mock_api.call_args.kwargs["profile"].fallback_models == ()
+
+
+def test_run_readiness_probe_reports_unavailable_alternate_transport_unverified(tmp_path):
+    config = _config(tmp_path)
+    config = ForgeConfig(
+        **{
+            **config.__dict__,
+            "review_pool": [
+                _api_profile(
+                    "deepseek-reviewer",
+                    provider="deepseek",
+                    model="deepseek-chat",
+                    phase="review",
+                )
+            ],
+        }
+    )
+    probe = next(probe for probe in build_readiness_probes(config) if probe.role == "review")
+
+    with patch("theforge.cli.provider_readiness.run_api_agent", return_value=_pass_result()):
+        result = run_readiness_probe(probe, secrets={})
+
+    alternate = _attempt(result, "cli")
+    assert result.status == READINESS_STATUS_READY
+    assert alternate.status == READINESS_STATUS_UNVERIFIED
+    assert "No CLI runner for provider 'deepseek'" in alternate.detail
+
+
+def test_run_readiness_probe_rejects_transport_or_model_fallback_mismatch(tmp_path):
+    config = _config(tmp_path)
+    config = ForgeConfig(
+        **{
+            **config.__dict__,
+            "dev_profile": _cli_profile(
+                "dev",
+                model="sonnet",
+                fallback_models=("haiku",),
+            ),
+        }
+    )
+    probe = next(probe for probe in build_readiness_probes(config) if probe.role == "dev")
+
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_pass_result(
+                structured=False,
+                transport_used="api",
+                model_used="haiku",
+            ),
+        ),
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            return_value=_pass_result(structured=False, transport_used="api"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    assert result.status == READINESS_STATUS_UNVERIFIED
+    assert "requested transport 'cli'" in result.detail
+
+
+def test_run_readiness_probe_marks_cli_cost_unavailable_unverified(tmp_path):
+    config = _config(tmp_path)
+    config = ForgeConfig(
+        **{
+            **config.__dict__,
+            "review_pool": [_cli_profile("review-cli", phase="review")],
+        }
+    )
+    probe = next(probe for probe in build_readiness_probes(config) if probe.role == "review")
+
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_pass_result(cost_usd=None, transport_used="cli"),
+        ),
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            return_value=_pass_result(transport_used="api"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    assert result.status == READINESS_STATUS_UNVERIFIED
+    assert "CLI cost is unavailable" in result.detail

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from theforge.cli.provider_readiness import (
     READINESS_CAPABILITY_TOOL_STRUCTURED,
+    READINESS_STATUS_FAILED,
     READINESS_STATUS_READY,
     READINESS_STATUS_UNSUPPORTED,
     READINESS_STATUS_UNVERIFIED,
@@ -352,6 +353,37 @@ def test_run_readiness_probe_exercises_declared_cli_profile_and_api_alternate(tm
     assert mock_api.call_args.kwargs["profile"].fallback_models == ()
 
 
+def test_run_readiness_probe_preserves_declared_explicit_cli_runner(tmp_path):
+    config = _config(tmp_path)
+    config = ForgeConfig(
+        **{
+            **config.__dict__,
+            "dev_profile": _cli_profile("dev", cli="ghaw", model="sonnet"),
+        }
+    )
+    probe = next(probe for probe in build_readiness_probes(config) if probe.role == "dev")
+
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_pass_result(structured=False, transport_used="cli"),
+        ) as mock_cli,
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            return_value=_pass_result(structured=False, transport_used="api"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    declared_profile = mock_cli.call_args.kwargs["profile"]
+    assert result.status == READINESS_STATUS_READY
+    assert declared_profile.cli == "ghaw"
+    assert declared_profile.transport is not None
+    assert declared_profile.transport.runner == "ghaw"
+    assert declared_profile.transport.executable == "gh"
+
+
 def test_run_readiness_probe_reports_unavailable_alternate_transport_unverified(tmp_path):
     config = _config(tmp_path)
     config = ForgeConfig(
@@ -438,3 +470,31 @@ def test_run_readiness_probe_marks_cli_cost_unavailable_unverified(tmp_path):
 
     assert result.status == READINESS_STATUS_UNVERIFIED
     assert "CLI cost is unavailable" in result.detail
+
+
+def test_run_readiness_probe_does_not_treat_plain_401_reference_as_auth_unverified(tmp_path):
+    probe = next(
+        probe for probe in build_readiness_probes(_config(tmp_path)) if probe.role == "review"
+    )
+    numbered_failure = AgentResult(
+        success=False,
+        output="I updated src/theforge/coordinator/engine.py:401 to guard the branch.",
+        session_id=None,
+        cost_usd=None,
+        exit_code=1,
+        raw={},
+        profile_name="reviewer",
+    )
+
+    with (
+        patch("theforge.cli.provider_readiness.run_api_agent", return_value=numbered_failure),
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_pass_result(transport_used="cli"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    assert result.status == READINESS_STATUS_FAILED
+    assert result.detail == numbered_failure.output[:120]


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior ghaw declared-transport findings are resolved; no blocking regressions found. | [anthropic-opus-cli] Iteration 3 adds only the mirrored CLI-declared --declared-only test I asked for in cycle 2 (37 added lines in tests/test_cli_setup.py, no production change), the cycle-1 ghaw runner-substitution P1 remains fixed, and the authoritative gate is PASS at the reviewed HEAD 968644b9.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $15.20
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

Nothing verifies that a declared transport can serve the model declared on it, so a wrong choice is accepted, certified, and only visible as failures several layers downstream (GitHub Issue #2380)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2380