### PR TITLE
A story's dev agent fails identically on every attempt in about a second while the same model and credential succeed when invoked by hand, so the story exhausts its iterations without the agent ever running

### DIFF
--- a/src/theforge/coordinator/agent_failure.py
+++ b/src/theforge/coordinator/agent_failure.py
@@ -277,11 +277,6 @@ def produced_model_output(result: Any) -> bool:
         return True
     if getattr(result, "dev_handoff", None):
         return True
-    if _has_model_usage_evidence(result):
-        return True
-    failure_code = str(getattr(result, "failure_code", "") or "").lower()
-    if failure_code in _MODEL_EXECUTION_FAILURE_CODES:
-        return True
     text = _text_of(result)
     if not text:
         return False
@@ -289,6 +284,11 @@ def produced_model_output(result: Any) -> bool:
         return False
     if _matches(text, _NO_OUTPUT_MARKERS):
         return False
+    if _has_model_usage_evidence(result):
+        return True
+    failure_code = str(getattr(result, "failure_code", "") or "").lower()
+    if failure_code in _MODEL_EXECUTION_FAILURE_CODES:
+        return True
     if _looks_like_auth_failure(text) or _looks_like_transport_failure(text):
         return False
     if _has_runner_artifacts(result):

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -41,6 +41,7 @@ from .agent_failure import (
     carries_agent_text,
     classify_agent_failure,
     mark_infrastructure_abort,
+    produced_model_output,
     record_invocation_failure,
     zero_charge_no_model_artifacts,
 )
@@ -1426,8 +1427,8 @@ def _run_dev_phase(
     _capture_dev_handoff(state, config, task, workspace_path, dev_result)
     if _dev_profile.mode == "cli" and dev_result.transport_used == "api":
         state.dev_session_id = None
-    else:
-        state.dev_session_id = dev_result.session_id or state.dev_session_id
+    elif dev_result.session_id and produced_model_output(dev_result):
+        state.dev_session_id = dev_result.session_id
     save_sessions(workspace_path, state.dev_session_id, state.reviewer_session_ids)
     log_agent_result(dev_result, "DEV")
     _dev_cost_total = sum_costs(result.cost_usd for result in _dev_results_this_iteration)

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -65,6 +65,7 @@ from .agent_failure import (
     AgentInvocationFailure,
     classify_agent_failure,
     mark_infrastructure_abort,
+    produced_model_output,
     record_degraded_pool,
     record_invocation_failure,
 )
@@ -323,7 +324,7 @@ def _retry_transient_plan_review_failures(
                 session_id=current.session_id if profile.mode == "cli" else None,
                 progress_cb=progress_channel.cb if progress_channel is not None else None,
             )
-            if retried.session_id:
+            if retried.session_id and produced_model_output(retried):
                 state.plan_review_session_ids[profile.name] = retried.session_id
             _write_log_artifact(
                 state.log_dir,
@@ -514,7 +515,7 @@ def _retry_parse_failed_plan_reviews(
                 secrets=config.secrets,
                 session_id=retry_session_id,
             )
-            if retried.session_id:
+            if retried.session_id and produced_model_output(retried):
                 state.plan_review_session_ids[profile.name] = retried.session_id
             _write_log_artifact(
                 state.log_dir,
@@ -1233,7 +1234,7 @@ def _run_plan_agent_review(
         state.plan_review_durations.append(_pr_elapsed)
 
         for _prof, _res in zip(par_profiles, pr_results):
-            if _res.session_id:
+            if _res.session_id and produced_model_output(_res):
                 state.plan_review_session_ids[_prof.name] = _res.session_id
         state.plan_review_results.extend(pr_results)
         save_sessions(

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -35,6 +35,7 @@ from theforge.traces import write_trace
 
 from . import story_budget as _story_budget
 from . import util as _cu
+from .agent_failure import produced_model_output
 from .agent_identity import resolved_identity_for_result
 from .log_tee import _write_log_artifact
 from .review_context import (
@@ -410,7 +411,7 @@ def _retry_transient_review_failures(
                 stop_event=stop_event,
                 progress_cb=progress_channel.cb if progress_channel is not None else None,
             )
-            if retried.session_id:
+            if retried.session_id and produced_model_output(retried):
                 state.reviewer_session_ids[profile.name] = retried.session_id
             state.review_agent_results.append(retried)
             log_agent_result(retried, f"REVIEW/{retried.profile_name}")
@@ -840,7 +841,7 @@ def _run_review_pool(
     )
     _pool_elapsed = time.monotonic() - _pool_start
     for profile, result in zip(pool, pool_results):
-        if result.session_id:
+        if result.session_id and produced_model_output(result):
             state.reviewer_session_ids[profile.name] = result.session_id
     save_sessions(
         workspace_path,

--- a/tests/test_coord_dev_phase_routing.py
+++ b/tests/test_coord_dev_phase_routing.py
@@ -14,10 +14,13 @@ from coord_test_helpers import (
     _PREFLIGHT_RESULT,
     APPROVE_REVIEW,
     REQUEST_CHANGES_REVIEW,
+    SYNTHESIS_PROFILE,
     _as_detailed,
     _handle_stale_check_cmd,
     _make_agent_result,
     _make_config,
+    _make_pool_config,
+    _make_review_profile,
     _make_task,
     _shell_with_gate,
     _write_handoff,
@@ -1132,3 +1135,59 @@ class TestCoordinatorSessionResume:
 
         assert result.success is True
         assert captured_session_ids == [[None], ["review-sess-1"]]
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_failed_textless_reviewer_result_does_not_poison_resume_session(
+        self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        r1 = _make_review_profile("review-a", budget_usd=1.0)
+        r2 = _make_review_profile("review-b", budget_usd=1.0)
+        config = _make_pool_config(tmp_path, [r1, r2], SYNTHESIS_PROFILE)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        captured_session_ids: list[list[str | None]] = []
+
+        mock_shell.side_effect = _shell_with_gate(workspace, ["PASS", "PASS"])
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.side_effect = [
+            _make_agent_result(success=True, output="Implemented.", profile_name="dev"),
+            _make_agent_result(success=True, output="Fixed.", profile_name="dev"),
+        ]
+
+        def pool_side_effect(**kwargs):
+            captured_session_ids.append(list(kwargs["session_ids"]))
+            return [
+                _make_agent_result(
+                    success=False,
+                    output=REQUEST_CHANGES_REVIEW,
+                    session_id="review-a-sess-1",
+                    profile_name="review-a",
+                ),
+                AgentResult(
+                    success=False,
+                    output=(
+                        "CLAUDE_STREAM_NO_TEXT: reason=result_missing_text "
+                        "subtype=error_during_execution"
+                    ),
+                    session_id="review-b-sess-poisoned",
+                    cost_usd=0.0,
+                    exit_code=1,
+                    raw={},
+                    profile_name="review-b",
+                ),
+            ]
+
+        mock_pool.side_effect = pool_side_effect
+
+        result = run_task(config, task)
+
+        assert result.success is False
+        assert captured_session_ids == [[None, None]]
+        assert result.state.reviewer_session_ids == {"review-a": "review-a-sess-1"}
+        sessions_data = json.loads((workspace / ".forge/sessions.json").read_text())
+        assert sessions_data["reviewer_session_ids"] == {"review-a": "review-a-sess-1"}

--- a/tests/test_coord_dev_phase_routing.py
+++ b/tests/test_coord_dev_phase_routing.py
@@ -6,6 +6,7 @@ Covers: prompt routing (fix vs dev prompt) and session resume/carry-through.
 from __future__ import annotations
 
 import dataclasses
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -813,6 +814,58 @@ class TestCoordinatorSessionResume:
         assert result.success is True
         assert dev_session_ids == [None, "sess-timeout"]
         assert result.state.dev_session_id == "sess-resumed"
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_failed_textless_dev_result_does_not_poison_resume_session(
+        self, mock_shell, mock_agent, mock_preflight, mock_pool, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        failed_result = AgentResult(
+            success=False,
+            output=(
+                "CLAUDE_STREAM_NO_TEXT: reason=result_missing_text subtype=error_during_execution"
+            ),
+            session_id="sess-poisoned",
+            cost_usd=0.0,
+            exit_code=1,
+            raw={},
+            profile_name="dev",
+        )
+        resumed_result = _make_agent_result(
+            success=True,
+            output="Implemented after fresh session.",
+            session_id="sess-fresh",
+            profile_name="dev",
+        )
+        dev_session_ids: list[str | None] = []
+
+        def fake_run_agent(prompt, profile, working_dir, session_id=None, **kwargs):
+            dev_session_ids.append(session_id)
+            if len(dev_session_ids) == 1:
+                return failed_result
+            return resumed_result
+
+        mock_shell.side_effect = _shell_with_gate(workspace, ["FAIL", "PASS"])
+        mock_preflight.return_value = _PREFLIGHT_RESULT
+        mock_agent.side_effect = fake_run_agent
+        mock_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task)
+
+        assert result.success is True
+        assert dev_session_ids == [None, None]
+        assert result.state.dev_session_id == "sess-fresh"
+        sessions_data = json.loads((workspace / ".forge/sessions.json").read_text())
+        assert sessions_data["dev_session_id"] == "sess-fresh"
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.preflight_flow.run_agent")

--- a/tests/test_coord_no_judgment_seam.py
+++ b/tests/test_coord_no_judgment_seam.py
@@ -168,6 +168,33 @@ class TestClassification:
         assert produced_model_output(result) is True
         assert classify_agent_failure(result, phase="DEV") is None
 
+    def test_no_text_marker_beats_usage_telemetry(self):
+        result = AgentResult(
+            success=False,
+            output=(
+                "CLAUDE_STREAM_NO_TEXT: reason=result_missing_text subtype=error_during_execution"
+            ),
+            session_id="sess-poisoned",
+            cost_usd=0.0,
+            exit_code=1,
+            raw={},
+            profile_name="dev",
+            model_usage=(
+                ModelUsage(
+                    model="claude-sonnet-4-5",
+                    input_tokens=321,
+                    output_tokens=0,
+                    cache_read_tokens=0,
+                    cache_creation_tokens=0,
+                    cost_usd=0.0,
+                ),
+            ),
+        )
+        assert produced_model_output(result) is False
+        failure = classify_agent_failure(result, phase="DEV")
+        assert failure is not None
+        assert failure.category == "process"
+
     def test_unrecognized_failure_text_is_not_reclassified(self):
         """Errs toward the pre-existing path when it cannot identify a substrate event."""
         result = _make_agent_result(success=False, output="The plan is wrong because ...")

--- a/tests/test_coord_plan_flow_agent.py
+++ b/tests/test_coord_plan_flow_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -40,6 +41,7 @@ from theforge.coordinator.plan_flow import (
     _retry_parse_failed_plan_reviews,
 )
 from theforge.coordinator.state import CoordinatorState, Phase
+from theforge.runners import AgentResult
 
 # ── Local helpers ─────────────────────────────────────────────────────
 
@@ -1737,6 +1739,108 @@ class TestPlanReviewerFailureAudit:
         assert (
             audit["plan_review"]["transport_retries"] == result.state.plan_review_transport_retries
         )
+
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))
+    @patch("theforge.coordinator.plan_flow.run_agent_pool")
+    @patch("theforge.coordinator.plan_flow.run_agent")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_textless_plan_review_result_does_not_poison_resume_session(
+        self,
+        mock_shell,
+        mock_agent,
+        mock_preflight,
+        mock_plan_agent,
+        mock_plan_pool,
+        mock_human_review,
+        mock_code_pool,
+        tmp_path,
+    ):
+        config = _make_plan_agent_review_config(tmp_path, dual_reviewer=True)
+        config = dataclasses.replace(
+            config,
+            plan_agent_review=dataclasses.replace(config.plan_agent_review, min_reviewers=1),
+        )
+        task = _make_task(tmp_path)
+        workspace = tmp_path / "test-task"
+        workspace.mkdir()
+
+        captured_session_ids: list[list[str | None]] = []
+
+        mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+        mock_plan_agent.side_effect = mock_agent
+        mock_preflight.return_value = _make_agent_result(
+            success=True, output=PREFLIGHT_PROCEED_MEDIUM, cost_usd=0.05
+        )
+        mock_agent.side_effect = [
+            _make_agent_result(
+                success=True,
+                output="# Plan\n\nOriginal plan.",
+                cost_usd=0.10,
+            ),
+            _make_agent_result(
+                success=True,
+                output="# Plan\n\nRevised plan.",
+                cost_usd=0.12,
+            ),
+            _make_agent_result(success=True, output="Implemented."),
+        ]
+
+        def plan_pool_side_effect(**kwargs):
+            captured_session_ids.append(list(kwargs["session_ids"]))
+            if len(captured_session_ids) == 1:
+                return [
+                    AgentResult(
+                        success=False,
+                        output=(
+                            "CLAUDE_STREAM_NO_TEXT: reason=result_missing_text "
+                            "subtype=error_during_execution"
+                        ),
+                        session_id="plan-review-poisoned",
+                        cost_usd=0.0,
+                        exit_code=1,
+                        raw={},
+                        profile_name="plan-review-a",
+                    ),
+                    _make_agent_result(
+                        success=True,
+                        output=PLAN_AGENT_REJECT_P1,
+                        session_id="plan-review-b-1",
+                        cost_usd=0.08,
+                        profile_name="plan-review-b",
+                    ),
+                ]
+            return [
+                _make_agent_result(
+                    success=True,
+                    output=PLAN_AGENT_APPROVE,
+                    session_id="plan-review-a-fresh",
+                    cost_usd=0.06,
+                    profile_name="plan-review-a",
+                ),
+                _make_agent_result(
+                    success=True,
+                    output=PLAN_AGENT_APPROVE,
+                    session_id="plan-review-b-2",
+                    cost_usd=0.06,
+                    profile_name="plan-review-b",
+                ),
+            ]
+
+        mock_plan_pool.side_effect = plan_pool_side_effect
+        mock_code_pool.return_value = [
+            _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+        ]
+
+        result = run_task(config, task, interactive=True)
+
+        assert result.success is True
+        assert captured_session_ids == [[None, None]]
+        assert result.state.plan_review_session_ids == {"plan-review-b": "plan-review-b-1"}
+        sessions_data = json.loads((workspace / ".forge/sessions.json").read_text())
+        assert sessions_data["plan_review_session_ids"] == {"plan-review-b": "plan-review-b-1"}
 
     @patch("theforge.coordinator.review_pool.run_agent_pool")
     @patch("theforge.coordinator.review_phase._human_review", return_value=("approve", None))


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The dev-session poisoning fix is covered by a seam test for the exact CLAUDE_STREAM_NO_TEXT signature, and I found no blocking regressions. | [anthropic-opus-cli] Cycle 2 addresses the earlier P2s: no-output markers now outrank usage telemetry in produced_model_output, and reviewer/plan-review session adoption is gated the same way as dev; HEAD 2349a248 matches the authoritative gate commit (PASS) and the touched test files pass locally (100 passed). Remaining findings are P2 residuals of the same class.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $5.64
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/agent_failure.py:284`** A failed invocation whose output is a runner no-output marker such as a timeout banner, or whose output is empty, is now classified as having produced no model output even when its own telemetry records consumed tokens or a model-execution failure code, so a billed timeout that salvaged no text is reported to the operator as an infrastructure abort stating that the dev agent produced no model output.
- **[P2] `src/theforge/coordinator/review_pool.py:410`** The in-place transport retry loops resume the session id taken directly from the failing result rather than from the gated stored session, so a result that produced no model output still supplies the resume target for its own immediate retry.
- **[P2] `src/theforge/coordinator/dev_phase.py:1430`** When a dev attempt that had already established a session ends in a text-less runner failure, the previously stored session id is retained and handed to the next attempt as a resume target, so a session that becomes unusable partway through a story keeps being resumed on every remaining iteration.

## Story

A story's dev agent fails identically on every attempt in about a second while the same model and credential succeed when invoked by hand, so the story exhausts its iterations without the agent ever running (GitHub Issue #2446)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2446