### PR TITLE
Whether a model has demonstrated a capability is established only by an operator-invoked probe that persists nothing, so routing cannot consult it and must assume capability at dispatch

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -245,6 +245,13 @@ probe subject has changed since (a repointed `base_url`, a different CLI binary)
 is treated as stale rather than current. Re-run this command after changing a
 model's endpoint to refresh the record.
 
+If the record rules out *every* candidate for a role, routing refuses the run
+rather than seating a model that has demonstrated it cannot do the job — the
+error names the role, the capability, and when each absence was established.
+Re-run `forge check-providers` if the record is out of date, or configure a model
+that can produce the capability. An explicitly pinned role is exempt: the
+operator's choice stands and is flagged in that role's routing rationale.
+
 ---
 
 ## `forge check-config`

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -231,7 +231,19 @@ forge check-providers [flags]
 | Flag | Description |
 |------|-------------|
 | `--profile <name>` | Test only one API profile |
+| `--declared-only` | Exercise only each probe's declared transport |
 | `--config <path>` | Path to `forge.yaml` |
+
+**What it records:** every probe that actually validates a capability (structured
+output) writes the outcome to `.forge/model_capabilities.yaml`, keyed by
+provider/model/transport and stamped with when it was established. Routing reads
+that record at dispatch and declines to seat a model whose required capability is
+currently demonstrated *absent*, reporting
+`capability_demonstrated_absent` in the `routing_decision` block. An identity with
+no record stays eligible — never-established is not absence — and a record whose
+probe subject has changed since (a repointed `base_url`, a different CLI binary)
+is treated as stale rather than current. Re-run this command after changing a
+model's endpoint to refresh the record.
 
 ---
 

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -29,6 +29,16 @@ from .config import (
 from .config.auth import check_agent_auth
 from .config.pricing import price_tiebreak_signal_for
 from .config.profiles import _apply_transport_fallback
+from .model_capabilities import (
+    CAPABILITY_TOOL_STRUCTURED,
+    identity_for_agent,
+    identity_for_profile,
+    signature_for_agent,
+    signature_for_profile,
+)
+from .model_capabilities import (
+    lookup as _capability_lookup,
+)
 from .routing import (
     KNOB_EFFORT,
     KNOB_NONE,
@@ -58,6 +68,10 @@ REASON_TIER_MISMATCH = "tier_mismatch"
 REASON_ANTI_SELF_REVIEW = "anti_self_review"
 REASON_PHASE_ELIGIBILITY = "phase_eligibility"
 REASON_EXPLICIT_OVERRIDE_LOCKED = "explicit_override_locked"
+# The capability the role requires is recorded as demonstrated ABSENT for this
+# candidate's identity (#2466). Never-established and stale records do not
+# produce this reason — only a current, demonstrated absence does.
+REASON_CAPABILITY_ABSENT = "capability_demonstrated_absent"
 REASON_NONE = "none"  # selected / included candidate
 
 EXCLUSION_REASONS: frozenset[str] = frozenset(
@@ -68,9 +82,25 @@ EXCLUSION_REASONS: frozenset[str] = frozenset(
         REASON_ANTI_SELF_REVIEW,
         REASON_PHASE_ELIGIBILITY,
         REASON_EXPLICIT_OVERRIDE_LOCKED,
+        REASON_CAPABILITY_ABSENT,
         REASON_NONE,
     }
 )
+
+
+# ── Demonstrated-capability gate (#2466) ───────────────────────────────
+#
+# Roles whose result is only usable when structured, mapped to the capability
+# the readiness probe establishes for them. ``dev`` and ``preflight`` are absent
+# from this map deliberately: their probes accept unstructured output by design
+# (see provider_readiness._requires_structured_verdict), so no probe ever
+# establishes structured capability for them and gating on it would be gating on
+# a fact nothing writes.
+ROLE_REQUIRED_CAPABILITY: dict[str, str] = {
+    "planner": CAPABILITY_TOOL_STRUCTURED,
+    "plan_review": CAPABILITY_TOOL_STRUCTURED,
+    "code_review": CAPABILITY_TOOL_STRUCTURED,
+}
 
 
 # ── Routing-symmetry invariant (#1389) ─────────────────────────────────
@@ -362,6 +392,113 @@ def _auth_reason(
     if "not found in path" in low or "npx" in low:
         return False, REASON_TRANSPORT_UNAVAILABLE
     return False, REASON_AUTH_MISSING
+
+
+def _capability_exclusions(
+    agents: list[AgentDef],
+    role: str,
+    capability_records: dict | None,
+) -> dict[str, dict[str, object]]:
+    """Which candidates the durable record rules out for ``role`` (#2466).
+
+    Returns ``{agent_name: {capability, established_at, detail, probe_role}}`` —
+    empty when the role requires no recorded capability, when no record has been
+    written, or when nothing in the pool has a *current* demonstrated absence.
+
+    Only demonstrated absence excludes. An identity with no record is
+    never-established, not absent, and stays eligible: the record must not
+    silently narrow the pool to whatever has happened to be probed. A record
+    whose probe subject has since changed is stale and likewise does not
+    exclude — it is reported, not enforced.
+    """
+    capability = ROLE_REQUIRED_CAPABILITY.get(role)
+    if not capability or not capability_records:
+        return {}
+    excluded: dict[str, dict[str, object]] = {}
+    for agent in agents:
+        result = _capability_lookup(
+            capability_records,
+            identity_for_agent(agent),
+            capability,
+            subject_signature=signature_for_agent(agent),
+        )
+        if result.current_absent:
+            excluded[agent.name] = {
+                "capability": capability,
+                "established_at": result.established_at,
+                "detail": result.detail,
+                "probe_role": result.probe_role,
+            }
+    return excluded
+
+
+def _capability_pool(
+    agents: list[AgentDef],
+    excluded: dict[str, dict[str, object]],
+) -> tuple[list[AgentDef], bool]:
+    """Apply a role's capability exclusions to its candidate pool.
+
+    Returns ``(pool, exhausted)``. When every candidate is ruled out the full
+    pool is handed back with ``exhausted=True``: routing still has to seat
+    somebody, and a silently empty pool would surface as an unexplained crash
+    instead of an explained last resort. Callers say so in the rationale.
+    """
+    if not excluded:
+        return agents, False
+    pool = [a for a in agents if a.name not in excluded]
+    if not pool:
+        return agents, True
+    return pool, False
+
+
+def _capability_exclusion_note(
+    excluded: dict[str, dict[str, object]],
+    exhausted: bool,
+) -> str:
+    """Operator-facing rationale fragment for a role's capability exclusions."""
+    if not excluded:
+        return ""
+    capability = next(iter(excluded.values()))["capability"]
+    names = ", ".join(sorted(excluded))
+    stamps = sorted({str(v.get("established_at") or "?") for v in excluded.values()})
+    note = (
+        f"; excluded [{names}] — {capability} demonstrated absent "
+        f"(established {', '.join(stamps)})"
+    )
+    if exhausted:
+        note += (
+            f"; WARNING: no candidate has {capability} available — seated from the "
+            "unfiltered pool as a last resort"
+        )
+    return note
+
+
+def _explicit_capability_warning(
+    profile: ModelProfile,
+    role: str,
+    capability_records: dict | None,
+) -> str:
+    """Warn when an operator's explicit pin has a demonstrated-absent capability.
+
+    An explicit override is operator intent and is never overridden here — but
+    the routing rationale must not read as though the pin were unremarkable when
+    the record says the identity cannot do the job.
+    """
+    capability = ROLE_REQUIRED_CAPABILITY.get(role)
+    if not capability or not capability_records:
+        return ""
+    result = _capability_lookup(
+        capability_records,
+        identity_for_profile(profile),
+        capability,
+        subject_signature=signature_for_profile(profile),
+    )
+    if not result.current_absent:
+        return ""
+    return (
+        f"; WARNING: {capability} demonstrated absent for {profile.model} "
+        f"(established {result.established_at}) — honored as an explicit override"
+    )
 
 
 # ── Data classes ───────────────────────────────────────────────────────
@@ -1477,6 +1614,7 @@ def _enforce_budget(
     dev_floor_tier: str = "cheap",
     planner_floor_tier: str | None = None,
     locked_roles: set[str] | None = None,
+    role_pools: dict[str, list[AgentDef]] | None = None,
 ) -> AssignmentDecision:
     """Downgrade highest-cost non-preflight model if over the per-story routing cost target.
 
@@ -1489,10 +1627,17 @@ def _enforce_budget(
     tier floor) to preserve the assignment guardrail.
     The planner can also carry a tier floor when adaptive routing chose a strong
     planner for a story that already assigned a strong dev model.
+
+    ``role_pools`` maps a role class (``planner`` / ``dev`` / ``plan_review`` /
+    ``code_review``) to the candidates that role may draw from, already filtered
+    by the demonstrated-capability gate (#2466). A cost downgrade is a routing
+    decision like any other, so it must not reach past that filter and seat a
+    model the record rules out. Roles absent from the map use the full pool.
     """
     from dataclasses import replace as _dc_replace
 
     locked_roles = locked_roles or set()
+    role_pools = role_pools or {}
     initial_total = _decision_total(decision)
     preferred_snapshot = _preferred_snapshot(decision, initial_total)
     budget_steps: list[dict[str, object]] = []
@@ -1521,7 +1666,8 @@ def _enforce_budget(
     # Build a lookup from profile name → AgentDef for downgrade
     agent_by_name = {a.name: a for a in agents}
 
-    def _next_cheaper_profile(profile: ModelProfile) -> ModelProfile | None:
+    def _next_cheaper_profile(profile: ModelProfile, role_class: str) -> ModelProfile | None:
+        pool = role_pools.get(role_class, agents)
         agent = agent_by_name.get(profile.name)
         if agent is not None:
             current_tier = agent.tier
@@ -1530,14 +1676,14 @@ def _enforce_budget(
                 return None  # already cheapest
             # Try each tier below current, from next-cheaper down to cheapest
             for cheaper_tier in _TIER_ORDER[idx - 1 :: -1]:
-                cheaper_agents = _agents_by_tier(agents, cheaper_tier)
+                cheaper_agents = _agents_by_tier(pool, cheaper_tier)
                 if cheaper_agents:
                     cheaper = cheaper_agents[0]
                     return cheaper.to_model_profile(allowed_tools=profile.allowed_tools)
             return None
         else:
             # Profile not in agent pool (e.g. explicit override) — find any cheaper agent
-            cheaper_options = [a for a in agents if a.budget_usd < profile.budget_usd]
+            cheaper_options = [a for a in pool if a.budget_usd < profile.budget_usd]
             if not cheaper_options:
                 return None
             cheapest = min(cheaper_options, key=lambda a: a.budget_usd)
@@ -1581,7 +1727,7 @@ def _enforce_budget(
             if role_class in locked_roles:
                 protected_roles.add(role_class)
                 continue
-            cheaper = _next_cheaper_profile(profile)
+            cheaper = _next_cheaper_profile(profile, role_class)
             if cheaper is not None:
                 cheaper_def = agent_by_name.get(cheaper.name)
                 # Guardrail: never downgrade dev below its complexity tier floor.
@@ -1789,20 +1935,49 @@ def _selected_tier(agents: list[AgentDef], name: str, fallback: str | None) -> s
     return fallback
 
 
+def _capability_pool_entry(
+    entry: dict[str, object],
+    record: dict[str, object] | None,
+) -> bool:
+    """Mark a pool entry excluded for a demonstrated-absent capability (#2466).
+
+    Returns True when the entry was marked. ``detail`` carries the capability
+    and when it was established so the operator reads *why* with the decision,
+    not from a failing gate an hour later.
+    """
+    if not record:
+        return False
+    entry["included"] = False
+    entry["reason"] = REASON_CAPABILITY_ABSENT
+    detail: dict[str, object] = {
+        "capability": record.get("capability"),
+        "established_at": record.get("established_at"),
+    }
+    if record.get("detail"):
+        detail["probe_detail"] = record["detail"]
+    if record.get("probe_role"):
+        detail["probe_role"] = record["probe_role"]
+    entry["detail"] = detail
+    return True
+
+
 def _single_model_pool(
     agents: list[AgentDef],
     target_tier: str | None,
     selected_name: str,
     locked: bool,
     secrets: dict[str, str] | None,
+    capability_excluded: dict[str, dict[str, object]] | None = None,
 ) -> list[dict[str, object]]:
     """Build the candidate pool for a single-model role (preflight/planner/dev).
 
     Every agent is listed with ``included`` and, when excluded, a canonical
     ``reason``. Priority of exclusion reasons is deterministic: the selected
     model is always included; an explicit override locks out the rest; then
-    tier mismatch; then auth/transport unavailability.
+    tier mismatch; then a demonstrated-absent capability; then auth/transport
+    unavailability.
     """
+    capability_excluded = capability_excluded or {}
     pool: list[dict[str, object]] = []
     for a in agents:
         entry: dict[str, object] = {"name": a.name, "tier": a.tier}
@@ -1815,6 +1990,8 @@ def _single_model_pool(
         elif target_tier is not None and a.tier != target_tier:
             entry["included"] = False
             entry["reason"] = REASON_TIER_MISMATCH
+        elif _capability_pool_entry(entry, capability_excluded.get(a.name)):
+            pass
         else:
             ready, reason = _auth_reason(a, secrets)
             if not ready:
@@ -1875,6 +2052,7 @@ def _reviewer_candidate_pool(
     locked: bool,
     secrets: dict[str, str] | None,
     health_deprioritized: set[str] | None = None,
+    capability_excluded: dict[str, dict[str, object]] | None = None,
 ) -> list[dict[str, object]]:
     """Build the candidate pool for a reviewer role (plan_review/code_review).
 
@@ -1887,6 +2065,7 @@ def _reviewer_candidate_pool(
     (a recent provider-shape failure is a transient transport unavailability).
     """
     health_deprioritized = health_deprioritized or set()
+    capability_excluded = capability_excluded or {}
     pool: list[dict[str, object]] = []
     for a in agents:
         entry: dict[str, object] = {"name": a.name, "tier": a.tier}
@@ -1899,6 +2078,8 @@ def _reviewer_candidate_pool(
         elif exclude_model is not None and a.model == exclude_model:
             entry["included"] = False
             entry["reason"] = REASON_ANTI_SELF_REVIEW
+        elif _capability_pool_entry(entry, capability_excluded.get(a.name)):
+            pass
         else:
             ready, reason = _auth_reason(a, secrets)
             if not ready:
@@ -2457,8 +2638,14 @@ def _build_routing_decision(
 
     # Dev pool at the effective (post-promotion) tier, annotated with the
     # profile signals the router actually weighed for each included candidate.
+    capability_exclusions = evidence.capability_exclusions
     dev_pool = _single_model_pool(
-        agents, dev_effective_tier, decision.dev.name, "dev" in explicit_roles, secrets
+        agents,
+        dev_effective_tier,
+        decision.dev.name,
+        "dev" in explicit_roles,
+        secrets,
+        capability_excluded=capability_exclusions.get("dev"),
     )
     dev_domain_signals = evidence.dev_domain_signals
     dev_cost_signals = evidence.dev_cost_signals
@@ -2609,6 +2796,7 @@ def _build_routing_decision(
                 decision.planner.name,
                 "planner" in explicit_roles,
                 secrets,
+                capability_excluded=capability_exclusions.get("planner"),
             ),
             "exploration": dict(exploration),
             **(
@@ -2693,6 +2881,7 @@ def _build_routing_decision(
                 "plan_review" in explicit_roles,
                 secrets,
                 health_deprioritized=pr_depri,
+                capability_excluded=capability_exclusions.get("plan_review"),
             ),
             "demotion_check": _reviewer_demotion_check(
                 pr_fired, pr_depri, pr_fellback, unhealthy_models
@@ -2719,6 +2908,7 @@ def _build_routing_decision(
                 "code_review" in explicit_roles,
                 secrets,
                 health_deprioritized=cr_depri,
+                capability_excluded=capability_exclusions.get("code_review"),
             ),
             "demotion_check": _reviewer_demotion_check(
                 cr_fired, cr_depri, cr_fellback, unhealthy_models
@@ -2741,6 +2931,7 @@ def reconcile_explicit_reviewer_pools(
     plan_reviewers: list[ModelProfile] | None = None,
     code_reviewers: list[ModelProfile] | None = None,
     secrets: dict[str, str] | None = None,
+    capability_records: dict | None = None,
 ) -> dict[str, object]:
     """Reconcile reviewer role blocks with explicit pools spliced post-assign.
 
@@ -2753,10 +2944,34 @@ def reconcile_explicit_reviewer_pools(
     profiles so the persisted block stays reconstructable and consistent with
     runtime (#1391 iter1). Other roles and the block ``origin`` are preserved.
 
+    An explicit pool is operator intent and is never filtered here — but a
+    spliced reviewer whose required capability is recorded demonstrably absent
+    (#2466) carries a ``capability_warning`` on its pool entry, so the block
+    cannot read as though an identity that cannot do the job were an
+    unremarkable inclusion.
+
     Mutates and returns ``routing_decision`` for convenience.
     """
     if not routing_decision:
         return routing_decision
+
+    def _capability_warning(role: str, profile: ModelProfile) -> dict[str, object] | None:
+        capability = ROLE_REQUIRED_CAPABILITY.get(role)
+        if not capability or not capability_records:
+            return None
+        result = _capability_lookup(
+            capability_records,
+            identity_for_profile(profile),
+            capability,
+            subject_signature=signature_for_profile(profile),
+        )
+        if not result.current_absent:
+            return None
+        return {
+            "capability": capability,
+            "established_at": result.established_at,
+            "note": "explicit override honored despite demonstrated absence",
+        }
 
     def _rebuild(role: str, reviewers: list[ModelProfile]) -> None:
         role_block = routing_decision.get(role)
@@ -2773,6 +2988,15 @@ def reconcile_explicit_reviewer_pools(
                 pool.append(
                     {"name": p.name, "tier": None, "included": True, "reason": REASON_NONE}
                 )
+        warnings_by_name = {
+            p.name: warning
+            for p in reviewers
+            if (warning := _capability_warning(role, p)) is not None
+        }
+        for entry in pool:
+            warning = warnings_by_name.get(entry.get("name"))
+            if warning is not None:
+                entry["capability_warning"] = warning
         role_block["candidate_pool"] = pool
         final = role_block.get("final")
         if isinstance(final, dict):
@@ -2833,6 +3057,7 @@ def apply_post_plan_checkpoint(
     domains: list[str] | None = None,
     recency: object | None = None,
     transport_fallbacks: dict[str, TransportFallbackConfig] | None = None,
+    capability_records: dict | None = None,
 ) -> AssignmentDecision:
     """Re-evaluate ONLY the dev tier after plan-review completes (#1387).
 
@@ -2860,6 +3085,9 @@ def apply_post_plan_checkpoint(
     agent pick so the cheaper tier is reranked by the same recency-weighted
     success rate and domain tiebreak as the original dev assignment (they are
     optional; omitting them falls back to the deterministic budget/price order).
+    ``capability_records`` is the durable demonstrated-capability record (#2466),
+    applied to the demoted-tier candidate pool on the same terms as in
+    :func:`assign_models`.
 
     Records the outcome into ``routing_decision['dev']['post_plan_checkpoint']``
     with fired/decision/baseline_tier/final_tier/plan_present/rationale, and
@@ -2959,10 +3187,19 @@ def apply_post_plan_checkpoint(
     # reranking and domain tiebreak the original dev assignment used, so the
     # cheaper tier still routes to its best-performing model rather than the raw
     # budget-ordered default (#1387 review P2).
+    # The rerouted dev is dispatched work like any other assignment, so it draws
+    # from the same demonstrated-capability-filtered pool the preflight pass used
+    # (#2466). ``dev`` requires no recorded capability today — no probe
+    # establishes one for it — so this is currently the identity filter; it is
+    # applied by policy rather than by assumption so a future dev capability
+    # cannot be reintroduced through the post-plan path.
+    dev_pool, _dev_pool_exhausted = _capability_pool(
+        agents, _capability_exclusions(agents, "dev", capability_records)
+    )
     target_tier = _reduced_tier(baseline_tier) if baseline_tier else None
     target_agent = (
         _pick_agent(
-            agents,
+            dev_pool,
             target_tier,
             secrets,
             model_profiles=model_profiles,
@@ -3283,6 +3520,7 @@ def assign_models(
     sprint_exploration_budget: int | None = None,
     explore_rng: random.Random | None = None,
     transport_fallbacks: dict[str, TransportFallbackConfig] | None = None,
+    capability_records: dict | None = None,
 ) -> AssignmentDecision:
     """Pure deterministic function — no LLM, no I/O.
 
@@ -3299,6 +3537,15 @@ def assign_models(
     window.  Reviewer selection deprioritizes them in favor of any same-tier
     or adjacent-tier healthy alternative; with no healthy alternative, the
     selection proceeds and surfaces the health context in the rationale.
+
+    ``capability_records`` is the durable record of what each identity has been
+    *demonstrated* to do (``.forge/model_capabilities.yaml``, written by
+    ``forge check-providers``). It is an optional pure input: a candidate is
+    skipped for a role only when the capability that role requires is currently
+    recorded as demonstrated absent for that candidate's identity. Never
+    established and stale records leave the candidate eligible, so passing no
+    record — or a record covering nothing in the pool — routes exactly as before
+    (#2466).
     """
     if not agents:
         raise ValueError("assign_models requires a non-empty agents pool")
@@ -3369,6 +3616,31 @@ def assign_models(
     if not adaptive_enabled:
         rationale["adaptive_enabled"] = "false (static band-only routing)"
 
+    # ── Demonstrated-capability gate (#2466) ───────────────────────────
+    # Resolved once, before any candidate scoring, so every selection path for a
+    # role — first pick, tier fallback, pool-exhaustion fallback, and the budget
+    # enforcer's cheaper-model search — draws from the same filtered pool and no
+    # path can reseat an identity the record rules out. Unlike the profile
+    # signals above this is NOT adaptive-only: a demonstrated absence is a hard
+    # eligibility fact about the model, not a learning signal, so static routing
+    # honors it too.
+    # Every routed role is filtered by the same policy, including the ones the
+    # policy currently exempts (dev, preflight): the exemption lives in
+    # ROLE_REQUIRED_CAPABILITY, not in which call sites remembered to filter.
+    capability_excluded = {
+        role: _capability_exclusions(agents, role, capability_records)
+        for role in ("preflight", "planner", "dev", "plan_review", "code_review")
+    }
+    evidence.capability_exclusions = {
+        role: excluded for role, excluded in capability_excluded.items() if excluded
+    }
+    role_pools: dict[str, list[AgentDef]] = {}
+    capability_notes: dict[str, str] = {}
+    for role, excluded in capability_excluded.items():
+        pool, exhausted = _capability_pool(agents, excluded)
+        role_pools[role] = pool
+        capability_notes[role] = _capability_exclusion_note(excluded, exhausted)
+
     # ── Dev tier with promotion ────────────────────────────────────────
     dev_base_tier = (
         _dev_tier_for_score(norm_complexity, score)
@@ -3381,10 +3653,12 @@ def assign_models(
         dev_profile = explicit_profiles["dev"]
         dev_selected_tier: str | None = None
         rationale["dev"] = f"explicit override: {dev_profile.model}"
+        rationale["dev"] += _explicit_capability_warning(dev_profile, "dev", capability_records)
     else:
         # Check promotion
+        dev_pool = role_pools["dev"]
         dev_agent_for_check: AgentDef | None = _pick_agent(
-            agents,
+            dev_pool,
             dev_base_tier,
             secrets,
             model_profiles=effective_profiles,
@@ -3438,7 +3712,7 @@ def assign_models(
 
         evidence.dev_effective_tier = effective_dev_tier
         dev_agent = _pick_agent(
-            agents,
+            dev_pool,
             effective_dev_tier,
             secrets,
             model_profiles=effective_profiles,
@@ -3482,7 +3756,7 @@ def assign_models(
             # mid models on HIGH.  dev_base_tier is the floor (cheap/mid/strong
             # for LOW/MEDIUM/HIGH respectively).
             floor_idx = _TIER_ORDER.index(dev_base_tier) if dev_base_tier in _TIER_ORDER else 0
-            authed = [a for a in agents if _has_auth(a, secrets)]
+            authed = [a for a in dev_pool if _has_auth(a, secrets)]
             floor_authed = [
                 a
                 for a in authed
@@ -3496,7 +3770,7 @@ def assign_models(
                 # agents before ever going below the floor.
                 floor_any = [
                     a
-                    for a in agents
+                    for a in dev_pool
                     if a.tier in _TIER_ORDER and _TIER_ORDER.index(a.tier) >= floor_idx
                 ]
                 if floor_any:
@@ -3516,12 +3790,13 @@ def assign_models(
                         f" WARNING: below {dev_base_tier} floor for {norm_complexity})"
                     )
                 else:
-                    dev_agent = sorted(agents, key=lambda a: a.budget_usd)[0]
+                    dev_agent = sorted(dev_pool, key=lambda a: a.budget_usd)[0]
                     rationale["dev"] += " (fallback: cheapest, no auth checked)"
         dev_selected_tier = dev_agent.tier
         dev_profile = _agent_to_profile(
             dev_agent, role="dev", transport_fallbacks=transport_fallbacks
         )
+        rationale["dev"] += capability_notes["dev"]
 
         # ── Challenger-sampling exploration (#325, ADR-0006 clause 8) ──────
         # The single sanctioned deviation from deterministic routing. Only
@@ -3529,7 +3804,7 @@ def assign_models(
         # decision is reconstructable even in on-policy winner mode.
         if adaptive_enabled:
             _exp = _apply_dev_exploration(
-                agents=agents,
+                agents=dev_pool,
                 incumbent=dev_agent,
                 dev_base_tier=dev_base_tier,
                 norm_complexity=norm_complexity,
@@ -3579,11 +3854,15 @@ def assign_models(
     if "preflight" in explicit_profiles:
         preflight_profile = explicit_profiles["preflight"]
         rationale["preflight"] = f"explicit override: {preflight_profile.model}"
+        rationale["preflight"] += _explicit_capability_warning(
+            preflight_profile, "preflight", capability_records
+        )
     else:
         tier = PHASE_TIER["preflight"][norm_complexity]
         _preflight_tier = tier
+        preflight_pool = role_pools["preflight"]
         agent = _pick_agent(
-            agents,
+            preflight_pool,
             tier,
             secrets,
             model_profiles=effective_profiles,
@@ -3595,21 +3874,26 @@ def assign_models(
             reliability_audit=evidence.preflight_reliability.audit,
         )
         if agent is None:
-            authed = [a for a in agents if _has_auth(a, secrets)]
-            agent = sorted(authed or agents, key=lambda a: a.budget_usd)[0]
+            authed = [a for a in preflight_pool if _has_auth(a, secrets)]
+            agent = sorted(authed or preflight_pool, key=lambda a: a.budget_usd)[0]
         preflight_profile = _agent_to_profile(
             agent,
             role="preflight",
             allowed_tools=DEFAULT_PREFLIGHT_PROFILE.allowed_tools,
             transport_fallbacks=transport_fallbacks,
         )
-        rationale["preflight"] = f"tier {tier} (${agent.budget_usd:.2f})"
+        rationale["preflight"] = (
+            f"tier {tier} (${agent.budget_usd:.2f}){capability_notes['preflight']}"
+        )
 
     # ── Planner ────────────────────────────────────────────────────────
     if "planner" in explicit_profiles:
         planner_profile = explicit_profiles["planner"]
         planner_target_tier: str | None = None
         rationale["planner"] = f"explicit override: {planner_profile.model}"
+        rationale["planner"] += _explicit_capability_warning(
+            planner_profile, "planner", capability_records
+        )
     else:
         tier = (
             _plan_tier_for_score(norm_complexity, score)
@@ -3617,8 +3901,9 @@ def assign_models(
             else PHASE_TIER["plan"][norm_complexity]
         )
         planner_target_tier = tier
+        planner_pool = role_pools["planner"]
         agent = _pick_agent(
-            agents,
+            planner_pool,
             tier,
             secrets,
             model_profiles=effective_profiles,
@@ -3630,8 +3915,8 @@ def assign_models(
             reliability_audit=evidence.planner_reliability.audit,
         )
         if agent is None:
-            authed = [a for a in agents if _has_auth(a, secrets)]
-            agent = sorted(authed or agents, key=lambda a: -a.budget_usd)[0]
+            authed = [a for a in planner_pool if _has_auth(a, secrets)]
+            agent = sorted(authed or planner_pool, key=lambda a: -a.budget_usd)[0]
         planner_profile = _agent_to_profile(
             agent, role="review", transport_fallbacks=transport_fallbacks
         )
@@ -3641,11 +3926,15 @@ def assign_models(
             )
         else:
             rationale["planner"] = f"tier {tier} (${agent.budget_usd:.2f})"
+        rationale["planner"] += capability_notes["planner"]
 
     # ── Plan reviewers ─────────────────────────────────────────────────
     if "plan_review" in explicit_profiles:
         plan_reviewers = [explicit_profiles["plan_review"]]
         rationale["plan_review"] = f"explicit override: {explicit_profiles['plan_review'].model}"
+        rationale["plan_review"] += _explicit_capability_warning(
+            explicit_profiles["plan_review"], "plan_review", capability_records
+        )
     else:
         tier = (
             _plan_tier_for_score(norm_complexity, score)
@@ -3667,8 +3956,9 @@ def assign_models(
             )
         )
         planner_model = planner_profile.model
+        plan_review_pool = role_pools["plan_review"]
         selected = _select_reviewers(
-            agents,
+            plan_review_pool,
             tier,
             n,
             assignment_config.prefer_cross_provider,
@@ -3701,17 +3991,25 @@ def assign_models(
             else ""
         )
         health_note = _reviewer_health_rationale(
-            agents, selected, tier, exclude_model=planner_model, unhealthy_models=unhealthy_models
+            plan_review_pool,
+            selected,
+            tier,
+            exclude_model=planner_model,
+            unhealthy_models=unhealthy_models,
         )
         rationale["plan_review"] = (
             f"{len(plan_reviewers)} reviewer(s), tier {tier}, "
             f"providers {providers}{score_note}{shortfall_note}{health_note}"
+            f"{capability_notes['plan_review']}"
         )
 
     # ── Code reviewers ─────────────────────────────────────────────────
     if "code_review" in explicit_profiles:
         code_reviewers = [explicit_profiles["code_review"]]
         rationale["code_review"] = f"explicit override: {explicit_profiles['code_review'].model}"
+        rationale["code_review"] += _explicit_capability_warning(
+            explicit_profiles["code_review"], "code_review", capability_records
+        )
     else:
         tier = (
             _plan_tier_for_score(norm_complexity, score)
@@ -3733,8 +4031,9 @@ def assign_models(
             )
         )
         dev_model = dev_profile.model
+        code_review_pool = role_pools["code_review"]
         selected = _select_reviewers(
-            agents,
+            code_review_pool,
             tier,
             n,
             assignment_config.prefer_cross_provider,
@@ -3768,7 +4067,11 @@ def assign_models(
             else ""
         )
         health_note = _reviewer_health_rationale(
-            agents, selected, tier, exclude_model=dev_model, unhealthy_models=unhealthy_models
+            code_review_pool,
+            selected,
+            tier,
+            exclude_model=dev_model,
+            unhealthy_models=unhealthy_models,
         )
         value_note = _reviewer_value_rationale(
             assignment_config.code_review_value_enabled,
@@ -3778,6 +4081,7 @@ def assign_models(
         rationale["code_review"] = (
             f"{len(code_reviewers)} reviewer(s), tier {tier}, "
             f"providers {providers}{score_note}{shortfall_note}{health_note}{value_note}"
+            f"{capability_notes['code_review']}"
         )
 
     decision = AssignmentDecision(
@@ -3872,6 +4176,7 @@ def assign_models(
         dev_floor_tier=_dev_floor,
         planner_floor_tier=planner_floor_tier,
         locked_roles=locked_roles,
+        role_pools=role_pools,
     )
 
     return _attach_routing_decision(decision)

--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -432,45 +432,71 @@ def _capability_exclusions(
     return excluded
 
 
+class NoCapableCandidateError(ValueError):
+    """No candidate can serve a role whose capability requirement is recorded (#2466).
+
+    Raised when the durable record says *every* candidate for a role has
+    demonstrated it cannot produce what that role requires. There is no correct
+    model to seat: dispatching anyway is exactly the failure this record exists
+    to prevent — the phase returns something unusable and the gate reports an
+    absence it cannot explain. Routing refuses instead, naming the role, the
+    capability, and when each absence was established, so the operator reads the
+    reason here rather than reconstructing it from the wreckage.
+
+    A ``ValueError`` subclass so it joins the module's existing unroutable-pool
+    contract (``assign_models`` already raises ``ValueError`` on an empty pool)
+    rather than introducing a second failure shape for callers to handle.
+    """
+
+    def __init__(
+        self,
+        role: str,
+        capability: str,
+        excluded: dict[str, dict[str, object]],
+    ) -> None:
+        self.role = role
+        self.capability = capability
+        self.excluded = excluded
+        detail = ", ".join(
+            f"{name} (established {record.get('established_at') or '?'})"
+            for name, record in sorted(excluded.items())
+        )
+        super().__init__(
+            f"no candidate can serve role {role!r}: every agent in the pool has "
+            f"{capability} demonstrated absent — {detail}. "
+            f"Re-run 'forge check-providers' if this record is out of date, or "
+            f"configure a model that can produce {capability}."
+        )
+
+
 def _capability_pool(
     agents: list[AgentDef],
     excluded: dict[str, dict[str, object]],
-) -> tuple[list[AgentDef], bool]:
+) -> list[AgentDef]:
     """Apply a role's capability exclusions to its candidate pool.
 
-    Returns ``(pool, exhausted)``. When every candidate is ruled out the full
-    pool is handed back with ``exhausted=True``: routing still has to seat
-    somebody, and a silently empty pool would surface as an unexplained crash
-    instead of an explained last resort. Callers say so in the rationale.
+    The filtered pool is returned as-is, **including when it is empty**. An
+    empty pool is a real answer — nothing configured can do this job — and
+    restoring the unfiltered pool to have somebody to seat would hand the role
+    right back to the models the record rules out. Callers refuse instead; see
+    :class:`NoCapableCandidateError`.
     """
     if not excluded:
-        return agents, False
-    pool = [a for a in agents if a.name not in excluded]
-    if not pool:
-        return agents, True
-    return pool, False
+        return agents
+    return [a for a in agents if a.name not in excluded]
 
 
-def _capability_exclusion_note(
-    excluded: dict[str, dict[str, object]],
-    exhausted: bool,
-) -> str:
+def _capability_exclusion_note(excluded: dict[str, dict[str, object]]) -> str:
     """Operator-facing rationale fragment for a role's capability exclusions."""
     if not excluded:
         return ""
     capability = next(iter(excluded.values()))["capability"]
     names = ", ".join(sorted(excluded))
     stamps = sorted({str(v.get("established_at") or "?") for v in excluded.values()})
-    note = (
+    return (
         f"; excluded [{names}] — {capability} demonstrated absent "
         f"(established {', '.join(stamps)})"
     )
-    if exhausted:
-        note += (
-            f"; WARNING: no candidate has {capability} available — seated from the "
-            "unfiltered pool as a last resort"
-        )
-    return note
 
 
 def _explicit_capability_warning(
@@ -3192,10 +3218,11 @@ def apply_post_plan_checkpoint(
     # (#2466). ``dev`` requires no recorded capability today — no probe
     # establishes one for it — so this is currently the identity filter; it is
     # applied by policy rather than by assumption so a future dev capability
-    # cannot be reintroduced through the post-plan path.
-    dev_pool, _dev_pool_exhausted = _capability_pool(
-        agents, _capability_exclusions(agents, "dev", capability_records)
-    )
+    # cannot be reintroduced through the post-plan path. An empty filtered pool
+    # needs no refusal here: this checkpoint is an optional *demotion*, so no
+    # capable cheaper candidate simply preserves the already-seated dev
+    # ("no_reduced_tier_candidate") rather than failing the run.
+    dev_pool = _capability_pool(agents, _capability_exclusions(agents, "dev", capability_records))
     target_tier = _reduced_tier(baseline_tier) if baseline_tier else None
     target_agent = (
         _pick_agent(
@@ -3545,7 +3572,9 @@ def assign_models(
     recorded as demonstrated absent for that candidate's identity. Never
     established and stale records leave the candidate eligible, so passing no
     record — or a record covering nothing in the pool — routes exactly as before
-    (#2466).
+    (#2466). Raises :class:`NoCapableCandidateError` when the record rules out
+    *every* candidate for a role: there is no correct model to seat, and seating
+    one anyway is the failure the record exists to prevent.
     """
     if not agents:
         raise ValueError("assign_models requires a non-empty agents pool")
@@ -3637,9 +3666,17 @@ def assign_models(
     role_pools: dict[str, list[AgentDef]] = {}
     capability_notes: dict[str, str] = {}
     for role, excluded in capability_excluded.items():
-        pool, exhausted = _capability_pool(agents, excluded)
-        role_pools[role] = pool
-        capability_notes[role] = _capability_exclusion_note(excluded, exhausted)
+        role_pools[role] = _capability_pool(agents, excluded)
+        capability_notes[role] = _capability_exclusion_note(excluded)
+    # Refuse rather than seat a model the record says cannot do the job. Checked
+    # here — before any selection runs — so the refusal names the role and the
+    # evidence instead of surfacing later as an empty pool or, worse, as a phase
+    # that returns something unusable. An explicitly overridden role is exempt:
+    # it never reaches candidate selection, and the operator's pin stands (it is
+    # flagged in that role's rationale instead).
+    for role, excluded in capability_excluded.items():
+        if excluded and not role_pools[role] and role not in explicit_profiles:
+            raise NoCapableCandidateError(role, ROLE_REQUIRED_CAPABILITY[role], excluded)
 
     # ── Dev tier with promotion ────────────────────────────────────────
     dev_base_tier = (

--- a/src/theforge/cli/provider_readiness.py
+++ b/src/theforge/cli/provider_readiness.py
@@ -25,6 +25,15 @@ from theforge.config.auth import check_agent_auth
 from theforge.config.models import mirror_fields_for_transport
 from theforge.config.profiles import iter_config_profiles, iter_plan_phase_profiles
 from theforge.config.types import ModelProfile
+from theforge.model_capabilities import (
+    CAPABILITY_PLAIN_STRUCTURED,
+    CAPABILITY_TOOL_STRUCTURED,
+    OUTCOME_ABSENT,
+    OUTCOME_DEMONSTRATED,
+    CapabilityObservation,
+    identity_for_profile,
+    signature_for_profile,
+)
 from theforge.runners.api import run_api_agent
 from theforge.runners.cli import run_agent
 from theforge.runners.schema_utils import openai_function_tool_request_shape
@@ -43,8 +52,11 @@ READINESS_STATUSES: tuple[str, ...] = (
     READINESS_STATUS_COST_UNAVAILABLE,
 )
 
-READINESS_CAPABILITY_PLAIN_STRUCTURED = "plain-structured"
-READINESS_CAPABILITY_TOOL_STRUCTURED = "tool-structured"
+# Aliases of the durable-record vocabulary (#2466): the probe and the store name
+# the same two capabilities, so they are declared once in model_capabilities and
+# re-exported here rather than restated.
+READINESS_CAPABILITY_PLAIN_STRUCTURED = CAPABILITY_PLAIN_STRUCTURED
+READINESS_CAPABILITY_TOOL_STRUCTURED = CAPABILITY_TOOL_STRUCTURED
 
 _READINESS_PROMPT = (
     "Review this diff: -    x = 1\n+    x = 2\n\n"
@@ -93,7 +105,21 @@ class ReadinessProbe:
 
 @dataclass(frozen=True)
 class ReadinessAttempt:
-    """Outcome of exercising one transport for a readiness probe."""
+    """Outcome of exercising one transport for a readiness probe.
+
+    ``capability_outcome`` is the attempt's *capability* verdict (#2466), which
+    is deliberately not derivable from ``status``. The overall status folds in
+    auth, transport, identity and cost concerns; the capability verdict answers
+    only "did this attempt establish that the identity can produce the probed
+    shape?" and is ``None`` — not evidence — whenever the attempt never
+    validated it. A dev/preflight probe returns READY on unstructured output by
+    design, so its READY establishes nothing here; a CLI attempt that returned a
+    valid structured result but no cost is UNVERIFIED overall yet *did* prove the
+    capability, and says so.
+
+    ``subject`` is the profile actually exercised (transport-substituted), so the
+    recorded identity describes the attempt rather than the declared profile.
+    """
 
     probe: ReadinessProbe
     attempted_transport_kind: str
@@ -102,6 +128,8 @@ class ReadinessAttempt:
     status: str
     detail: str
     outcome: AgentResult | Exception | None = None
+    capability_outcome: str | None = None
+    subject: ModelProfile | None = None
 
     @property
     def ready(self) -> bool:
@@ -153,6 +181,38 @@ class ReadinessResult:
             for attempt in self.attempts
             if not attempt.is_declared_transport and attempt.ready
         )
+
+
+def capability_observations(results: list[ReadinessResult]) -> list[CapabilityObservation]:
+    """Extract the durable capability evidence from a set of probe results (#2466).
+
+    Every attempt that actually established an outcome is reported — including
+    alternate-transport attempts, which exercise a *different* canonical identity
+    (transport is part of the identity) and are therefore evidence in their own
+    right, not a footnote on the declared one. Attempts that established nothing
+    (never exercised, auth failure, runtime error, phase that never validated the
+    shape) are omitted rather than written as absence.
+    """
+    observations: list[CapabilityObservation] = []
+    for result in results:
+        for attempt in result.attempts:
+            if attempt.capability_outcome is None:
+                continue
+            subject = attempt.subject or result.probe.profile
+            identity = identity_for_profile(subject)
+            if identity is None:
+                continue
+            observations.append(
+                CapabilityObservation(
+                    identity=identity,
+                    capability=result.probe.capability,
+                    outcome=attempt.capability_outcome,
+                    subject_signature=signature_for_profile(subject),
+                    detail=attempt.detail,
+                    probe_role=result.probe.role,
+                )
+            )
+    return observations
 
 
 def build_readiness_probes(config: ForgeConfig) -> list[ReadinessProbe]:
@@ -301,6 +361,10 @@ def _run_transport_attempt(
                     "not exercised: no supported OpenAI tool-bearing request shape "
                     "is configured for this model"
                 ),
+                # No request shape exists to carry tools at all — a determination
+                # about the capability itself, not a runtime failure.
+                capability_outcome=OUTCOME_ABSENT,
+                subject=profile,
             )
 
     t0 = time.perf_counter()
@@ -362,6 +426,12 @@ def _run_transport_attempt(
             outcome=result,
         )
 
+    # Capability verdict (#2466): established only where the probe actually
+    # validated the shape. When the phase accepts unstructured output, nothing
+    # about the capability was exercised, so the attempt is not evidence — the
+    # remaining returns carry ``validated`` unchanged, including the ones whose
+    # overall status is degraded for cost reasons that say nothing about it.
+    validated: str | None = None
     if _requires_structured_verdict(probe):
         payload = _structured_payload(result)
         if payload is None or "verdict" not in payload:
@@ -373,7 +443,10 @@ def _run_transport_attempt(
                 status=READINESS_STATUS_FAILED,
                 detail="no valid verdict in structured output",
                 outcome=result,
+                capability_outcome=OUTCOME_ABSENT,
+                subject=profile,
             )
+        validated = OUTCOME_DEMONSTRATED
 
     if result.cost_usd is None:
         if transport.kind == "cli":
@@ -383,6 +456,8 @@ def _run_transport_attempt(
                 detail="not exercised: structured result returned but CLI cost is unavailable",
                 elapsed=elapsed,
                 outcome=result,
+                capability_outcome=validated,
+                subject=profile,
             )
         if not _is_local_endpoint(getattr(profile, "base_url", None)):
             return ReadinessAttempt(
@@ -393,6 +468,8 @@ def _run_transport_attempt(
                 status=READINESS_STATUS_COST_UNAVAILABLE,
                 detail="structured result returned but cost is unavailable",
                 outcome=result,
+                capability_outcome=validated,
+                subject=profile,
             )
 
     return ReadinessAttempt(
@@ -403,6 +480,8 @@ def _run_transport_attempt(
         status=READINESS_STATUS_READY,
         detail=_success_suffix(profile=profile, result=result, elapsed=elapsed),
         outcome=result,
+        capability_outcome=validated,
+        subject=profile,
     )
 
 
@@ -531,6 +610,8 @@ def _unverified_attempt(
     detail: str,
     elapsed: float = 0.0,
     outcome: AgentResult | Exception | None = None,
+    capability_outcome: str | None = None,
+    subject: ModelProfile | None = None,
 ) -> ReadinessAttempt:
     return ReadinessAttempt(
         probe=probe,
@@ -540,6 +621,8 @@ def _unverified_attempt(
         status=READINESS_STATUS_UNVERIFIED,
         detail=detail,
         outcome=outcome,
+        capability_outcome=capability_outcome,
+        subject=subject,
     )
 
 

--- a/src/theforge/cli/providers.py
+++ b/src/theforge/cli/providers.py
@@ -10,10 +10,17 @@ from theforge.cli.provider_readiness import (
     READINESS_STATUS_READY,
     ReadinessResult,
     build_readiness_probes,
+    capability_observations,
     run_readiness_probe,
 )
 from theforge.cli.shared import _find_config
 from theforge.config import load_config
+from theforge.model_capabilities import (
+    capabilities_path,
+    load_capabilities,
+    record_observations,
+    save_capabilities,
+)
 
 _MAX_READINESS_WORKERS = 4
 
@@ -89,6 +96,8 @@ def cmd_check_providers(args: object) -> int:
         )
     )
 
+    _record_capability_evidence(config, config_path, results)
+
     any_failed = False
     for result in results:
         profile = result.probe.profile
@@ -134,6 +143,30 @@ def register_parser(subparsers: object) -> None:
     check_providers_parser.add_argument(
         "--config",
         help="Path to forge.yaml (default: auto-detect)",
+    )
+
+
+def _record_capability_evidence(
+    config: object,
+    config_path: Path,
+    results: list[ReadinessResult],
+) -> None:
+    """Persist what this run demonstrated so routing can consult it later (#2466).
+
+    Thin by design: the probe decides which attempts are evidence and
+    ``model_capabilities`` owns keying, merging and staleness. This function only
+    moves the result from one to the other and tells the operator where it went.
+    """
+    observations = capability_observations(results)
+    if not observations:
+        return
+    project_root = getattr(config, "project_root", None) or config_path.parent
+    path = capabilities_path(Path(project_root))
+    data = record_observations(load_capabilities(path), observations)
+    save_capabilities(path, data)
+    print(
+        f"\n[check-providers] recorded {len(observations)} capability outcome(s) "
+        f"to {path} — routing reads this at dispatch"
     )
 
 

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -632,6 +632,13 @@ def _apply_post_plan_dev_checkpoint(
     # domain signals the preflight dev assignment used — only under adaptive
     # routing, mirroring assign_models (static mode ignores profile learning).
     _adaptive_enabled = config.assignment.adaptive_enabled
+    # Demonstrated-capability record (#2466): loaded OUTSIDE the adaptive guard.
+    # It is not a learning signal that static routing may ignore — it is a hard
+    # eligibility fact about the identity, so the post-plan reroute honors it in
+    # both modes.
+    from theforge.model_capabilities import capabilities_path, load_capabilities  # noqa: PLC0415
+
+    _capability_records = load_capabilities(capabilities_path(config.project_root))
     _model_profiles = None
     _observed_costs = None
     _recency = None
@@ -671,6 +678,7 @@ def _apply_post_plan_dev_checkpoint(
         domains=_domains,
         recency=_recency,
         transport_fallbacks=config.transport_fallbacks,
+        capability_records=_capability_records,
     )
     state._adaptive_decision = _updated
     if _updated.routing_decision:

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -1352,6 +1352,19 @@ def _apply_preflight_config(
     _profiles_path = config.project_root / ".forge" / "model_profiles.yaml"
     _model_profiles = _load_profiles(_profiles_path)
 
+    # Durable demonstrated-capability record (#2466), written by
+    # ``forge check-providers``. Loaded unconditionally — unlike the learning
+    # profiles above, a demonstrated absence is a hard eligibility fact about the
+    # model, so static routing must honor it too.
+    from theforge.model_capabilities import (  # noqa: PLC0415
+        capabilities_path as _capabilities_path,
+    )
+    from theforge.model_capabilities import (
+        load_capabilities as _load_capabilities,
+    )
+
+    _capability_records = _load_capabilities(_capabilities_path(config.project_root))
+
     from theforge.provider_health import (  # noqa: PLC0415
         load_provider_health as _load_provider_health,
     )
@@ -1424,6 +1437,7 @@ def _apply_preflight_config(
             excluded_for_taint=_excluded_for_taint,
             sprint_exploration_budget=explore_budget,
             transport_fallbacks=config.transport_fallbacks,
+            capability_records=_capability_records,
         )
 
     _explore_remaining = _explore_budget.remaining_budget(
@@ -1561,6 +1575,7 @@ def _apply_preflight_config(
                 plan_reviewers=(_decision.plan_reviewers if _explicit_plan_review_pool else None),
                 code_reviewers=(_decision.code_reviewers if _explicit_review_pool else None),
                 secrets=config.secrets,
+                capability_records=_capability_records,
             )
         state.routing_decision = _routing_block
     _existing_routing_audit = dict(state.complexity_routing_audit or {})

--- a/src/theforge/model_capabilities.py
+++ b/src/theforge/model_capabilities.py
@@ -1,0 +1,455 @@
+"""Durable record of what a model has been *demonstrated* to do (#2466).
+
+``forge check-providers`` exercises each configured identity and reports the
+result to whoever ran it. Before this module the finding died with the
+invocation: routing had no way to consult it, so every dispatch assumed any
+eligible model could serve whatever the phase required, and a capability
+mismatch was discovered by failing a phase an hour later.
+
+This module is the fact's storage. It maintains ``.forge/model_capabilities.yaml``
+— deliberately separate from ``model_profiles.yaml``, which aggregates *run
+outcomes* (success rate, cost, iterations) rather than *demonstrations*. A run
+outcome is a statistic about attempts; a capability record is a claim about what
+an identity did when a probe exercised exactly that capability.
+
+**What counts as a demonstration.** Only a probe that actually validated the
+capability establishes it. The readiness check exercises some roles without
+validating structured output at all (the dev and preflight phases accept
+unstructured output by design), so those probes establish *nothing* here — a
+READY status is not, by itself, evidence of structured capability. The probe
+classifies its own attempts (see
+``theforge.cli.provider_readiness.capability_observations``); this module stores
+what it is told and never re-derives a capability from a readiness status.
+
+**Three states, and the fourth that is not a state.** A lookup answers
+``demonstrated``, ``demonstrated_absent``, or ``never_established`` for any
+identity+capability. Never-established is *not* absence: an unprobed identity
+stays eligible, so introducing this record cannot silently narrow the routing
+pool to whatever has been probed. ``stale`` is reported alongside those three:
+a record whose probe subject no longer matches the identity it describes is not
+presented as current.
+
+Pure stdlib + YAML. No LLM calls, no policy about *which* role needs *which*
+capability — that lives in :mod:`theforge.assignment`, which is the component
+that decides where work goes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+# ── Capability vocabulary ─────────────────────────────────────────────
+#
+# Kept as a closed set so the persisted record stays machine-queryable. These
+# are the names the readiness probe already uses for the two shapes it can
+# exercise; ``provider_readiness`` aliases them rather than redeclaring them so
+# the probe and the store can never drift.
+CAPABILITY_PLAIN_STRUCTURED = "plain-structured"
+CAPABILITY_TOOL_STRUCTURED = "tool-structured"
+
+CAPABILITIES: tuple[str, ...] = (
+    CAPABILITY_PLAIN_STRUCTURED,
+    CAPABILITY_TOOL_STRUCTURED,
+)
+
+# What a probe attempt established about a capability. ``None`` (no outcome) is
+# the third possibility at the probe boundary and means "this attempt is not
+# evidence" — it is never written.
+OUTCOME_DEMONSTRATED = "demonstrated"
+OUTCOME_ABSENT = "absent"
+
+OUTCOMES: tuple[str, ...] = (OUTCOME_DEMONSTRATED, OUTCOME_ABSENT)
+
+# What a lookup reports to the router.
+STATE_DEMONSTRATED = "demonstrated"
+STATE_DEMONSTRATED_ABSENT = "demonstrated_absent"
+STATE_NEVER_ESTABLISHED = "never_established"
+
+STATES: tuple[str, ...] = (
+    STATE_DEMONSTRATED,
+    STATE_DEMONSTRATED_ABSENT,
+    STATE_NEVER_ESTABLISHED,
+)
+
+SCHEMA_VERSION = 1
+
+CAPABILITIES_FILENAME = "model_capabilities.yaml"
+
+
+def capabilities_path(project_root: Path) -> Path:
+    """Return the durable capability-record path for a project."""
+    return Path(project_root) / ".forge" / CAPABILITIES_FILENAME
+
+
+# ── Identity ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CapabilityIdentity:
+    """The identity a probe exercised: (provider family, model, transport).
+
+    This is the same tuple routing dispatches on, so a record written by the
+    probe is addressable by the router without a translation table. Transport is
+    part of the identity because the same model reached over CLI and over API is
+    two different things to exercise — one can demonstrate a capability the
+    other cannot.
+    """
+
+    provider: str
+    model: str
+    transport: str
+
+    @property
+    def key(self) -> str:
+        """Canonical storage key: ``provider/model/transport``."""
+        return f"{self.provider}/{self.model}/{self.transport}"
+
+    def as_dict(self) -> dict[str, str]:
+        return {"provider": self.provider, "model": self.model, "transport": self.transport}
+
+
+def make_identity(
+    provider: str | None,
+    model: str | None,
+    transport: str | None,
+) -> CapabilityIdentity | None:
+    """Build a canonical identity, or None when any half of it is unknown.
+
+    An identity missing its provider family or model cannot be addressed later,
+    so it is not recorded at all rather than recorded under a placeholder that
+    would collide with every other unknown.
+    """
+    provider = (provider or "").strip().lower()
+    model = (model or "").strip()
+    transport = (transport or "").strip().lower() or "cli"
+    if not provider or not model:
+        return None
+    return CapabilityIdentity(provider=provider, model=model, transport=transport)
+
+
+def identity_for_profile(profile: Any) -> CapabilityIdentity | None:
+    """Canonical identity of a :class:`~theforge.config.types.ModelProfile`.
+
+    ``ModelProfile`` exposes the cross-transport provider as ``provider_family``
+    and the transport kind as ``mode``.
+    """
+    return make_identity(
+        getattr(profile, "provider_family", None),
+        getattr(profile, "model", None),
+        getattr(profile, "mode", None),
+    )
+
+
+def identity_for_agent(agent: Any) -> CapabilityIdentity | None:
+    """Canonical identity of an :class:`~theforge.config.models.AgentDef`.
+
+    ``AgentDef`` has no ``provider_family``; its cross-transport provider is
+    ``effective_provider`` (``provider`` stays None on CLI entries). The
+    transport comes from the carried ``TransportSpec``, defaulting to CLI when
+    the entry declares no provider — the same default dispatch uses.
+    """
+    transport = getattr(agent, "transport", None)
+    kind = getattr(transport, "kind", None)
+    if kind is None:
+        kind = "api" if getattr(agent, "provider", None) else "cli"
+    return make_identity(
+        getattr(agent, "effective_provider", None),
+        getattr(agent, "model", None),
+        kind,
+    )
+
+
+def _signature(
+    *,
+    provider: str | None,
+    model: str | None,
+    transport: str | None,
+    base_url: str | None,
+    cli: str | None,
+) -> str:
+    """Fingerprint of the *subject* a probe exercised.
+
+    The canonical identity (provider/model/transport) names the record; this
+    signature covers the rest of what determines what actually gets invoked —
+    the endpoint an API identity is pointed at, the binary a CLI identity runs
+    through. Repointing either means the recorded outcome describes a subject
+    that no longer exists, which is what :func:`lookup` reports as stale. It
+    never changes the identity, so a re-probe updates the same record rather
+    than orphaning it.
+    """
+    raw = "|".join(
+        [
+            (provider or "").strip().lower(),
+            (model or "").strip(),
+            (transport or "").strip().lower(),
+            (base_url or "").strip(),
+            (cli or "").strip(),
+        ]
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def signature_for_profile(profile: Any) -> str:
+    """Probe-subject signature for a ``ModelProfile``."""
+    return _signature(
+        provider=getattr(profile, "provider_family", None),
+        model=getattr(profile, "model", None),
+        transport=getattr(profile, "mode", None),
+        base_url=getattr(profile, "base_url", None),
+        cli=getattr(profile, "cli", None),
+    )
+
+
+def signature_for_agent(agent: Any) -> str:
+    """Probe-subject signature for an ``AgentDef``."""
+    transport = getattr(agent, "transport", None)
+    kind = getattr(transport, "kind", None)
+    if kind is None:
+        kind = "api" if getattr(agent, "provider", None) else "cli"
+    return _signature(
+        provider=getattr(agent, "effective_provider", None),
+        model=getattr(agent, "model", None),
+        transport=kind,
+        base_url=getattr(agent, "base_url", None),
+        cli=getattr(agent, "cli", None),
+    )
+
+
+# ── Values ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CapabilityObservation:
+    """One probe attempt that actually established a capability outcome.
+
+    Produced by the readiness probe (which alone knows whether an attempt
+    validated the capability) and consumed by :func:`record_observations`.
+    ``detail`` carries the probe's own explanation so an operator reading a
+    routing rationale can tell a structured-output failure from an unsupported
+    request shape.
+    """
+
+    identity: CapabilityIdentity
+    capability: str
+    outcome: str
+    subject_signature: str
+    detail: str = ""
+    probe_role: str = ""
+
+
+@dataclass(frozen=True)
+class CapabilityLookup:
+    """What the record says about one identity+capability, right now.
+
+    ``state`` is one of :data:`STATES`. ``stale`` is orthogonal: a stale record
+    still reports the outcome it recorded, but callers must not treat it as
+    current — see :func:`is_demonstrated_absent`, which declines to block on a
+    stale record.
+    """
+
+    state: str
+    established_at: str | None = None
+    detail: str = ""
+    probe_role: str = ""
+    stale: bool = False
+    recorded_signature: str = ""
+
+    @property
+    def current_absent(self) -> bool:
+        """True only for a *current* demonstrated-absent record."""
+        return self.state == STATE_DEMONSTRATED_ABSENT and not self.stale
+
+
+NEVER_ESTABLISHED = CapabilityLookup(state=STATE_NEVER_ESTABLISHED)
+
+
+# ── I/O ───────────────────────────────────────────────────────────────
+
+
+def _empty() -> dict[str, Any]:
+    return {"version": SCHEMA_VERSION, "identities": {}}
+
+
+def load_capabilities(path: Path) -> dict[str, Any]:
+    """Read ``model_capabilities.yaml``; return an empty record if absent/bad.
+
+    Never raises: an unreadable record means *nothing has been established*,
+    which leaves every identity eligible. A malformed file must not take routing
+    down, and it must not silently narrow the pool either.
+    """
+    if not Path(path).exists():
+        return _empty()
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[model_capabilities] Failed to load %s: %s", path, exc)
+        return _empty()
+    if not isinstance(data, dict):
+        return _empty()
+    if not isinstance(data.get("identities"), dict):
+        data["identities"] = {}
+    data.setdefault("version", SCHEMA_VERSION)
+    return data
+
+
+def save_capabilities(path: Path, data: dict[str, Any]) -> None:
+    """Write the capability record to disk; best-effort (warns, never raises)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=True)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[model_capabilities] Failed to write %s: %s", path, exc)
+
+
+def utc_now() -> str:
+    """Second-resolution UTC timestamp, matching the profile store's format."""
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+# ── Recording ─────────────────────────────────────────────────────────
+
+
+def record_observations(
+    data: dict[str, Any],
+    observations: list[CapabilityObservation],
+    *,
+    established_at: str | None = None,
+) -> dict[str, Any]:
+    """Fold a batch of probe observations into ``data`` (mutated and returned).
+
+    One ``check-providers`` run can produce several observations for the same
+    identity+capability — the agent pool probes the same model under several
+    roles, and both transports of one profile are exercised. Merging is
+    deterministic and independent of the order threads happen to finish:
+    **absent wins over demonstrated within a batch**. A model that failed to
+    produce the capability in any probe of that capability has shown it cannot
+    be relied on for it, and the probe detail records which attempt said so.
+
+    A record is overwritten wholesale (outcome, timestamp, subject signature) —
+    the latest demonstration is the current fact, so a re-probe of a changed
+    subject *updates* rather than leaving a stale record behind.
+    """
+    if not observations:
+        return data
+    if not isinstance(data.get("identities"), dict):
+        data["identities"] = {}
+    stamp = established_at or utc_now()
+
+    merged: dict[tuple[str, str], CapabilityObservation] = {}
+    for obs in observations:
+        if obs.outcome not in OUTCOMES:
+            continue
+        key = (obs.identity.key, obs.capability)
+        prior = merged.get(key)
+        if prior is None or (
+            prior.outcome == OUTCOME_DEMONSTRATED and obs.outcome == OUTCOME_ABSENT
+        ):
+            merged[key] = obs
+
+    for (identity_key, capability), obs in sorted(merged.items()):
+        entry = data["identities"].get(identity_key)
+        if not isinstance(entry, dict):
+            entry = dict(obs.identity.as_dict())
+            data["identities"][identity_key] = entry
+        else:
+            entry.update(obs.identity.as_dict())
+        capabilities = entry.get("capabilities")
+        if not isinstance(capabilities, dict):
+            capabilities = {}
+            entry["capabilities"] = capabilities
+        capabilities[capability] = {
+            "outcome": obs.outcome,
+            "established_at": stamp,
+            "subject_signature": obs.subject_signature,
+            "detail": obs.detail,
+            "probe_role": obs.probe_role,
+        }
+    return data
+
+
+# ── Reading ───────────────────────────────────────────────────────────
+
+
+def lookup(
+    data: dict[str, Any] | None,
+    identity: CapabilityIdentity | None,
+    capability: str,
+    *,
+    subject_signature: str | None = None,
+) -> CapabilityLookup:
+    """Report what the record establishes for ``identity`` + ``capability``.
+
+    Returns :data:`NEVER_ESTABLISHED` when there is no record, no identity, or
+    the stored entry is unreadable — never-established, never "absent". When
+    ``subject_signature`` is supplied and differs from the one the probe
+    recorded, the result is flagged ``stale``: the outcome describes a subject
+    that has since changed, so it is reported but not presented as current.
+    """
+    if not data or identity is None or not capability:
+        return NEVER_ESTABLISHED
+    identities = data.get("identities")
+    if not isinstance(identities, dict):
+        return NEVER_ESTABLISHED
+    entry = identities.get(identity.key)
+    if not isinstance(entry, dict):
+        return NEVER_ESTABLISHED
+    capabilities = entry.get("capabilities")
+    if not isinstance(capabilities, dict):
+        return NEVER_ESTABLISHED
+    record = capabilities.get(capability)
+    if not isinstance(record, dict):
+        return NEVER_ESTABLISHED
+
+    outcome = record.get("outcome")
+    if outcome == OUTCOME_DEMONSTRATED:
+        state = STATE_DEMONSTRATED
+    elif outcome == OUTCOME_ABSENT:
+        state = STATE_DEMONSTRATED_ABSENT
+    else:
+        return NEVER_ESTABLISHED
+
+    recorded_signature = str(record.get("subject_signature") or "")
+    stale = bool(
+        subject_signature and recorded_signature and subject_signature != recorded_signature
+    )
+    return CapabilityLookup(
+        state=state,
+        established_at=(str(record["established_at"]) if record.get("established_at") else None),
+        detail=str(record.get("detail") or ""),
+        probe_role=str(record.get("probe_role") or ""),
+        stale=stale,
+        recorded_signature=recorded_signature,
+    )
+
+
+def is_demonstrated_absent(
+    data: dict[str, Any] | None,
+    identity: CapabilityIdentity | None,
+    capability: str,
+    *,
+    subject_signature: str | None = None,
+) -> bool:
+    """True only when the capability is *currently* demonstrated to be absent.
+
+    The one predicate routing needs. Never-established and stale both answer
+    False: an unprobed identity stays eligible, and a record about a subject
+    that has since changed is not current evidence.
+    """
+    return lookup(
+        data,
+        identity,
+        capability,
+        subject_signature=subject_signature,
+    ).current_absent

--- a/src/theforge/routing_evidence.py
+++ b/src/theforge/routing_evidence.py
@@ -137,3 +137,8 @@ class RoutingEvidence:
     # Per-phase reasoning-effort axis (#1108). Resolved after budget enforcement
     # so it lands on the profiles that actually run; None until then.
     reasoning_effort_block: dict[str, object] | None = None
+    # Candidates ruled out by the durable capability record (#2466), keyed
+    # role → agent name → {capability, established_at, detail, probe_role}. Only
+    # *current demonstrated absence* appears here; never-established and stale
+    # records leave a candidate eligible and therefore unlisted.
+    capability_exclusions: dict[str, dict[str, dict]] = field(default_factory=dict)

--- a/tests/test_capability_routing_seam.py
+++ b/tests/test_capability_routing_seam.py
@@ -31,7 +31,9 @@ from coord_test_helpers import _make_config  # noqa: E402
 from theforge.assignment import (  # noqa: E402
     EXCLUSION_REASONS,
     REASON_CAPABILITY_ABSENT,
+    ROLE_REQUIRED_CAPABILITY,
     AssignmentConfig,
+    NoCapableCandidateError,
     assign_models,
 )
 from theforge.cli import providers as _providers  # noqa: E402
@@ -58,6 +60,7 @@ from theforge.config import (  # noqa: E402
 )
 from theforge.coordinator.state import CoordinatorState  # noqa: E402
 from theforge.model_capabilities import (  # noqa: E402
+    CAPABILITY_PLAIN_STRUCTURED,
     CAPABILITY_TOOL_STRUCTURED,
     OUTCOME_ABSENT,
     OUTCOME_DEMONSTRATED,
@@ -484,6 +487,135 @@ def test_reviewer_pool_exhaustion_fallback_does_not_reseat_an_absent_candidate(_
     # Only the one remaining eligible reviewer is seated — a short panel, not a
     # silently refilled one.
     assert seated == {"sonnet"}
+
+
+def _all_absent_records() -> dict:
+    """Every agent in ``_agents()`` recorded demonstrated-absent."""
+    records = _records()
+    for key in ("anthropic/opus/api", "anthropic/sonnet/api"):
+        records["identities"].update(_records(identity_key=key)["identities"])
+    return records
+
+
+def test_routing_refuses_when_no_candidate_can_serve_a_required_capability(_authed):
+    """The last-resort seat is the failure this record exists to prevent."""
+    with pytest.raises(NoCapableCandidateError) as excinfo:
+        assign_models(
+            _agents(),
+            _cfg(),
+            complexity="HIGH",
+            complexity_score=9,
+            capability_records=_all_absent_records(),
+        )
+
+    error = excinfo.value
+    assert error.capability == CAPABILITY_TOOL_STRUCTURED
+    assert error.role in ROLE_REQUIRED_CAPABILITY
+    assert set(error.excluded) == {"sonnet", "opus", "gpt"}
+    # The refusal carries the evidence: which models, and when each was established.
+    message = str(error)
+    assert CAPABILITY_TOOL_STRUCTURED in message
+    assert "2026-08-15T09:00:00Z" in message
+    for name in ("sonnet", "opus", "gpt"):
+        assert name in message
+    # It is a ValueError, so it joins the module's existing unroutable-pool contract.
+    assert isinstance(error, ValueError)
+
+
+@pytest.mark.parametrize("role", ["planner", "plan_review", "code_review"])
+def test_every_structured_role_refuses_rather_than_seating_an_absent_model(_authed, role):
+    """Each role that requires the capability refuses on its own account — the
+    guard is not a property of whichever role happens to be selected first."""
+    explicit = {
+        other: ModelProfile(
+            name="pinned",
+            provider="anthropic",
+            model="pinned-model",
+            budget_usd=1.0,
+            timeout_seconds=300,
+            allowed_tools=("Read",),
+        )
+        for other in ROLE_REQUIRED_CAPABILITY
+        if other != role
+    }
+
+    with pytest.raises(NoCapableCandidateError) as excinfo:
+        assign_models(
+            _agents(),
+            _cfg(),
+            complexity="HIGH",
+            complexity_score=9,
+            explicit_profiles=explicit,
+            capability_records=_all_absent_records(),
+        )
+
+    assert excinfo.value.role == role
+
+
+def test_all_absent_record_for_an_exempt_role_does_not_refuse(_authed):
+    """dev and preflight require no recorded capability, so a record about them
+    is not an eligibility fact and must not stop the run."""
+    records = _records(capability=CAPABILITY_PLAIN_STRUCTURED)
+    for key in ("anthropic/opus/api", "anthropic/sonnet/api"):
+        records["identities"].update(
+            _records(identity_key=key, capability=CAPABILITY_PLAIN_STRUCTURED)["identities"]
+        )
+
+    decision = assign_models(
+        _agents(), _cfg(), complexity="HIGH", complexity_score=9, capability_records=records
+    )
+
+    assert decision.dev.model
+    assert decision.preflight.model
+
+
+def test_explicit_override_survives_an_otherwise_all_absent_pool(_authed):
+    """An operator pin never reaches candidate selection, so the refusal must
+    not fire for a role the operator already decided."""
+    pinned = ModelProfile(
+        name="pinned",
+        provider="anthropic",
+        model="pinned-model",
+        budget_usd=1.0,
+        timeout_seconds=300,
+        allowed_tools=("Read",),
+    )
+    explicit = dict.fromkeys(ROLE_REQUIRED_CAPABILITY, pinned)
+
+    decision = assign_models(
+        _agents(),
+        _cfg(),
+        complexity="HIGH",
+        complexity_score=9,
+        explicit_profiles=explicit,
+        capability_records=_all_absent_records(),
+    )
+
+    assert decision.planner.model == "pinned-model"
+    assert [p.model for p in decision.code_reviewers] == ["pinned-model"]
+
+
+def test_post_plan_checkpoint_preserves_dev_rather_than_failing(_authed):
+    """The checkpoint is an optional demotion: no capable cheaper candidate
+    preserves the seated dev instead of stopping the run."""
+    from theforge.assignment import apply_post_plan_checkpoint
+
+    cfg = _cfg(plan_tier_reduction=True)
+    decision = assign_models(_agents(), cfg, complexity="MEDIUM", complexity_score=5)
+
+    updated = apply_post_plan_checkpoint(
+        decision,
+        _agents(),
+        cfg,
+        "MEDIUM",
+        plan_review_decision="APPROVE",
+        plan_review_cycles=1,
+        p1_count=0,
+        p2_count=0,
+        capability_records=_all_absent_records(),
+    )
+
+    assert updated.dev.model == decision.dev.model
 
 
 @pytest.mark.filterwarnings("ignore:.*routing cost target.*:UserWarning")

--- a/tests/test_capability_routing_seam.py
+++ b/tests/test_capability_routing_seam.py
@@ -1,0 +1,647 @@
+"""Probe → durable record → routing seam for demonstrated capability (#2466).
+
+Three boundaries, in the order the fact travels:
+
+  1. ``forge check-providers`` turns probe attempts into capability evidence and
+     writes it — and, critically, does *not* invent evidence from a probe that
+     never validated the capability.
+  2. ``assign_models`` consults that record: it declines only a *currently*
+     demonstrated-absent candidate, leaves never-established and stale ones
+     eligible, and says so in the routing_decision rather than at a later gate.
+  3. The coordinator loads the record at both assignment boundaries and forwards
+     it — in static mode as well as adaptive, because a demonstrated absence is
+     an eligibility fact, not a learning signal.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from coord_test_helpers import _make_config  # noqa: E402
+
+from theforge.assignment import (  # noqa: E402
+    EXCLUSION_REASONS,
+    REASON_CAPABILITY_ABSENT,
+    AssignmentConfig,
+    assign_models,
+)
+from theforge.cli import providers as _providers  # noqa: E402
+from theforge.cli.provider_readiness import (  # noqa: E402
+    READINESS_STATUS_FAILED,
+    READINESS_STATUS_READY,
+    READINESS_STATUS_UNVERIFIED,
+    ReadinessProbe,
+    build_readiness_probes,
+    capability_observations,
+    run_readiness_probe,
+)
+from theforge.config import (  # noqa: E402
+    DEFAULT_VALIDATION,
+    AgentDef,
+    ForgeConfig,
+    LogConfig,
+    ModelProfile,
+    PlanAgentReviewConfig,
+    PlanConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+    transport_for,
+)
+from theforge.coordinator.state import CoordinatorState  # noqa: E402
+from theforge.model_capabilities import (  # noqa: E402
+    CAPABILITY_TOOL_STRUCTURED,
+    OUTCOME_ABSENT,
+    OUTCOME_DEMONSTRATED,
+    capabilities_path,
+    load_capabilities,
+)
+from theforge.runners import AgentResult  # noqa: E402
+
+# ── Fixtures / builders ───────────────────────────────────────────────
+
+
+@pytest.fixture()
+def _authed(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+
+def _cfg(**kwargs) -> AssignmentConfig:
+    defaults = dict(
+        enabled=True,
+        min_reviewers=1,
+        max_reviewers=2,
+        prefer_cross_provider=True,
+        max_cost_per_story_usd=100.0,
+        escalation_memory=True,
+    )
+    defaults.update(kwargs)
+    return AssignmentConfig(**defaults)
+
+
+def _agents() -> list[AgentDef]:
+    return [
+        AgentDef(
+            name="sonnet",
+            provider="anthropic",
+            model="sonnet",
+            budget_usd=3.0,
+            timeout_seconds=600,
+            tier="mid",
+        ),
+        AgentDef(
+            name="opus",
+            provider="anthropic",
+            model="opus",
+            budget_usd=5.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+        AgentDef(
+            name="gpt",
+            provider="openai",
+            model="gpt-5.4",
+            budget_usd=8.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+    ]
+
+
+def _records(
+    *,
+    outcome: str = OUTCOME_ABSENT,
+    identity_key: str = "openai/gpt-5.4/api",
+    signature: str = "",
+    capability: str = CAPABILITY_TOOL_STRUCTURED,
+) -> dict:
+    provider, model, transport = identity_key.split("/")
+    return {
+        "version": 1,
+        "identities": {
+            identity_key: {
+                "provider": provider,
+                "model": model,
+                "transport": transport,
+                "capabilities": {
+                    capability: {
+                        "outcome": outcome,
+                        "established_at": "2026-08-15T09:00:00Z",
+                        "subject_signature": signature,
+                        "detail": "no valid verdict in structured output",
+                        "probe_role": "agent-code-review",
+                    }
+                },
+            }
+        },
+    }
+
+
+def _api_profile(name, *, provider="openai", model="gpt-5.4", tools=("Read", "Grep"), phase=None):
+    return ModelProfile(
+        name=name,
+        provider=provider,
+        model=model,
+        budget_usd=1.0,
+        timeout_seconds=120,
+        allowed_tools=tools,
+        phase=phase,
+    )
+
+
+def _probe_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="feat/{slug}",
+        ),
+        validation=DEFAULT_VALIDATION,
+        dev_profile=ModelProfile(
+            name="dev",
+            cli="claude",
+            model="sonnet",
+            budget_usd=2.0,
+            timeout_seconds=300,
+            allowed_tools=("Read",),
+        ),
+        preflight_profile=_api_profile("preflight", phase="preflight"),
+        review_pool=[_api_profile("reviewer", phase="review")],
+        synthesis_profile=None,
+        retry=RetryPolicy(),
+        plan=PlanConfig.of(
+            enabled=True,
+            cli=None,
+            provider="openai",
+            model="gpt-5.4",
+            budget_usd=0.5,
+            timeout=300,
+            transport=transport_for("openai", "api"),
+        ),
+        plan_agent_review=PlanAgentReviewConfig(
+            enabled=True, pool=[_api_profile("plan-reviewer", phase="plan_review")]
+        ),
+        log=LogConfig(enabled=False),
+    )
+
+
+def _result(*, success=True, structured=True, cost_usd=0.003, transport_used=None):
+    return AgentResult(
+        success=success,
+        output='{"verdict":"APPROVE","summary":"ok"}' if structured else "prose, no verdict",
+        session_id=None,
+        cost_usd=cost_usd,
+        exit_code=0,
+        raw={},
+        profile_name="probe",
+        structured_data={"verdict": "APPROVE", "summary": "ok"} if structured else None,
+        transport_used=transport_used,
+    )
+
+
+def _probe(config: ForgeConfig, role: str) -> ReadinessProbe:
+    return next(probe for probe in build_readiness_probes(config) if probe.role == role)
+
+
+# ── 1. Probe → evidence ───────────────────────────────────────────────
+
+
+def test_structured_success_establishes_the_capability(tmp_path):
+    probe = _probe(_probe_config(tmp_path), "review")
+
+    with (
+        patch("theforge.cli.provider_readiness.run_api_agent", return_value=_result()),
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_result(transport_used="cli"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    assert result.status == READINESS_STATUS_READY
+    observations = capability_observations([result])
+    by_transport = {obs.identity.transport: obs for obs in observations}
+    # Both transports were exercised, and each is evidence for its OWN identity.
+    assert set(by_transport) == {"api", "cli"}
+    assert {obs.outcome for obs in observations} == {OUTCOME_DEMONSTRATED}
+    assert by_transport["api"].capability == CAPABILITY_TOOL_STRUCTURED
+    assert by_transport["api"].identity.key == "openai/gpt-5.4/api"
+
+
+def test_unstructured_phase_ready_establishes_nothing(tmp_path):
+    """A preflight probe accepts prose by design — its READY is not evidence."""
+    probe = _probe(_probe_config(tmp_path), "preflight")
+
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            return_value=_result(structured=False),
+        ),
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_result(structured=False, transport_used="cli"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    assert result.status == READINESS_STATUS_READY
+    assert capability_observations([result]) == []
+
+
+def test_failed_structured_output_establishes_absence(tmp_path):
+    probe = _probe(_probe_config(tmp_path), "review")
+
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            return_value=_result(structured=False),
+        ),
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_result(structured=False, transport_used="cli"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    assert result.status == READINESS_STATUS_FAILED
+    assert {obs.outcome for obs in capability_observations([result])} == {OUTCOME_ABSENT}
+
+
+def test_cli_cost_unavailable_still_establishes_the_capability(tmp_path):
+    """Overall status is degraded for a cost reason that says nothing about the
+    capability the probe just validated."""
+    config = _probe_config(tmp_path)
+    config = replace(config, review_pool=[_api_profile("reviewer", phase="review")])
+    probe = _probe(config, "review")
+
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            return_value=_result(cost_usd=None),
+        ),
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_result(cost_usd=None, transport_used="cli"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    cli_attempt = next(a for a in result.attempts if a.attempted_transport_kind == "cli")
+    assert cli_attempt.status == READINESS_STATUS_UNVERIFIED
+    cli_obs = [obs for obs in capability_observations([result]) if obs.identity.transport == "cli"]
+    assert [obs.outcome for obs in cli_obs] == [OUTCOME_DEMONSTRATED]
+
+
+def test_check_providers_writes_the_record(tmp_path, capsys):
+    config = _probe_config(tmp_path)
+    probe = _probe(config, "review")
+
+    with (
+        patch("theforge.cli.provider_readiness.run_api_agent", return_value=_result()),
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_result(transport_used="cli"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        result = run_readiness_probe(probe, secrets={})
+
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project: test\n", encoding="utf-8")
+    with (
+        patch.object(_providers, "load_config", return_value=config),
+        patch.object(_providers, "build_readiness_probes", return_value=[probe]),
+        patch.object(_providers, "run_readiness_probe", return_value=result),
+    ):
+        _providers.cmd_check_providers(
+            SimpleNamespace(config=str(forge_yaml), profile=None, declared_only=False)
+        )
+
+    path = capabilities_path(tmp_path)
+    assert path.exists(), "check-providers must persist what it demonstrated"
+    stored = yaml.safe_load(path.read_text(encoding="utf-8"))
+    entry = stored["identities"]["openai/gpt-5.4/api"]["capabilities"][CAPABILITY_TOOL_STRUCTURED]
+    assert entry["outcome"] == OUTCOME_DEMONSTRATED
+    assert entry["established_at"], "when it was established must be recorded"
+    assert "model_capabilities.yaml" in capsys.readouterr().out
+
+
+def test_check_providers_writes_nothing_when_no_capability_was_established(tmp_path):
+    """A run of probes that validated nothing leaves the record untouched."""
+    config = _probe_config(tmp_path)
+    probe = _probe(config, "preflight")
+    with (
+        patch(
+            "theforge.cli.provider_readiness.run_api_agent",
+            return_value=_result(structured=False),
+        ),
+        patch(
+            "theforge.cli.provider_readiness.run_agent",
+            return_value=_result(structured=False, transport_used="cli"),
+        ),
+        patch("theforge.cli.provider_readiness.check_agent_auth", return_value=(True, "")),
+    ):
+        empty = run_readiness_probe(probe, secrets={})
+
+    forge_yaml = tmp_path / "forge.yaml"
+    forge_yaml.write_text("project: test\n", encoding="utf-8")
+    with (
+        patch.object(_providers, "load_config", return_value=config),
+        patch.object(_providers, "build_readiness_probes", return_value=[probe]),
+        patch.object(_providers, "run_readiness_probe", return_value=empty),
+    ):
+        _providers.cmd_check_providers(
+            SimpleNamespace(config=str(forge_yaml), profile=None, declared_only=False)
+        )
+
+    assert not capabilities_path(tmp_path).exists()
+
+
+# ── 2. Record → routing ───────────────────────────────────────────────
+
+
+def test_demonstrated_absent_candidate_is_not_seated(_authed):
+    baseline = assign_models(_agents(), _cfg(), complexity="HIGH", complexity_score=9)
+    assert "gpt-5.4" in [p.model for p in baseline.code_reviewers] + [baseline.planner.model]
+
+    decision = assign_models(
+        _agents(),
+        _cfg(),
+        complexity="HIGH",
+        complexity_score=9,
+        capability_records=_records(),
+    )
+
+    assert "gpt-5.4" not in [p.model for p in decision.code_reviewers]
+    assert "gpt-5.4" not in [p.model for p in decision.plan_reviewers]
+    assert decision.planner.model != "gpt-5.4"
+
+
+def test_never_established_candidate_stays_eligible(_authed):
+    """The record must not narrow the pool to whatever has been probed."""
+    with_record = assign_models(
+        _agents(),
+        _cfg(),
+        complexity="HIGH",
+        complexity_score=9,
+        # A record about a model that is not in the pool at all.
+        capability_records=_records(identity_key="openai/some-other-model/api"),
+    )
+    without_record = assign_models(_agents(), _cfg(), complexity="HIGH", complexity_score=9)
+
+    assert [p.model for p in with_record.code_reviewers] == [
+        p.model for p in without_record.code_reviewers
+    ]
+    assert with_record.planner.model == without_record.planner.model
+
+
+def test_stale_record_does_not_exclude(_authed):
+    """The recorded outcome predates a change to the identity it describes."""
+    stale = assign_models(
+        _agents(),
+        _cfg(),
+        complexity="HIGH",
+        complexity_score=9,
+        capability_records=_records(signature="a-signature-from-a-different-subject"),
+    )
+    baseline = assign_models(_agents(), _cfg(), complexity="HIGH", complexity_score=9)
+
+    assert [p.model for p in stale.code_reviewers] == [p.model for p in baseline.code_reviewers]
+
+
+def test_demonstrated_capability_does_not_exclude(_authed):
+    demonstrated = assign_models(
+        _agents(),
+        _cfg(),
+        complexity="HIGH",
+        complexity_score=9,
+        capability_records=_records(outcome=OUTCOME_DEMONSTRATED),
+    )
+    baseline = assign_models(_agents(), _cfg(), complexity="HIGH", complexity_score=9)
+
+    assert [p.model for p in demonstrated.code_reviewers] == [
+        p.model for p in baseline.code_reviewers
+    ]
+
+
+def test_routing_decision_reports_the_reason_with_the_decision(_authed):
+    decision = assign_models(
+        _agents(),
+        _cfg(),
+        complexity="HIGH",
+        complexity_score=9,
+        capability_records=_records(),
+    )
+    block = decision.routing_decision
+
+    for role in ("planner", "plan_review", "code_review"):
+        entry = next(e for e in block[role]["candidate_pool"] if e["name"] == "gpt")
+        assert entry["included"] is False
+        assert entry["reason"] == REASON_CAPABILITY_ABSENT
+        assert entry["reason"] in EXCLUSION_REASONS
+        assert entry["detail"]["capability"] == CAPABILITY_TOOL_STRUCTURED
+        assert entry["detail"]["established_at"] == "2026-08-15T09:00:00Z"
+
+    # And the operator-facing rationale names it too, with the decision.
+    assert "demonstrated absent" in decision.rationale["code_review"]
+
+
+def test_reviewer_pool_exhaustion_fallback_does_not_reseat_an_absent_candidate(_authed):
+    """The widening fallbacks (self-exclusion, unauthed) must not reach past the
+    capability filter to refill a short panel."""
+    agents = _agents()
+    records = _records()
+    records["identities"].update(_records(identity_key="anthropic/opus/api")["identities"])
+
+    decision = assign_models(
+        agents,
+        _cfg(min_reviewers=3, max_reviewers=3),
+        complexity="HIGH",
+        complexity_score=9,
+        capability_records=records,
+    )
+
+    seated = {p.model for p in decision.code_reviewers}
+    seated |= {p.model for p in decision.plan_reviewers}
+    assert "gpt-5.4" not in seated
+    assert "opus" not in seated
+    # Only the one remaining eligible reviewer is seated — a short panel, not a
+    # silently refilled one.
+    assert seated == {"sonnet"}
+
+
+@pytest.mark.filterwarnings("ignore:.*routing cost target.*:UserWarning")
+def test_cost_downgrade_does_not_seat_an_absent_candidate(_authed):
+    """A budget downgrade is a routing decision and honors the same filter."""
+    agents = [
+        AgentDef(
+            name="cheap-absent",
+            provider="openai",
+            model="gpt-mini",
+            budget_usd=0.5,
+            timeout_seconds=300,
+            tier="cheap",
+        ),
+        AgentDef(
+            name="cheap-ok",
+            provider="anthropic",
+            model="haiku",
+            budget_usd=1.0,
+            timeout_seconds=300,
+            tier="cheap",
+        ),
+        AgentDef(
+            name="mid",
+            provider="anthropic",
+            model="sonnet",
+            budget_usd=6.0,
+            timeout_seconds=600,
+            tier="mid",
+        ),
+        AgentDef(
+            name="strong",
+            provider="anthropic",
+            model="opus",
+            budget_usd=20.0,
+            timeout_seconds=900,
+            tier="strong",
+        ),
+    ]
+    cfg = _cfg(max_cost_per_story_usd=3.0, min_reviewers=1, max_reviewers=1)
+
+    baseline = assign_models(agents, cfg, complexity="MEDIUM", complexity_score=5)
+    # Without the record the cheapest candidate the enforcer reaches for IS the
+    # one that cannot do the job — so this test would pass vacuously otherwise.
+    assert baseline.planner.model == "gpt-mini"
+
+    decision = assign_models(
+        agents,
+        cfg,
+        complexity="MEDIUM",
+        complexity_score=5,
+        capability_records=_records(identity_key="openai/gpt-mini/api"),
+    )
+
+    assert decision.budget_audit["downgraded"] is True
+    assert "gpt-mini" not in {step["to_model"] for step in decision.budget_audit["steps"]}
+    assert decision.planner.model == "haiku"
+    assert "gpt-mini" not in [p.model for p in decision.code_reviewers]
+    assert "gpt-mini" not in [p.model for p in decision.plan_reviewers]
+
+
+def test_explicit_override_is_honored_but_flagged(_authed):
+    """Operator intent wins — the rationale must not read as unremarkable."""
+    explicit = ModelProfile(
+        name="gpt",
+        provider="openai",
+        model="gpt-5.4",
+        budget_usd=8.0,
+        timeout_seconds=900,
+        allowed_tools=("Read",),
+    )
+
+    decision = assign_models(
+        _agents(),
+        _cfg(),
+        complexity="HIGH",
+        complexity_score=9,
+        explicit_profiles={"code_review": explicit},
+        capability_records=_records(),
+    )
+
+    assert [p.model for p in decision.code_reviewers] == ["gpt-5.4"]
+    assert "demonstrated absent" in decision.rationale["code_review"]
+
+
+# ── 3. Coordinator boundaries ─────────────────────────────────────────
+
+
+def _pool_config(tmp_path, *, adaptive: bool):
+    return replace(
+        _make_config(tmp_path),
+        agents=_agents(),
+        assignment=_cfg(adaptive_enabled=adaptive, max_cost_per_story_usd=100.0),
+        # Default (unpinned) role config, so the router selects rather than
+        # honoring an explicit override.
+        review_pool_is_default=True,
+        plan_model_is_default=True,
+    )
+
+
+@pytest.mark.parametrize("adaptive", [True, False])
+def test_preflight_forwards_capability_records_to_assign_models(
+    tmp_path, monkeypatch, _authed, adaptive
+):
+    """Loaded outside the adaptive guard: a demonstrated absence is an
+    eligibility fact, so static routing consults it too."""
+    from theforge.coordinator import preflight as _pf
+
+    config = _pool_config(tmp_path, adaptive=adaptive)
+    path = capabilities_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(_records()), encoding="utf-8")
+
+    state = CoordinatorState()
+    state.preflight_complexity = "medium"
+    state.preflight_complexity_score = 5
+
+    captured: dict = {}
+    real_assign = assign_models
+
+    def _spy(*args, **kwargs):
+        captured["capability_records"] = kwargs.get("capability_records")
+        return real_assign(*args, **kwargs)
+
+    monkeypatch.setattr("theforge.assignment.assign_models", _spy)
+    _pf._apply_preflight_config(config, state)
+
+    assert captured["capability_records"] == load_capabilities(path)
+    pool = state.routing_decision["code_review"]["candidate_pool"]
+    assert next(e for e in pool if e["name"] == "gpt")["reason"] == REASON_CAPABILITY_ABSENT
+
+
+@pytest.mark.parametrize("adaptive", [True, False])
+def test_post_plan_checkpoint_receives_capability_records(
+    tmp_path, monkeypatch, _authed, adaptive
+):
+    from theforge.coordinator import plan_flow as _pf
+
+    config = _pool_config(tmp_path, adaptive=adaptive)
+    path = capabilities_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(_records()), encoding="utf-8")
+
+    state = CoordinatorState()
+    state.preflight_complexity = "MEDIUM"
+    state.preflight_complexity_score = 5
+    state._adaptive_decision = assign_models(
+        _agents(), config.assignment, complexity="MEDIUM", complexity_score=5
+    )
+    state.plan_attempt_metadata = [{"p1_count": 0, "p2_count": 0}]
+
+    captured: dict = {}
+
+    def _spy(*args, **kwargs):
+        captured["capability_records"] = kwargs.get("capability_records")
+        return args[0]
+
+    monkeypatch.setattr("theforge.assignment.apply_post_plan_checkpoint", _spy)
+    _pf._apply_post_plan_dev_checkpoint(state, config, plan_review_decision="APPROVE")
+
+    assert captured["capability_records"] == load_capabilities(path)

--- a/tests/test_model_capabilities.py
+++ b/tests/test_model_capabilities.py
@@ -1,0 +1,292 @@
+"""Durable capability-record storage semantics (#2466).
+
+Covers the store in isolation: load/save defaults, identity+capability keying,
+established_at persistence, the three lookup states, staleness on a changed
+probe subject, and the deterministic merge when one run produces several
+observations for the same identity+capability.
+"""
+
+from __future__ import annotations
+
+from theforge.config import AgentDef, ModelProfile, transport_for
+from theforge.model_capabilities import (
+    CAPABILITY_PLAIN_STRUCTURED,
+    CAPABILITY_TOOL_STRUCTURED,
+    OUTCOME_ABSENT,
+    OUTCOME_DEMONSTRATED,
+    STATE_DEMONSTRATED,
+    STATE_DEMONSTRATED_ABSENT,
+    STATE_NEVER_ESTABLISHED,
+    CapabilityObservation,
+    capabilities_path,
+    identity_for_agent,
+    identity_for_profile,
+    is_demonstrated_absent,
+    load_capabilities,
+    lookup,
+    make_identity,
+    record_observations,
+    save_capabilities,
+    signature_for_agent,
+    signature_for_profile,
+)
+
+
+def _identity(provider="openai", model="gpt-5.4", transport="api"):
+    return make_identity(provider, model, transport)
+
+
+def _observation(
+    *,
+    outcome=OUTCOME_ABSENT,
+    capability=CAPABILITY_TOOL_STRUCTURED,
+    identity=None,
+    signature="sig-1",
+    detail="no valid verdict in structured output",
+    probe_role="review",
+):
+    return CapabilityObservation(
+        identity=identity or _identity(),
+        capability=capability,
+        outcome=outcome,
+        subject_signature=signature,
+        detail=detail,
+        probe_role=probe_role,
+    )
+
+
+# ── Load / save ───────────────────────────────────────────────────────
+
+
+def test_load_returns_empty_record_when_file_absent(tmp_path):
+    data = load_capabilities(capabilities_path(tmp_path))
+    assert data["identities"] == {}
+
+
+def test_load_returns_empty_record_when_file_is_malformed(tmp_path):
+    path = capabilities_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not: a: valid: mapping: [", encoding="utf-8")
+
+    # A broken record means nothing has been established — never "everything is
+    # absent", which would silently empty the routing pool.
+    assert load_capabilities(path)["identities"] == {}
+
+
+def test_save_then_load_round_trips(tmp_path):
+    path = capabilities_path(tmp_path)
+    data = record_observations({"identities": {}}, [_observation()])
+    save_capabilities(path, data)
+
+    reloaded = load_capabilities(path)
+    assert reloaded["identities"] == data["identities"]
+
+
+# ── Keying and timestamps ─────────────────────────────────────────────
+
+
+def test_record_is_keyed_by_identity_and_capability(tmp_path):
+    data = record_observations(
+        {"identities": {}},
+        [
+            _observation(capability=CAPABILITY_TOOL_STRUCTURED, outcome=OUTCOME_ABSENT),
+            _observation(capability=CAPABILITY_PLAIN_STRUCTURED, outcome=OUTCOME_DEMONSTRATED),
+            _observation(
+                identity=_identity(transport="cli"),
+                capability=CAPABILITY_TOOL_STRUCTURED,
+                outcome=OUTCOME_DEMONSTRATED,
+            ),
+        ],
+    )
+
+    assert set(data["identities"]) == {"openai/gpt-5.4/api", "openai/gpt-5.4/cli"}
+    api_caps = data["identities"]["openai/gpt-5.4/api"]["capabilities"]
+    assert api_caps[CAPABILITY_TOOL_STRUCTURED]["outcome"] == OUTCOME_ABSENT
+    assert api_caps[CAPABILITY_PLAIN_STRUCTURED]["outcome"] == OUTCOME_DEMONSTRATED
+    # Transport is part of the identity: the CLI half is a separate fact.
+    cli_caps = data["identities"]["openai/gpt-5.4/cli"]["capabilities"]
+    assert cli_caps[CAPABILITY_TOOL_STRUCTURED]["outcome"] == OUTCOME_DEMONSTRATED
+
+
+def test_established_at_is_recorded_and_readable(tmp_path):
+    data = record_observations(
+        {"identities": {}}, [_observation()], established_at="2026-08-15T09:00:00Z"
+    )
+
+    result = lookup(data, _identity(), CAPABILITY_TOOL_STRUCTURED)
+    assert result.established_at == "2026-08-15T09:00:00Z"
+    assert result.detail == "no valid verdict in structured output"
+    assert result.probe_role == "review"
+
+
+def test_reprobe_updates_the_same_record(tmp_path):
+    data = record_observations(
+        {"identities": {}},
+        [_observation(outcome=OUTCOME_ABSENT)],
+        established_at="2026-08-01T00:00:00Z",
+    )
+    data = record_observations(
+        data,
+        [_observation(outcome=OUTCOME_DEMONSTRATED, signature="sig-2", detail="0.4s $0.001")],
+        established_at="2026-08-15T00:00:00Z",
+    )
+
+    result = lookup(data, _identity(), CAPABILITY_TOOL_STRUCTURED)
+    assert result.state == STATE_DEMONSTRATED
+    assert result.established_at == "2026-08-15T00:00:00Z"
+
+
+# ── Three states ──────────────────────────────────────────────────────
+
+
+def test_lookup_reports_demonstrated():
+    data = record_observations({"identities": {}}, [_observation(outcome=OUTCOME_DEMONSTRATED)])
+
+    assert lookup(data, _identity(), CAPABILITY_TOOL_STRUCTURED).state == STATE_DEMONSTRATED
+    assert is_demonstrated_absent(data, _identity(), CAPABILITY_TOOL_STRUCTURED) is False
+
+
+def test_lookup_reports_demonstrated_absent():
+    data = record_observations({"identities": {}}, [_observation(outcome=OUTCOME_ABSENT)])
+
+    assert lookup(data, _identity(), CAPABILITY_TOOL_STRUCTURED).state == STATE_DEMONSTRATED_ABSENT
+    assert is_demonstrated_absent(data, _identity(), CAPABILITY_TOOL_STRUCTURED) is True
+
+
+def test_never_established_is_not_absent():
+    data = record_observations({"identities": {}}, [_observation(outcome=OUTCOME_ABSENT)])
+
+    # A different identity, and a different capability of the same identity, are
+    # both never-established — not absent.
+    other = lookup(data, _identity(model="other"), CAPABILITY_TOOL_STRUCTURED)
+    assert other.state == STATE_NEVER_ESTABLISHED
+    assert is_demonstrated_absent(data, _identity(model="other"), CAPABILITY_TOOL_STRUCTURED) is (
+        False
+    )
+
+    plain = lookup(data, _identity(), CAPABILITY_PLAIN_STRUCTURED)
+    assert plain.state == STATE_NEVER_ESTABLISHED
+
+
+def test_empty_record_reports_never_established():
+    assert lookup({}, _identity(), CAPABILITY_TOOL_STRUCTURED).state == STATE_NEVER_ESTABLISHED
+    assert lookup(None, _identity(), CAPABILITY_TOOL_STRUCTURED).state == STATE_NEVER_ESTABLISHED
+    assert lookup({"identities": {}}, None, CAPABILITY_TOOL_STRUCTURED).state == (
+        STATE_NEVER_ESTABLISHED
+    )
+
+
+# ── Staleness ─────────────────────────────────────────────────────────
+
+
+def test_changed_probe_subject_reports_stale_and_does_not_exclude():
+    data = record_observations(
+        {"identities": {}}, [_observation(outcome=OUTCOME_ABSENT, signature="sig-old")]
+    )
+
+    result = lookup(data, _identity(), CAPABILITY_TOOL_STRUCTURED, subject_signature="sig-new")
+    assert result.stale is True
+    assert result.state == STATE_DEMONSTRATED_ABSENT  # still reported…
+    assert result.current_absent is False  # …but not presented as current
+    assert (
+        is_demonstrated_absent(
+            data, _identity(), CAPABILITY_TOOL_STRUCTURED, subject_signature="sig-new"
+        )
+        is False
+    )
+
+
+def test_matching_probe_subject_is_not_stale():
+    data = record_observations({"identities": {}}, [_observation(signature="sig-1")])
+
+    result = lookup(data, _identity(), CAPABILITY_TOOL_STRUCTURED, subject_signature="sig-1")
+    assert result.stale is False
+    assert result.current_absent is True
+
+
+# ── Merge determinism ─────────────────────────────────────────────────
+
+
+def test_absent_wins_over_demonstrated_within_one_batch():
+    """Several role probes hit one identity+capability; the merge is order-free."""
+    demonstrated = _observation(outcome=OUTCOME_DEMONSTRATED, probe_role="agent-plan-review")
+    absent = _observation(outcome=OUTCOME_ABSENT, probe_role="agent-code-review")
+
+    for batch in ([demonstrated, absent], [absent, demonstrated]):
+        data = record_observations({"identities": {}}, batch)
+        result = lookup(data, _identity(), CAPABILITY_TOOL_STRUCTURED)
+        assert result.state == STATE_DEMONSTRATED_ABSENT
+        assert result.probe_role == "agent-code-review"
+
+
+def test_observations_without_a_recognised_outcome_are_ignored():
+    data = record_observations(
+        {"identities": {}},
+        [CapabilityObservation(_identity(), CAPABILITY_TOOL_STRUCTURED, "maybe", "sig")],
+    )
+    assert data["identities"] == {}
+
+
+# ── Identity adapters ─────────────────────────────────────────────────
+
+
+def test_identity_and_signature_agree_between_profile_and_agent():
+    """The probe writes from a ModelProfile; the router reads from an AgentDef."""
+    agent = AgentDef(
+        name="gpt",
+        provider="openai",
+        model="gpt-5.4",
+        budget_usd=8.0,
+        timeout_seconds=900,
+        tier="strong",
+        transport=transport_for("openai", "api"),
+    )
+    profile = ModelProfile(
+        name="gpt",
+        provider="openai",
+        transport=transport_for("openai", "api"),
+        model="gpt-5.4",
+        budget_usd=8.0,
+        timeout_seconds=900,
+        allowed_tools=("Read",),
+    )
+
+    assert identity_for_agent(agent) == identity_for_profile(profile)
+    assert identity_for_agent(agent).key == "openai/gpt-5.4/api"
+    assert signature_for_agent(agent) == signature_for_profile(profile)
+
+
+def test_cli_agent_identity_uses_effective_provider():
+    agent = AgentDef(
+        name="claude",
+        provider=None,
+        cli="claude",
+        model="sonnet",
+        budget_usd=3.0,
+        timeout_seconds=600,
+        tier="mid",
+    )
+
+    assert identity_for_agent(agent).key == "anthropic/sonnet/cli"
+
+
+def test_identity_is_none_when_provider_or_model_is_unknown():
+    assert make_identity(None, "gpt-5.4", "api") is None
+    assert make_identity("openai", "", "api") is None
+
+
+def test_repointed_endpoint_changes_the_signature_but_not_the_identity():
+    base = AgentDef(
+        name="local",
+        provider="openai",
+        model="qwen",
+        budget_usd=0.0,
+        timeout_seconds=600,
+        tier="cheap",
+        transport=transport_for("openai", "api"),
+        base_url="http://localhost:1234/v1",
+    )
+    moved = AgentDef(**{**base.__dict__, "base_url": "http://localhost:9999/v1"})
+
+    assert identity_for_agent(base) == identity_for_agent(moved)
+    assert signature_for_agent(base) != signature_for_agent(moved)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The prior all-candidates-demonstrated-absent fallback is fixed, the focused capability-routing tests pass, and I found no P1 regressions. | [google-gemini-3.5-flash-api] The implementation persists and consults demonstrated capabilities at dispatch correctly, resolving the Cycle 1 finding by refusing to seat any candidate when all are demonstrated absent. | [anthropic-claude-haiku-4-5-cli] Cycle 1 P1 is resolved: _capability_pool now returns empty pools as-is, and assign_models raises NoCapableCandidateError before any selection runs when every candidate is demonstrated-absent for a required capability. Explicitly pinned roles remain exempt. Test coverage includes per-role refusal attribution, exempt-role and explicit-pin cases, and the post-plan preservation path. No regressions detected.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $24.73
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Whether a model has demonstrated a capability is established only by an operator-invoked probe that persists nothing, so routing cannot consult it and must assume capability at dispatch (GitHub Issue #2466)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2466