### PR TITLE
An agent invocation that produces no output and bills nothing consumes a development iteration, so three such failures exhaust the pool and the story is reported as needing a larger budget or a narrower scope

### DIFF
--- a/src/theforge/coordinator/agent_failure.py
+++ b/src/theforge/coordinator/agent_failure.py
@@ -153,6 +153,18 @@ _TRANSPORT_FAILURE_CODES: frozenset[str] = frozenset(
     {"rate_limit", "provider_internal_error", "connection_reset"}
 )
 _AUTH_FAILURE_CODES: frozenset[str] = frozenset({"auth_error", "authentication_error"})
+_MODEL_EXECUTION_FAILURE_CODES: frozenset[str] = frozenset(
+    {
+        # Keep in sync with the API/CLI loop runners: these codes mean the
+        # model executed and the run reached a work-ending condition, even if
+        # the final failure text is a runner-authored summary line and the
+        # transport billed $0.00 (e.g. a localhost endpoint).
+        "agent_ended_without_result",
+        "max_iterations_reached",
+        "no_submit_completion",
+        "stuck_pattern",
+    }
+)
 
 
 def _text_of(result: Any) -> str:
@@ -171,6 +183,59 @@ def _looks_like_auth_failure(text: str) -> bool:
 def _looks_like_transport_failure(text: str) -> bool:
     """True when ``text`` is a transport drop / provider outage (phrase or 5xx/429)."""
     return _matches(text, _TRANSPORT_PATTERNS) or bool(_TRANSPORT_CODE_RE.search(text))
+
+
+def _has_model_usage_evidence(result: Any) -> bool:
+    """True when token/cost telemetry proves a model actually ran."""
+    for usage in tuple(getattr(result, "model_usage", ()) or ()):
+        for usage_field in (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_creation_tokens",
+            "thinking_tokens",
+        ):
+            value = getattr(usage, usage_field, 0)
+            if isinstance(value, int) and value > 0:
+                return True
+        cost = getattr(usage, "cost_usd", None)
+        if isinstance(cost, (int, float)) and cost > 0.0:
+            return True
+    return False
+
+
+def _has_runner_artifacts(result: Any) -> bool:
+    """True when the runner captured provider/session artifacts for the call."""
+    if getattr(result, "session_id", None):
+        return True
+    raw = getattr(result, "raw", None)
+    return isinstance(raw, dict) and bool(raw)
+
+
+def zero_charge_no_model_artifacts(result: Any) -> bool:
+    """True when the failed invocation billed nothing and shows no model artifacts."""
+    if result is None or getattr(result, "success", False):
+        return False
+    exit_code = getattr(result, "exit_code", None)
+    if not isinstance(exit_code, int) or exit_code == 0:
+        return False
+    cost = getattr(result, "cost_usd", None)
+    if cost != 0.0:
+        return False
+    if str(getattr(result, "partial_output", "") or "").strip():
+        return False
+    if getattr(result, "tool_trace", ()):
+        return False
+    if getattr(result, "structured_data", None):
+        return False
+    if getattr(result, "dev_handoff", None):
+        return False
+    if _has_runner_artifacts(result):
+        return False
+    if _has_model_usage_evidence(result):
+        return False
+    failure_code = str(getattr(result, "failure_code", "") or "").lower()
+    return failure_code not in _MODEL_EXECUTION_FAILURE_CODES
 
 
 def carries_agent_text(output: str | None) -> bool:
@@ -195,9 +260,10 @@ def produced_model_output(result: Any) -> bool:
     judgment. A failed invocation whose only content is a recognized substrate
     marker (auth rejection, transport drop, runner no-output marker) did not.
 
-    Unrecognized failure text is treated as model output: this predicate gates a
-    behavior change, so it errs toward the pre-existing path rather than
-    reclassifying failures it cannot positively identify as substrate events.
+    Unrecognized failure text is ordinarily treated as model output. The one
+    extra no-judgment heuristic is a failed non-zero process result that billed
+    exactly $0.00 and carries no runner/provider/model artifacts at all: that
+    shape is a runner/process failure, not a silent model judgment.
     """
     if result is None:
         return False
@@ -211,6 +277,11 @@ def produced_model_output(result: Any) -> bool:
         return True
     if getattr(result, "dev_handoff", None):
         return True
+    if _has_model_usage_evidence(result):
+        return True
+    failure_code = str(getattr(result, "failure_code", "") or "").lower()
+    if failure_code in _MODEL_EXECUTION_FAILURE_CODES:
+        return True
     text = _text_of(result)
     if not text:
         return False
@@ -219,6 +290,10 @@ def produced_model_output(result: Any) -> bool:
     if _matches(text, _NO_OUTPUT_MARKERS):
         return False
     if _looks_like_auth_failure(text) or _looks_like_transport_failure(text):
+        return False
+    if _has_runner_artifacts(result):
+        return True
+    if zero_charge_no_model_artifacts(result):
         return False
     return True
 

--- a/src/theforge/coordinator/commit_guard.py
+++ b/src/theforge/coordinator/commit_guard.py
@@ -103,6 +103,37 @@ def _worktree_has_changes(workspace_path: Path) -> bool:
     return bool(proc.stdout.strip())
 
 
+def _worktree_changed_since_commit(workspace_path: Path, base_commit: str | None) -> bool | None:
+    """Return whether the worktree changed since ``base_commit``.
+
+    ``base_commit`` is the HEAD captured immediately before the dev iteration
+    started. Comparing against it answers a different question from
+    ``_has_commits_ahead_of_base``: whether *this invocation* changed the
+    workspace, even when preserved commits from an earlier run already leave the
+    branch ahead of base.
+
+    Returns ``None`` when git cannot answer safely (invalid/missing commit,
+    non-repo path, command failure) so callers can fail open to their broader
+    branch-level guard instead of falsely claiming "no changes".
+    """
+    if not isinstance(base_commit, str) or not base_commit.strip():
+        return None
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "--quiet", base_commit, "HEAD"],
+            cwd=str(workspace_path),
+            capture_output=True,
+            timeout=10,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    if diff.returncode == 1:
+        return True
+    if diff.returncode != 0:
+        return None
+    return _worktree_has_changes(workspace_path)
+
+
 def _checkpoint_commit(workspace_path: Path, reason: str) -> bool:
     """Commit the worktree's uncommitted changes as a coordinator checkpoint.
 

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -42,11 +42,13 @@ from .agent_failure import (
     classify_agent_failure,
     mark_infrastructure_abort,
     record_invocation_failure,
+    zero_charge_no_model_artifacts,
 )
 from .commit_guard import (
     _checkpoint_commit,
     _commits_exist_strict,
     _has_commits_ahead_of_base,
+    _worktree_changed_since_commit,
     _worktree_has_changes,
 )
 from .dev_verification import DevVerificationBroker
@@ -812,6 +814,22 @@ def _capture_dev_handoff(
         return None
 
 
+def _rollback_recorded_dev_attempt(
+    state: CoordinatorState,
+    *,
+    dev_results_len: int,
+    dev_durations_len: int,
+    dev_handoff_len: int,
+) -> None:
+    """Remove the just-recorded DEV attempt from ordinary iteration accounting."""
+    del state.dev_results[dev_results_len:]
+    del state.dev_durations[dev_durations_len:]
+    del state.dev_handoff_snapshots[dev_handoff_len:]
+    state.pending_dev_transport_retry_count = 0
+    state.pending_dev_transport_retry_events = []
+    state.pending_dev_verification_requests = []
+
+
 def _resolve_dev_sandbox_capabilities(config: ForgeConfig) -> dict:
     """Resolve the project's sandbox capability profile for audit + logging (#1947).
 
@@ -1295,6 +1313,9 @@ def _run_dev_phase(
     _dev_total_start = time.monotonic()
     _dev_results_this_iteration = []
     _dev_durations_this_iteration = []
+    _dev_results_before = len(state.dev_results)
+    _dev_durations_before = len(state.dev_durations)
+    _dev_handoff_before = len(state.dev_handoff_snapshots)
     _runner_failure = None
     _current_session_id = state.dev_session_id
     _dev_retry_events: list[dict] = []
@@ -1746,7 +1767,14 @@ def _run_dev_phase(
         # If the dev agent exited with failure (non-zero or signal-killed) and
         # the worktree has no new commits ahead of base, escalate immediately
         # rather than letting an empty diff flow through to a fake APPROVE.
-        if not _has_commits_ahead_of_base(workspace_path, config.workspace.base_branch):
+        _has_branch_commits = _has_commits_ahead_of_base(
+            workspace_path, config.workspace.base_branch
+        )
+        _changed_since_start = _worktree_changed_since_commit(
+            workspace_path, state.last_dev_start_commit
+        )
+        _left_no_observable_work = (not _has_branch_commits) or (_changed_since_start is False)
+        if _left_no_observable_work:
             # ── Infrastructure abort vs. genuine escalation (#1951) ──────
             # Refusing to APPROVE an empty diff is right either way. What
             # differs is what the run is entitled to CLAIM about the story.
@@ -1765,23 +1793,37 @@ def _run_dev_phase(
             )
             if _invocation_failure is not None:
                 record_invocation_failure(state, _invocation_failure)
+                _unused_dev_iteration = zero_charge_no_model_artifacts(dev_result)
+                if _unused_dev_iteration:
+                    _rollback_recorded_dev_attempt(
+                        state,
+                        dev_results_len=_dev_results_before,
+                        dev_durations_len=_dev_durations_before,
+                        dev_handoff_len=_dev_handoff_before,
+                    )
                 state.phase = Phase.ESCALATE
                 # Name the failure the way the phase already names it
                 # (_failure_detail states a timeout and its limit rather than the
                 # signal number, per #1216) and add the substrate category.
+                _work_clause = (
+                    "and no commits ahead of base"
+                    if not _has_branch_commits
+                    else "and left the preserved branch unchanged"
+                )
                 state.error = (
                     f"Dev agent produced no model output "
-                    f"(category={_invocation_failure.category}: {_failure_detail}) and "
-                    "no commits ahead of base — aborting as an infrastructure failure; "
+                    f"(category={_invocation_failure.category}: {_failure_detail}) {_work_clause} "
+                    "— aborting as an infrastructure failure; "
                     "no judgment was obtained about this story"
                 )
                 mark_infrastructure_abort(state, _invocation_failure, message=state.error)
-                record_dev_iteration_telemetry(
-                    state,
-                    workspace_path,
-                    max_iterations=state.adaptive_dev_max or config.retry.max_dev_iterations,
-                    gate_result="DEV_INFRA_FAILURE",
-                )
+                if not _unused_dev_iteration:
+                    record_dev_iteration_telemetry(
+                        state,
+                        workspace_path,
+                        max_iterations=state.adaptive_dev_max or config.retry.max_dev_iterations,
+                        gate_result="DEV_INFRA_FAILURE",
+                    )
                 _log(f"✗ ABORT   infrastructure failure: {state.error}")
                 if logger:
                     logger._safe_emit(
@@ -1798,6 +1840,7 @@ def _run_dev_phase(
                     state=state,
                     message=state.error,
                     infrastructure_failure=True,
+                    unused_dev_iteration=_unused_dev_iteration,
                 )
             state.phase = Phase.ESCALATE
             state.error = (

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -821,13 +821,15 @@ def _rollback_recorded_dev_attempt(
     dev_durations_len: int,
     dev_handoff_len: int,
 ) -> None:
-    """Remove the just-recorded DEV attempt from ordinary iteration accounting."""
-    del state.dev_results[dev_results_len:]
-    del state.dev_durations[dev_durations_len:]
-    del state.dev_handoff_snapshots[dev_handoff_len:]
+    """Remove only the trailing no-judgment DEV attempt from ordinary accounting."""
+    if len(state.dev_results) > dev_results_len:
+        state.dev_results.pop()
+    if len(state.dev_durations) > dev_durations_len:
+        state.dev_durations.pop()
+    if len(state.dev_handoff_snapshots) > dev_handoff_len:
+        state.dev_handoff_snapshots.pop()
     state.pending_dev_transport_retry_count = 0
     state.pending_dev_transport_retry_events = []
-    state.pending_dev_verification_requests = []
 
 
 def _resolve_dev_sandbox_capabilities(config: ForgeConfig) -> dict:
@@ -1773,24 +1775,25 @@ def _run_dev_phase(
         _changed_since_start = _worktree_changed_since_commit(
             workspace_path, state.last_dev_start_commit
         )
-        _left_no_observable_work = (not _has_branch_commits) or (_changed_since_start is False)
+        # ── Infrastructure abort vs. genuine escalation (#1951) ──────
+        # Refusing to APPROVE an empty diff is right either way. What differs
+        # is what the run is entitled to CLAIM about the story. ESCALATE is the
+        # outcome reserved for a story whose framing an agent found invalid —
+        # it asserts a judgment. When the dev invocation produced no model
+        # output at all (credential rejected, transport dropped, process never
+        # started), no agent judged anything, and recording ESCALATE writes a
+        # story-quality verdict that no model ever formed — one that then
+        # outlives the run in escalation memory.
+        _invocation_failure = classify_agent_failure(
+            dev_result,
+            phase="DEV",
+            profile_name=getattr(config.dev_profile, "name", None),
+            detail=_failure_detail,
+        )
+        _left_no_observable_work = (not _has_branch_commits) or (
+            _invocation_failure is not None and _changed_since_start is False
+        )
         if _left_no_observable_work:
-            # ── Infrastructure abort vs. genuine escalation (#1951) ──────
-            # Refusing to APPROVE an empty diff is right either way. What
-            # differs is what the run is entitled to CLAIM about the story.
-            # ESCALATE is the outcome reserved for a story whose framing an
-            # agent found invalid — it asserts a judgment. When the dev
-            # invocation produced no model output at all (credential rejected,
-            # transport dropped, process never started), no agent judged
-            # anything, and recording ESCALATE writes a story-quality verdict
-            # that no model ever formed — one that then outlives the run in
-            # escalation memory.
-            _invocation_failure = classify_agent_failure(
-                dev_result,
-                phase="DEV",
-                profile_name=getattr(config.dev_profile, "name", None),
-                detail=_failure_detail,
-            )
             if _invocation_failure is not None:
                 record_invocation_failure(state, _invocation_failure)
                 _unused_dev_iteration = zero_charge_no_model_artifacts(dev_result)
@@ -1843,9 +1846,14 @@ def _run_dev_phase(
                     unused_dev_iteration=_unused_dev_iteration,
                 )
             state.phase = Phase.ESCALATE
+            _work_clause = (
+                "produced no commits ahead of base"
+                if not _has_branch_commits
+                else "left the preserved branch unchanged"
+            )
             state.error = (
-                f"Dev agent failed ({_failure_detail}) and produced no commits "
-                "ahead of base — escalating to avoid an empty-diff APPROVE"
+                f"Dev agent failed ({_failure_detail}) and {_work_clause} "
+                "— escalating to avoid an empty-diff APPROVE"
             )
             record_dev_iteration_telemetry(
                 state,

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -832,6 +832,19 @@ def _rollback_recorded_dev_attempt(
     state.pending_dev_transport_retry_events = []
 
 
+def _pending_dev_transport_retry_failure_extra(state: CoordinatorState) -> dict:
+    """Audit-visible transport-retry evidence for a DEV failure record."""
+    if (
+        state.pending_dev_transport_retry_count <= 0
+        and not state.pending_dev_transport_retry_events
+    ):
+        return {}
+    return {
+        "transport_retry_count": state.pending_dev_transport_retry_count,
+        "transport_retry_events": list(state.pending_dev_transport_retry_events),
+    }
+
+
 def _resolve_dev_sandbox_capabilities(config: ForgeConfig) -> dict:
     """Resolve the project's sandbox capability profile for audit + logging (#1947).
 
@@ -1795,6 +1808,12 @@ def _run_dev_phase(
         )
         if _left_no_observable_work:
             if _invocation_failure is not None:
+                _failure_extra = {
+                    **_invocation_failure.extra,
+                    **_pending_dev_transport_retry_failure_extra(state),
+                }
+                if _failure_extra != _invocation_failure.extra:
+                    _invocation_failure = _dc_replace(_invocation_failure, extra=_failure_extra)
                 record_invocation_failure(state, _invocation_failure)
                 _unused_dev_iteration = zero_charge_no_model_artifacts(dev_result)
                 if _unused_dev_iteration:

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -696,6 +696,8 @@ def _coordinator_loop(
                 stop_event=stop_event,
             )
             if escalation is not None:
+                if escalation.unused_dev_iteration:
+                    state.budget.release_unused()
                 # ── Failed-challenger recovery (#325, ADR-0006 clause 8) ──────
                 # If this dev slot ran an exploration challenger and it failed,
                 # the failure must NOT be the story's final routing outcome:

--- a/src/theforge/coordinator/retry_budget.py
+++ b/src/theforge/coordinator/retry_budget.py
@@ -52,6 +52,15 @@ class RetryBudget:
             )
         )
 
+    def release_unused(self) -> bool:
+        """Undo the most recent consume() when that reserved slot was never used."""
+        if not self.consumption_log or self.total_count <= 0:
+            return False
+        self.consumption_log.pop()
+        self.total_count = max(0, self.total_count - 1)
+        self.cycle_count = max(0, self.cycle_count - 1)
+        return True
+
     def reset_cycle(self) -> None:
         """Zero the per-cycle counter. Call when a new review cycle starts."""
         self.cycle_count = 0

--- a/src/theforge/coordinator/state.py
+++ b/src/theforge/coordinator/state.py
@@ -1346,3 +1346,7 @@ class CoordinatorResult:
     # still ESCALATE, but this run made no statement about the story and must
     # not be reported, notified, or persisted as if it had.
     infrastructure_failure: bool = False
+    # True when the reserved DEV slot returned a no-charge, no-artifact failure
+    # before any actual development attempt began, so engine.py should release
+    # the just-consumed RetryBudget slot.
+    unused_dev_iteration: bool = False

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -2502,6 +2502,10 @@ def _recommend_actions(
         # The story stopped on money, not on iterations. Raising an iteration
         # budget buys attempts the allocation will not fund (#2292).
         "allocation_exhaustion",
+        # The run stopped on shared infrastructure before the story was judged,
+        # so iteration-budget advice points at a lever the evidence says had no
+        # bearing on the outcome.
+        "shared_infrastructure",
         # The iteration limit is how a capability gap *presents*; the budget was
         # never the constraint, so budget advice here would restate the wrong
         # cause the class exists to replace (#2029).

--- a/tests/test_coord_dev_verification_seam.py
+++ b/tests/test_coord_dev_verification_seam.py
@@ -416,6 +416,66 @@ class TestDevLoopConsumesCoordinatorVerification:
         assert record["refusal_reason"] == "cancelled_at_iteration_end"
         assert state.pending_dev_verification_requests == state.dev_verification_requests
 
+    def test_discounted_no_judgment_abort_keeps_served_verification_records_visible(
+        self, tmp_path
+    ):
+        """A discounted DEV abort should not erase the verification it actually ran."""
+        from theforge.coordinator.dev_phase import _run_dev_phase
+        from theforge.coordinator.state import CoordinatorState
+
+        config = _config_with_verification(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+        state = CoordinatorState()
+        state.dev_iteration = 1
+
+        gate = _gate_side_effect(workspace, "PASS")
+
+        def shell(cmd, cwd, **kwargs):
+            if cmd == VERIFY_WATCH.command:
+                return (True, VERIFY_OUTPUT, 0, False)
+            return gate(cmd, cwd, **kwargs)
+
+        def run_agent(*, prompt, **kwargs):
+            request_dir = Path(_extract_dir(prompt, "requests"))
+            response_dir = Path(_extract_dir(prompt, "responses"))
+            tmp = request_dir / "r1.json.tmp"
+            tmp.write_text(json.dumps({"command": "verify-watch"}), encoding="utf-8")
+            tmp.rename(request_dir / "r1.json")
+            final = response_dir / "r1.json"
+            for _ in range(400):
+                if final.exists():
+                    break
+                _sleep()
+            assert final.exists(), "verification response was not written"
+            return dataclasses.replace(
+                _make_agent_result(
+                    success=False,
+                    output="runner exited before agent output was available",
+                ),
+                cost_usd=0.0,
+                session_id=None,
+                raw={},
+            )
+
+        with (
+            patch_gate_shell(side_effect=shell),
+            patch("theforge.coordinator.dev_phase.run_agent", side_effect=run_agent),
+            patch("theforge.coordinator.dev_phase.log_agent_result"),
+            patch("theforge.coordinator.dev_phase._has_commits_ahead_of_base", return_value=False),
+        ):
+            result = _run_dev_phase(
+                state, config, task, "# t\n", workspace, "feat/x", notify=False, logger=None
+            )
+
+        assert result is not None
+        assert result.infrastructure_failure is True
+        assert result.unused_dev_iteration is True
+        (record,) = state.dev_verification_requests
+        assert record["command_name"] == "verify-watch"
+        assert state.pending_dev_verification_requests == state.dev_verification_requests
+
     def test_project_declaring_nothing_sees_no_channel_and_no_prompt_section(self, tmp_path):
         config = _make_config(tmp_path)
         task = _make_task(tmp_path)

--- a/tests/test_coord_no_judgment_seam.py
+++ b/tests/test_coord_no_judgment_seam.py
@@ -81,6 +81,21 @@ def _generic_process_failure(profile_name: str = "dev") -> AgentResult:
     )
 
 
+def _transient_transport_failure(
+    *, profile_name: str = "dev", cost_usd: float | None = 0.42
+) -> AgentResult:
+    return AgentResult(
+        success=False,
+        output="http 429 rate limited",
+        session_id=None,
+        cost_usd=cost_usd,
+        exit_code=1,
+        raw={},
+        profile_name=profile_name,
+        failure_code="rate_limit",
+    )
+
+
 def _init_repo(path: Path) -> None:
     subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
@@ -209,6 +224,71 @@ class TestClassification:
 
 
 class TestDevNoJudgment:
+    @pytest.mark.parametrize(
+        ("retry_cost", "expected_dev_usd"),
+        [
+            pytest.param(0.42, 0.42, id="measured"),
+            pytest.param(None, None, id="unmeasured"),
+        ],
+    )
+    @patch("theforge.coordinator.model_profiles_bridge.update_profiles_from_run")
+    @patch("theforge.coordinator.dev_phase.time.sleep", return_value=None)
+    @patch("theforge.coordinator.dev_phase._has_commits_ahead_of_base", return_value=False)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_transport_retry_cost_survives_discounted_zero_charge_abort(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        _mock_commits,
+        _mock_sleep,
+        mock_profiles,
+        tmp_path,
+        retry_cost,
+        expected_dev_usd,
+    ):
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=_PREFLIGHT_PROCEED, cost_usd=0.05
+        )
+        mock_dev.side_effect = [
+            _transient_transport_failure(cost_usd=retry_cost),
+            _generic_process_failure("dev"),
+        ]
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert result.infrastructure_failure is True
+        assert result.unused_dev_iteration is True
+        assert len(result.state.dev_results) == 1
+        assert len(result.state.dev_durations) == 1
+        assert result.state.dev_results[0].failure_code == "rate_limit"
+        assert result.state.dev_results[0].cost_usd == retry_cost
+        assert result.state.dev_iteration_telemetry == []
+        assert result.state.budget.consumption_log == []
+        assert result.state.budget.total_count == 0
+        assert result.state.budget.cycle_count == 0
+        assert result.state.budget.remaining() == config.retry.max_dev_iterations
+
+        audit = generate_audit_log(config, task, result)
+        assert audit["iterations"]["usage_summary"]["dev"]["used"] == 0
+        assert audit["cost"]["dev_invocations"] == 1
+        assert audit["cost"]["dev_usd"] == expected_dev_usd
+        assert mock_profiles.call_count == 0
+
     @patch("theforge.coordinator.model_profiles_bridge.update_profiles_from_run")
     @patch("theforge.coordinator.dev_phase._has_commits_ahead_of_base", return_value=False)
     @patch("theforge.coordinator.review_pool.run_agent_pool")
@@ -387,6 +467,55 @@ class TestDevNoJudgment:
         assert "left the preserved branch unchanged" in (result.message or "")
         assert result.state.dev_results == []
         assert result.state.dev_iteration_telemetry == []
+
+    def test_preexisting_branch_work_with_model_output_is_not_reclassified_as_infrastructure(
+        self, tmp_path
+    ):
+        _init_repo(tmp_path)
+        subprocess.run(["git", "checkout", "-q", "-b", "feat/test-task"], cwd=tmp_path, check=True)
+        (tmp_path / "feature.txt").write_text("preserved work\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "preserved"], cwd=tmp_path, check=True)
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = CoordinatorState()
+        state.adaptive_dev_max = config.retry.max_dev_iterations
+        state.budget.max_iterations = config.retry.max_dev_iterations
+        state.budget.consume(review_cycle=0)
+
+        with (
+            patch(
+                "theforge.coordinator.dev_phase.run_agent",
+                return_value=AgentResult(
+                    success=False,
+                    output="I checked the preserved branch state and it already contains the fix.",
+                    session_id="sess-1",
+                    cost_usd=0.5,
+                    exit_code=1,
+                    raw={},
+                    profile_name="dev",
+                ),
+            ),
+            patch("theforge.coordinator.dev_phase.log_agent_result"),
+            patch_gate_shell(side_effect=_shell_with_gate(tmp_path, "PASS")),
+        ):
+            result = _run_dev_phase(
+                state,
+                config,
+                task,
+                "# Test Spec\n",
+                tmp_path,
+                "feat/test-task",
+                notify=False,
+                logger=None,
+            )
+
+        assert result is None
+        assert state.infrastructure_failure is None
+        assert len(state.dev_results) == 1
+        assert state.dev_results[0].cost_usd == 0.5
+        assert state.dev_iteration_telemetry == []
 
 
 # ── PLAN_REVIEW: degraded pool vs. genuine rejection ─────────────────────

--- a/tests/test_coord_no_judgment_seam.py
+++ b/tests/test_coord_no_judgment_seam.py
@@ -282,11 +282,22 @@ class TestDevNoJudgment:
         assert result.state.budget.total_count == 0
         assert result.state.budget.cycle_count == 0
         assert result.state.budget.remaining() == config.retry.max_dev_iterations
+        failure_extra = result.state.infrastructure_failure["extra"]
+        assert failure_extra["transport_retry_count"] == 1
+        assert len(failure_extra["transport_retry_events"]) == 1
+        assert failure_extra["transport_retry_events"][0]["iteration"] == 1
+        assert failure_extra["transport_retry_events"][0]["retry"] == 1
+        assert "rate_limit" in failure_extra["transport_retry_events"][0]["error"]
+        assert "429" in failure_extra["transport_retry_events"][0]["error"]
 
         audit = generate_audit_log(config, task, result)
         assert audit["iterations"]["usage_summary"]["dev"]["used"] == 0
         assert audit["cost"]["dev_invocations"] == 1
         assert audit["cost"]["dev_usd"] == expected_dev_usd
+        assert (
+            audit["agent_invocation"]["infrastructure_failure"]["extra"]["transport_retry_events"]
+            == failure_extra["transport_retry_events"]
+        )
         assert mock_profiles.call_count == 0
 
     @patch("theforge.coordinator.model_profiles_bridge.update_profiles_from_run")

--- a/tests/test_coord_no_judgment_seam.py
+++ b/tests/test_coord_no_judgment_seam.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -30,6 +32,7 @@ from coord_test_helpers import (
     patch_gate_shell,
 )
 
+from theforge.agent_types import ModelUsage
 from theforge.config.types import ModelProfile, PlanAgentReviewConfig, PlanConfig
 from theforge.coordinator import audit_substrate
 from theforge.coordinator.agent_failure import (
@@ -41,8 +44,9 @@ from theforge.coordinator.agent_failure import (
     produced_model_output,
 )
 from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.dev_phase import _run_dev_phase
 from theforge.coordinator.engine import run_task
-from theforge.coordinator.state import Phase
+from theforge.coordinator.state import CoordinatorState, Phase
 from theforge.coordinator.trust_status import TRUST_TAINTED
 from theforge.runners import AgentResult
 
@@ -63,6 +67,28 @@ def _auth_failure(profile_name: str = "", cost_usd: float = 0.0) -> AgentResult:
         raw={},
         profile_name=profile_name,
     )
+
+
+def _generic_process_failure(profile_name: str = "dev") -> AgentResult:
+    return AgentResult(
+        success=False,
+        output="runner exited before agent output was available",
+        session_id=None,
+        cost_usd=0.0,
+        exit_code=1,
+        raw={},
+        profile_name=profile_name,
+    )
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / ".gitignore").write_text(".forge/\nspec.md\n", encoding="utf-8")
+    (path / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
 
 
 # ── Classification unit coverage ─────────────────────────────────────────
@@ -91,6 +117,38 @@ class TestClassification:
             profile_name="dev",
             failure_code="timeout",
             partial_output="I refactored the coordinator loop.",
+        )
+        assert produced_model_output(result) is True
+        assert classify_agent_failure(result, phase="DEV") is None
+
+    def test_zero_charge_process_failure_without_model_artifacts_is_process(self):
+        result = _generic_process_failure()
+        assert produced_model_output(result) is False
+        failure = classify_agent_failure(result, phase="DEV")
+        assert failure is not None
+        assert failure.category == "process"
+        assert failure.exit_code == 1
+
+    def test_zero_cost_local_model_usage_still_counts_as_model_output(self):
+        result = AgentResult(
+            success=False,
+            output="Agent loop terminated: max iterations reached after 3 iterations.",
+            session_id=None,
+            cost_usd=0.0,
+            exit_code=1,
+            raw={},
+            profile_name="dev",
+            failure_code="max_iterations_reached",
+            model_usage=(
+                ModelUsage(
+                    model="codestral",
+                    input_tokens=100,
+                    output_tokens=25,
+                    cache_read_tokens=0,
+                    cache_creation_tokens=0,
+                    cost_usd=0.0,
+                ),
+            ),
         )
         assert produced_model_output(result) is True
         assert classify_agent_failure(result, phase="DEV") is None
@@ -188,10 +246,15 @@ class TestDevNoJudgment:
         # ...but the run is classified as an infrastructure abort, not as a
         # story whose framing an agent found invalid.
         assert result.infrastructure_failure is True
+        assert result.unused_dev_iteration is True
         assert result.state.error_type == "infrastructure_abort"
         assert result.state.infrastructure_failure["phase"] == "DEV"
         assert result.state.infrastructure_failure["category"] == CATEGORY_AUTH
         assert "no judgment was obtained" in (result.message or "")
+        assert result.state.dev_results == []
+        assert result.state.dev_durations == []
+        assert result.state.dev_iteration_telemetry == []
+        assert result.state.dev_iteration == 0
 
         # Nothing durable was written about the story.
         assert mock_profiles.call_count == 0
@@ -199,6 +262,8 @@ class TestDevNoJudgment:
         assert audit["trust_status"] == TRUST_TAINTED
         assert audit["agent_invocation"]["infrastructure_failure"]["category"] == CATEGORY_AUTH
         assert audit["agent_invocation"]["no_judgment_failures"][0]["phase"] == "DEV"
+        assert audit["iterations"]["usage_summary"]["dev"]["used"] == 0
+        assert audit["cost"]["dev_invocations"] == 0
 
         # End-to-end: once persisted, this run contributes no escalation memory.
         # (Spec fix-success criterion: the story must not appear in escalation
@@ -281,6 +346,47 @@ class TestDevNoJudgment:
         assert "escalating to avoid an empty-diff APPROVE" in (result.message or "")
         # A real (if failed) judgment still teaches the adaptive substrate.
         assert mock_profiles.call_count == 1
+
+    def test_preexisting_branch_work_unchanged_by_zero_charge_failure_aborts(self, tmp_path):
+        _init_repo(tmp_path)
+        subprocess.run(["git", "checkout", "-q", "-b", "feat/test-task"], cwd=tmp_path, check=True)
+        (tmp_path / "feature.txt").write_text("preserved work\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "preserved"], cwd=tmp_path, check=True)
+
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        state = CoordinatorState()
+        state.adaptive_dev_max = config.retry.max_dev_iterations
+        state.budget.max_iterations = config.retry.max_dev_iterations
+        state.budget.consume(review_cycle=0)
+
+        with (
+            patch(
+                "theforge.coordinator.dev_phase.run_agent",
+                return_value=_generic_process_failure(),
+            ),
+            patch("theforge.coordinator.dev_phase.log_agent_result"),
+            patch_gate_shell(side_effect=_shell_with_gate(tmp_path, "PASS")),
+        ):
+            result = _run_dev_phase(
+                state,
+                config,
+                task,
+                "# Test Spec\n",
+                tmp_path,
+                "feat/test-task",
+                notify=False,
+                logger=None,
+            )
+
+        assert result is not None
+        assert result.infrastructure_failure is True
+        assert result.unused_dev_iteration is True
+        assert result.state.infrastructure_failure["category"] == "process"
+        assert "left the preserved branch unchanged" in (result.message or "")
+        assert result.state.dev_results == []
+        assert result.state.dev_iteration_telemetry == []
 
 
 # ── PLAN_REVIEW: degraded pool vs. genuine rejection ─────────────────────

--- a/tests/test_retry_budget.py
+++ b/tests/test_retry_budget.py
@@ -90,6 +90,35 @@ class TestRetryBudgetResetCycle:
         assert entry.total_count == 2  # cumulative
 
 
+class TestRetryBudgetReleaseUnused:
+    def test_release_unused_decrements_counters_and_log(self) -> None:
+        budget = RetryBudget(max_iterations=3)
+        budget.consume(review_cycle=0)
+        budget.consume(review_cycle=0)
+
+        assert budget.release_unused() is True
+        assert budget.cycle_count == 1
+        assert budget.total_count == 1
+        assert len(budget.consumption_log) == 1
+
+    def test_release_unused_updates_remaining(self) -> None:
+        budget = RetryBudget(max_iterations=2)
+        budget.consume(review_cycle=0)
+        budget.consume(review_cycle=0)
+
+        budget.release_unused()
+
+        assert budget.remaining() == 1
+
+    def test_release_unused_on_empty_budget_is_noop(self) -> None:
+        budget = RetryBudget(max_iterations=2)
+
+        assert budget.release_unused() is False
+        assert budget.cycle_count == 0
+        assert budget.total_count == 0
+        assert budget.consumption_log == []
+
+
 class TestRetryBudgetIsExhausted:
     def test_not_exhausted_when_below_max(self) -> None:
         budget = RetryBudget(max_iterations=3)

--- a/tests/test_sprint_infrastructure_attribution.py
+++ b/tests/test_sprint_infrastructure_attribution.py
@@ -108,3 +108,54 @@ def test_advisory_persistence_failure_classifies_as_shared_infrastructure(
     actions = " ".join(story["recommended_next_actions"])
     assert "forge diagnose" not in actions
     assert "shared run infrastructure" in actions
+
+
+def test_infrastructure_abort_suppresses_iteration_budget_advice(tmp_path: Path) -> None:
+    """A run that only *looks* iteration-exhausted still follows its infra cause."""
+    sprint_dir = tmp_path / ".forge" / "logs" / "issues-2443"
+    story_dir = sprint_dir / "issue-2443"
+    story_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "sprint": {"name": "s", "run_id": "r1", "finished_at": "2026-08-13T03:00:00Z"},
+        "stories": [
+            {
+                "slug": "issue-2443",
+                "outcome": "FAILED",
+                "error": "dev exhausted iterations",
+                "error_type": ERROR_TYPE_INFRASTRUCTURE_ABORT,
+                "iteration_usage": {
+                    "dev": {"used": 3, "max": 3, "hit_limit": True, "early_finish": False},
+                    "review": {
+                        "used": 0,
+                        "max": 2,
+                        "hit_limit": False,
+                        "early_finish": False,
+                        "early_terminated": False,
+                    },
+                },
+                "contributing_factors": ["dev_iteration_limit"],
+            }
+        ],
+    }
+    audit = {
+        "outcome": {"error_type": ERROR_TYPE_INFRASTRUCTURE_ABORT},
+        "agent_invocation": {
+            "infrastructure_failure": {
+                "category": "process",
+                "detail": "runner exited before agent output was available",
+            }
+        },
+        "iterations": {"usage_summary": summary["stories"][0]["iteration_usage"]},
+    }
+    (sprint_dir / "sprint-summary.yaml").write_text(yaml.safe_dump(summary), encoding="utf-8")
+    (story_dir / "audit.yaml").write_text(yaml.safe_dump(audit), encoding="utf-8")
+
+    payload = build_sprint_rca(sprint_dir / "sprint-summary.yaml")
+    story = payload["stories"]["issue-2443"]
+    actions = " ".join(story["recommended_next_actions"]).lower()
+
+    assert story["primary_failure_class"] == "shared_infrastructure"
+    assert any(e["rule_id"] == "shared_infrastructure_abort" for e in story["evidence"])
+    assert any("process" in e["excerpt"] for e in story["evidence"])
+    assert "iteration budget" not in actions
+    assert "narrow" not in actions


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior transport-retry cost regression is fixed, and I found no new P1 regressions in the reviewed diff. | [anthropic-opus-cli] Cycle-1 P1 (bulk truncation erasing a billed transport retry) and the cycle-2 audit-visibility P2 are both resolved: the rollback pops only the trailing discounted attempt, and the retry count and event summaries are folded into the recorded invocation failure before the pending buffers are cleared, so the paid retry stays in dev_results, in the cost aggregate, and in the audit record; the frozen-dataclass replace re-runs category validation and no key collides with the DEV classifier's empty extra, so I found no regression in commit 75a4c6ba.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $13.30
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

An agent invocation that produces no output and bills nothing consumes a development iteration, so three such failures exhaust the pool and the story is reported as needing a larger budget or a narrower scope (GitHub Issue #2443)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2443