### PR TITLE
Rates are declared in two places, one of which no configuration can override, so the catalog is authoritative only until the compiled fallback is consulted

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -463,6 +463,7 @@ models:
         cached_input_per_mtok: 0.20     # only if the provider bills its cache
                                         # tier at its own published rate
         pricing_provenance: gemini-4-pro-2026-08
+        rate_basis: token_rates         # or `provider_reported`, with no figures
       identity:
         status: served                  # served | retired
         verified_against: provider model list
@@ -489,6 +490,21 @@ price-attributable nor explained is a load error rather than a silent guess.
 prompt-cache hit rather than expressing it as a fraction of the uncached rate.
 Omit it and forge applies its generic 10%-of-input discount, which is what
 OpenAI and Anthropic actually bill.
+
+**A rate is declared here and nowhere else.** The catalog entry (shipped or
+yours) is the only place a per-MTok figure comes from — there is no packaged
+rate table behind it that a release could change and your configuration could
+not (#2388; `docs/reference/dropped-legacy-rates.md` records the one that used
+to exist). So an entry with no figures is an entry that cannot be priced, and
+`rate_basis` is how you say which kind of "no figures" you mean:
+
+- `token_rates` (the default) — spend is token count × the rates on this entry.
+  Declaring no figures under this basis means the identity records its cost as
+  unknown, and `forge check-config` says so at load.
+- `provider_reported` — the transport returns the figure it was billed (the
+  Claude CLI does), so no rate card is ever consulted and none is missing. An
+  entry declaring this may not also declare per-MTok figures: a rate nothing
+  reads is a rate nothing keeps current.
 
 **Upstream identifiers.** `identity` is what the entry claims about the name the
 *provider* serves, and when that claim was last checked. It matters because a

--- a/docs/reference/dropped-legacy-rates.md
+++ b/docs/reference/dropped-legacy-rates.md
@@ -1,0 +1,80 @@
+# Dropped legacy rates (`PRICING_TABLE`, removed in #2388)
+
+Until #2388 a rate could be declared in two places: the model catalog
+(`src/theforge/config/data/models.yaml`, data, per-entry provenance, overridable
+per project) and `PRICING_TABLE`, a dictionary compiled into
+`src/theforge/runners/rate_registry.py` that no configuration could override and
+that accounting consulted whenever the registry missed.
+
+The table is gone. This file is the record of what it held, so a rate removed
+here is not a rate silently lost: an operator who later enables one of these
+models has the figure that was in force and can declare it on a catalog entry —
+with `pricing_provenance`, which is what the table could never carry.
+
+Figures are USD per 1M tokens, `(input, output)`, as the table stated them on
+the day it was removed. **They are unattributed and undated** — that is the
+defect that removed them. Treat any figure below as a starting point to check
+against the provider's current pricing page, not as a price to declare as-is.
+
+## Carried into the catalog
+
+These ten rows duplicated a catalog entry that already priced the same
+`(provider, model)` with provenance. The catalog figures are identical to the
+table's, so removing the row changed no price. Nothing to migrate.
+
+| Provider  | Model                  | Table rate      | Catalog entry (with provenance) |
+| --------- | ---------------------- | --------------- | ------------------------------- |
+| openai    | `gpt-5.4-mini`         | 0.25 / 2.00     | `openai/gpt-5.4-mini` (cli, api) |
+| openai    | `gpt-5.4`              | 1.25 / 10.00    | `openai/gpt-5.4` (cli, api)     |
+| openai    | `gpt-5.4-pro`          | 15.00 / 120.00  | `openai/gpt-5.4-pro` (cli, api) |
+| openai    | `gpt-5.5`              | 5.00 / 30.00    | `openai/gpt-5.5` (cli)          |
+| anthropic | `claude-opus-4-6`      | 15.00 / 75.00   | `anthropic/claude-opus-4-6` (cli) |
+| anthropic | `claude-sonnet-4-6`    | 3.00 / 15.00    | `anthropic/claude-sonnet-4-6` (cli) |
+| anthropic | `claude-haiku-4-5`     | 1.00 / 5.00     | `anthropic/claude-haiku-4-5` (cli) |
+| google    | `gemini-3.5-flash`     | 1.50 / 9.00     | `google/gemini-3.5-flash` (api) |
+| google    | `gemini-3.1-pro-preview` | 2.00 / 12.00  | `google/gemini-3.1-pro-preview` (api, cli) |
+| google    | `gemini-2.5-pro`       | 1.25 / 10.00    | `google/gemini-2.5-pro` (api, cli) |
+
+## Dropped
+
+These eleven rows priced identities no catalog entry names, so nothing this
+repository can dispatch could reach them: they were prior-generation families
+kept alive only by the table. They are recorded here and declared nowhere.
+
+| Provider | Model                                | Rate at removal |
+| -------- | ------------------------------------ | --------------- |
+| openai   | `o4-mini`                            | 1.10 / 4.40     |
+| openai   | `gpt-4o`                             | 2.50 / 10.00    |
+| openai   | `gpt-4o-mini`                        | 0.15 / 0.60     |
+| openai   | `gpt-5.1-codex-mini`                 | 1.50 / 6.00     |
+| openai   | `gpt-5.1-codex`                      | 3.00 / 12.00    |
+| openai   | `gpt-5.1-codex-max`                  | 6.00 / 24.00    |
+| google   | `gemini-3.1-pro-preview-customtools` | 2.00 / 12.00    |
+| google   | `gemini-2.5-flash`                   | 0.30 / 2.50     |
+| google   | `gemini-2.5-flash-lite`              | 0.10 / 0.40     |
+| google   | `gemini-2.0-flash`                   | 0.10 / 0.40     |
+| google   | `gemini-2.0-flash-lite`              | 0.075 / 0.30    |
+
+## Re-enabling one of these
+
+Add a catalog entry (or a `models.custom` entry in `forge.yaml`) naming the
+identity and its transport, and declare the price you checked against the
+provider today:
+
+```yaml
+- provider: google
+  model: gemini-2.5-flash
+  transport: {kind: api}
+  routing:
+    tier: cheap
+    capability: 7
+    cost_rank: 1
+  cost:
+    input_per_mtok: 0.30
+    output_per_mtok: 2.50
+    pricing_provenance: gemini-2.5-flash
+```
+
+An entry whose transport reports what it was billed instead of token counts
+(the Claude CLI) declares `cost: {rate_basis: provider_reported}` and no
+figures — see `claude-opus-5` in the catalog.

--- a/src/theforge/config/data/models.yaml
+++ b/src/theforge/config/data/models.yaml
@@ -21,7 +21,7 @@
 #               cost_rank_basis
 #   base_url:   endpoint metadata (locally served OpenAI-compatible servers)
 #   cost:       input_per_mtok, output_per_mtok, cached_input_per_mtok,
-#               pricing_provenance
+#               pricing_provenance, rate_basis
 #   identity:   status (served|retired), verified_against, verified_on,
 #               retired_reason
 #   invocation: reasoning_mode (enabled|disabled)
@@ -47,6 +47,16 @@
 # recorded for. Omitting it marks them *unattributed*: routing ignores them.
 # `routing.cost_rank_basis` must be stated whenever the band is not this entry's
 # own attributable price band — an unstated, underivable band is a load error.
+#
+# `cost.rate_basis` states whether spend on the entry is established from a rate
+# card at all. It defaults to `token_rates`. `provider_reported` says the
+# transport returns the figure it was billed, so the entry declares no rates and
+# none can be *missing* — the distinction an absent `cost:` block cannot make
+# (#2388). An entry declaring it may not also declare per-MTok figures.
+#
+# This file is the ONLY place a rate is declared. There is no packaged fallback
+# table behind it: since #2388 a per-MTok figure reaches accounting from a
+# catalog entry here or from a project's forge.yaml, and from nowhere else.
 
 version: 1
 
@@ -55,8 +65,8 @@ models:
   #
   # `sonnet`/`opus` are Claude-CLI shorthands, not billed identities: the CLI
   # resolves each to whichever concrete version it currently ships (the vendor
-  # bills `claude-sonnet-4-6` / `claude-opus-4-6`-style names — see
-  # runners/schema_utils.PRICING_TABLE). The entry identity can therefore move
+  # bills `claude-sonnet-4-6` / `claude-opus-4-6`-style names, which are pinned
+  # entries of their own below). The entry identity can therefore move
   # while the literal below does not, so these figures carry no
   # pricing_provenance: they are indicative only and routing ignores them.
   # Re-attributing them requires pinning the entry to the concrete version the
@@ -129,16 +139,20 @@ models:
   # unaffected by their presence.
   #
   # Unlike the shorthands, a pinned model string IS the identity the vendor
-  # bills under (runners/schema_utils.PRICING_TABLE keys them identically), so
-  # where a price has been observed for one it carries pricing_provenance and its
-  # band derives from that price — no cost_rank_basis needed. Where no price has
-  # been attributed yet, the band restates the vendor's tier naming exactly as
-  # the shorthand's does, and says so.
+  # bills under, so where a price has been observed for one it carries
+  # pricing_provenance and its band derives from that price — no cost_rank_basis
+  # needed. Where no price has been attributed yet, the band restates the
+  # vendor's tier naming exactly as the shorthand's does, and says so.
+  #
+  # The rates the priced entries below carry are not for routing alone: the
+  # Claude CLI reports the *billed* name in each stream event, so a run killed
+  # before its result event is repriced from these figures by the kill-path
+  # reconstruction in runners/runner_claude.py.
 
-  # Current flagship. No per-MTok figure has been attributed to this identity in
-  # this repo yet (PRICING_TABLE has none), so it declares no cost block and
-  # bands on the vendor's own tier naming rather than borrowing the shorthand's
-  # indicative literal.
+  # Current flagship. Declares no rates and needs none: the Claude CLI reports
+  # what it was billed, so nothing here is ever multiplied by a token count.
+  # `rate_basis` says that outright — an empty cost block would be
+  # indistinguishable from a rate somebody forgot to record.
   - provider: anthropic
     model: claude-opus-5
     transport: {kind: cli}
@@ -147,6 +161,8 @@ models:
       capability: 10
       cost_rank: 3
       cost_rank_basis: vendor-tier
+    cost:
+      rate_basis: provider_reported
 
   # Current mid-priced workhorse. Same attribution position as claude-opus-5.
   - provider: anthropic
@@ -157,6 +173,8 @@ models:
       capability: 7
       cost_rank: 1
       cost_rank_basis: vendor-tier
+    cost:
+      rate_basis: provider_reported
 
   # Prior flagship generation — the candidate the shorthand cannot name. Priced
   # under its own billed identity, so its band (3) is derived, and it is
@@ -209,8 +227,9 @@ models:
   #
   # Unlike the Claude-CLI shorthands above, these model strings are the identity
   # the vendor bills under — they are passed through verbatim and priced under
-  # the same name (runners/schema_utils.PRICING_TABLE keys them identically), so
-  # the figures are attributable to the entry.
+  # the same name — so the figures are attributable to the entry. The Codex CLI
+  # reports token counts and no price, so these rates are what makes a run on
+  # them accountable at all.
   - provider: openai
     model: gpt-5.4
     transport: {kind: cli}

--- a/src/theforge/config/dispatch_rates.py
+++ b/src/theforge/config/dispatch_rates.py
@@ -7,7 +7,7 @@ site thereafter looks the dispatched identity up in that registry. One
 declaration of a model's cost therefore serves both the decision to use it and
 the record of what using it cost.
 
-Three things happen here, in order:
+Two things happen here, in order:
 
 1. **Compile.** Every ``AgentSpec`` in the merged registry yields an entry keyed
    by ``(provider, model, transport.kind)``. Because the key includes the
@@ -16,16 +16,17 @@ Three things happen here, in order:
    reproduced (the merged dict is itself keyed by canonical id, so two specs
    cannot collide on one identity by construction).
 
-2. **Materialize legacy prices.** The packaged, transport-agnostic
-   :data:`PRICING_TABLE` keeps working by being resolved onto concrete
-   transport identities *here*, under three restrictions spelled out in
-   :func:`_materialize_legacy_rates`. This is what replaces a transport-agnostic
-   fallback tier at query time, and it is why a CLI price an operator declared
-   can never become the API path's price.
-
-3. **Report.** Identities the configuration can actually dispatch on but cannot
+2. **Report.** Identities the configuration can actually dispatch on but cannot
    account for are warned about at load, naming the paths they are reachable on,
    rather than discovered as a cost-unknown after the spend has happened.
+
+There used to be a third step between them: a packaged, transport-agnostic
+``PRICING_TABLE`` was *materialized* onto concrete transport identities here, so
+a rate compiled into the runner package could price an identity the catalog
+never described. That table was a second declaration surface no configuration
+could override, and it is gone (#2388) — the registry is compiled from the
+merged model registry and nothing else, so every figure in it came from the
+shipped catalog or from ``forge.yaml``.
 """
 
 from __future__ import annotations
@@ -34,7 +35,6 @@ import logging
 from dataclasses import dataclass, field
 
 from theforge.runners.rate_registry import (
-    PRICING_TABLE,
     AccountingMode,
     DispatchIdentity,
     ModelRates,
@@ -115,7 +115,7 @@ def _profile_identities(
     fallback_models = getattr(profile, "fallback_models", ()) or ()
     # None when the provider has no API adapter: no model fallback can be
     # attempted at all, so those entries name no reachable identity and are not
-    # enumerated (target restriction, rule b).
+    # enumerated.
     model_fb_transport = model_fallback_transport(provider) if fallback_models else None
     if model_fb_transport is not None:
         for fallback_model in fallback_models:
@@ -151,10 +151,10 @@ def _profile_identities(
 def reachable_identities(config: object) -> tuple[ReachableIdentity, ...]:
     """Every identity the loaded configuration can dispatch on.
 
-    Computed once and used for BOTH the legacy-materialization target
-    restriction and the load-time report, so what is widened and what is
-    reported are derived from one list rather than two enumerations that can
-    drift apart.
+    Computed once and used both to give every dispatchable identity a registry
+    entry (priced or not, so its accounting mode survives the lookup) and to
+    drive the load-time report, so what is compiled and what is reported are
+    derived from one list rather than two enumerations that can drift apart.
     """
     found: dict[DispatchIdentity, _Reach] = {}
 
@@ -201,6 +201,13 @@ def _spec_rates(spec: AgentSpec) -> ModelRates | None:
     """The rate card an ``AgentSpec`` declares, honouring attribution rules."""
     from .pricing import PRICING_PROVENANCE_LOCAL_ENDPOINT  # noqa: PLC0415
 
+    if not spec.uses_rate_card:
+        # The entry states that its transport reports what it was billed, so no
+        # rate card is consulted for it. Honoured here rather than trusted to be
+        # accompanied by absent figures: an overlay can declare the basis and
+        # inherit a built-in entry's numbers, and those numbers must not become
+        # a price nothing keeps current.
+        return None
     if spec.input_cost_per_mtok is None or spec.output_cost_per_mtok is None:
         return None
     if not spec.pricing_attributable:
@@ -217,74 +224,18 @@ def _spec_rates(spec: AgentSpec) -> ModelRates | None:
     )
 
 
-def _materialize_legacy_rates(
-    entries: dict[DispatchIdentity, RateEntry],
-    reachable: tuple[ReachableIdentity, ...],
-    project_priced: set[tuple[str, str]],
-) -> set[DispatchIdentity]:
-    """Widen packaged transport-agnostic prices onto concrete identities.
-
-    Three restrictions, each closing one way a price could reach an identity it
-    was never recorded for:
-
-    (a) **Source.** Materialization draws ONLY from the packaged
-        :data:`PRICING_TABLE`. A project-declared per-transport entry never
-        widens to another transport — that is the reported failure (a model
-        priced on the CLI lending its rate to the API path) and it is refused
-        structurally, not by convention.
-    (b) **Target.** A legacy price is materialized only onto an identity this
-        configuration can actually dispatch on. Entries that resolve onto no
-        reachable identity are dropped; nothing unscoped enters the registry.
-    (c) **Conflict.** Materialization is refused for a ``(provider, model)``
-        that carries any project-declared per-transport price. A genuine
-        per-transport disagreement must surface at load, not be resolved by
-        borrowing either figure.
-
-    Returns the identities whose widening rule (c) suppressed, so the load-time
-    report can name the conflict as the operator-actionable case it is.
-    """
-    conflicted: set[DispatchIdentity] = set()
-    for reach in reachable:
-        identity = reach.identity
-        existing = entries.get(identity)
-        if existing is not None and (
-            existing.priced or existing.mode is AccountingMode.INDEPENDENTLY_MEASURED
-        ):
-            continue
-        legacy = PRICING_TABLE.get((identity.provider, identity.model))
-        if legacy is None:
-            continue
-        if (identity.provider, identity.model) in project_priced:
-            conflicted.add(identity)
-            continue
-        mode = accounting_mode_for(identity.transport, reach.runner)
-        origin = f"PRICING_TABLE[{identity.provider}/{identity.model}]"
-        entries[identity] = RateEntry(
-            identity=identity,
-            rates=ModelRates(input_per_mtok=legacy[0], output_per_mtok=legacy[1]),
-            mode=mode,
-            source=RateSource.LEGACY_COMPAT,
-            origin=origin,
-        )
-        log.info(
-            "Pricing %s from the packaged rate table (%s): no per-transport entry declares it.",
-            identity.label,
-            origin,
-        )
-    return conflicted
-
-
 def compile_rate_registry(
     model_registry: dict[str, AgentSpec],
     reachable: tuple[ReachableIdentity, ...],
-) -> tuple[RateRegistry, set[DispatchIdentity]]:
+) -> RateRegistry:
     """Build the registry for one configuration.
 
-    Returns ``(registry, conflicted)`` where ``conflicted`` names identities
-    whose legacy widening was suppressed by a per-transport pricing conflict.
+    Every priced entry comes from a spec in ``model_registry`` — the merged
+    catalog + ``forge.yaml`` view — so a figure in the compiled registry is one
+    an operator could have supplied. Nothing is widened onto an identity the
+    registry does not describe.
     """
     entries: dict[DispatchIdentity, RateEntry] = {}
-    project_priced: set[tuple[str, str]] = set()
 
     from .pricing import PRICING_PROVENANCE_LOCAL_ENDPOINT  # noqa: PLC0415
 
@@ -307,8 +258,6 @@ def compile_rate_registry(
                 origin=canonical_id,
             )
             continue
-        if rates is not None and is_project:
-            project_priced.add((identity.provider, identity.model))
         entries[identity] = RateEntry(
             identity=identity,
             rates=rates,
@@ -322,8 +271,6 @@ def compile_rate_registry(
             or canonical_model_id(spec.provider, spec.model, spec.transport.kind),
         )
 
-    conflicted = _materialize_legacy_rates(entries, reachable, project_priced)
-
     # Every reachable identity gets an entry even when it is unpriced, so its
     # accounting mode survives the lookup and the report can classify it.
     for reach in reachable:
@@ -336,17 +283,15 @@ def compile_rate_registry(
             source=RateSource.NONE,
         )
 
-    registry = RateRegistry(
+    return RateRegistry(
         entries=entries,
         reachable={reach.identity: reach.paths for reach in reachable},
     )
-    return registry, conflicted
 
 
 def report_unaccountable_identities(
     registry: RateRegistry,
     reachable: tuple[ReachableIdentity, ...],
-    conflicted: set[DispatchIdentity],
 ) -> list[str]:
     """Warn once per dispatchable identity whose spend could not be accounted for.
 
@@ -361,14 +306,6 @@ def report_unaccountable_identities(
         reason = entry.unaccountable_reason()
         if reason is None:
             continue
-        if reach.identity in conflicted:
-            reason = (
-                f"{reach.identity.provider}/{reach.identity.model} is priced on another "
-                f"transport but dispatched on {reach.identity.transport} with no "
-                f"{reach.identity.transport} price — a per-transport pricing conflict "
-                "suppressed the packaged fallback rather than borrowing the other "
-                "transport's rate"
-            )
         paths = ", ".join(reach.paths) or "unknown path"
         message = (
             f"Cost cannot be accounted for {reach.identity.label}: {reason}. "
@@ -388,9 +325,7 @@ def install_rate_registry(config: object) -> RateRegistry:
     so a load that raises never leaves its partial rates installed.
     """
     reachable = reachable_identities(config)
-    registry, conflicted = compile_rate_registry(
-        getattr(config, "model_registry", None) or {}, reachable
-    )
+    registry = compile_rate_registry(getattr(config, "model_registry", None) or {}, reachable)
     install(registry)
-    report_unaccountable_identities(registry, reachable, conflicted)
+    report_unaccountable_identities(registry, reachable)
     return registry

--- a/src/theforge/config/model_catalog.py
+++ b/src/theforge/config/model_catalog.py
@@ -30,6 +30,7 @@ Canonical shape::
       input_per_mtok: 1.25
       output_per_mtok: 10.00
       pricing_provenance: gpt-5.5
+      rate_basis: token_rates    # or `provider_reported`, with no figures
 
 Two resolution modes sit on top of that one syntax:
 
@@ -83,6 +84,9 @@ from .pricing import (
     COST_BAND_BASIS_OPERATOR_DECLARED,
     COST_BAND_BASIS_UNPRICED_DEFAULT,
     PRICING_PROVENANCE_OPERATOR_DECLARED,
+    RATE_BASES,
+    RATE_BASIS_PROVIDER_REPORTED,
+    RATE_BASIS_TOKEN_RATES,
     UNPRICED_COST_RANK,
     custom_model_cost_rank,
     price_cost_band_basis,
@@ -112,6 +116,7 @@ COST_KEYS: frozenset[str] = frozenset(
         "output_per_mtok",
         "cached_input_per_mtok",
         "pricing_provenance",
+        "rate_basis",
     }
 )
 IDENTITY_KEYS: frozenset[str] = frozenset(
@@ -134,6 +139,7 @@ PROVENANCE_FIELDS: tuple[str, ...] = (
     "output_cost_per_mtok",
     "cached_input_cost_per_mtok",
     "pricing_provenance",
+    "rate_basis",
     "identity",
     "reasoning_mode",
 )
@@ -447,6 +453,27 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
         if provenance is not None:
             provenance = _require_str(provenance, where=f"{where}.cost.pricing_provenance")
         cost["pricing_provenance"] = provenance
+    if "rate_basis" in cost_raw:
+        rate_basis = _require_str(cost_raw["rate_basis"], where=f"{where}.cost.rate_basis")
+        if rate_basis not in RATE_BASES:
+            raise ValueError(
+                f"forge.yaml '{where}.cost.rate_basis' must be one of "
+                f"{sorted(RATE_BASES)}, got {rate_basis!r}"
+            )
+        priced_fields = {
+            "input_cost_per_mtok",
+            "output_cost_per_mtok",
+            "cached_input_cost_per_mtok",
+        }
+        if rate_basis == RATE_BASIS_PROVIDER_REPORTED and priced_fields & set(cost):
+            raise ValueError(
+                f"forge.yaml '{where}.cost' declares rate_basis "
+                f"{RATE_BASIS_PROVIDER_REPORTED!r} together with per-MTok figures. "
+                "A transport that reports what it was billed never consults a rate card, "
+                "so the figures would be a price nothing reads and nothing keeps current — "
+                "declare one or the other."
+            )
+        cost["rate_basis"] = rate_basis
 
     declared = (
         frozenset(routing)
@@ -549,6 +576,7 @@ def resolve_packaged(defn: ParsedDefinition, *, where: str) -> ResolvedModel:
         pricing_provenance=provenance,
         identity=defn.identity,
         reasoning_mode=defn.reasoning_mode,
+        rate_basis=defn.cost.get("rate_basis", RATE_BASIS_TOKEN_RATES),
     )
     return ResolvedModel(
         canonical_id=defn.canonical_id,
@@ -667,6 +695,20 @@ def resolve_project(
         sources["pricing_provenance"] = SOURCE_BUILTIN if builtin is not None else SOURCE_PROJECT
         provenance = builtin.pricing_provenance if builtin is not None else None
 
+    # A declaration that states figures is declaring a rate card, whatever the
+    # entry it overlays said — otherwise an overlay adding rates to a
+    # provider-reported built-in would inherit "no rate card is consulted here"
+    # and its own figures would be unreachable.
+    if "rate_basis" in defn.declared:
+        sources["rate_basis"] = SOURCE_PROJECT
+        rate_basis = defn.cost["rate_basis"]
+    elif declares_price:
+        sources["rate_basis"] = SOURCE_PROJECT
+        rate_basis = RATE_BASIS_TOKEN_RATES
+    else:
+        sources["rate_basis"] = SOURCE_BUILTIN if builtin is not None else SOURCE_PROJECT
+        rate_basis = builtin.rate_basis if builtin is not None else RATE_BASIS_TOKEN_RATES
+
     banded_cost_rank = (
         custom_model_cost_rank(
             float(input_cost or 0.0),
@@ -763,6 +805,7 @@ def resolve_project(
         pricing_provenance=provenance,
         identity=identity or UNCONFIRMED_IDENTITY,
         reasoning_mode=reasoning_mode,
+        rate_basis=rate_basis,
     )
     return ResolvedModel(
         canonical_id=defn.canonical_id,

--- a/src/theforge/config/model_identity.py
+++ b/src/theforge/config/model_identity.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, timedelta
 
-from .pricing import AttributablePricing
+from .pricing import RATE_BASIS_TOKEN_RATES, AttributablePricing
 
 TRANSPORT_KINDS: frozenset[str] = frozenset({"cli", "api"})
 
@@ -321,6 +321,16 @@ class AgentSpec(AttributablePricing):
     # Request-level behavioural mode to ask for at invocation, where the provider
     # expresses one. None = send nothing and take the provider's default.
     reasoning_mode: str | None = None
+    # Whether spend on this entry is established from a rate card at all. The
+    # default says it is; ``provider_reported`` says the transport returns the
+    # billed figure, which is what makes "needs no rate" readable as a stated
+    # property rather than inferred from the absence of one (#2388).
+    rate_basis: str = RATE_BASIS_TOKEN_RATES
+
+    @property
+    def uses_rate_card(self) -> bool:
+        """Does pricing this entry require declared per-MTok rates?"""
+        return self.rate_basis == RATE_BASIS_TOKEN_RATES
 
     @property
     def tier(self) -> str:

--- a/src/theforge/config/pricing.py
+++ b/src/theforge/config/pricing.py
@@ -32,6 +32,29 @@ PRICING_PROVENANCE_LOCAL_ENDPOINT = "local-endpoint"
 # derived from an untraceable price.
 UNPRICED_COST_RANK = 1
 
+# ── Whether an entry is priced from a rate card at all ───────────────────
+#
+# "No rate declared" used to have two meanings that looked identical in the
+# catalog: a rate that is *missing* (the entry needs one and nobody recorded it)
+# and a rate that is *not applicable* (the transport returns the billed figure,
+# so no rate card is ever consulted). Only the first is a defect, and telling
+# them apart meant knowing which runner the entry's transport dispatches to —
+# an inference from an absent field (#2388).
+#
+# ``cost.rate_basis`` states it instead. It is a claim about how spend on this
+# entry is established, not a price, so it is the one cost field an entry with no
+# figures at all can still carry.
+
+# Default: spend is token count × the rates declared on this entry.
+RATE_BASIS_TOKEN_RATES = "token_rates"
+# The transport reports what it was billed (the Claude CLI's ``total_cost_usd`` /
+# per-model ``costUSD``), so this entry deliberately declares no rates and none
+# can be missing. An entry declaring this may not also declare per-MTok figures:
+# a rate nothing consults is a figure that can silently go stale.
+RATE_BASIS_PROVIDER_REPORTED = "provider_reported"
+
+RATE_BASES: frozenset[str] = frozenset({RATE_BASIS_TOKEN_RATES, RATE_BASIS_PROVIDER_REPORTED})
+
 # ── Cost-band attribution ────────────────────────────────────────────────
 #
 # ``RoutingPolicy.cost_rank`` is the *other* price-shaped routing input: it

--- a/src/theforge/runners/rate_registry.py
+++ b/src/theforge/runners/rate_registry.py
@@ -16,24 +16,30 @@ priced by what it dispatched, not by what it was seated as.
 
 **The lookup never crosses transports.** Every key in a compiled registry is a
 concrete ``(provider, model, transport)``. An exact miss is unpriced, full stop.
-Cross-transport reuse of a legacy, transport-agnostic price exists only as a
-COMPILE-TIME materialization (see :mod:`theforge.config.dispatch_rates`) that is
-recorded on the entry as :attr:`RateSource.LEGACY_COMPAT` with the key it came
-from, so it is inspectable rather than implicit at query time. That is what stops
-a model priced by the operator on the CLI from silently lending its price to the
-same model reached over the API.
+There is no transport-agnostic tier to fall through to: a model priced by the
+operator on the CLI cannot lend its price to the same model reached over the API,
+because no code path can widen one identity's rate onto another.
+
+**Rates are declared in one kind of place, and it is not here.** This module
+carries the rate *types* and the registry mechanism; the figures live in the
+shipped catalog (``config/data/models.yaml``) or in a project's ``forge.yaml``,
+both of which an operator can edit without a release. A packaged
+``PRICING_TABLE`` used to sit here as a second declaration surface that no
+configuration could override and that accounting consulted whenever the registry
+missed — it was removed in #2388 (see ``docs/reference/dropped-legacy-rates.md``
+for the rows it held and where each went).
 
 **This module is an import leaf.** It has no ``theforge`` imports at all — not
 at module scope, not inside a function. That is deliberate and load-bearing:
 configuration load compiles the registry, so ``theforge.config.dispatch_rates``
 imports this module, and anything this module reached would become reachable
 from ``theforge.config`` — which is how a pricing key ends up in an import cycle
-with half the runners package. So the pure rate *data* (:class:`ModelRates`,
-:data:`PRICING_TABLE`) lives here, while the catalog-backed resolution that
-needs ``theforge.config.models`` stays in :mod:`theforge.runners.schema_utils`,
-which imports this module one way and re-exports these names for compatibility.
-:func:`resolve` returns None when no registry is installed rather than falling
-back to ``pricing_for``; ``schema_utils.rates_for`` owns that baseline.
+with half the runners package. So the pure rate types (:class:`ModelRates`) live
+here, while the catalog-backed resolution that needs ``theforge.config.models``
+stays in :mod:`theforge.runners.schema_utils`, which imports this module one way
+and re-exports these names for compatibility. :func:`resolve` returns None when
+no registry is installed rather than falling back to ``pricing_for``;
+``schema_utils.rates_for`` owns that baseline.
 """
 
 from __future__ import annotations
@@ -69,7 +75,7 @@ class PricedProfile(Protocol):
     def mode(self) -> str: ...
 
 
-# ── Rate data (pure, packaged) ────────────────────────────────────────
+# ── Rate types (pure — the figures live in the catalog) ───────────────
 
 
 @dataclass(frozen=True)
@@ -93,64 +99,6 @@ class ModelRates:
 # the uncached rate approximates) states it on its catalog entry and is priced
 # from that figure rather than from this multiplier — see :class:`ModelRates`.
 CACHED_INPUT_RATE_MULT = 0.1
-
-
-# The PACKAGED BASELINE rate card (per 1M tokens). Since #2335 this is no longer
-# a second, competing source of truth that accounting reads while routing reads
-# the model registry — the two could disagree, and a model priced in
-# configuration and absent here routed as priced and recorded its spend as
-# unknown.
-#
-# What it is now: transport-agnostic figures that config load MATERIALIZES onto
-# concrete (provider, model, transport) identities when compiling the rate
-# registry, and only onto identities the configuration can actually dispatch on
-# (theforge.config.dispatch_rates._materialize_legacy_rates). A row here can
-# therefore never widen onto a transport a project already priced separately,
-# and it is not consulted at all once a registry is installed.
-#
-# It remains authoritative for concrete billed identifiers that are not registry
-# entries in their own right — a vendor CLI reports ``claude-sonnet-4-6`` while
-# the profile dispatches under the ``sonnet`` shorthand — and it is the answer
-# for any process that never loads a configuration (unit tests).
-#
-# Key: (provider, model_name)
-# Value: (input_cost_per_mtok, output_cost_per_mtok)
-PRICING_TABLE: dict[tuple[str, str], tuple[float, float]] = {
-    ("openai", "o4-mini"): (1.10, 4.40),
-    ("openai", "gpt-4o"): (2.50, 10.00),
-    ("openai", "gpt-4o-mini"): (0.15, 0.60),
-    ("openai", "gpt-5.1-codex-mini"): (1.50, 6.00),
-    ("openai", "gpt-5.1-codex"): (3.00, 12.00),
-    ("openai", "gpt-5.1-codex-max"): (6.00, 24.00),
-    ("openai", "gpt-5.4-mini"): (0.25, 2.00),
-    ("openai", "gpt-5.4"): (1.25, 10.00),
-    ("openai", "gpt-5.4-pro"): (15.00, 120.00),
-    # Was a hand-kept mirror of the forge.yaml figures, because routing read the
-    # config and accounting read this table. It no longer has to be: a project
-    # price now reaches accounting through the compiled registry (#2335). Kept as
-    # the packaged baseline for a project that does not declare this model.
-    ("openai", "gpt-5.5"): (5.00, 30.00),
-    ("anthropic", "claude-opus-4-6"): (15.00, 75.00),
-    ("anthropic", "claude-sonnet-4-6"): (3.00, 15.00),
-    # Mirrors the figures the `haiku` shorthand carries and the pinned
-    # `anthropic/claude-haiku-4-5/cli` catalog entry attributes to this name.
-    ("anthropic", "claude-haiku-4-5"): (1.00, 5.00),
-    ("google", "gemini-3.5-flash"): (1.50, 9.00),  # mirrors forge.yaml overlay
-    ("google", "gemini-3.1-pro-preview"): (2.00, 12.00),  # ≤200k tokens
-    ("google", "gemini-3.1-pro-preview-customtools"): (2.00, 12.00),
-    ("google", "gemini-2.5-pro"): (1.25, 10.00),  # ≤200k tokens
-    ("google", "gemini-2.5-flash"): (0.30, 2.50),
-    ("google", "gemini-2.5-flash-lite"): (0.10, 0.40),
-    ("google", "gemini-2.0-flash"): (0.10, 0.40),
-    ("google", "gemini-2.0-flash-lite"): (0.075, 0.30),
-    # DeepSeek is deliberately absent. Its rates — including the cache-hit tier
-    # it bills separately, which this table has no column for — are declared on
-    # the catalog entries in config/data/models.yaml and read through
-    # :func:`theforge.runners.schema_utils.pricing_for`. The rows that used to
-    # sit here were the third hand-maintained copy of a rate card and outlived
-    # two of its revisions (#2352); the retired identifiers they priced now
-    # record no price at all.
-}
 
 
 class AccountingMode(str, Enum):
@@ -200,8 +148,7 @@ class RateSource(str, Enum):
 
     PROJECT = "project"  # declared in forge.yaml
     CATALOG = "catalog"  # shipped model catalog entry
-    LEGACY_COMPAT = "legacy_compat"  # widened from the transport-agnostic table
-    BASELINE = "baseline"  # no registry installed: today's pricing_for answer
+    BASELINE = "baseline"  # no registry installed: the catalog answer, transport-blind
     NONE = "none"  # unpriced
 
 
@@ -299,8 +246,7 @@ class RateEntry:
     rates: ModelRates | None = None
     mode: AccountingMode = AccountingMode.UNKNOWN
     source: RateSource = RateSource.NONE
-    #: For LEGACY_COMPAT, the transport-agnostic key this was materialized from;
-    #: otherwise the registry key or catalog id the figures were declared on.
+    #: The registry key or catalog id the figures were declared on.
     origin: str = ""
 
     @property
@@ -330,9 +276,8 @@ class RateRegistry:
     """Compiled ``DispatchIdentity -> RateEntry`` map with a strict lookup.
 
     ``lookup`` matches the exact key only. There is no transport-agnostic tier
-    and no fallthrough to :data:`PRICING_TABLE`: once a registry is installed, a
-    miss is unpriced and says so. Cross-transport reuse happens at compile time
-    or not at all.
+    and no packaged table to fall through to: once a registry is installed, a
+    miss is unpriced and says so.
     """
 
     entries: Mapping[DispatchIdentity, RateEntry] = field(default_factory=dict)
@@ -448,7 +393,7 @@ def known_models(provider: str, transport: str) -> tuple[str, ...]:
 
     Used by the Claude CLI's dated-id prefix match, which must run against keys
     of the SAME transport only. Empty when nothing is installed; the caller
-    falls back to the packaged table in that case.
+    falls back to the shipped catalog's rates in that case.
     """
     registry = active()
     if registry is None:

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -136,15 +136,17 @@ def _parse_model_usage(result_json: dict[str, Any]) -> tuple[ModelUsage, ...]:
 # aggregated ``modelUsage`` block — never arrives, so the normal cost path
 # produces nothing. But every ``assistant`` stream event already captured in
 # memory carries a per-message ``usage`` block (Anthropic usage shape). We
-# aggregate those and price them via the shared pricing table so a killed run's
-# real spend is attributed rather than silently dropped to $0.00. Where no
+# aggregate those and price them from the model catalog's rates for the billed
+# name the events report, so a killed run's real spend is attributed rather than
+# silently dropped to $0.00. Where no
 # usable usage was ever received, cost is recorded as unknown (None) — never a
 # fabricated zero, so "unmeasured" stays distinct from "free".
 
 # Anthropic prompt-cache pricing is expressed as multiples of the base input
 # rate: cache reads bill at 0.1x and 5-minute cache writes at 1.25x (Anthropic
-# pricing docs). The shared PRICING_TABLE only carries (input, output) rates,
-# so we apply these multipliers here to price the cached-token components.
+# pricing docs). A catalog entry that publishes its own cache-hit rate states it
+# and is priced from that; otherwise these multipliers price the cached-token
+# components off the entry's input rate.
 _CACHE_READ_RATE_MULT = 0.1
 _CACHE_WRITE_RATE_MULT = 1.25
 
@@ -167,19 +169,20 @@ def _anthropic_cli_pricing_names() -> tuple[str, ...]:
     Drawn from the installed rate registry, which is keyed by ``(provider, model,
     transport)`` — so the prefix match below can never resolve a CLI stream event
     onto a price declared for the same model name over the API (#2335). With no
-    registry installed (unit tests, non-config code paths) this falls back to the
-    packaged table, reproducing the previous behaviour exactly.
+    registry installed (unit tests, non-config code paths) the shipped catalog's
+    own rates answer instead.
     """
-    from theforge.runners.rate_registry import PRICING_TABLE, known_models  # noqa: PLC0415
+    from theforge.runners.rate_registry import known_models  # noqa: PLC0415
+    from theforge.runners.schema_utils import catalog_rates  # noqa: PLC0415
 
-    # The packaged table is unioned in rather than used only as a fallback: the
+    # The shipped catalog is unioned in rather than used only as a fallback: the
     # names the CLI reports are concrete *billed* ids (``claude-sonnet-4-6``)
-    # that are never registry entries in their own right — the registry knows the
-    # shorthand (``sonnet``) the profile dispatches under. Both halves are
-    # packaged baseline, so nothing project-declared for another transport can
-    # enter here.
+    # that a configuration need not have enabled — the registry may only know the
+    # shorthand (``sonnet``) the profile dispatches under. ``catalog_rates`` reads
+    # the packaged catalog only, so nothing project-declared for another
+    # transport can enter here.
     names = set(known_models("anthropic", "cli"))
-    names.update(model for provider, model in PRICING_TABLE if provider == "anthropic")
+    names.update(model for provider, model in catalog_rates() if provider == "anthropic")
     # Longest first so a dated id matches its most specific family entry rather
     # than whichever shorter prefix happened to be enumerated first.
     return tuple(sorted(names, key=len, reverse=True))
@@ -217,22 +220,20 @@ def _estimate_anthropic_cost(
     the resolved rate card publishes its own cache-read figure — that is
     preferred over the generic 0.1x multiplier when declared.
     """
-    from theforge.runners.rate_registry import PRICING_TABLE, ModelRates  # noqa: PLC0415
-    from theforge.runners.schema_utils import rates_for  # noqa: PLC0415
+    from theforge.runners.schema_utils import catalog_rates, rates_for  # noqa: PLC0415
 
     key = _resolve_anthropic_pricing_key(model)
     if key is None:
         return None
     rates = rates_for("anthropic", key, "cli")
     if rates is None:
-        # Packaged-baseline-only last resort, for the concrete billed ids above
-        # that no registry entry names. Deliberately reads PRICING_TABLE rather
-        # than pricing_for: a project-declared price for another transport must
-        # never reach this path.
-        packaged = PRICING_TABLE.get(("anthropic", key))
-        if packaged is None:
+        # Shipped-catalog last resort, for the concrete billed ids above that the
+        # loaded configuration does not enable. Deliberately reads the packaged
+        # catalog rather than the merged registry: a project-declared price for
+        # another transport must never reach this path.
+        rates = catalog_rates().get(("anthropic", key))
+        if rates is None:
             return None
-        rates = ModelRates(input_per_mtok=packaged[0], output_per_mtok=packaged[1])
     in_rate = rates.input_per_mtok
     out_rate = rates.output_per_mtok
     cache_read_rate = (

--- a/src/theforge/runners/schema_utils.py
+++ b/src/theforge/runners/schema_utils.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol
 from theforge.agent_types import ModelUsage
 from theforge.runners.rate_registry import (
     CACHED_INPUT_RATE_MULT,
-    PRICING_TABLE,
     AccountingMode,
     ModelRates,
     RateEntry,
@@ -242,15 +241,17 @@ def cache_reads_are_subset_of_input(provider: str) -> bool:
 
 
 def _catalog_rates() -> dict[tuple[str, str], ModelRates]:
-    """Rate cards carried by the shipped model catalog, keyed like PRICING_TABLE.
+    """Rate cards carried by the shipped model catalog, keyed ``(provider, model)``.
 
     The catalog is where a model's price is *declared alongside the identity it
     was recorded for* — a price with no ``pricing_provenance`` is a literal
     nothing can vouch for (see config/pricing.py), so those entries are skipped
-    and fall through to the table below. Where two catalog entries share a
+    and the identity reads as unpriced. Where two catalog entries share a
     ``(provider, model)`` and disagree on price (the same model offered over both
     CLI and API), the pair is dropped rather than arbitrated: an ambiguous rate
-    is not a better answer than the explicit table.
+    is not a better answer than none. Both drops are why this is the
+    transport-blind *baseline* only — the compiled registry keys by transport and
+    never has to arbitrate.
 
     Imported lazily so this module keeps its light import graph, and recomputed
     per call is avoided by the module-level cache below.
@@ -261,6 +262,10 @@ def _catalog_rates() -> dict[tuple[str, str], ModelRates]:
     rates: dict[tuple[str, str], ModelRates] = {}
     ambiguous: set[tuple[str, str]] = set()
     for spec in AGENT_REGISTRY.values():
+        if not spec.uses_rate_card:
+            # States that its transport reports the billed figure: no rate card
+            # is consulted for it, so it contributes none.
+            continue
         if spec.input_cost_per_mtok is None or spec.output_cost_per_mtok is None:
             continue
         if not spec.pricing_attributable:
@@ -305,24 +310,17 @@ def pricing_for(provider: str, model: str) -> ModelRates | None:
     resolves through :func:`rates_for`, which is keyed by
     ``(provider, model, transport)``; this function answers when no registry is
     installed, which is the case for unit tests and for any process that never
-    loads a configuration. Its behaviour is deliberately unchanged so that
-    baseline is bit-for-bit what it was before #2335.
+    loads a configuration.
 
-    Catalog first, :data:`PRICING_TABLE` second. The catalog is the surface where
-    a rate is declared next to the identity it was recorded for and the date that
-    identity was last checked against the provider, so it is the one that gets to
-    answer when both do. The table remains for identities the catalog does not
-    describe — vendor CLI shorthands resolve to concrete billed names that are
-    never catalog entries in their own right (``claude-sonnet-4-6``), and stream
-    events report those names directly.
+    **The catalog is the whole answer.** It used to be the first of two: a
+    packaged ``PRICING_TABLE`` answered whatever the catalog did not, which made
+    it a rate declaration no configuration could override and a place a figure
+    could disagree with the catalog and win by being consulted second (#2388).
+    The identities it uniquely served are catalog entries in their own right
+    now — the concrete billed names a vendor CLI reports (``claude-sonnet-4-6``)
+    are pinned entries — so removing it left no reachable identity unpriced.
     """
-    catalog = catalog_rates().get((provider, model))
-    if catalog is not None:
-        return catalog
-    price = PRICING_TABLE.get((provider, model))
-    if price is None:
-        return None
-    return ModelRates(input_per_mtok=price[0], output_per_mtok=price[1])
+    return catalog_rates().get((provider, model))
 
 
 def rate_card_confirmed(provider: str, model: str, *, today: date | None = None) -> bool:
@@ -330,10 +328,10 @@ def rate_card_confirmed(provider: str, model: str, *, today: date | None = None)
 
     True only when the figures came from a catalog entry whose upstream
     identifier has been checked against the provider inside the verification
-    window. A rate read from :data:`PRICING_TABLE` is never confirmed: that table
-    records no identity and no date, which is exactly how it carried DeepSeek's
-    superseded rates across two revisions of the provider's pricing without
-    anything noticing.
+    window. The packaged rate table this used to have to exclude could never be
+    confirmed — it recorded no identity and no date, which is exactly how it
+    carried DeepSeek's superseded rates across two revisions of the provider's
+    pricing without anything noticing — and it no longer exists (#2388).
 
     Consumed by the API cost-provenance stamp so an estimate off a rate card that
     may no longer apply is distinguishable from one that is current (#2352).
@@ -445,8 +443,9 @@ def _estimate_cost(
         if key not in _MISSING_PRICING_WARNED:
             logger.warning(
                 "Missing pricing entry for provider=%s model=%s transport=%s; cost cannot "
-                "be estimated. Declare a cost block on the model's catalog entry (or add "
-                "it to PRICING_TABLE) so audit and budget totals stay accurate.",
+                "be estimated. Declare a cost block on the model's catalog entry (in "
+                "config/data/models.yaml or in your forge.yaml) so audit and budget "
+                "totals stay accurate.",
                 provider,
                 model,
                 transport or "unspecified",

--- a/tests/test_dispatch_rate_registry.py
+++ b/tests/test_dispatch_rate_registry.py
@@ -161,15 +161,12 @@ class TestNoBorrowAcrossTransports:
         assert warnings, "load must name the unaccountable API identity"
         assert "transport fallback" in warnings[0] or "review pool" in warnings[0]
 
-    def test_a_pricing_conflict_suppresses_the_packaged_widening_and_is_named(
-        self, tmp_path, caplog
-    ):
-        """Rule (c): a per-transport disagreement surfaces, it is not resolved.
+    def test_a_price_declared_on_one_transport_leaves_the_other_unpriced(self, tmp_path, caplog):
+        """A per-transport gap surfaces; it is not filled from somewhere else.
 
-        ``gpt-5.5`` carries a packaged PRICING_TABLE row. The project prices it
-        on the CLI only. The API path must therefore NOT inherit the packaged
-        figure either — the conflict is operator-actionable and is reported as
-        such rather than papered over with whichever number is nearest.
+        The project prices ``gpt-5.5`` on the CLI only. The API path must stay
+        unpriced and be named at load: there is no packaged row behind it to
+        borrow from (#2388), and the CLI's own figure must never widen onto it.
         """
         with caplog.at_level(logging.WARNING, logger="theforge.config"):
             _load(
@@ -204,17 +201,25 @@ class TestNoBorrowAcrossTransports:
 
         messages = [record.getMessage() for record in caplog.records]
         assert any(
-            "gpt-5.5" in message and "per-transport pricing conflict" in message
+            "gpt-5.5" in message and "(api)" in message and "no rate card" in message
             for message in messages
         ), messages
 
 
-# ── Legacy materialization: rules (a), (b), (c) ───────────────────────
+# ── One declaration surface: the catalog, or forge.yaml ───────────────
 
 
-class TestLegacyMaterialization:
-    def test_packaged_price_materializes_onto_a_reachable_api_identity(self, tmp_path):
-        """Rule (a)/(b): a transport-agnostic packaged row still prices, as today."""
+class TestSingleDeclarationSurface:
+    """Every rate in a compiled registry came from a place config can edit (#2388).
+
+    The packaged ``PRICING_TABLE`` these tests used to exercise was the second
+    place a rate could be declared: compiled into the runner package, unreachable
+    from any configuration, and consulted whenever the registry missed. It is
+    gone, and what replaced it is not a different fallback — it is the catalog
+    entries that already priced the identities anything could dispatch.
+    """
+
+    def test_a_catalog_price_reaches_a_reachable_api_identity(self, tmp_path):
         cfg = _load(tmp_path, {"models": ["openai/gpt-5.4/api"], "budget_usd": 50.0})
         assert cfg.dev_profile.mode == "api"
 
@@ -222,38 +227,45 @@ class TestLegacyMaterialization:
         assert registry is not None
         entry = registry.lookup(DispatchIdentity("openai", "gpt-5.4", "api"))
         assert entry.priced
+        assert entry.source is RateSource.CATALOG
+        assert entry.origin == "openai/gpt-5.4/api"
         assert _estimate_cost("openai", "gpt-5.4", 1_000_000, 0, transport="api") == pytest.approx(
             pricing_for("openai", "gpt-5.4").input_per_mtok
         )
 
-    def test_an_unreachable_packaged_row_is_absent_from_the_compiled_registry(self):
-        """Rule (b): nothing unscoped enters the registry.
+    def test_every_priced_entry_names_a_registry_entry_as_its_origin(self, tmp_path):
+        """No entry can be priced from a source configuration could not supply."""
+        cfg = _load(
+            tmp_path,
+            {
+                "models": ["openai/gpt-5.4/api", "openai/gpt-5.4-mini/api"],
+                "budget_usd": 50.0,
+            },
+        )
+        registry = rr.active()
+        assert registry is not None
+        priced = [entry for entry in registry.entries.values() if entry.priced]
+        assert priced
+        for entry in priced:
+            assert entry.source in (RateSource.CATALOG, RateSource.PROJECT), entry
+            assert entry.origin in cfg.model_registry, entry
 
-        ``gpt-4o`` is in the packaged table but reachable on nothing here, so it
-        is dropped at compile time rather than retained as a wildcard that some
-        later identity could match against.
+    def test_an_identity_no_registry_entry_describes_is_unpriced(self):
+        """A model the merged registry does not name is priced by nothing.
+
+        ``gpt-4o`` was a packaged-table row and is reachable on nothing here. It
+        used to be materialized onto any identity that named it; now the absence
+        of a registry entry IS the answer.
         """
-        reachable = (rr.make_identity("openai", "gpt-5.4", "api"),)
+        identity = rr.make_identity("openai", "gpt-4o", "api")
         from theforge.config.dispatch_rates import ReachableIdentity
 
-        registry, _ = compile_rate_registry(
+        registry = compile_rate_registry(
             {},
-            (ReachableIdentity(identity=reachable[0], runner="openai", paths=("dev",)),),
+            (ReachableIdentity(identity=identity, runner="openai", paths=("dev",)),),
         )
-        assert DispatchIdentity("openai", "gpt-4o", "api") not in registry.entries
-        assert registry.lookup(DispatchIdentity("openai", "gpt-4o", "api")).priced is False
-
-    def test_a_materialized_entry_records_where_it_was_widened_from(self, tmp_path):
-        """The widening is inspectable, not implicit."""
-        _load(tmp_path, {"models": ["openai/gpt-5.4/api"], "budget_usd": 50.0})
-        registry = rr.active()
-        entry = registry.lookup(DispatchIdentity("openai", "gpt-5.4", "api"))
-        if entry.source is RateSource.LEGACY_COMPAT:
-            assert entry.origin.startswith("PRICING_TABLE[")
-        else:
-            # A catalog entry already prices this identity per-transport, which
-            # is strictly better than a widening — assert it says so.
-            assert entry.source in (RateSource.CATALOG, RateSource.PROJECT)
+        assert registry.lookup(identity).priced is False
+        assert registry.lookup(identity).source is RateSource.NONE
 
 
 # ── Every dispatch path is priced by what it dispatched ───────────────
@@ -934,9 +946,14 @@ class TestRateRegistryIsAnImportLeaf:
         assert offenders == [], f"rate_registry must stay an import leaf; found {offenders}"
 
     def test_schema_utils_re_exports_the_moved_names(self):
-        """Existing imports keep working after the pricing data moved."""
+        """Existing imports keep working after the pricing types moved.
+
+        ``PRICING_TABLE`` is deliberately absent from both: the packaged rate
+        dictionary was removed in #2388, so there is nothing to re-export.
+        """
         from theforge.runners import rate_registry, schema_utils
 
-        assert schema_utils.PRICING_TABLE is rate_registry.PRICING_TABLE
         assert schema_utils.ModelRates is rate_registry.ModelRates
         assert schema_utils.CACHED_INPUT_RATE_MULT == rate_registry.CACHED_INPUT_RATE_MULT
+        assert not hasattr(rate_registry, "PRICING_TABLE")
+        assert not hasattr(schema_utils, "PRICING_TABLE")

--- a/tests/test_model_identity_verification.py
+++ b/tests/test_model_identity_verification.py
@@ -59,9 +59,9 @@ from theforge.runners.adapters.deepseek import _run_deepseek, deepseek_request_k
 from theforge.runners.adapters.openai import _read_chat_usage
 from theforge.runners.api import _estimated_provenance
 from theforge.runners.schema_utils import (
-    PRICING_TABLE,
     ToolCallRequest,
     _estimate_cost,
+    catalog_rates,
     pricing_for,
     rate_card_confirmed,
 )
@@ -155,14 +155,17 @@ class TestRetiredIdentifiers:
             assert spec.pricing_provenance is None
             assert pricing_for(spec.provider, spec.model) is None
 
-    def test_the_accounting_table_no_longer_carries_deepseek_at_all(self):
+    def test_only_the_served_deepseek_identifiers_carry_rates(self):
         """The third hand-maintained copy of the rate card is gone.
 
         It held four rows, two commented as aliases of a generation two releases
         old, at the superseded rates. Rates now live on the catalog entry beside
-        the identity and verification date they were recorded with.
+        the identity and verification date they were recorded with — and since
+        #2388 that catalog is the only place they live, so the retired
+        identifiers price nothing anywhere.
         """
-        assert not [key for key in PRICING_TABLE if key[0] == "deepseek"]
+        deepseek = {model for provider, model in catalog_rates() if provider == "deepseek"}
+        assert deepseek == {"deepseek-v4-pro", "deepseek-v4-flash"}
 
     def test_a_retirement_must_state_a_reason(self):
         """A withdrawn name with no stated reason tells an operator nothing."""

--- a/tests/test_rate_declaration_single_source.py
+++ b/tests/test_rate_declaration_single_source.py
@@ -1,0 +1,267 @@
+"""A rate is declared in one kind of place, and configuration can reach it (#2388).
+
+Rates used to be declared twice: in the model catalog — data, per-entry
+provenance, editable without a release and overridable per project — and in
+``PRICING_TABLE``, a dictionary compiled into the runner package that no
+configuration could change and that accounting consulted whenever the registry
+missed. Of its 21 rows, 10 duplicated a catalog entry and 11 priced identities
+nothing could dispatch, so the second source persisted mainly as a place a rate
+could disagree with the catalog and win by being consulted second.
+
+These tests pin what replaced it:
+
+- every identity a *token-returning* transport can dispatch is priced from the
+  one source, so nothing enabled is unpriced by construction;
+- an entry whose transport reports what it was billed says so
+  (``cost.rate_basis``), which is what makes "needs no rate" different from
+  "rate is missing" without inferring it from an absent field;
+- no accounting path answers from a rate configuration could not have supplied —
+  including the Claude kill-path reconstruction, which used to read the table
+  directly;
+- the rows that were dropped are recorded, so re-enabling one of those models is
+  a lookup rather than an archaeology exercise.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from theforge.config import load_config
+from theforge.config.model_catalog import load_packaged_catalog, parse_definition
+from theforge.config.models import AGENT_REGISTRY, RETIRED_MODEL_REGISTRY
+from theforge.config.pricing import (
+    PRICING_PROVENANCE_LOCAL_ENDPOINT,
+    RATE_BASIS_PROVIDER_REPORTED,
+    RATE_BASIS_TOKEN_RATES,
+)
+from theforge.runners import rate_registry as rr
+from theforge.runners import runner_claude as runner_claude_mod
+from theforge.runners.rate_registry import accounting_mode_for
+from theforge.runners.schema_utils import _estimate_cost, catalog_rates, pricing_for
+
+_RECORD = Path(__file__).resolve().parents[1] / "docs" / "reference" / "dropped-legacy-rates.md"
+
+
+def _mode_of(spec) -> object:
+    return accounting_mode_for(spec.transport.kind, spec.transport.runner)
+
+
+# ── Coverage: nothing dispatchable is unpriced by construction ────────
+
+
+class TestEveryTokenReturningIdentityIsPriced:
+    def test_shipped_entries_that_need_rates_have_them_in_the_catalog(self):
+        """A transport that returns token counts must find a rate on its entry.
+
+        The catalog is now the only place that rate can come from, so an entry
+        this check misses is an entry that would record its spend as unknown on
+        every run — there is no packaged row behind it any more.
+        """
+        unpriced = []
+        for canonical_id, spec in sorted(AGENT_REGISTRY.items()):
+            if not _mode_of(spec).needs_rates:
+                continue
+            if spec.pricing_provenance == PRICING_PROVENANCE_LOCAL_ENDPOINT:
+                # A local endpoint is free by construction and the runners record
+                # 0.00 for it from base_url, with no rate card involved.
+                continue
+            if pricing_for(spec.provider, spec.model) is None:
+                unpriced.append(canonical_id)
+        assert unpriced == [], (
+            "these shipped entries dispatch on a token-returning transport with no "
+            f"rate reachable from the catalog: {unpriced}"
+        )
+
+    def test_a_rate_free_entry_says_so_rather_than_leaving_the_field_out(self):
+        """ "Needs no rate" and "rate is missing" must not look identical."""
+        silent = [
+            canonical_id
+            for canonical_id, spec in sorted(AGENT_REGISTRY.items())
+            if spec.input_cost_per_mtok is None
+            and spec.output_cost_per_mtok is None
+            and spec.rate_basis == RATE_BASIS_TOKEN_RATES
+        ]
+        assert silent == [], (
+            "these shipped entries declare no rate and no reason they need none; "
+            f"state cost.rate_basis: {silent}"
+        )
+
+    def test_the_provider_reported_entries_are_the_claude_cli_ones(self):
+        """The property is stated where it is true, not sprinkled about."""
+        declared = {
+            canonical_id
+            for canonical_id, spec in AGENT_REGISTRY.items()
+            if spec.rate_basis == RATE_BASIS_PROVIDER_REPORTED
+        }
+        assert declared == {"anthropic/claude-opus-5/cli", "anthropic/claude-sonnet-5/cli"}
+        for canonical_id in declared:
+            spec = AGENT_REGISTRY[canonical_id]
+            assert _mode_of(spec) is rr.AccountingMode.PROVIDER_REPORTED
+            assert not spec.uses_rate_card
+            # Being rate-free is not being unaccountable: the transport reports
+            # the bill, so a run on this identity still produces a cost record.
+            entry = rr.RateEntry(
+                identity=rr.make_identity(spec.provider, spec.model, spec.transport.kind),
+                rates=None,
+                mode=_mode_of(spec),
+            )
+            assert entry.accountable
+            assert entry.unaccountable_reason() is None
+
+    def test_a_provider_reported_entry_contributes_no_rate_card(self):
+        """Nothing can price tokens off an entry that says it is not priced that way."""
+        assert ("anthropic", "claude-opus-5") not in catalog_rates()
+        assert pricing_for("anthropic", "claude-opus-5") is None
+        with rr.scoped_registry(None):
+            assert _estimate_cost("anthropic", "claude-opus-5", 1_000_000, 0, transport="cli") is (
+                None
+            )
+
+
+# ── The stated property is enforced, not decorative ───────────────────
+
+
+def _entry(**cost) -> dict:
+    return {
+        "provider": "anthropic",
+        "model": "claude-whatever-9",
+        "transport": {"kind": "cli"},
+        "routing": {"tier": "strong", "capability": 9, "cost_rank": 3},
+        "cost": cost,
+    }
+
+
+class TestRateBasisSchema:
+    def test_provider_reported_may_not_also_declare_figures(self):
+        with pytest.raises(ValueError, match="rate_basis"):
+            parse_definition(
+                _entry(
+                    rate_basis=RATE_BASIS_PROVIDER_REPORTED,
+                    input_per_mtok=1.0,
+                    output_per_mtok=2.0,
+                    pricing_provenance="claude-whatever-9",
+                ),
+                where="models[0]",
+            )
+
+    def test_an_unknown_basis_is_refused_at_load(self):
+        with pytest.raises(ValueError, match="rate_basis"):
+            parse_definition(_entry(rate_basis="vibes"), where="models[0]")
+
+    def test_the_default_basis_is_token_rates(self):
+        defn = parse_definition(
+            _entry(input_per_mtok=1.0, output_per_mtok=2.0, pricing_provenance="x"),
+            where="models[0]",
+        )
+        assert "rate_basis" not in defn.cost
+
+    def test_a_declared_basis_survives_the_catalog_round_trip(self):
+        registry = load_packaged_catalog()
+        assert registry["anthropic/claude-opus-5/cli"].rate_basis == RATE_BASIS_PROVIDER_REPORTED
+        assert registry["anthropic/claude-opus-4-6/cli"].rate_basis == RATE_BASIS_TOKEN_RATES
+
+    def test_a_project_that_declares_figures_is_declaring_a_rate_card(self, tmp_path):
+        """An overlay's own price must not be swallowed by an inherited basis.
+
+        The shipped ``claude-opus-5`` entry states that its transport reports the
+        bill. A project that declares figures for that identity is saying
+        something else, and the figures it wrote have to be the ones that price
+        it — inheriting ``provider_reported`` would leave them unread.
+        """
+        path = tmp_path / "forge.yaml"
+        path.write_text(
+            yaml.dump(
+                {
+                    "project": "p",
+                    "models": {
+                        "enabled": ["anthropic/sonnet/cli", "pinned-opus-5"],
+                        "custom": {
+                            "pinned-opus-5": {
+                                "provider": "anthropic",
+                                "model": "claude-opus-5",
+                                "transport": {"kind": "cli"},
+                                "override": True,
+                                "routing": {"tier": "strong", "capability": 10, "cost_rank": 3},
+                                "cost": {
+                                    "input_per_mtok": 20.0,
+                                    "output_per_mtok": 100.0,
+                                    "pricing_provenance": "claude-opus-5",
+                                },
+                            }
+                        },
+                    },
+                    "budget_usd": 30.0,
+                }
+            ),
+            encoding="utf-8",
+        )
+        with patch("theforge.config.load.check_agent_auth", return_value=(True, "")):
+            config = load_config(path)
+        spec = (config.model_registry or {})["anthropic/claude-opus-5/cli"]
+        assert spec.rate_basis == RATE_BASIS_TOKEN_RATES
+        assert spec.uses_rate_card
+        entry = rr.resolve(rr.make_identity("anthropic", "claude-opus-5", "cli"))
+        assert entry is not None
+        assert entry.rates == rr.ModelRates(input_per_mtok=20.0, output_per_mtok=100.0)
+
+
+# ── No accounting path consults an unsupplied rate ────────────────────
+
+
+def _dropped_identities() -> list[tuple[str, str]]:
+    """The ``(provider, model)`` rows the migration record says were dropped."""
+    body = _RECORD.read_text(encoding="utf-8").split("## Dropped", 1)[1]
+    body = body.split("## Re-enabling", 1)[0]
+    rows = re.findall(r"^\|\s*(\w[\w.]*)\s*\|\s*`([^`]+)`\s*\|", body, flags=re.MULTILINE)
+    return [(provider, model) for provider, model in rows]
+
+
+class TestNoPackagedFallbackSurvives:
+    def test_the_migration_record_lists_the_rows_that_were_dropped(self):
+        dropped = _dropped_identities()
+        assert len(dropped) == 11, dropped
+        assert ("openai", "gpt-4o") in dropped
+        assert ("google", "gemini-2.5-flash") in dropped
+
+    @pytest.mark.parametrize("identity", _dropped_identities())
+    def test_a_dropped_row_prices_nothing_anywhere(self, identity):
+        """The rows nothing could dispatch are recorded, not still consulted."""
+        provider, model = identity
+        canonical = {f"{provider}/{model}/cli", f"{provider}/{model}/api"}
+        assert not canonical & set(AGENT_REGISTRY)
+        assert not canonical & set(RETIRED_MODEL_REGISTRY)
+        with rr.scoped_registry(None):
+            assert pricing_for(provider, model) is None
+            for transport in ("cli", "api", None):
+                assert (
+                    _estimate_cost(provider, model, 1_000_000, 1_000_000, transport=transport)
+                    is None
+                )
+
+    def test_the_claude_kill_path_prices_from_the_catalog(self):
+        """The billed ids the CLI reports resolve to catalog entries, not a table.
+
+        ``_estimate_anthropic_cost`` read ``PRICING_TABLE`` as a last resort for
+        exactly these names. They are pinned catalog entries now, so the figures
+        are the ones an operator can see, date and override.
+        """
+        with rr.scoped_registry(None):
+            cost = runner_claude_mod._estimate_anthropic_cost(
+                "claude-sonnet-4-6", 1_000_000, 0, 0, 0
+            )
+            rates = catalog_rates()[("anthropic", "claude-sonnet-4-6")]
+            assert cost == pytest.approx(rates.input_per_mtok)
+            # A dated id still resolves to its family entry through the same set.
+            assert runner_claude_mod._estimate_anthropic_cost(
+                "claude-opus-4-6-20260115", 1_000_000, 0, 0, 0
+            ) == pytest.approx(catalog_rates()[("anthropic", "claude-opus-4-6")].input_per_mtok)
+
+    def test_the_claude_name_set_is_exactly_what_the_catalog_prices(self):
+        with rr.scoped_registry(None):
+            names = set(runner_claude_mod._anthropic_cli_pricing_names())
+        assert names == {model for provider, model in catalog_rates() if provider == "anthropic"}

--- a/tests/test_runner_api_local.py
+++ b/tests/test_runner_api_local.py
@@ -444,7 +444,7 @@ class TestLocalEndpointCostZeroing:
             output_tokens=50,
             raw={},
         )
-        # For unknown model "codestral" there's no PRICING_TABLE entry → None
+        # "codestral" is priced only as a local endpoint, which is not a rate → None
         assert result.cost_usd is None
 
     def test_loop_mode_localhost_cost_is_zero(self, tmp_path):

--- a/tests/test_runner_api_loop.py
+++ b/tests/test_runner_api_loop.py
@@ -270,7 +270,7 @@ class TestAgentLoopLifecycle:
                 text_output="done",
                 structured_data=None,
                 usage=ModelUsage(
-                    model="gemini-2.5-flash",
+                    model="gemini-3-flash-preview",
                     input_tokens=1_000_000,
                     output_tokens=500_000,
                     cache_read_tokens=0,
@@ -280,7 +280,7 @@ class TestAgentLoopLifecycle:
                 ),
             )
 
-        profile = _make_profile(provider="google", model="gemini-2.5-flash")
+        profile = _make_profile(provider="google", model="gemini-3-flash-preview")
         manager = AgentLoopManager(
             profile=profile,
             provider="google",
@@ -296,7 +296,7 @@ class TestAgentLoopLifecycle:
 
         assert result.success
         assert result.model_usage[0].thinking_tokens == 250_000
-        assert result.cost_usd == 0.30 + (0.75 * 2.50)
+        assert result.cost_usd == 0.50 + (0.75 * 3.00)
 
     def test_max_iterations_terminates_loop_with_accumulated_cost(self, tmp_path):
         """Loop terminates after max_iterations, still reports cost."""

--- a/tests/test_runner_codex.py
+++ b/tests/test_runner_codex.py
@@ -35,7 +35,7 @@ def _make_profile(
     return ModelProfile(
         name="dev",
         cli="codex",
-        model="o4-mini",
+        model="gpt-5.4-mini",
         budget_usd=2.0,
         timeout_seconds=900,
         allowed_tools=("Read", "Edit", "Write", "Bash"),
@@ -389,18 +389,18 @@ class TestCodexCachedTokenPricing:
             reasoning_output_tokens=14,
         )
         cost, model_usage = _price_codex_usage(profile=profile, usage=usage)
-        # o4-mini: (1.10, 4.40)/Mtok. uncached = 12892 - 9088 = 3804.
-        expected = (3804 / 1e6) * 1.10 + (9088 / 1e6) * 1.10 * 0.1 + (21 / 1e6) * 4.40
+        # gpt-5.4-mini: (0.25, 2.00)/Mtok. uncached = 12892 - 9088 = 3804.
+        expected = (3804 / 1e6) * 0.25 + (9088 / 1e6) * 0.25 * 0.1 + (21 / 1e6) * 2.00
         assert cost == pytest.approx(expected)
         # A flat-rate charge would be strictly larger — that overstatement is the
         # bug this guards.
-        assert cost < (12892 / 1e6) * 1.10 + (21 / 1e6) * 4.40
+        assert cost < (12892 / 1e6) * 0.25 + (21 / 1e6) * 2.00
 
     def test_reasoning_tokens_recorded_but_not_double_billed(self) -> None:
         profile = _make_profile()
         usage = _CodexUsage(input_tokens=0, output_tokens=1000, reasoning_output_tokens=800)
         cost, model_usage = _price_codex_usage(profile=profile, usage=usage)
-        assert cost == pytest.approx((1000 / 1e6) * 4.40)
+        assert cost == pytest.approx((1000 / 1e6) * 2.00)
         assert model_usage[0].thinking_tokens == 800
 
     def test_cache_write_tokens_surface_in_model_usage(self) -> None:
@@ -590,15 +590,15 @@ class TestCodexLifecycle:
     ) -> None:
         """A codex JSON blob with a usage block is priced via the pricing table."""
         self._patch_env(monkeypatch, "usage")
-        profile = _make_profile(sandbox_mode="none")  # model o4-mini: (1.10, 4.40)/Mtok
+        profile = _make_profile(sandbox_mode="none")  # model gpt-5.4-mini: (0.25, 2.00)/Mtok
         result = _run_codex(
             prompt="do the thing",
             profile=profile,
             working_dir=tmp_path,
         )
-        # 1000 in * 1.10/M + 500 out * 4.40/M = 0.0011 + 0.0022 = 0.0033
+        # 1000 in * 0.25/M + 500 out * 2.00/M = 0.00025 + 0.001 = 0.00125
         assert result.cost_usd is not None
-        assert result.cost_usd == pytest.approx(0.0033)
+        assert result.cost_usd == pytest.approx(0.00125)
         assert len(result.model_usage) == 1
         usage = result.model_usage[0]
         assert usage.input_tokens == 1000
@@ -615,7 +615,7 @@ class TestCodexLifecycle:
             profile=profile,
             working_dir=tmp_path,
         )
-        assert result.cost_usd == pytest.approx(0.0033)
+        assert result.cost_usd == pytest.approx(0.00125)
         assert len(result.model_usage) == 1
 
     def test_json_event_usage_yields_measured_cost(
@@ -623,7 +623,7 @@ class TestCodexLifecycle:
     ) -> None:
         """A `codex exec --json` turn.completed event is parsed into measured cost."""
         self._patch_env(monkeypatch, "json_usage")
-        profile = _make_profile(sandbox_mode="none")  # o4-mini: (1.10, 4.40)/Mtok
+        profile = _make_profile(sandbox_mode="none")  # gpt-5.4-mini: (0.25, 2.00)/Mtok
         result = _run_codex(prompt="do the thing", profile=profile, working_dir=tmp_path)
 
         assert result.success is True
@@ -635,7 +635,7 @@ class TestCodexLifecycle:
         assert usage.cache_creation_tokens == 256
         assert usage.output_tokens == 2100
         assert usage.thinking_tokens == 1400
-        expected = (3804 / 1e6) * 1.10 + (9088 / 1e6) * 1.10 * 0.1 + (2100 / 1e6) * 4.40
+        expected = (3804 / 1e6) * 0.25 + (9088 / 1e6) * 0.25 * 0.1 + (2100 / 1e6) * 2.00
         assert result.cost_usd == pytest.approx(expected)
 
     def test_json_mode_does_not_leak_events_into_agent_output(

--- a/tests/test_runner_google.py
+++ b/tests/test_runner_google.py
@@ -18,7 +18,7 @@ from theforge.runners.schema_utils import ToolCallRequest
 def _make_profile(
     name: str = "test-reviewer",
     provider: str = "google",
-    model: str = "gemini-2.5-flash",
+    model: str = "gemini-3-flash-preview",
     thinking_budget: int | None = None,
     phase: str | None = None,
 ) -> ModelProfile:
@@ -215,13 +215,13 @@ class TestRunGoogle:
         fake_client.models.generate_content.return_value = fake_response
 
         _, modules = _make_google_modules(fake_client)
-        profile = _make_profile(model="gemini-2.5-flash")
+        profile = _make_profile(model="gemini-3-flash-preview")
 
         with patch.dict(sys.modules, modules):
             result = _run_google("test prompt", profile)
 
         assert result.success
-        assert result.cost_usd == 0.30 + (0.75 * 2.50)
+        assert result.cost_usd == 0.50 + (0.75 * 3.00)
         assert result.model_usage[0].thinking_tokens == 250_000
 
     def test_none_response_text_returns_clear_error(self):
@@ -539,7 +539,7 @@ class TestGoogleAdapter:
         fake_client.models.generate_content.side_effect = [first_response, second_response]
 
         _, modules = _make_google_modules(fake_client)
-        profile = _make_profile(model="gemini-2.5-flash")
+        profile = _make_profile(model="gemini-3-flash-preview")
 
         with patch.dict(sys.modules, modules):
             adapter = _make_google_adapter(profile, secrets=None)
@@ -551,7 +551,7 @@ class TestGoogleAdapter:
         assert turn.usage.input_tokens == 300 + 310
         assert turn.usage.output_tokens == 40 + 50
         assert turn.usage.thinking_tokens == 20 + 30
-        assert turn.usage.cost_usd == (610 / 1_000_000 * 0.30) + (140 / 1_000_000 * 2.50)
+        assert turn.usage.cost_usd == (610 / 1_000_000 * 0.50) + (140 / 1_000_000 * 3.00)
 
     def test_content_parts_none_yields_empty(self):
         """Google adapter with candidate.content.parts = None → no tool_calls, no text."""


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Verified removal of the packaged fallback rate table and the new rate_basis semantics; the change meets the pricing single-source acceptance criteria with targeted coverage. | [google-gemini-3.5-flash-api] Successfully consolidated all pricing into a single configuration-driven source by removing the hardcoded PRICING_TABLE and introducing cost.rate_basis. | [anthropic-claude-haiku-4-5-cli] Pricing is now declared in exactly one place. PRICING_TABLE removed, all accounting paths read from the model catalog, rate_basis property added to distinguish "needs no rate" from "rate is missing". All acceptance criteria verified through comprehensive tests covering dropped rows, schema enforcement, and accounting-path consistency.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $17.16
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Rates are declared in two places, one of which no configuration can override, so the catalog is authoritative only until the compiled fallback is consulted (GitHub Issue #2388)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2388