### PR TITLE
A decision notification omits the run identifier and the permitted actions, so the operator it is sent to cannot answer without reaching the machine

### DIFF
--- a/src/theforge/coordinator/pending_hitl.py
+++ b/src/theforge/coordinator/pending_hitl.py
@@ -35,7 +35,7 @@ def _pending_human_review(
     approve | reject | escalate | extend | timeout
     """
     from theforge import pending as _pending
-    from theforge.notify_backends import send_notifications
+    from theforge.notify_backends import format_pending_decision_notification, send_notifications
 
     p1 = sum(1 for f in parsed_review.findings if f.severity == "P1")
     p2 = sum(1 for f in parsed_review.findings if f.severity == "P2")
@@ -62,7 +62,7 @@ def _pending_human_review(
     _cu._log(f"  Run ID:  {_eff_run_id}")
     _cu._log(f"  Timeout: {_cu._fmt_duration(timeout_seconds)}")
 
-    _pending.write_pending(
+    pending_path = _pending.write_pending(
         run_id=_eff_run_id,
         story=task.slug,
         phase="HUMAN_REVIEW",
@@ -72,10 +72,11 @@ def _pending_human_review(
         project_root=project_root,
     )
 
+    pending_record = _pending.read_pending(_eff_run_id, project_root=project_root) or {}
     send_notifications(
         config,
-        title=f"TheForge: review needed — {task.slug}",
-        body=reason[:300],
+        title=f"TheForge: review needed — {task.slug} (HUMAN_REVIEW)",
+        body=format_pending_decision_notification(pending_record, pending_path=pending_path),
     )
 
     _poll_start = time.monotonic()
@@ -137,7 +138,7 @@ def _pending_escalate_gate(
         ACTION_TAXONOMY,
         render_advisory_for_pending,
     )
-    from theforge.notify_backends import send_notifications
+    from theforge.notify_backends import format_pending_decision_notification, send_notifications
 
     from .escalate_actions import available_escalate_actions, omitted_actions_note
 
@@ -248,7 +249,7 @@ def _pending_escalate_gate(
         for _action, _why in sorted(omitted_actions.items()):
             _cu._log(f"  Not offered: {_action} — {_why}")
 
-    _pending.write_pending(
+    pending_path = _pending.write_pending(
         run_id=_eff_run_id,
         story=task.slug,
         phase="ESCALATE",
@@ -259,10 +260,11 @@ def _pending_escalate_gate(
         extra=extra,
     )
 
+    pending_record = _pending.read_pending(_eff_run_id, project_root=project_root) or {}
     send_notifications(
         config,
-        title=f"TheForge: ESCALATE — {task.slug}",
-        body=reason[:300],
+        title=f"TheForge: decision needed — {task.slug} (ESCALATE)",
+        body=format_pending_decision_notification(pending_record, pending_path=pending_path),
     )
 
     _poll_start = time.monotonic()
@@ -379,7 +381,7 @@ def _pending_plan_review(
 ) -> str:
     """Pending-file-based plan review. Returns 'approve' | 'regenerate' | 'abandon'."""
     from theforge import pending as _pending
-    from theforge.notify_backends import send_notifications
+    from theforge.notify_backends import format_pending_decision_notification, send_notifications
 
     timeout_seconds = int(
         _pending.bounded_gate_wait(config.plan_review.timeout_seconds, "PLAN_REVIEW")
@@ -395,7 +397,7 @@ def _pending_plan_review(
     _cu._log(f"  Run ID:  {_eff_run_id}")
     _cu._log(f"  Timeout: {_cu._fmt_duration(timeout_seconds)}")
 
-    _pending.write_pending(
+    pending_path = _pending.write_pending(
         run_id=_eff_run_id,
         story=task.slug,
         phase="PLAN_REVIEW",
@@ -405,10 +407,11 @@ def _pending_plan_review(
         project_root=project_root,
     )
 
+    pending_record = _pending.read_pending(_eff_run_id, project_root=project_root) or {}
     send_notifications(
         config,
-        title=f"TheForge: plan ready — {task.slug}",
-        body=reason[:300],
+        title=f"TheForge: plan ready — {task.slug} (PLAN_REVIEW)",
+        body=format_pending_decision_notification(pending_record, pending_path=pending_path),
     )
 
     _pr_start = time.monotonic()

--- a/src/theforge/notify_backends.py
+++ b/src/theforge/notify_backends.py
@@ -95,37 +95,71 @@ def format_pending_decision_notification(
         f"Full option set omitted from this notification; read {pending_path_str}",
     ]
 
-    def _compose(command_block: Sequence[str], *, reason_text: str) -> str:
+    def _compose(
+        command_block: Sequence[str],
+        *,
+        reason_text: str,
+        metadata_block: Sequence[str] | None = None,
+    ) -> str:
         lines: list[str] = []
         if reason_text:
             lines.append(reason_text)
-        if metadata_lines:
+        effective_metadata = metadata_lines if metadata_block is None else list(metadata_block)
+        if effective_metadata:
             if lines:
                 lines.append("")
-            lines.extend(metadata_lines)
+            lines.extend(effective_metadata)
         if command_block:
             if lines:
                 lines.append("")
             lines.extend(command_block)
         return "\n".join(lines)
 
-    if command_lines:
-        full_body = _compose(command_lines, reason_text=reason)
-        if len(full_body) <= max_chars:
-            return full_body
-        available_reason = max_chars - len(_compose(command_lines, reason_text=""))
-        trimmed_body = _compose(
-            command_lines,
-            reason_text=_truncate_notification_text(reason, available_reason),
+    def _compose_with_truncated_reason(
+        command_block: Sequence[str],
+        *,
+        metadata_block: Sequence[str] | None = None,
+    ) -> str:
+        if not reason:
+            return _compose(command_block, reason_text="", metadata_block=metadata_block)
+        candidate = _compose(command_block, reason_text=reason, metadata_block=metadata_block)
+        if len(candidate) <= max_chars:
+            return candidate
+        available_reason = (
+            max_chars
+            - len(
+                _compose(
+                    command_block,
+                    reason_text="x",
+                    metadata_block=metadata_block,
+                )
+            )
+            + 1
         )
+        return _compose(
+            command_block,
+            reason_text=_truncate_notification_text(reason, available_reason),
+            metadata_block=metadata_block,
+        )
+
+    if command_lines:
+        trimmed_body = _compose_with_truncated_reason(command_lines)
         if len(trimmed_body) <= max_chars:
             return trimmed_body
 
-    available_reason = max_chars - len(_compose(fallback_lines, reason_text=""))
-    return _compose(
-        fallback_lines,
-        reason_text=_truncate_notification_text(reason, available_reason),
-    )
+    fallback_metadata_variants = [
+        metadata_lines,
+        [line for line in metadata_lines if not line.startswith("Phase: ")],
+        [line for line in metadata_lines if not line.startswith(("Phase: ", "Deadline: "))],
+        [],
+    ]
+    for metadata_variant in fallback_metadata_variants:
+        fallback_body = _compose_with_truncated_reason(
+            fallback_lines, metadata_block=metadata_variant
+        )
+        if len(fallback_body) <= max_chars:
+            return fallback_body
+    return _truncate_notification_text(_compose(fallback_lines, reason_text=""), max_chars)
 
 
 def send_notifications(

--- a/src/theforge/notify_backends.py
+++ b/src/theforge/notify_backends.py
@@ -37,6 +37,16 @@ def _truncate_notification_text(text: str, limit: int) -> str:
     return text[: limit - 3].rstrip() + "..."
 
 
+def _first_fitting_whole_body(candidates: Sequence[str], limit: int) -> str:
+    """Return the first complete notification body that fits the budget."""
+    if limit <= 0:
+        return ""
+    for candidate in candidates:
+        if candidate and len(candidate) <= limit:
+            return candidate
+    return ""
+
+
 def _format_pending_deadline(timeout_at: str, *, now: datetime | None = None) -> str:
     """Render an absolute deadline plus the remaining or overdue window."""
     deadline = datetime.fromisoformat(timeout_at)
@@ -159,7 +169,24 @@ def format_pending_decision_notification(
         )
         if len(fallback_body) <= max_chars:
             return fallback_body
-    return _truncate_notification_text(_compose(fallback_lines, reason_text=""), max_chars)
+
+    last_resort_candidates = []
+    if run_id:
+        last_resort_candidates.extend(
+            [
+                _compose(
+                    command_lines or ["Reply with:", f"  forge decide {run_id} <action>"],
+                    reason_text="",
+                    metadata_block=[f"Run ID: {run_id}"],
+                ),
+                f"Run ID: {run_id}",
+                run_id,
+            ]
+        )
+    else:
+        last_resort_candidates.append("Pending decision; read the pending file on this machine.")
+
+    return _first_fitting_whole_body(last_resort_candidates, max_chars)
 
 
 def send_notifications(

--- a/src/theforge/notify_backends.py
+++ b/src/theforge/notify_backends.py
@@ -12,13 +12,120 @@ import platform
 import shutil
 import subprocess
 import urllib.request
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .coordinator import util as _cu
 
 if TYPE_CHECKING:
     from .config import ForgeConfig
+
+
+MAX_PENDING_NOTIFICATION_BODY_CHARS = 900
+
+
+def _truncate_notification_text(text: str, limit: int) -> str:
+    """Trim text to fit a notification body budget."""
+    if limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    if limit <= 3:
+        return text[:limit]
+    return text[: limit - 3].rstrip() + "..."
+
+
+def _format_pending_deadline(timeout_at: str, *, now: datetime | None = None) -> str:
+    """Render an absolute deadline plus the remaining or overdue window."""
+    deadline = datetime.fromisoformat(timeout_at)
+    if deadline.tzinfo is None:
+        deadline = deadline.replace(tzinfo=timezone.utc)
+    now_utc = now or datetime.now(timezone.utc)
+    remaining_seconds = (deadline - now_utc).total_seconds()
+    deadline_utc = deadline.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    if remaining_seconds >= 0:
+        return (
+            f"Deadline: {deadline_utc} "
+            f"({_cu._fmt_duration(max(0.0, remaining_seconds))} remaining)"
+        )
+    return f"Deadline: {deadline_utc} ({_cu._fmt_duration(abs(remaining_seconds))} overdue)"
+
+
+def format_pending_decision_notification(
+    pending_record: Mapping[str, object],
+    *,
+    pending_path: Path | str,
+    max_chars: int = MAX_PENDING_NOTIFICATION_BODY_CHARS,
+) -> str:
+    """Build an actionable notification body from the pending decision record."""
+    reason = str(pending_record.get("reason") or "").strip()
+    run_id = str(pending_record.get("run_id") or "").strip()
+    timeout_at = str(pending_record.get("timeout_at") or "").strip()
+    options = [
+        str(option).strip() for option in pending_record.get("options") or [] if str(option)
+    ]
+    phase = str(pending_record.get("phase") or "").strip()
+    pending_path_str = str(pending_path)
+    metadata_lines = []
+    if phase:
+        metadata_lines.append(f"Phase: {phase}")
+    if run_id:
+        metadata_lines.append(f"Run ID: {run_id}")
+    if timeout_at:
+        metadata_lines.append(_format_pending_deadline(timeout_at))
+
+    command_lines: list[str] = []
+    if run_id and options:
+        option_set = "|".join(options)
+        command_lines = [
+            "Reply with:",
+            f"  forge decide {run_id} <{option_set}>",
+        ]
+    elif run_id:
+        command_lines = [
+            "Reply with:",
+            f"  forge decide {run_id} <action>",
+        ]
+
+    fallback_lines = [
+        "Reply with:",
+        f"  forge decide {run_id} <action>" if run_id else "  forge decide <run-id> <action>",
+        f"Full option set omitted from this notification; read {pending_path_str}",
+    ]
+
+    def _compose(command_block: Sequence[str], *, reason_text: str) -> str:
+        lines: list[str] = []
+        if reason_text:
+            lines.append(reason_text)
+        if metadata_lines:
+            if lines:
+                lines.append("")
+            lines.extend(metadata_lines)
+        if command_block:
+            if lines:
+                lines.append("")
+            lines.extend(command_block)
+        return "\n".join(lines)
+
+    if command_lines:
+        full_body = _compose(command_lines, reason_text=reason)
+        if len(full_body) <= max_chars:
+            return full_body
+        available_reason = max_chars - len(_compose(command_lines, reason_text=""))
+        trimmed_body = _compose(
+            command_lines,
+            reason_text=_truncate_notification_text(reason, available_reason),
+        )
+        if len(trimmed_body) <= max_chars:
+            return trimmed_body
+
+    available_reason = max_chars - len(_compose(fallback_lines, reason_text=""))
+    return _compose(
+        fallback_lines,
+        reason_text=_truncate_notification_text(reason, available_reason),
+    )
 
 
 def send_notifications(

--- a/tests/test_coord_pending_notifications.py
+++ b/tests/test_coord_pending_notifications.py
@@ -1,0 +1,139 @@
+"""Pending-gate notifications must be actionable away from the machine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from theforge.coordinator.pending_hitl import (
+    _pending_escalate_gate,
+    _pending_human_review,
+    _pending_plan_review,
+)
+
+DECIDED_AT = "2026-08-14T19:05:00+00:00"
+
+
+def _config(project_root: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        project_root=project_root,
+        notifications=SimpleNamespace(human_review_timeout_seconds=3600, backends=()),
+        plan_review=SimpleNamespace(timeout_seconds=1800, mode="blocking"),
+    )
+
+
+def _capture_notification(sent: dict[str, str]):
+    def _capture(*_args, **kwargs):
+        sent.update(kwargs)
+
+    return _capture
+
+
+def test_pending_human_review_notification_includes_run_id_options_and_deadline(
+    tmp_path: Path,
+) -> None:
+    state = SimpleNamespace(
+        total_cost_measured=1.25,
+        total_cost=1.25,
+        human_review_waited_seconds=None,
+        human_review_mode=None,
+    )
+    parsed_review = SimpleNamespace(
+        verdict="REQUEST_CHANGES",
+        findings=[SimpleNamespace(severity="P1"), SimpleNamespace(severity="P2")],
+        summary="One blocking finding needs a decision.",
+    )
+    task = SimpleNamespace(slug="issue-2312")
+    sent: dict[str, str] = {}
+
+    with (
+        patch(
+            "theforge.notify_backends.send_notifications",
+            side_effect=_capture_notification(sent),
+        ),
+        patch("theforge.pending.poll_pending", return_value=("approve", DECIDED_AT)),
+    ):
+        decision, _feedback = _pending_human_review(
+            state,
+            parsed_review,
+            tmp_path,
+            "feat/issue-2312",
+            task,
+            _config(tmp_path),
+            task_start=0.0,
+            run_id="65273305e89c",
+        )
+
+    assert decision == "approve"
+    assert sent["title"] == "TheForge: review needed — issue-2312 (HUMAN_REVIEW)"
+    assert "Run ID: 65273305e89c" in sent["body"]
+    assert "forge decide 65273305e89c <approve|reject|escalate|extend>" in sent["body"]
+    assert "Deadline:" in sent["body"]
+
+
+def test_pending_escalate_notification_uses_pending_record_options(tmp_path: Path) -> None:
+    state = SimpleNamespace(
+        human_review_waited_seconds=0.0,
+        advisory_packet=None,
+        advisory_launch_failure=False,
+        advisory_launch_reason=None,
+    )
+    task = SimpleNamespace(slug="issue-2312")
+    sent: dict[str, str] = {}
+
+    with (
+        patch(
+            "theforge.coordinator.escalate_actions.available_escalate_actions",
+            return_value=(["accept", "redirect", "defer_or_abandon"], {}),
+        ),
+        patch(
+            "theforge.notify_backends.send_notifications",
+            side_effect=_capture_notification(sent),
+        ),
+        patch("theforge.pending.poll_pending", return_value=("redirect", DECIDED_AT)),
+    ):
+        decision = _pending_escalate_gate(
+            state,
+            task,
+            _config(tmp_path),
+            "Quorum unmet.",
+            reviewer_verdicts={"r1": "APPROVE", "r2": "REQUEST_CHANGES"},
+            gate_result="threshold not met",
+            run_id="65273305e89c",
+            advisory=None,
+        )
+
+    assert decision == "redirect"
+    assert sent["title"] == "TheForge: decision needed — issue-2312 (ESCALATE)"
+    assert "Run ID: 65273305e89c" in sent["body"]
+    assert "forge decide 65273305e89c <accept|redirect|defer_or_abandon>" in sent["body"]
+    assert "Deadline:" in sent["body"]
+
+
+def test_pending_plan_review_notification_includes_run_id_and_actions(tmp_path: Path) -> None:
+    state = SimpleNamespace(plan_review_mode=None, plan_review_waited_seconds=None)
+    task = SimpleNamespace(slug="issue-2312")
+    sent: dict[str, str] = {}
+
+    with (
+        patch(
+            "theforge.notify_backends.send_notifications",
+            side_effect=_capture_notification(sent),
+        ),
+        patch("theforge.pending.poll_pending", return_value=("approve", DECIDED_AT)),
+    ):
+        decision = _pending_plan_review(
+            state,
+            "# Plan\n\n1. Fix notifications.\n2. Add tests.",
+            tmp_path,
+            task,
+            _config(tmp_path),
+            run_id="65273305e89c",
+        )
+
+    assert decision == "approve"
+    assert sent["title"] == "TheForge: plan ready — issue-2312 (PLAN_REVIEW)"
+    assert "Run ID: 65273305e89c" in sent["body"]
+    assert "forge decide 65273305e89c <approve|regenerate|abandon>" in sent["body"]
+    assert "Deadline:" in sent["body"]

--- a/tests/test_notify_backends.py
+++ b/tests/test_notify_backends.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from theforge.config import BackendConfig
 from theforge.notify_backends import (
+    MAX_PENDING_NOTIFICATION_BODY_CHARS,
     _send_ntfy,
     _send_slack,
     _send_terminal,
@@ -203,6 +204,35 @@ def test_format_pending_decision_notification_reports_when_full_option_set_is_om
     assert "Full option set omitted from this notification;" in body
     assert "/tmp/.forge/pending/run-42.yaml" in body
     assert "<option_00|option_01" not in body
+
+
+def test_format_pending_decision_notification_truncates_long_reason_and_keeps_options():
+    body = format_pending_decision_notification(
+        {
+            "reason": "Escalation advisory:\n" + ("review drift detected\n" * 200),
+            "run_id": "65273305e89c",
+            "phase": "ESCALATE",
+            "options": [
+                "accept",
+                "redirect",
+                "defer_or_abandon",
+                "re_review",
+                "split_story",
+                "abort",
+            ],
+            "timeout_at": "2026-08-14T20:00:00+00:00",
+        },
+        pending_path="/tmp/.forge/pending/65273305e89c.yaml",
+    )
+
+    assert "Phase: ESCALATE" in body
+    assert "Run ID: 65273305e89c" in body
+    assert (
+        "forge decide 65273305e89c "
+        "<accept|redirect|defer_or_abandon|re_review|split_story|abort>" in body
+    )
+    assert "Full option set omitted from this notification;" not in body
+    assert len(body) <= MAX_PENDING_NOTIFICATION_BODY_CHARS
 
 
 # ── Slack backend tests ────────────────────────────────────────────────

--- a/tests/test_notify_backends.py
+++ b/tests/test_notify_backends.py
@@ -235,6 +235,22 @@ def test_format_pending_decision_notification_truncates_long_reason_and_keeps_op
     assert len(body) <= MAX_PENDING_NOTIFICATION_BODY_CHARS
 
 
+def test_format_pending_decision_notification_last_resort_never_truncates_command_mid_token():
+    body = format_pending_decision_notification(
+        {
+            "reason": "Operator action required.",
+            "run_id": "run-42",
+            "phase": "ESCALATE",
+            "options": [f"option_{idx:02d}" for idx in range(20)],
+            "timeout_at": "2026-08-14T20:00:00+00:00",
+        },
+        pending_path="/" + ("very-long-segment/" * 20) + "run-42.yaml",
+        max_chars=14,
+    )
+
+    assert body == "Run ID: run-42"
+
+
 # ── Slack backend tests ────────────────────────────────────────────────
 
 

--- a/tests/test_notify_backends.py
+++ b/tests/test_notify_backends.py
@@ -11,6 +11,7 @@ from theforge.notify_backends import (
     _send_slack,
     _send_terminal,
     _send_webhook,
+    format_pending_decision_notification,
     send_notifications,
 )
 
@@ -164,6 +165,44 @@ def test_send_notifications_unknown_backend_logs_warning():
     config = _make_config([BackendConfig(type="unknown")])
     # Should not raise
     send_notifications(config, "title", "body")
+
+
+def test_format_pending_decision_notification_includes_actionable_command():
+    body = format_pending_decision_notification(
+        {
+            "reason": "Quorum unmet: 1/2 reviewers approved.",
+            "run_id": "65273305e89c",
+            "phase": "ESCALATE",
+            "options": ["accept", "redirect", "extend"],
+            "timeout_at": "2026-08-14T20:00:00+00:00",
+        },
+        pending_path="/tmp/.forge/pending/65273305e89c.yaml",
+    )
+
+    assert "Quorum unmet: 1/2 reviewers approved." in body
+    assert "Phase: ESCALATE" in body
+    assert "Run ID: 65273305e89c" in body
+    assert "Deadline: 2026-08-14 20:00 UTC" in body
+    assert "forge decide 65273305e89c <accept|redirect|extend>" in body
+
+
+def test_format_pending_decision_notification_reports_when_full_option_set_is_omitted():
+    body = format_pending_decision_notification(
+        {
+            "reason": "Operator action required.",
+            "run_id": "run-42",
+            "phase": "ESCALATE",
+            "options": [f"option_{idx:02d}" for idx in range(20)],
+            "timeout_at": "2026-08-14T20:00:00+00:00",
+        },
+        pending_path="/tmp/.forge/pending/run-42.yaml",
+        max_chars=180,
+    )
+
+    assert "forge decide run-42 <action>" in body
+    assert "Full option set omitted from this notification;" in body
+    assert "/tmp/.forge/pending/run-42.yaml" in body
+    assert "<option_00|option_01" not in body
 
 
 # ── Slack backend tests ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The prior long-reason truncation issue is resolved, and the reviewed change satisfies the actionable pending-decision notification criteria. | [anthropic-opus-cli] Cycle 1 P1 stays fixed (3000-char ESCALATE reason still yields a 900-char body carrying the full six-action forge decide command), and the iter-2 last-resort rework removes the mid-command truncation without regressing any earlier path; all notification and pending-gate tests pass and ruff is clean.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $6.12
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/notify_backends.py:172`** When every candidate layout exceeds the character budget — for example a budget smaller than the run identifier itself, or a record with no run identifier under a small budget — the formatter returns an empty string, so the gate sends a notification with no body at all.

## Story

A decision notification omits the run identifier and the permitted actions, so the operator it is sent to cannot answer without reaching the machine (GitHub Issue #2334)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2334