### PR TITLE
Deterministic knowledge index for run summaries

### DIFF
--- a/docs/plans/knowledge-capture.md
+++ b/docs/plans/knowledge-capture.md
@@ -337,11 +337,24 @@ entries:
     summary_path: ".forge/knowledge/summaries/20260410-143022-api-retry.yaml"
 ```
 
+The shipped contract is:
+
+- Path: `.forge/knowledge/index.yaml`
+- Source of truth: only persisted summary artifacts under
+  `.forge/knowledge/summaries/*.yaml`
+- Rebuild behavior: deterministic stable sort by `generated_at` (with nulls
+  sorted first), then `run_id`, then summary path
+- Data boundary: the index copies persisted lookup fields only (`run_id`,
+  `generated_at`, `story`, `story_shape`, `domains`, `changed_files`,
+  `learned_patterns`, `summary_path`) and remains a materialized view rather
+  than an authority over summaries or audits
+- Malformed summaries: invalid YAML, non-mapping roots, mismatched `run_id`,
+  missing required mappings, or non-list lookup fields are skipped with visible
+  diagnostics during rebuild rather than partially indexed
+
 The index is **rebuilt deterministically from summaries** — no LLM in the
-loop. Simple keyword extraction from `what_changed.description`,
-file paths from `files_modified`, and domain from preflight classification
-(already captured in audit). The index is a materialized view, not a source
-of truth. It can be deleted and rebuilt at any time from the summary files.
+loop and no audit reads. It can be deleted and rebuilt at any time from the
+summary files.
 
 #### 3b. Context assembly integration
 

--- a/src/theforge/cli/index.py
+++ b/src/theforge/cli/index.py
@@ -1,4 +1,4 @@
-"""forge index subcommand — generate a structural module index."""
+"""forge index subcommand — generate structural or knowledge indexes."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from theforge.cli.shared import _find_config
 from theforge.indexer import INDEX_PATH, generate_index
+from theforge.knowledge_index import rebuild_knowledge_index
 
 
 def cmd_index(args: argparse.Namespace) -> int:
@@ -21,6 +22,13 @@ def cmd_index(args: argparse.Namespace) -> int:
         return 1
 
     project_root = config_path.parent
+    if getattr(args, "knowledge", False):
+        result = rebuild_knowledge_index(project_root)
+        for diagnostic in result.diagnostics:
+            print(f"Skipped {diagnostic.path}: {diagnostic.reason}", file=sys.stderr)
+        print(str(result.path))
+        return 0
+
     generate_index(project_root)
     print(str(project_root / INDEX_PATH))
     return 0
@@ -29,3 +37,8 @@ def cmd_index(args: argparse.Namespace) -> int:
 def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     parser = subparsers.add_parser("index", help="Generate .forge/index/modules.yaml")
     parser.add_argument("--config", help="Path to forge.yaml (default: auto-detect)")
+    parser.add_argument(
+        "--knowledge",
+        action="store_true",
+        help="Rebuild .forge/knowledge/index.yaml from persisted summaries",
+    )

--- a/src/theforge/knowledge_index.py
+++ b/src/theforge/knowledge_index.py
@@ -123,6 +123,11 @@ def rebuild_knowledge_index(project_root: Path) -> KnowledgeIndexBuildResult:
         rel_path = str(path.relative_to(project_root))
         try:
             summary = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError) as exc:
+            diagnostics.append(
+                KnowledgeIndexDiagnostic(path=rel_path, reason=f"unreadable summary: {exc}")
+            )
+            continue
         except yaml.YAMLError as exc:
             diagnostics.append(
                 KnowledgeIndexDiagnostic(path=rel_path, reason=f"invalid YAML: {exc}")

--- a/src/theforge/knowledge_index.py
+++ b/src/theforge/knowledge_index.py
@@ -1,0 +1,158 @@
+"""Deterministic index over persisted run summaries.
+
+This module builds Layer 3a from Layer 2 artifacts only: a disposable,
+rebuildable materialized view over ``.forge/knowledge/summaries/*.yaml``.
+It never reads audits and never calls a model. If a consumer needs an
+authoritative fact, it must follow the summary's backlink to the run record.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from theforge.knowledge_summary import SUMMARIES_DIR
+
+KNOWLEDGE_INDEX_PATH = Path(".forge") / "knowledge" / "index.yaml"
+KNOWLEDGE_INDEX_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class KnowledgeIndexDiagnostic:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class KnowledgeIndexBuildResult:
+    path: Path
+    payload: dict[str, object]
+    diagnostics: tuple[KnowledgeIndexDiagnostic, ...]
+
+
+def _summary_sort_key(entry: dict[str, object]) -> tuple[str, str, str]:
+    return (
+        str(entry.get("generated_at") or ""),
+        str(entry.get("run_id") or ""),
+        str(entry.get("summary_path") or ""),
+    )
+
+
+def _expect_mapping(data: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return data
+
+
+def _expect_list(data: Any, *, label: str) -> list[Any]:
+    if not isinstance(data, list):
+        raise ValueError(f"{label} must be a list")
+    return data
+
+
+def _validate_summary(summary: Any, *, expected_run_id: str) -> dict[str, Any]:
+    data = _expect_mapping(summary, label="summary root")
+
+    run_id = data.get("run_id")
+    if not isinstance(run_id, str) or not run_id.strip():
+        raise ValueError("run_id must be a non-empty string")
+    if run_id != expected_run_id:
+        raise ValueError(f"run_id {run_id!r} does not match summary filename {expected_run_id!r}")
+
+    if "generated_at" not in data:
+        raise ValueError("generated_at is required")
+    generated_at = data.get("generated_at")
+    if generated_at is not None and not isinstance(generated_at, str):
+        raise ValueError("generated_at must be a string or null")
+
+    story = _expect_mapping(data.get("story"), label="story")
+    story_shape = _expect_mapping(data.get("story_shape"), label="story_shape")
+    domains = _expect_list(data.get("domains"), label="domains")
+    changed_files = _expect_list(data.get("changed_files"), label="changed_files")
+    learned_patterns = _expect_list(data.get("learned_patterns"), label="learned_patterns")
+
+    if any(not isinstance(value, str) for value in domains):
+        raise ValueError("domains entries must be strings")
+    if any(not isinstance(value, str) for value in changed_files):
+        raise ValueError("changed_files entries must be strings")
+    if any(not isinstance(value, str) for value in learned_patterns):
+        raise ValueError("learned_patterns entries must be strings")
+
+    return {
+        "run_id": run_id,
+        "generated_at": generated_at,
+        "story": {
+            "slug": story.get("slug"),
+            "name": story.get("name"),
+            "github_issue": story.get("github_issue"),
+        },
+        "story_shape": story_shape,
+        "domains": domains,
+        "changed_files": changed_files,
+        "learned_patterns": learned_patterns,
+    }
+
+
+def _build_entry(summary: dict[str, Any], *, summary_path: str) -> dict[str, object]:
+    return {
+        "run_id": summary["run_id"],
+        "generated_at": summary["generated_at"],
+        "story": summary["story"],
+        "story_shape": summary["story_shape"],
+        "domains": list(summary["domains"]),
+        "changed_files": list(summary["changed_files"]),
+        "learned_patterns": list(summary["learned_patterns"]),
+        "summary_path": summary_path,
+    }
+
+
+def rebuild_knowledge_index(project_root: Path) -> KnowledgeIndexBuildResult:
+    """Rebuild ``.forge/knowledge/index.yaml`` from persisted summary artifacts."""
+    project_root = Path(project_root)
+    summaries_root = project_root / SUMMARIES_DIR
+    index_path = project_root / KNOWLEDGE_INDEX_PATH
+
+    entries: list[dict[str, object]] = []
+    diagnostics: list[KnowledgeIndexDiagnostic] = []
+    summary_paths = sorted(summaries_root.glob("*.yaml")) if summaries_root.exists() else []
+
+    for path in summary_paths:
+        rel_path = str(path.relative_to(project_root))
+        try:
+            summary = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            diagnostics.append(
+                KnowledgeIndexDiagnostic(path=rel_path, reason=f"invalid YAML: {exc}")
+            )
+            continue
+
+        try:
+            validated = _validate_summary(summary, expected_run_id=path.stem)
+        except ValueError as exc:
+            diagnostics.append(KnowledgeIndexDiagnostic(path=rel_path, reason=str(exc)))
+            continue
+
+        entries.append(_build_entry(validated, summary_path=rel_path))
+
+    entries.sort(key=_summary_sort_key)
+    payload: dict[str, object] = {
+        "schema_version": KNOWLEDGE_INDEX_SCHEMA_VERSION,
+        "source_count": len(summary_paths),
+        "indexed_count": len(entries),
+        "skipped_count": len(diagnostics),
+        "entries": entries,
+    }
+
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+    return KnowledgeIndexBuildResult(
+        path=index_path,
+        payload=payload,
+        diagnostics=tuple(diagnostics),
+    )

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -7,6 +7,7 @@ import yaml
 
 from theforge.cli.index import cmd_index
 from theforge.indexer import generate_index
+from theforge.knowledge_index import KNOWLEDGE_INDEX_PATH
 
 
 def test_generate_index_writes_modules_yaml(tmp_path: Path) -> None:
@@ -87,7 +88,41 @@ def test_cmd_index_generates_index_file(tmp_path: Path) -> None:
     (tmp_path / "forge.yaml").write_text("project: test\n", encoding="utf-8")
     (tmp_path / "module.py").write_text("def public_fn():\n    return 1\n", encoding="utf-8")
 
-    rc = cmd_index(type("Args", (), {"config": str(tmp_path / "forge.yaml")})())
+    args = type("Args", (), {"config": str(tmp_path / "forge.yaml"), "knowledge": False})()
+    rc = cmd_index(args)
 
     assert rc == 0
     assert (tmp_path / ".forge" / "index" / "modules.yaml").exists()
+
+
+def test_cmd_index_can_rebuild_the_knowledge_index_and_report_skips(
+    tmp_path: Path, capsys
+) -> None:
+    (tmp_path / "forge.yaml").write_text("project: test\n", encoding="utf-8")
+    summaries = tmp_path / ".forge" / "knowledge" / "summaries"
+    summaries.mkdir(parents=True)
+    (summaries / "run-good.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "run_id": "run-good",
+                "generated_at": "2026-08-14T09:00:00+00:00",
+                "story": {"slug": "api-retry", "name": "API retry", "github_issue": 301},
+                "story_shape": {"work_type": "feature", "complexity": "medium"},
+                "domains": ["backend"],
+                "changed_files": ["src/client.py"],
+                "learned_patterns": ["retry"],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (summaries / "run-bad.yaml").write_text("run_id: [unterminated\n", encoding="utf-8")
+
+    args = type("Args", (), {"config": str(tmp_path / "forge.yaml"), "knowledge": True})()
+    rc = cmd_index(args)
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.strip() == str(tmp_path / KNOWLEDGE_INDEX_PATH)
+    assert "Skipped .forge/knowledge/summaries/run-bad.yaml: invalid YAML:" in captured.err
+    assert not (tmp_path / ".forge" / "index" / "modules.yaml").exists()

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from theforge.knowledge_index import KNOWLEDGE_INDEX_PATH, rebuild_knowledge_index
+
+
+def _write_summary(
+    project_root: Path,
+    run_id: str,
+    *,
+    generated_at: str | None,
+    slug: str,
+    name: str,
+    github_issue: int | None,
+    work_type: str,
+    complexity: str,
+    complexity_score: int,
+    contract_change: bool,
+    domains: list[str],
+    changed_files: list[str],
+    learned_patterns: list[str],
+) -> Path:
+    path = project_root / ".forge" / "knowledge" / "summaries" / f"{run_id}.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "generated_at": generated_at,
+        "story": {
+            "slug": slug,
+            "name": name,
+            "github_issue": github_issue,
+        },
+        "story_shape": {
+            "work_type": work_type,
+            "complexity": complexity,
+            "complexity_score": complexity_score,
+            "contract_change": contract_change,
+        },
+        "domains": domains,
+        "changed_files": changed_files,
+        "learned_patterns": learned_patterns,
+    }
+    path.write_text(
+        yaml.safe_dump(payload, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _entry_ids(payload: dict[str, object]) -> list[str]:
+    entries = payload["entries"]
+    assert isinstance(entries, list)
+    return [entry["run_id"] for entry in entries]
+
+
+def test_rebuild_is_deterministic_and_order_is_stable(tmp_path: Path) -> None:
+    _write_summary(
+        tmp_path,
+        "run-review-prompt",
+        generated_at="2026-08-14T11:00:00+00:00",
+        slug="review-prompt",
+        name="Review prompt tightening",
+        github_issue=303,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["review", "prompting"],
+        changed_files=["src/theforge/task/review_prompts.py"],
+        learned_patterns=["prompt-contract"],
+    )
+    _write_summary(
+        tmp_path,
+        "run-api-retry",
+        generated_at="2026-08-14T09:00:00+00:00",
+        slug="api-retry",
+        name="API retry hardening",
+        github_issue=301,
+        work_type="feature",
+        complexity="medium",
+        complexity_score=5,
+        contract_change=False,
+        domains=["backend", "api"],
+        changed_files=["src/client.py", "tests/test_client.py"],
+        learned_patterns=["retry", "timeout"],
+    )
+    _write_summary(
+        tmp_path,
+        "run-cli-config",
+        generated_at=None,
+        slug="cli-config",
+        name="CLI config validation",
+        github_issue=302,
+        work_type="bugfix",
+        complexity="small",
+        complexity_score=3,
+        contract_change=True,
+        domains=["cli", "config"],
+        changed_files=["src/theforge/cli/check_config.py"],
+        learned_patterns=["config-guardrails"],
+    )
+
+    first = rebuild_knowledge_index(tmp_path)
+    second = rebuild_knowledge_index(tmp_path)
+
+    first_loaded = yaml.safe_load(first.path.read_text(encoding="utf-8"))
+    second_loaded = yaml.safe_load(second.path.read_text(encoding="utf-8"))
+
+    assert first.payload == second.payload
+    assert first_loaded == second_loaded
+    assert _entry_ids(first.payload) == [
+        "run-cli-config",
+        "run-api-retry",
+        "run-review-prompt",
+    ]
+
+
+def test_deleting_the_index_and_rebuilding_produces_an_equivalent_payload(tmp_path: Path) -> None:
+    _write_summary(
+        tmp_path,
+        "run-api-retry",
+        generated_at="2026-08-14T09:00:00+00:00",
+        slug="api-retry",
+        name="API retry hardening",
+        github_issue=301,
+        work_type="feature",
+        complexity="medium",
+        complexity_score=5,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+    )
+
+    first = rebuild_knowledge_index(tmp_path)
+    loaded_before = yaml.safe_load(first.path.read_text(encoding="utf-8"))
+    first.path.unlink()
+
+    second = rebuild_knowledge_index(tmp_path)
+    loaded_after = yaml.safe_load(second.path.read_text(encoding="utf-8"))
+
+    assert loaded_before == loaded_after == first.payload == second.payload
+
+
+def test_malformed_and_invalid_summaries_are_skipped_with_diagnostics(tmp_path: Path) -> None:
+    _write_summary(
+        tmp_path,
+        "run-valid",
+        generated_at="2026-08-14T09:00:00+00:00",
+        slug="api-retry",
+        name="API retry hardening",
+        github_issue=301,
+        work_type="feature",
+        complexity="medium",
+        complexity_score=5,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+    )
+
+    summaries = tmp_path / ".forge" / "knowledge" / "summaries"
+    summaries.mkdir(parents=True, exist_ok=True)
+    (summaries / "bad-yaml.yaml").write_text("run_id: [unterminated\n", encoding="utf-8")
+    (summaries / "bad-shape.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "run_id": "bad-shape",
+                "generated_at": "2026-08-14T10:00:00+00:00",
+                "story": [],
+                "story_shape": {},
+                "domains": ["backend"],
+                "changed_files": ["src/client.py"],
+                "learned_patterns": ["retry"],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (summaries / "wrong-run-id.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "run_id": "different-run-id",
+                "generated_at": "2026-08-14T10:00:00+00:00",
+                "story": {"slug": "x", "name": "X", "github_issue": None},
+                "story_shape": {},
+                "domains": ["backend"],
+                "changed_files": ["src/client.py"],
+                "learned_patterns": ["retry"],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = rebuild_knowledge_index(tmp_path)
+
+    assert result.payload["source_count"] == 4
+    assert result.payload["indexed_count"] == 1
+    assert result.payload["skipped_count"] == 3
+    assert _entry_ids(result.payload) == ["run-valid"]
+    assert [diagnostic.path for diagnostic in result.diagnostics] == [
+        ".forge/knowledge/summaries/bad-shape.yaml",
+        ".forge/knowledge/summaries/bad-yaml.yaml",
+        ".forge/knowledge/summaries/wrong-run-id.yaml",
+    ]
+    assert "story must be a mapping" in result.diagnostics[0].reason
+    assert "invalid YAML" in result.diagnostics[1].reason
+    assert "does not match summary filename" in result.diagnostics[2].reason
+
+
+def test_entries_expose_lookup_fields_needed_by_next_story(tmp_path: Path) -> None:
+    _write_summary(
+        tmp_path,
+        "run-api-retry",
+        generated_at="2026-08-14T09:00:00+00:00",
+        slug="api-retry",
+        name="API retry hardening",
+        github_issue=301,
+        work_type="feature",
+        complexity="medium",
+        complexity_score=5,
+        contract_change=False,
+        domains=["backend", "api"],
+        changed_files=["src/client.py", "tests/test_client.py"],
+        learned_patterns=["retry", "timeout"],
+    )
+
+    result = rebuild_knowledge_index(tmp_path)
+
+    assert result.path == tmp_path / KNOWLEDGE_INDEX_PATH
+    assert result.diagnostics == ()
+    assert result.payload["schema_version"] == 1
+    assert result.payload["source_count"] == 1
+    assert result.payload["indexed_count"] == 1
+    assert result.payload["skipped_count"] == 0
+    assert result.payload["entries"] == [
+        {
+            "run_id": "run-api-retry",
+            "generated_at": "2026-08-14T09:00:00+00:00",
+            "story": {
+                "slug": "api-retry",
+                "name": "API retry hardening",
+                "github_issue": 301,
+            },
+            "story_shape": {
+                "work_type": "feature",
+                "complexity": "medium",
+                "complexity_score": 5,
+                "contract_change": False,
+            },
+            "domains": ["backend", "api"],
+            "changed_files": ["src/client.py", "tests/test_client.py"],
+            "learned_patterns": ["retry", "timeout"],
+            "summary_path": ".forge/knowledge/summaries/run-api-retry.yaml",
+        }
+    ]

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -213,6 +213,38 @@ def test_malformed_and_invalid_summaries_are_skipped_with_diagnostics(tmp_path: 
     assert "does not match summary filename" in result.diagnostics[2].reason
 
 
+def test_unreadable_or_non_utf8_summaries_are_skipped_with_diagnostics(tmp_path: Path) -> None:
+    _write_summary(
+        tmp_path,
+        "run-valid",
+        generated_at="2026-08-14T09:00:00+00:00",
+        slug="api-retry",
+        name="API retry hardening",
+        github_issue=301,
+        work_type="feature",
+        complexity="medium",
+        complexity_score=5,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+    )
+
+    summaries = tmp_path / ".forge" / "knowledge" / "summaries"
+    summaries.mkdir(parents=True, exist_ok=True)
+    (summaries / "run-non-utf8.yaml").write_bytes(b"\xff\xfe\x00broken")
+
+    result = rebuild_knowledge_index(tmp_path)
+
+    assert result.payload["source_count"] == 2
+    assert result.payload["indexed_count"] == 1
+    assert result.payload["skipped_count"] == 1
+    assert _entry_ids(result.payload) == ["run-valid"]
+    assert len(result.diagnostics) == 1
+    assert result.diagnostics[0].path == ".forge/knowledge/summaries/run-non-utf8.yaml"
+    assert "unreadable summary:" in result.diagnostics[0].reason
+
+
 def test_entries_expose_lookup_fields_needed_by_next_story(tmp_path: Path) -> None:
     _write_summary(
         tmp_path,


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Knowledge index rebuild is wired through the CLI, deterministic from summary artifacts, and cycle 2 unreadable-summary handling does not introduce a regression. | [anthropic-opus-cli] Iteration 2 resolves the prior P2 (unreadable/non-UTF-8 summaries are now skipped with an 'unreadable summary' diagnostic instead of aborting the rebuild); no regressions found and 10 tests pass at 5d7f3cfa, matching the authoritative PASS gate commit.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $3.32
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Deterministic knowledge index for run summaries (GitHub Issue #1865)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1865