### PR TITLE
The seam #2399 built has never been used, so every sprint-lifecycle responsibility still lives in one module and unrelated sprint changes still collide on it

### DIFF
--- a/src/theforge/sprint/CONVENTIONS.md
+++ b/src/theforge/sprint/CONVENTIONS.md
@@ -38,6 +38,15 @@ and sprint-level audit/display behavior.
 - `tests/test_sprint_runner_structure.py` asserts both of the above against the
   parsed module, so re-introducing frame capture fails a test rather than
   passing review.
+- A responsibility moved out of `runner.py` does not import it back.
+  `audit_publish.py` is the first move (#2402) and the shape to copy: it takes
+  the execution state (and reads the run context off it) rather than a list of
+  members, and it depends on the writers in `audit.py`, never on the runner.
+  `tests/test_sprint_audit_publish.py` asserts the absence of that import, so a
+  relocation-with-a-dependency-left-behind fails a test. The cost of annotating
+  the state without importing the runner is deliberate: the parameter is `Any`
+  and documented, because the alternative is exactly the coupling the move
+  removed.
 
 ## Context
 
@@ -50,3 +59,6 @@ and sprint-level audit/display behavior.
   safety rails for concurrent or repeated execution.
 - `display.py` and `audit.py` shape operator-facing visibility into sprint
   progress and outcomes.
+- `audit_publish.py` owns the end of a run: it builds the terminal audit and
+  summary inputs from the run's state, writes the audit/summary/RCA artifacts,
+  and commits and pushes the canonical per-run audit JSON to the base branch.

--- a/src/theforge/sprint/audit_publish.py
+++ b/src/theforge/sprint/audit_publish.py
@@ -1,0 +1,455 @@
+"""Terminal sprint audit publication (#2402).
+
+A sprint's last act is to write down what it did and put that record where the
+next run — and the operator — can find it. That is one responsibility with a
+boundary this module owns end to end: it begins by constructing the inputs the
+sprint audit and summary writers need out of the run's context and execution
+state, and it ends with the canonical per-run audit JSON committed and pushed to
+the base branch, or a publication failure reported against a recorded end state.
+
+It moved here out of ``sprint/runner.py`` under ADR-0008. The point of the move
+is independent changeability, so the one rule this module keeps is that **it does
+not import the runner**: a change to how a sprint publishes its audits claims
+this file, and a change to how it resolves a queued PR claims the runner, and the
+scheduler is free to run them at the same time. A dependency back on the runner
+would give the two a shared claim again and make the move a relocation.
+
+That rule is why the entry points annotate the sprint's execution state as
+``Any`` rather than importing :class:`~theforge.sprint.runner.SprintExecutionState`
+for the annotation alone. They take the state object itself — never a list of the
+members it carries, which is the parameter threading #2399 ended — and read
+``state.context`` for the frozen run context.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import shlex
+from pathlib import Path
+from typing import Any
+
+from ..coordinator import workspace as coordinator_workspace
+from ..log_util import _log_line
+from .audit import _write_sprint_audit, _write_sprint_summary
+from .manifest import SprintResult
+
+_STORY_RUN_AUDIT_DIR = ".forge/audits/runs"
+_STORY_RUN_AUDIT_COMMIT_CMD = (
+    f'git commit -m "chore(audit): record sprint run audits" -- {_STORY_RUN_AUDIT_DIR}'
+)
+
+# Where the outcome of the publish step is recorded. Lives under .forge/ (which
+# .gitignore denies wholesale), so writing it never dirties the base-branch
+# checkout the sprint is publishing from.
+_STORY_RUN_AUDIT_PUBLISH_STATE_PATH = ".forge/audit-publish-state.json"
+
+# A push rejected because the base branch moved is reconciled and retried. Three
+# attempts covers the sprint's own merges landing while the push is in flight;
+# beyond that the remote is being advanced by something other than this run and
+# looping longer just delays the operator's answer.
+_STORY_RUN_AUDIT_PUSH_ATTEMPTS = 3
+
+# Publish end states, recorded to ``_STORY_RUN_AUDIT_PUBLISH_STATE_PATH`` and
+# carried on ``StoryRunAuditPublishError.state``. They exist so that an operator
+# looking at local-only audit commits can tell *which* thing happened: the run
+# never got here (no/stale record), it got here and the remote refused
+# (``push_refused``), or publishing was deliberately skipped (``local_only``).
+AUDIT_PUBLISH_CLEAN = "clean"
+AUDIT_PUBLISH_COMMITTED = "committed_unpublished"
+AUDIT_PUBLISH_PUBLISHED = "published"
+AUDIT_PUBLISH_LOCAL_ONLY = "local_only"
+AUDIT_PUBLISH_COMMIT_FAILED = "commit_failed"
+AUDIT_PUBLISH_BRANCH_MISMATCH = "branch_mismatch"
+AUDIT_PUBLISH_PUSH_REFUSED = "push_refused"
+AUDIT_PUBLISH_RECONCILE_FAILED = "reconcile_failed"
+AUDIT_PUBLISH_VERIFY_FAILED = "verify_failed"
+
+
+def _log(msg: str) -> None:
+    # Worker-slug prefixing (parallel attribution) is applied centrally by
+    # ``_log_line``; do not prepend it here or it would double-tag. The prefix
+    # stays "[sprint]" after the move: this is still the sprint speaking, and an
+    # operator reading a run log should not have to learn a new tag because a
+    # function changed files.
+    _log_line("[sprint]", msg)
+
+
+class StoryRunAuditPublishError(RuntimeError):
+    """Canonical story run audits could not be published to the base branch.
+
+    ``state`` is one of the ``AUDIT_PUBLISH_*`` constants and names the end
+    state the checkout was left in. It is a ``RuntimeError`` subclass because
+    the sprint entry point already treats a publish failure as fatal; the extra
+    attribute only makes the *kind* of failure legible to callers and tests.
+    """
+
+    def __init__(self, message: str, *, state: str) -> None:
+        super().__init__(message)
+        self.state = state
+
+
+def _record_audit_publish_state(
+    project_root: Path,
+    base_branch: str,
+    state: str,
+    detail: str | None = None,
+) -> None:
+    """Record the publish end state next to the checkout it describes.
+
+    Best-effort: a sprint must not fail because this marker could not be
+    written, and the marker must never mask the error it is describing.
+    """
+    path = project_root / _STORY_RUN_AUDIT_PUBLISH_STATE_PATH
+    payload = {
+        "state": state,
+        "base_branch": base_branch,
+        "recorded_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "detail": detail,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:  # pragma: no cover — filesystem-level failure
+        _log(f"Warning: could not record story run audit publish state: {exc}")
+
+
+def _require_audit_publish_branch(project_root: Path, base_branch: str, *, operation: str) -> None:
+    """Refuse before mutating the project root from the wrong checked-out branch."""
+    try:
+        current_branch = coordinator_workspace._current_checked_out_branch(project_root)
+    except RuntimeError as exc:
+        raise StoryRunAuditPublishError(
+            f"Failed to verify the checked-out branch before {operation} story run audits: {exc}",
+            state=AUDIT_PUBLISH_BRANCH_MISMATCH,
+        ) from exc
+    if current_branch == base_branch:
+        return
+    raise StoryRunAuditPublishError(
+        f"Refusing to {operation} story run audits for base branch '{base_branch}' because "
+        f"the project root currently has '{current_branch}' checked out. Check out "
+        f"{base_branch} and rerun the publish, or move the pending audit records off "
+        f"'{current_branch}'.",
+        state=AUDIT_PUBLISH_BRANCH_MISMATCH,
+    )
+
+
+def _reconcile_base_with_origin(project_root: Path, base_branch: str) -> None:
+    """Fetch origin and rebase the local base branch onto its current head.
+
+    Raises ``StoryRunAuditPublishError`` when the reconcile itself cannot be
+    completed, aborting any partial rebase so the checkout is left usable.
+    """
+    from ..coordinator import util as _cu  # noqa: PLC0415
+
+    _require_audit_publish_branch(project_root, base_branch, operation="reconcile")
+    quoted_base = shlex.quote(base_branch)
+    ok_fetch, fetch_out = _cu._run_shell(f"git fetch origin {quoted_base}", project_root)
+    if not ok_fetch:
+        raise StoryRunAuditPublishError(
+            f"Failed to fetch origin/{base_branch} while publishing story run audits: "
+            f"{fetch_out.strip()}",
+            state=AUDIT_PUBLISH_RECONCILE_FAILED,
+        )
+
+    ok_rebase, rebase_out = _cu._run_shell(
+        f"git rebase origin/{quoted_base} {quoted_base}",
+        project_root,
+    )
+    if not ok_rebase:
+        _cu._run_shell("git rebase --abort", project_root)
+        raise StoryRunAuditPublishError(
+            f"Failed to rebase '{base_branch}' onto origin/{base_branch} while publishing "
+            f"story run audits: {rebase_out.strip()}",
+            state=AUDIT_PUBLISH_RECONCILE_FAILED,
+        )
+
+
+def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: bool) -> None:
+    """Commit and publish canonical per-run audit JSON emitted during a sprint.
+
+    The sprint writes these records to the project-root base-branch checkout on
+    the operator's behalf. A commit that is never pushed is unowned state: later
+    story worktrees are cut from that checkout and GitHub attributes the audit
+    JSON to whichever story happens to be running. So the commit is only half
+    the operation — this pushes it to origin and verifies the base branch is no
+    longer ahead, raising loudly if either step fails.
+
+    ``publish`` comes from ``_base_branch_tracks_origin``: it is false only when
+    this run lands stories by merging into the local base checkout *and* has
+    opted out of pushing them. Pushing a branch publishes all of its ancestors,
+    so a push here would then also publish those local merges. In that one
+    configuration the commit stays local and the fact is warned about instead.
+
+    A rejected push is not a failure of this step so much as a statement about
+    where the remote is: the sprint's own merges are what usually advance the
+    base branch, so a run that landed stories is the *normal* case for the local
+    branch being behind. So a rejection is reconciled (fetch + rebase onto the
+    current remote head) and retried, and only exhausting that raises. Whichever
+    end state the checkout lands in is recorded to
+    ``.forge/audit-publish-state.json`` so it survives to where the state is
+    observed.
+    """
+    from ..coordinator import util as _cu  # noqa: PLC0415
+
+    if not (project_root / ".git").exists():
+        return
+
+    try:
+        _require_audit_publish_branch(project_root, base_branch, operation="publish")
+    except StoryRunAuditPublishError as exc:
+        _record_audit_publish_state(project_root, base_branch, exc.state, detail=str(exc))
+        raise
+
+    audit_dir = Path(_STORY_RUN_AUDIT_DIR)
+    quoted_audit_dir = shlex.quote(audit_dir.as_posix())
+    ok_status, status_out = _cu._run_shell(
+        f"git status --porcelain -- {quoted_audit_dir}",
+        project_root,
+    )
+    if not ok_status:
+        raise StoryRunAuditPublishError(
+            f"Failed to inspect story run audits: {status_out}",
+            state=AUDIT_PUBLISH_COMMIT_FAILED,
+        )
+    if not status_out.strip():
+        # Nothing pending. Record it so a marker from an earlier run cannot be
+        # mistaken for this one's outcome.
+        _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_CLEAN)
+        return
+
+    ok_add, add_out = _cu._run_shell(f"git add -- {quoted_audit_dir}", project_root)
+    if not ok_add:
+        raise StoryRunAuditPublishError(
+            f"Failed to stage story run audits: {add_out}",
+            state=AUDIT_PUBLISH_COMMIT_FAILED,
+        )
+
+    ok_commit, commit_out = _cu._run_shell(_STORY_RUN_AUDIT_COMMIT_CMD, project_root)
+    if not ok_commit:
+        raise StoryRunAuditPublishError(
+            f"Failed to commit story run audits: {commit_out}",
+            state=AUDIT_PUBLISH_COMMIT_FAILED,
+        )
+    _log("Committed canonical story run audit records to the base branch checkout.")
+    # Written before the push so that a crash mid-publish is distinguishable
+    # from a run that never reached this function at all.
+    _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_COMMITTED)
+
+    if not publish:
+        _record_audit_publish_state(
+            project_root,
+            base_branch,
+            AUDIT_PUBLISH_LOCAL_ONLY,
+            detail="workspace.auto_push is off for a run that lands stories locally",
+        )
+        _log(
+            f"⚠ SPRINT  story run audit records remain local: this run merges stories into "
+            f"'{base_branch}' with workspace.auto_push off, so pushing would also publish those "
+            f"local merges. Push '{base_branch}' yourself before any workflow that diffs a story "
+            f"branch against origin/{base_branch}."
+        )
+        return
+
+    quoted_base = shlex.quote(base_branch)
+    push_out = ""
+    for attempt in range(1, _STORY_RUN_AUDIT_PUSH_ATTEMPTS + 1):
+        ok_push, push_out = _cu._run_shell(
+            f"git push origin {quoted_base}",
+            project_root,
+        )
+        if ok_push:
+            break
+        if attempt == _STORY_RUN_AUDIT_PUSH_ATTEMPTS:
+            _record_audit_publish_state(
+                project_root,
+                base_branch,
+                AUDIT_PUBLISH_PUSH_REFUSED,
+                detail=push_out.strip(),
+            )
+            raise StoryRunAuditPublishError(
+                f"Failed to push story run audits to origin/{base_branch} after "
+                f"{_STORY_RUN_AUDIT_PUSH_ATTEMPTS} attempts (fetch + rebase between "
+                f"attempts): {push_out.strip()}",
+                state=AUDIT_PUBLISH_PUSH_REFUSED,
+            )
+        _log(
+            f"Push of story run audits to origin/{base_branch} was refused "
+            f"(attempt {attempt}/{_STORY_RUN_AUDIT_PUSH_ATTEMPTS}); reconciling with the "
+            f"current remote head and retrying."
+        )
+        try:
+            _reconcile_base_with_origin(project_root, base_branch)
+        except StoryRunAuditPublishError as exc:
+            _record_audit_publish_state(
+                project_root,
+                base_branch,
+                exc.state,
+                detail=str(exc),
+            )
+            raise
+
+    ok_ahead, ahead_out = _cu._run_shell(
+        f"git rev-list --count origin/{quoted_base}..{quoted_base}",
+        project_root,
+    )
+    if not ok_ahead:
+        message = (
+            f"Failed to verify story run audits reached origin/{base_branch}: {ahead_out.strip()}"
+        )
+        _record_audit_publish_state(
+            project_root, base_branch, AUDIT_PUBLISH_VERIFY_FAILED, detail=message
+        )
+        raise StoryRunAuditPublishError(message, state=AUDIT_PUBLISH_VERIFY_FAILED)
+    try:
+        ahead = int(ahead_out.strip())
+    except ValueError:
+        message = (
+            f"Failed to verify story run audits reached origin/{base_branch}: "
+            f"unexpected rev-list output {ahead_out.strip()!r}"
+        )
+        _record_audit_publish_state(
+            project_root, base_branch, AUDIT_PUBLISH_VERIFY_FAILED, detail=message
+        )
+        raise StoryRunAuditPublishError(message, state=AUDIT_PUBLISH_VERIFY_FAILED) from None
+    if ahead > 0:
+        message = (
+            f"Story run audits were committed but '{base_branch}' is still {ahead} commit(s) "
+            f"ahead of origin/{base_branch} after push. Publish or reset it before rerunning."
+        )
+        _record_audit_publish_state(
+            project_root, base_branch, AUDIT_PUBLISH_VERIFY_FAILED, detail=message
+        )
+        raise StoryRunAuditPublishError(message, state=AUDIT_PUBLISH_VERIFY_FAILED)
+    _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_PUBLISHED)
+    _log(f"Pushed canonical story run audit records to origin/{base_branch}.")
+
+
+def write_terminal_sprint_audits(
+    state: Any,  # SprintExecutionState — see the module docstring on why not typed
+    *,
+    result: SprintResult,
+    started_at: datetime.datetime,
+    finished_at: datetime.datetime,
+    duration: float,
+    sprint_log_dir: Path | None,
+    dropped_slugs: dict[str, str] | None,
+    triages: dict[str, Any],
+) -> None:
+    """Write the terminal sprint audit, summary and RCA for a finished run.
+
+    The inputs both writers key by slug or canonical ref — the ref→slug map, the
+    canonical refs themselves, the tasks by slug, and each story's triage action
+    — are derived here rather than at the call site. They are derived from the
+    run context's resolved sprint, so the two writers cannot be handed mappings
+    that disagree with each other or with the sprint that ran.
+
+    ``sprint_log_dir`` is ``None`` when the run could not create its log
+    directory; the summary and RCA are the artifacts that live in it, so they
+    are skipped and the audit — which is written to the project root — is not.
+    """
+    ctx = state.context
+    slug_map: dict[str, str] = ctx.slug_by_canonical_ref
+    canonical_refs = [entry[2] for entry in ctx.slug_to_context.values()]
+    tasks_by_slug = {slug: entry[0] for slug, entry in ctx.slug_to_context.items()}
+    triage_actions_by_ref = {
+        canonical_ref: triage.action for canonical_ref, triage in triages.items()
+    }
+
+    # sprint-audit.yaml (existing format; kept for backward compatibility)
+    _write_sprint_audit(
+        manifest=ctx.resolved,
+        result=result,
+        canonical_refs=canonical_refs,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration=duration,
+        project_root=ctx.config.project_root,
+        story_times=state.story_times,
+        batch_assignments=state.batch_assignments,
+        slug_map=slug_map,
+        tasks_by_slug=tasks_by_slug,
+        ci_break_slug=state.stop.halt_slug,
+        sprint_id=ctx.sprint_id,
+        dropped_slugs=dropped_slugs,
+        skipped_issues=ctx.skipped_issues,
+        current_story_entries_by_ref=state.current_story_entries_by_ref,
+        triage_actions_by_ref=triage_actions_by_ref,
+        run_id=ctx.run_id,
+        live_telemetry_snapshots=state.live_telemetry_snapshots,
+    )
+
+    if sprint_log_dir is None:
+        return
+
+    # sprint-summary.yaml to .forge/logs/<sprint-name>/
+    _write_sprint_summary(
+        manifest=ctx.resolved,
+        result=result,
+        canonical_refs=canonical_refs,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration=duration,
+        sprint_log_dir=sprint_log_dir,
+        story_times=state.story_times,
+        batch_assignments=state.batch_assignments,
+        slug_map=slug_map,
+        run_id=ctx.run_id,
+        tasks_by_slug=tasks_by_slug,
+        ci_break_slug=state.stop.halt_slug,
+        sprint_id=ctx.sprint_id,
+        project_root=ctx.config.project_root,
+        dropped_slugs=dropped_slugs,
+        skipped_issues=ctx.skipped_issues,
+        triage_actions_by_ref=triage_actions_by_ref,
+        current_story_entries_by_ref=state.current_story_entries_by_ref,
+        story_state=state.stories,
+        config=ctx.config,
+        live_telemetry_snapshots=state.live_telemetry_snapshots,
+    )
+
+    # Eagerly generate sprint-rca.yaml when any story finished non-DONE.
+    # The RCA engine is a pure function over the artifacts just written
+    # (sprint-summary.yaml + per-story audit/logs), so it runs off the
+    # runner's hot path and stays regenerable via `forge rca`.
+    try:
+        from .rca import write_sprint_rca  # noqa: PLC0415
+
+        rca_path = write_sprint_rca(sprint_log_dir)
+        if rca_path is not None:
+            _log(f"Sprint RCA written: {rca_path}")
+    except Exception as rca_exc:  # noqa: BLE001 — RCA is best-effort
+        _log(f"Warning: sprint RCA generation failed: {rca_exc}")
+
+
+def publish_story_run_audits(
+    state: Any,  # SprintExecutionState — see the module docstring on why not typed
+    *,
+    lands_locally: bool,
+) -> None:
+    """Publish this run's canonical audit JSON, reporting a failure loudly.
+
+    The failure is logged with the recorded end state and re-raised rather than
+    swallowed: a local-only audit commit contaminates every later story PR cut
+    from this checkout, so the sprint must exit nonzero rather than report
+    success over divergent base-branch state.
+    """
+    from ..coordinator.workspace import _base_branch_tracks_origin  # noqa: PLC0415
+
+    config = state.context.config
+    base_branch = config.workspace.base_branch
+    try:
+        _commit_story_run_audits(
+            config.project_root,
+            base_branch,
+            publish=_base_branch_tracks_origin(config, lands_locally=lands_locally),
+        )
+    except RuntimeError as exc:
+        end_state = getattr(exc, "state", None)
+        state_suffix = (
+            f" [state={end_state}; recorded in {_STORY_RUN_AUDIT_PUBLISH_STATE_PATH}]"
+            if end_state
+            else ""
+        )
+        _log(f"✗ SPRINT  canonical story run audit publish failed: {exc}{state_suffix}")
+        raise

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import datetime
-import json
 import logging
 import os
-import shlex
 import shutil
 import subprocess
 import sys
@@ -76,7 +74,6 @@ from .audit import (
     _get_or_create_sprint_id,
     _load_accepted_unmeasured_spend,
     _write_sprint_audit,
-    _write_sprint_summary,
     _write_story_audit,
     load_prior_generation_story_audit,
     persist_accepted_unmeasured_spend,
@@ -84,6 +81,7 @@ from .audit import (
     preflight_degraded_row_fields,
     write_live_story_audit,
 )
+from .audit_publish import publish_story_run_audits, write_terminal_sprint_audits
 from .auth_gate import enforce_sprint_auth_readiness
 from .budget import budget_verification_spend, evaluate_budget
 from .carry import (
@@ -185,37 +183,6 @@ def _cli_cost_untracked(runner: str | None) -> bool:
     return accounting_mode_for("cli", runner) in _UNTRACKED_ACCOUNTING_MODES
 
 
-_STORY_RUN_AUDIT_DIR = ".forge/audits/runs"
-_STORY_RUN_AUDIT_COMMIT_CMD = (
-    f'git commit -m "chore(audit): record sprint run audits" -- {_STORY_RUN_AUDIT_DIR}'
-)
-
-# Where the outcome of the publish step is recorded. Lives under .forge/ (which
-# .gitignore denies wholesale), so writing it never dirties the base-branch
-# checkout the sprint is publishing from.
-_STORY_RUN_AUDIT_PUBLISH_STATE_PATH = ".forge/audit-publish-state.json"
-
-# A push rejected because the base branch moved is reconciled and retried. Three
-# attempts covers the sprint's own merges landing while the push is in flight;
-# beyond that the remote is being advanced by something other than this run and
-# looping longer just delays the operator's answer.
-_STORY_RUN_AUDIT_PUSH_ATTEMPTS = 3
-
-# Publish end states, recorded to ``_STORY_RUN_AUDIT_PUBLISH_STATE_PATH`` and
-# carried on ``StoryRunAuditPublishError.state``. They exist so that an operator
-# looking at local-only audit commits can tell *which* thing happened: the run
-# never got here (no/stale record), it got here and the remote refused
-# (``push_refused``), or publishing was deliberately skipped (``local_only``).
-AUDIT_PUBLISH_CLEAN = "clean"
-AUDIT_PUBLISH_COMMITTED = "committed_unpublished"
-AUDIT_PUBLISH_PUBLISHED = "published"
-AUDIT_PUBLISH_LOCAL_ONLY = "local_only"
-AUDIT_PUBLISH_COMMIT_FAILED = "commit_failed"
-AUDIT_PUBLISH_BRANCH_MISMATCH = "branch_mismatch"
-AUDIT_PUBLISH_PUSH_REFUSED = "push_refused"
-AUDIT_PUBLISH_RECONCILE_FAILED = "reconcile_failed"
-AUDIT_PUBLISH_VERIFY_FAILED = "verify_failed"
-
 run_agent = None
 log_agent_result = None
 
@@ -224,256 +191,6 @@ def _log(msg: str) -> None:
     # Worker-slug prefixing (parallel attribution) is applied centrally by
     # ``_log_line``; do not prepend it here or it would double-tag.
     _log_line("[sprint]", msg)
-
-
-class StoryRunAuditPublishError(RuntimeError):
-    """Canonical story run audits could not be published to the base branch.
-
-    ``state`` is one of the ``AUDIT_PUBLISH_*`` constants and names the end
-    state the checkout was left in. It is a ``RuntimeError`` subclass because
-    the sprint entry point already treats a publish failure as fatal; the extra
-    attribute only makes the *kind* of failure legible to callers and tests.
-    """
-
-    def __init__(self, message: str, *, state: str) -> None:
-        super().__init__(message)
-        self.state = state
-
-
-def _record_audit_publish_state(
-    project_root: Path,
-    base_branch: str,
-    state: str,
-    detail: str | None = None,
-) -> None:
-    """Record the publish end state next to the checkout it describes.
-
-    Best-effort: a sprint must not fail because this marker could not be
-    written, and the marker must never mask the error it is describing.
-    """
-    path = project_root / _STORY_RUN_AUDIT_PUBLISH_STATE_PATH
-    payload = {
-        "state": state,
-        "base_branch": base_branch,
-        "recorded_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-        "detail": detail,
-    }
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    except OSError as exc:  # pragma: no cover — filesystem-level failure
-        _log(f"Warning: could not record story run audit publish state: {exc}")
-
-
-def _require_audit_publish_branch(project_root: Path, base_branch: str, *, operation: str) -> None:
-    """Refuse before mutating the project root from the wrong checked-out branch."""
-    try:
-        current_branch = coordinator_workspace._current_checked_out_branch(project_root)
-    except RuntimeError as exc:
-        raise StoryRunAuditPublishError(
-            f"Failed to verify the checked-out branch before {operation} story run audits: {exc}",
-            state=AUDIT_PUBLISH_BRANCH_MISMATCH,
-        ) from exc
-    if current_branch == base_branch:
-        return
-    raise StoryRunAuditPublishError(
-        f"Refusing to {operation} story run audits for base branch '{base_branch}' because "
-        f"the project root currently has '{current_branch}' checked out. Check out "
-        f"{base_branch} and rerun the publish, or move the pending audit records off "
-        f"'{current_branch}'.",
-        state=AUDIT_PUBLISH_BRANCH_MISMATCH,
-    )
-
-
-def _reconcile_base_with_origin(project_root: Path, base_branch: str) -> None:
-    """Fetch origin and rebase the local base branch onto its current head.
-
-    Raises ``StoryRunAuditPublishError`` when the reconcile itself cannot be
-    completed, aborting any partial rebase so the checkout is left usable.
-    """
-    from ..coordinator import util as _cu  # noqa: PLC0415
-
-    _require_audit_publish_branch(project_root, base_branch, operation="reconcile")
-    quoted_base = shlex.quote(base_branch)
-    ok_fetch, fetch_out = _cu._run_shell(f"git fetch origin {quoted_base}", project_root)
-    if not ok_fetch:
-        raise StoryRunAuditPublishError(
-            f"Failed to fetch origin/{base_branch} while publishing story run audits: "
-            f"{fetch_out.strip()}",
-            state=AUDIT_PUBLISH_RECONCILE_FAILED,
-        )
-
-    ok_rebase, rebase_out = _cu._run_shell(
-        f"git rebase origin/{quoted_base} {quoted_base}",
-        project_root,
-    )
-    if not ok_rebase:
-        _cu._run_shell("git rebase --abort", project_root)
-        raise StoryRunAuditPublishError(
-            f"Failed to rebase '{base_branch}' onto origin/{base_branch} while publishing "
-            f"story run audits: {rebase_out.strip()}",
-            state=AUDIT_PUBLISH_RECONCILE_FAILED,
-        )
-
-
-def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: bool) -> None:
-    """Commit and publish canonical per-run audit JSON emitted during a sprint.
-
-    The sprint writes these records to the project-root base-branch checkout on
-    the operator's behalf. A commit that is never pushed is unowned state: later
-    story worktrees are cut from that checkout and GitHub attributes the audit
-    JSON to whichever story happens to be running. So the commit is only half
-    the operation — this pushes it to origin and verifies the base branch is no
-    longer ahead, raising loudly if either step fails.
-
-    ``publish`` comes from ``_base_branch_tracks_origin``: it is false only when
-    this run lands stories by merging into the local base checkout *and* has
-    opted out of pushing them. Pushing a branch publishes all of its ancestors,
-    so a push here would then also publish those local merges. In that one
-    configuration the commit stays local and the fact is warned about instead.
-
-    A rejected push is not a failure of this step so much as a statement about
-    where the remote is: the sprint's own merges are what usually advance the
-    base branch, so a run that landed stories is the *normal* case for the local
-    branch being behind. So a rejection is reconciled (fetch + rebase onto the
-    current remote head) and retried, and only exhausting that raises. Whichever
-    end state the checkout lands in is recorded to
-    ``.forge/audit-publish-state.json`` so it survives to where the state is
-    observed.
-    """
-    from ..coordinator import util as _cu  # noqa: PLC0415
-
-    if not (project_root / ".git").exists():
-        return
-
-    try:
-        _require_audit_publish_branch(project_root, base_branch, operation="publish")
-    except StoryRunAuditPublishError as exc:
-        _record_audit_publish_state(project_root, base_branch, exc.state, detail=str(exc))
-        raise
-
-    audit_dir = Path(_STORY_RUN_AUDIT_DIR)
-    quoted_audit_dir = shlex.quote(audit_dir.as_posix())
-    ok_status, status_out = _cu._run_shell(
-        f"git status --porcelain -- {quoted_audit_dir}",
-        project_root,
-    )
-    if not ok_status:
-        raise StoryRunAuditPublishError(
-            f"Failed to inspect story run audits: {status_out}",
-            state=AUDIT_PUBLISH_COMMIT_FAILED,
-        )
-    if not status_out.strip():
-        # Nothing pending. Record it so a marker from an earlier run cannot be
-        # mistaken for this one's outcome.
-        _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_CLEAN)
-        return
-
-    ok_add, add_out = _cu._run_shell(f"git add -- {quoted_audit_dir}", project_root)
-    if not ok_add:
-        raise StoryRunAuditPublishError(
-            f"Failed to stage story run audits: {add_out}",
-            state=AUDIT_PUBLISH_COMMIT_FAILED,
-        )
-
-    ok_commit, commit_out = _cu._run_shell(_STORY_RUN_AUDIT_COMMIT_CMD, project_root)
-    if not ok_commit:
-        raise StoryRunAuditPublishError(
-            f"Failed to commit story run audits: {commit_out}",
-            state=AUDIT_PUBLISH_COMMIT_FAILED,
-        )
-    _log("Committed canonical story run audit records to the base branch checkout.")
-    # Written before the push so that a crash mid-publish is distinguishable
-    # from a run that never reached this function at all.
-    _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_COMMITTED)
-
-    if not publish:
-        _record_audit_publish_state(
-            project_root,
-            base_branch,
-            AUDIT_PUBLISH_LOCAL_ONLY,
-            detail="workspace.auto_push is off for a run that lands stories locally",
-        )
-        _log(
-            f"⚠ SPRINT  story run audit records remain local: this run merges stories into "
-            f"'{base_branch}' with workspace.auto_push off, so pushing would also publish those "
-            f"local merges. Push '{base_branch}' yourself before any workflow that diffs a story "
-            f"branch against origin/{base_branch}."
-        )
-        return
-
-    quoted_base = shlex.quote(base_branch)
-    push_out = ""
-    for attempt in range(1, _STORY_RUN_AUDIT_PUSH_ATTEMPTS + 1):
-        ok_push, push_out = _cu._run_shell(
-            f"git push origin {quoted_base}",
-            project_root,
-        )
-        if ok_push:
-            break
-        if attempt == _STORY_RUN_AUDIT_PUSH_ATTEMPTS:
-            _record_audit_publish_state(
-                project_root,
-                base_branch,
-                AUDIT_PUBLISH_PUSH_REFUSED,
-                detail=push_out.strip(),
-            )
-            raise StoryRunAuditPublishError(
-                f"Failed to push story run audits to origin/{base_branch} after "
-                f"{_STORY_RUN_AUDIT_PUSH_ATTEMPTS} attempts (fetch + rebase between "
-                f"attempts): {push_out.strip()}",
-                state=AUDIT_PUBLISH_PUSH_REFUSED,
-            )
-        _log(
-            f"Push of story run audits to origin/{base_branch} was refused "
-            f"(attempt {attempt}/{_STORY_RUN_AUDIT_PUSH_ATTEMPTS}); reconciling with the "
-            f"current remote head and retrying."
-        )
-        try:
-            _reconcile_base_with_origin(project_root, base_branch)
-        except StoryRunAuditPublishError as exc:
-            _record_audit_publish_state(
-                project_root,
-                base_branch,
-                exc.state,
-                detail=str(exc),
-            )
-            raise
-
-    ok_ahead, ahead_out = _cu._run_shell(
-        f"git rev-list --count origin/{quoted_base}..{quoted_base}",
-        project_root,
-    )
-    if not ok_ahead:
-        message = (
-            f"Failed to verify story run audits reached origin/{base_branch}: {ahead_out.strip()}"
-        )
-        _record_audit_publish_state(
-            project_root, base_branch, AUDIT_PUBLISH_VERIFY_FAILED, detail=message
-        )
-        raise StoryRunAuditPublishError(message, state=AUDIT_PUBLISH_VERIFY_FAILED)
-    try:
-        ahead = int(ahead_out.strip())
-    except ValueError:
-        message = (
-            f"Failed to verify story run audits reached origin/{base_branch}: "
-            f"unexpected rev-list output {ahead_out.strip()!r}"
-        )
-        _record_audit_publish_state(
-            project_root, base_branch, AUDIT_PUBLISH_VERIFY_FAILED, detail=message
-        )
-        raise StoryRunAuditPublishError(message, state=AUDIT_PUBLISH_VERIFY_FAILED) from None
-    if ahead > 0:
-        message = (
-            f"Story run audits were committed but '{base_branch}' is still {ahead} commit(s) "
-            f"ahead of origin/{base_branch} after push. Publish or reset it before rerunning."
-        )
-        _record_audit_publish_state(
-            project_root, base_branch, AUDIT_PUBLISH_VERIFY_FAILED, detail=message
-        )
-        raise StoryRunAuditPublishError(message, state=AUDIT_PUBLISH_VERIFY_FAILED)
-    _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_PUBLISHED)
-    _log(f"Pushed canonical story run audit records to origin/{base_branch}.")
 
 
 def _scrub_root_forge_artifacts(config: ForgeConfig) -> None:
@@ -3706,6 +3423,20 @@ class SprintRunContext:
         an agent sidecar is not evidence the agent is gone (#2079).
         """
         return self.live_story_slugs | self.unresolved_live_slugs
+
+    @property
+    def slug_by_canonical_ref(self) -> dict[str, str]:
+        """The reverse of :attr:`slug_to_context`: canonical ref → slug.
+
+        Derived here beside the mapping it inverts because two unrelated
+        consumers need it — the terminal audit writers, which key every story
+        row by ref, and the post-sprint hook, which falls back to it for a
+        story whose workspace never got created. Deriving it twice would be two
+        chances to disagree about the sprint that ran.
+        """
+        return {
+            canonical_ref: slug for slug, (_t, _s, canonical_ref) in self.slug_to_context.items()
+        }
 
     @property
     def name(self) -> str:
@@ -7864,76 +7595,19 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 _sc_body_lines.append(f"Stopped: {_sprint_state.stop.reason}")
             send_notifications(_ctx.config, _sc_title, "\n".join(_sc_body_lines))
 
-    # Build slug map and canonical_refs for audit writers
-    slug_map: dict[str, str] = {ctx[2]: slug for slug, ctx in _ctx.slug_to_context.items()}
-    canonical_refs = [ctx[2] for ctx in _ctx.slug_to_context.values()]
-
-    # Write sprint-audit.yaml (existing format; kept for backward compatibility)
-    _write_sprint_audit(
-        manifest=_ctx.resolved,
+    # The terminal audit, summary and RCA — inputs and all — belong to
+    # sprint.audit_publish (#2402); the runner hands over the state and the
+    # facts only this call knows.
+    write_terminal_sprint_audits(
+        _sprint_state,
         result=sprint_result,
-        canonical_refs=canonical_refs,
         started_at=started_at,
         finished_at=finished_at,
         duration=duration,
-        project_root=_ctx.config.project_root,
-        story_times=_sprint_state.story_times,
-        batch_assignments=_sprint_state.batch_assignments,
-        slug_map=slug_map,
-        tasks_by_slug={slug: ctx[0] for slug, ctx in _ctx.slug_to_context.items()},
-        ci_break_slug=_sprint_state.stop.halt_slug,
-        sprint_id=_ctx.sprint_id,
+        sprint_log_dir=_sprint_log_dir,
         dropped_slugs=_dropped_slugs,
-        skipped_issues=_ctx.skipped_issues,
-        current_story_entries_by_ref=_sprint_state.current_story_entries_by_ref,
-        triage_actions_by_ref={
-            canonical_ref: triage.action for canonical_ref, triage in triages.items()
-        },
-        run_id=_ctx.run_id,
-        live_telemetry_snapshots=_sprint_state.live_telemetry_snapshots,
+        triages=triages,
     )
-
-    # Write sprint-summary.yaml to .forge/logs/<sprint-name>/
-    if _sprint_log_dir is not None:
-        _write_sprint_summary(
-            manifest=_ctx.resolved,
-            result=sprint_result,
-            canonical_refs=canonical_refs,
-            started_at=started_at,
-            finished_at=finished_at,
-            duration=duration,
-            sprint_log_dir=_sprint_log_dir,
-            story_times=_sprint_state.story_times,
-            batch_assignments=_sprint_state.batch_assignments,
-            slug_map=slug_map,
-            run_id=_ctx.run_id,
-            tasks_by_slug={slug: ctx[0] for slug, ctx in _ctx.slug_to_context.items()},
-            ci_break_slug=_sprint_state.stop.halt_slug,
-            sprint_id=_ctx.sprint_id,
-            project_root=_ctx.config.project_root,
-            dropped_slugs=_dropped_slugs,
-            skipped_issues=_ctx.skipped_issues,
-            triage_actions_by_ref={
-                canonical_ref: triage.action for canonical_ref, triage in triages.items()
-            },
-            current_story_entries_by_ref=_sprint_state.current_story_entries_by_ref,
-            story_state=_sprint_state.stories,
-            config=_ctx.config,
-            live_telemetry_snapshots=_sprint_state.live_telemetry_snapshots,
-        )
-
-        # Eagerly generate sprint-rca.yaml when any story finished non-DONE.
-        # The RCA engine is a pure function over the artifacts just written
-        # (sprint-summary.yaml + per-story audit/logs), so it runs off the
-        # runner's hot path and stays regenerable via `forge rca`.
-        try:
-            from .rca import write_sprint_rca
-
-            _rca_path = write_sprint_rca(_sprint_log_dir)
-            if _rca_path is not None:
-                _log(f"Sprint RCA written: {_rca_path}")
-        except Exception as _rca_exc:  # noqa: BLE001 — RCA is best-effort
-            _log(f"Warning: sprint RCA generation failed: {_rca_exc}")
 
     if _sprint_state.state_writer is not None:
         _sprint_state.state_writer.remove()
@@ -7942,23 +7616,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
     # but the failure is NOT swallowed: a local-only audit commit contaminates
     # every later story PR cut from this checkout, so the sprint must exit
     # nonzero rather than report success over divergent base-branch state.
-    from ..coordinator.workspace import _base_branch_tracks_origin
-
-    try:
-        _commit_story_run_audits(
-            _ctx.config.project_root,
-            _ctx.config.workspace.base_branch,
-            publish=_base_branch_tracks_origin(_ctx.config, lands_locally=_sprint_lands_locally),
-        )
-    except RuntimeError as exc:
-        _state = getattr(exc, "state", None)
-        _state_suffix = (
-            f" [state={_state}; recorded in {_STORY_RUN_AUDIT_PUBLISH_STATE_PATH}]"
-            if _state
-            else ""
-        )
-        _log(f"✗ SPRINT  canonical story run audit publish failed: {exc}{_state_suffix}")
-        raise
+    publish_story_run_audits(_sprint_state, lands_locally=_sprint_lands_locally)
 
     # ── POST_SPRINT hook ──────────────────────────────────────────────
     if _ctx.config.hooks and _ctx.config.hooks.post_sprint:
@@ -7972,7 +7630,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
             if _ws is not None:
                 _slug = _ws.name
             else:
-                _slug = slug_map.get(spec_str, Path(spec_str).stem)
+                _slug = _ctx.slug_by_canonical_ref.get(spec_str, Path(spec_str).stem)
             _verdict = ""
             if res.state.review_results:
                 _verdict = res.state.review_results[-1].verdict

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -357,8 +357,8 @@ def test_state_update_fn_called_in_run_sprint(tmp_path: Path) -> None:
 
     with patch("theforge.sprint.runner.run_task", return_value=mock_result):
         with patch("theforge.sprint.runner._triage_spec"):
-            with patch("theforge.sprint.runner._write_sprint_audit"):
-                with patch("theforge.sprint.runner._write_sprint_summary"):
+            with patch("theforge.sprint.audit_publish._write_sprint_audit"):
+                with patch("theforge.sprint.audit_publish._write_sprint_summary"):
                     with patch(
                         "theforge.sprint.runner._validate_story_paths", return_value=[story_path]
                     ):

--- a/tests/test_sprint_audit_publish.py
+++ b/tests/test_sprint_audit_publish.py
@@ -1,22 +1,30 @@
-"""Tests for publishing canonical story run audit records at end of sprint.
+"""Tests for ``sprint/audit_publish.py``: terminal sprint audits and their publish.
 
-The publish step pushes the audit commit to the base branch. Because the
+The module owns one responsibility end to end — build the terminal audit and
+summary inputs, write the run's artifacts, then commit and push the canonical
+per-run audit JSON — and every test here calls it directly, with no sprint
+running, no worktree and no agent invoked (#2402).
+
+The publish half pushes the audit commit to the base branch. Because the
 sprint's own merges are what usually advance that branch, a non-fast-forward
 rejection is the ordinary case for a run that landed stories — it must be
-reconciled and retried rather than raised as terminal. These tests drive the
+reconciled and retried rather than raised as terminal. Those tests drive the
 real git plumbing (a bare "origin" plus two clones) so the reconcile is
 exercised end to end, and assert the recorded publish end state.
 """
 
 from __future__ import annotations
 
+import datetime
 import json
 import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
+from coord_test_helpers import _make_config
 
-from theforge.sprint.runner import (
+from theforge.sprint.audit_publish import (
     _STORY_RUN_AUDIT_PUBLISH_STATE_PATH,
     AUDIT_PUBLISH_BRANCH_MISMATCH,
     AUDIT_PUBLISH_CLEAN,
@@ -26,7 +34,13 @@ from theforge.sprint.runner import (
     AUDIT_PUBLISH_RECONCILE_FAILED,
     StoryRunAuditPublishError,
     _commit_story_run_audits,
+    publish_story_run_audits,
+    write_terminal_sprint_audits,
 )
+from theforge.sprint.dag import StoryTriage
+from theforge.sprint.manifest import ResolvedSprint, SprintResult
+from theforge.sprint.runner import SprintExecutionState, SprintRunContext
+from theforge.task import TaskStory
 
 BASE = "release/v0.13"
 
@@ -267,3 +281,217 @@ def test_publish_records_clean_state_when_no_audits_are_pending(
     _commit_story_run_audits(clone, BASE, publish=True)
 
     assert _read_state(clone)["state"] == AUDIT_PUBLISH_CLEAN
+
+
+# ── the write half: terminal audit + summary, called directly ─────────────
+#
+# No sprint runs in any of these. The state a run would hold is constructed
+# here and handed to the module, which is the property the move was for: the
+# responsibility is exercisable on its own (#2402).
+
+
+def _make_state(
+    tmp_path: Path,
+    *,
+    base_branch: str = "main",
+    auto_push: bool = True,
+) -> SprintExecutionState:
+    """The execution state a one-story sprint would hold at its terminal write."""
+    import dataclasses
+
+    config = _make_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        workspace=dataclasses.replace(
+            config.workspace, base_branch=base_branch, auto_push=auto_push
+        ),
+    )
+    task = TaskStory(name="Export service", slug="export-service", github_issue=42)
+    resolved = ResolvedSprint(
+        name="audit-move",
+        budget_usd=10.0,
+        stories=[(task, None, "issue:42")],
+        max_parallel=1,
+    )
+    context = SprintRunContext(
+        config=config,
+        resolved=resolved,
+        sprint_id="sprint-abc",
+        run_id="run-xyz",
+    )
+    return SprintExecutionState.for_run(context)
+
+
+def _make_result() -> SprintResult:
+    return SprintResult(
+        name="audit-move",
+        specs_total=1,
+        specs_succeeded=1,
+        specs_failed=0,
+        specs_skipped=0,
+        total_cost_usd=1.25,
+        budget_usd=10.0,
+        results=[],
+    )
+
+
+def test_terminal_write_emits_audit_and_summary_from_the_state(tmp_path: Path) -> None:
+    state = _make_state(tmp_path)
+    started = datetime.datetime(2026, 8, 13, 9, 0, tzinfo=datetime.timezone.utc)
+    finished = started + datetime.timedelta(minutes=12)
+    state.story_times["export-service"] = (started, finished)
+    state.batch_assignments["export-service"] = 1
+    state.current_story_entries_by_ref["issue:42"] = {
+        "slug": "export-service",
+        "outcome": "done",
+        "cost_usd": 1.25,
+    }
+    log_dir = tmp_path / ".forge" / "logs" / "audit-move"
+
+    write_terminal_sprint_audits(
+        state,
+        result=_make_result(),
+        started_at=started,
+        finished_at=finished,
+        duration=720.0,
+        sprint_log_dir=log_dir,
+        dropped_slugs={},
+        triages={"issue:42": StoryTriage(story_path="issue:42", action="full", reason="new")},
+    )
+
+    audit = yaml.safe_load(
+        (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text(encoding="utf-8")
+    )
+    assert audit["sprint"]["name"] == "audit-move"
+    assert audit["sprint"]["sprint_id"] == "sprint-abc"
+    assert audit["sprint"]["duration_seconds"] == 720.0
+    # The ref → slug map and the tasks-by-slug map are built inside the module
+    # from the run context, so the story is identifiable in the record without
+    # the caller having assembled either.
+    assert [spec["slug"] for spec in audit["specs"]] == ["export-service"]
+
+    summary = yaml.safe_load((log_dir / "sprint-summary.yaml").read_text(encoding="utf-8"))
+    assert summary["sprint"]["name"] == "audit-move"
+    assert [story["slug"] for story in summary["stories"]] == ["export-service"]
+    # Both artifacts describe the same run: one derivation, two writers.
+    assert summary["sprint"]["run_id"] == "run-xyz"
+    assert summary["sprint"]["sprint_id"] == audit["sprint"]["sprint_id"]
+
+
+def test_terminal_write_skips_log_dir_artifacts_when_there_is_no_log_dir(
+    tmp_path: Path,
+) -> None:
+    """A run that could not create its log directory still records the audit."""
+    state = _make_state(tmp_path)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    write_terminal_sprint_audits(
+        state,
+        result=_make_result(),
+        started_at=now,
+        finished_at=now,
+        duration=0.0,
+        sprint_log_dir=None,
+        dropped_slugs={},
+        triages={},
+    )
+
+    assert (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").exists()
+    assert not (tmp_path / ".forge" / "logs").exists()
+
+
+def test_terminal_write_records_a_dropped_story_reason(tmp_path: Path) -> None:
+    state = _make_state(tmp_path)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    write_terminal_sprint_audits(
+        state,
+        result=_make_result(),
+        started_at=now,
+        finished_at=now,
+        duration=0.0,
+        sprint_log_dir=None,
+        dropped_slugs={"export-service": "collision with sibling"},
+        triages={},
+    )
+
+    audit = yaml.safe_load(
+        (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text(encoding="utf-8")
+    )
+    spec = audit["specs"][0]
+    assert spec["outcome"] == "DROPPED"
+    assert spec["drop_reason"] == "collision with sibling"
+
+
+# ── the publish half, entered as the runner enters it ─────────────────────
+
+
+def test_publish_entry_point_publishes_for_the_state_it_is_given(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    origin, clone = origin_and_clone
+    _write_audit(clone, "run-h.json")
+    state = _make_state(clone, base_branch=BASE)
+
+    publish_story_run_audits(state, lands_locally=False)
+
+    assert "run-h.json" in _git(origin, "ls-tree", "-r", "--name-only", BASE)
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_PUBLISHED
+
+
+def test_publish_entry_point_keeps_the_commit_local_when_pushing_would_publish_merges(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    """auto_push off on a run that lands locally: commit, do not push, say so."""
+    origin, clone = origin_and_clone
+    _write_audit(clone, "run-i.json")
+    state = _make_state(clone, base_branch=BASE, auto_push=False)
+
+    publish_story_run_audits(state, lands_locally=True)
+
+    assert "run-i.json" not in _git(origin, "ls-tree", "-r", "--name-only", BASE)
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_LOCAL_ONLY
+
+
+def test_publish_entry_point_reports_the_failure_and_re_raises(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    """Reporting is part of the responsibility — and the sprint still exits nonzero."""
+    _origin, clone = origin_and_clone
+    _git(clone, "checkout", "-b", "feature/wrong-branch")
+    _write_audit(clone, "run-j.json")
+    state = _make_state(clone, base_branch=BASE)
+
+    with pytest.raises(StoryRunAuditPublishError) as excinfo:
+        publish_story_run_audits(state, lands_locally=False)
+
+    assert excinfo.value.state == AUDIT_PUBLISH_BRANCH_MISMATCH
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_BRANCH_MISMATCH
+
+
+def test_the_module_does_not_import_the_sprint_runner() -> None:
+    """Separation is the point of the move — a dependency back would undo it.
+
+    Two stories changing unrelated parts of a sprint run should claim different
+    files. An import of ``sprint.runner`` here — including one hidden inside a
+    function or behind ``TYPE_CHECKING`` — puts this module back in the runner's
+    dependency graph and makes the move a relocation (#2402).
+    """
+    import ast
+
+    from theforge.sprint import audit_publish
+
+    tree = ast.parse(Path(audit_publish.__file__).read_text(encoding="utf-8"))
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "runner" or module.endswith(".runner"):
+                offenders.append(f"line {node.lineno}: from {'.' * node.level}{module} import ...")
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.endswith("sprint.runner"):
+                    offenders.append(f"line {node.lineno}: import {alias.name}")
+    assert not offenders, "sprint/audit_publish.py imports the sprint runner: " + "; ".join(
+        offenders
+    )

--- a/tests/test_sprint_auth_gate.py
+++ b/tests/test_sprint_auth_gate.py
@@ -486,8 +486,8 @@ def test_healthy_credential_lets_the_sprint_run(tmp_path: Path) -> None:
             return_value={"passed": True, "message": "ok"},
         ),
         patch("theforge.sprint.runner.run_task", return_value=_ok_result()) as mock_run_task,
-        patch("theforge.sprint.runner._write_sprint_audit"),
-        patch("theforge.sprint.runner._write_sprint_summary"),
+        patch("theforge.sprint.audit_publish._write_sprint_audit"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
     ):
         result = run_sprint_ctx(config, resolved)
 
@@ -549,8 +549,8 @@ def _run_two_story_sprint(
             return_value={"passed": True, "message": "ok"},
         ),
         patch("theforge.sprint.runner.run_task", side_effect=_fake_run_task),
-        patch("theforge.sprint.runner._write_sprint_audit"),
-        patch("theforge.sprint.runner._write_sprint_summary"),
+        patch("theforge.sprint.audit_publish._write_sprint_audit"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
         patch("theforge.sprint.runner._write_story_audit"),
     ):
         result = run_sprint_ctx(config, resolved)
@@ -663,8 +663,8 @@ def test_inflight_sibling_cancelled_by_breaker_is_not_a_story_failure(
             return_value={"passed": True, "message": "ok"},
         ),
         patch("theforge.sprint.runner.run_task", side_effect=_fake_run_task),
-        patch("theforge.sprint.runner._write_sprint_audit"),
-        patch("theforge.sprint.runner._write_sprint_summary"),
+        patch("theforge.sprint.audit_publish._write_sprint_audit"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
         patch("theforge.sprint.runner._write_story_audit"),
     ):
         result = run_sprint_ctx(config, resolved)

--- a/tests/test_sprint_baseline_gate.py
+++ b/tests/test_sprint_baseline_gate.py
@@ -453,8 +453,8 @@ def test_baseline_pass_proceeds_to_normal_sprint_flow(
             "theforge.sprint.runner.run_task",
             return_value=_fake_result(),
         ) as mock_run_task,
-        patch("theforge.sprint.runner._write_sprint_audit"),
-        patch("theforge.sprint.runner._write_sprint_summary"),
+        patch("theforge.sprint.audit_publish._write_sprint_audit"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
     ):
         result = run_sprint_ctx(config, resolved)
 
@@ -763,10 +763,10 @@ def test_an_unreproduced_baseline_failure_lets_the_sprint_run_its_stories(
     with (
         patch("theforge.coordinator.workspace.assert_base_branch_checked_out"),
         patch("theforge.sprint.runner.run_task", return_value=_fake_result()) as mock_run_task,
-        patch("theforge.sprint.runner._write_sprint_summary"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
         # The fixture repo sits on the feature branch, which the audit publish
         # refuses; unrelated to what this test pins.
-        patch("theforge.sprint.runner._commit_story_run_audits"),
+        patch("theforge.sprint.audit_publish._commit_story_run_audits"),
     ):
         result = run_sprint_ctx(config, resolved, no_pull=True, run_id="abc123")
 

--- a/tests/test_sprint_github_query.py
+++ b/tests/test_sprint_github_query.py
@@ -449,8 +449,8 @@ class TestRunSprintAcceptsResolvedSprint:
             with patch(
                 "theforge.sprint.runner.run_task", return_value=self._make_coordinator_result()
             ):
-                with patch("theforge.sprint.runner._write_sprint_audit"):
-                    with patch("theforge.sprint.runner._write_sprint_summary"):
+                with patch("theforge.sprint.audit_publish._write_sprint_audit"):
+                    with patch("theforge.sprint.audit_publish._write_sprint_summary"):
                         result = run_sprint_ctx(config, resolved)
 
         assert result.specs_total == 1
@@ -482,8 +482,8 @@ class TestRunSprintAcceptsResolvedSprint:
             with patch(
                 "theforge.sprint.runner.run_task", return_value=self._make_coordinator_result()
             ):
-                with patch("theforge.sprint.runner._write_sprint_audit"):
-                    with patch("theforge.sprint.runner._write_sprint_summary"):
+                with patch("theforge.sprint.audit_publish._write_sprint_audit"):
+                    with patch("theforge.sprint.audit_publish._write_sprint_summary"):
                         result = run_sprint_ctx(config, resolved)
 
         assert result.specs_total == 1

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -3455,7 +3455,7 @@ class TestSprintRunAuditCommit:
                 return_value={"merged": True, "success": True, "action": "merge"},
             ),
             patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
-            patch("theforge.sprint.runner._log", side_effect=warnings.append),
+            patch("theforge.sprint.audit_publish._log", side_effect=warnings.append),
             pytest.raises(RuntimeError, match="Failed to push story run audits"),
         ):
             run_sprint_ctx(config, manifest_path, auto_merge=True)
@@ -3498,7 +3498,7 @@ class TestSprintRunAuditCommit:
                 return_value={"merged": True, "success": True, "action": "merge"},
             ),
             patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
-            patch("theforge.sprint.runner._log", side_effect=warnings.append),
+            patch("theforge.sprint.audit_publish._log", side_effect=warnings.append),
             pytest.raises(RuntimeError, match="still 1 commit"),
         ):
             run_sprint_ctx(config, manifest_path, auto_merge=True)
@@ -3544,7 +3544,7 @@ class TestSprintRunAuditCommit:
         with (
             patch("theforge.sprint.runner.run_task", return_value=result),
             patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
-            patch("theforge.sprint.runner._log", side_effect=logs.append),
+            patch("theforge.sprint.audit_publish._log", side_effect=logs.append),
         ):
             run_sprint_ctx(config, manifest_path)
 
@@ -3591,7 +3591,7 @@ class TestSprintRunAuditCommit:
                 return_value={"merged": True, "success": True, "action": "merge"},
             ),
             patch("theforge.coordinator.util._run_shell", side_effect=fake_shell),
-            patch("theforge.sprint.runner._log", side_effect=logs.append),
+            patch("theforge.sprint.audit_publish._log", side_effect=logs.append),
         ):
             sprint = run_sprint_ctx(config, manifest_path, auto_merge=True)
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The extraction moves terminal sprint audit publication into its own module, keeps the runner decoupled from the moved responsibility, and adds direct tests for the extracted boundary without changing the observed sprint flow. | [google-gemini-3.5-flash-api] Successfully moved sprint audit publication out of sprint/runner.py into its own single-purpose module sprint/audit_publish.py with high test coverage and no back-dependency on the runner. | [anthropic-claude-haiku-4-5-cli] Responsibility move is complete and tested: sprint audit publication moved to independent module audit_publish.py with structural guarantees (no runner imports, direct testability). Gate verdict PASS.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $8.14
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

The seam #2399 built has never been used, so every sprint-lifecycle responsibility still lives in one module and unrelated sprint changes still collide on it (GitHub Issue #2402)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2402