### PR TITLE
Knowledge summary admissibility and staleness filtering

### DIFF
--- a/docs/plans/knowledge-capture.md
+++ b/docs/plans/knowledge-capture.md
@@ -360,11 +360,16 @@ The shipped contract is:
   `admissible`, `admissible_with_reduced_rank`, or `inadmissible`. Plainly
   unchanged, resolved summaries are `admissible`. Relevance drift stays
   admissible but reduced-rank with machine-readable reasons
-  (`sources_changed`, `sources_moved`, `relevance_indeterminate`). Soundness
+  (`sources_changed`, `sources_moved`, `relevance_indeterminate`). That
+  includes cited files whose source run and provenance still resolve but whose
+  stored git baseline refs are unavailable in the repository being indexed:
+  history uncertainty is relevance drift, not a soundness failure. Soundness
   failures are `inadmissible` with machine-readable reasons
   (`source_run_tainted`, `provenance_unresolved`, `cited_source_deleted`,
-  `soundness_indeterminate`). A persisted record read without an evaluated
-  verdict fails closed as `inadmissible` with `no_verdict`.
+  `soundness_indeterminate`). Deleted-source detection is based on committed
+  repository state rather than leftover working-tree files. A persisted record
+  read without an evaluated verdict fails closed as `inadmissible` with
+  `no_verdict`.
 - Consumer boundary: this story only produces the verdict and its facts. Issue
   `#1860` consumes them in context assembly / manifest reporting.
 

--- a/docs/plans/knowledge-capture.md
+++ b/docs/plans/knowledge-capture.md
@@ -344,17 +344,34 @@ The shipped contract is:
   `.forge/knowledge/summaries/*.yaml`
 - Rebuild behavior: deterministic stable sort by `generated_at` (with nulls
   sorted first), then `run_id`, then summary path
-- Data boundary: the index copies persisted lookup fields only (`run_id`,
-  `generated_at`, `story`, `story_shape`, `domains`, `changed_files`,
-  `learned_patterns`, `summary_path`) and remains a materialized view rather
-  than an authority over summaries or audits
+- Data boundary: schema v2 still treats the summary artifact as the source
+  record, but now materializes the deterministic non-LLM facts required to
+  judge summary admissibility before prompt assembly: source-run taint from the
+  authoritative run record, provenance-resolution status against that record's
+  anchors, and cited-source change / move / delete facts from repository
+  history. The view therefore copies persisted lookup fields
+  (`run_id`, `generated_at`, `story`, `story_shape`, `domains`,
+  `changed_files`, `learned_patterns`, `summary_path`) and adds
+  `admissibility_facts` / `admissibility_verdict` for producer-side filtering.
 - Malformed summaries: invalid YAML, non-mapping roots, mismatched `run_id`,
   missing required mappings, or non-list lookup fields are skipped with visible
   diagnostics during rebuild rather than partially indexed
+- Verdict contract: producer-side evaluation emits exactly one of
+  `admissible`, `admissible_with_reduced_rank`, or `inadmissible`. Plainly
+  unchanged, resolved summaries are `admissible`. Relevance drift stays
+  admissible but reduced-rank with machine-readable reasons
+  (`sources_changed`, `sources_moved`, `relevance_indeterminate`). Soundness
+  failures are `inadmissible` with machine-readable reasons
+  (`source_run_tainted`, `provenance_unresolved`, `cited_source_deleted`,
+  `soundness_indeterminate`). A persisted record read without an evaluated
+  verdict fails closed as `inadmissible` with `no_verdict`.
+- Consumer boundary: this story only produces the verdict and its facts. Issue
+  `#1860` consumes them in context assembly / manifest reporting.
 
-The index is **rebuilt deterministically from summaries** — no LLM in the
-loop and no audit reads. It can be deleted and rebuilt at any time from the
-summary files.
+The index is **rebuilt deterministically from summaries plus those
+deterministic facts** — no LLM in the loop and no context-assembly dependence.
+It can be deleted and rebuilt at any time from the summary files, their linked
+run records, and repository history.
 
 #### 3b. Context assembly integration
 

--- a/src/theforge/knowledge_admissibility.py
+++ b/src/theforge/knowledge_admissibility.py
@@ -177,12 +177,12 @@ def interpret_persisted_verdict(raw: Any) -> KnowledgeSummaryVerdict:
     return KnowledgeSummaryVerdict(status=status, rank=rank, reasons=tuple(reasons))
 
 
-def _summary_cited_paths(summary: Mapping[str, Any]) -> frozenset[str]:
+def extract_summary_cited_paths(summary: Mapping[str, Any]) -> tuple[str, ...]:
     """Return the file-path citations named directly by the persisted summary."""
     cited: set[str] = set()
     learned = summary.get("what_was_learned")
     if not isinstance(learned, list):
-        return frozenset()
+        return ()
 
     for claim in learned:
         if not isinstance(claim, Mapping):
@@ -198,7 +198,7 @@ def _summary_cited_paths(summary: Mapping[str, Any]) -> frozenset[str]:
             path = _text(item.get("path") or item.get("reference"))
             if path:
                 cited.add(path)
-    return frozenset(cited)
+    return tuple(sorted(cited))
 
 
 def evaluate_summary_admissibility(
@@ -209,7 +209,7 @@ def evaluate_summary_admissibility(
 
     reasons: list[str] = []
 
-    summary_paths = _summary_cited_paths(summary)
+    summary_paths = frozenset(extract_summary_cited_paths(summary))
     fact_paths = {source.cited_path for source in facts.cited_sources}
     if not summary_paths.issubset(fact_paths):
         reasons.append(REASON_SOUNDNESS_INDETERMINATE)

--- a/src/theforge/knowledge_admissibility.py
+++ b/src/theforge/knowledge_admissibility.py
@@ -1,0 +1,252 @@
+"""Pure verdict model for persisted knowledge-summary admissibility.
+
+This module is deliberately stdlib-only. It owns the machine-readable verdict
+statuses/reasons and the pure evaluation over a persisted summary plus
+deterministic facts already materialized into the knowledge index.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+STATUS_ADMISSIBLE = "admissible"
+STATUS_ADMISSIBLE_WITH_REDUCED_RANK = "admissible_with_reduced_rank"
+STATUS_INADMISSIBLE = "inadmissible"
+
+RANK_FULL = "full"
+RANK_REDUCED = "reduced"
+RANK_EXCLUDED = "excluded"
+
+SOURCE_STATE_UNCHANGED = "unchanged"
+SOURCE_STATE_CHANGED = "changed"
+SOURCE_STATE_MOVED = "moved"
+SOURCE_STATE_DELETED = "deleted"
+SOURCE_STATE_RELEVANCE_INDETERMINATE = "relevance_indeterminate"
+SOURCE_STATE_SOUNDNESS_INDETERMINATE = "soundness_indeterminate"
+
+RESOLUTION_RESOLVED = "resolved"
+RESOLUTION_UNRESOLVED = "unresolved"
+RESOLUTION_INDETERMINATE = "indeterminate"
+
+REASON_SOURCES_CHANGED = "sources_changed"
+REASON_SOURCES_MOVED = "sources_moved"
+REASON_RELEVANCE_INDETERMINATE = "relevance_indeterminate"
+REASON_CITED_SOURCE_DELETED = "cited_source_deleted"
+REASON_SOURCE_RUN_TAINTED = "source_run_tainted"
+REASON_PROVENANCE_UNRESOLVED = "provenance_unresolved"
+REASON_SOUNDNESS_INDETERMINATE = "soundness_indeterminate"
+REASON_NO_VERDICT = "no_verdict"
+
+_INADMISSIBLE_REASONS = frozenset(
+    {
+        REASON_CITED_SOURCE_DELETED,
+        REASON_SOURCE_RUN_TAINTED,
+        REASON_PROVENANCE_UNRESOLVED,
+        REASON_SOUNDNESS_INDETERMINATE,
+        REASON_NO_VERDICT,
+    }
+)
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+@dataclass(frozen=True)
+class KnowledgeSourceFact:
+    cited_path: str
+    state: str
+    current_path: str | None = None
+    commits_since_summary: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        data: dict[str, object] = {
+            "cited_path": self.cited_path,
+            "state": self.state,
+        }
+        if self.current_path is not None:
+            data["current_path"] = self.current_path
+        if self.commits_since_summary is not None:
+            data["commits_since_summary"] = self.commits_since_summary
+        return data
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "KnowledgeSourceFact | None":
+        cited_path = _text(raw.get("cited_path"))
+        state = _text(raw.get("state"))
+        if not cited_path or not state:
+            return None
+
+        commits = raw.get("commits_since_summary")
+        commits_since_summary = commits if isinstance(commits, int) and commits >= 0 else None
+        current_path = _text(raw.get("current_path")) or None
+        return cls(
+            cited_path=cited_path,
+            state=state,
+            current_path=current_path,
+            commits_since_summary=commits_since_summary,
+        )
+
+
+@dataclass(frozen=True)
+class KnowledgeSummaryFacts:
+    source_run_tainted: bool
+    source_run_resolution: str
+    provenance_resolution: str
+    cited_sources: tuple[KnowledgeSourceFact, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "source_run": {
+                "tainted": self.source_run_tainted,
+                "resolution": self.source_run_resolution,
+            },
+            "provenance": {"resolution": self.provenance_resolution},
+            "cited_sources": [source.to_dict() for source in self.cited_sources],
+        }
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "KnowledgeSummaryFacts":
+        source_run_raw = raw.get("source_run")
+        provenance_raw = raw.get("provenance")
+        sources_raw = raw.get("cited_sources")
+
+        source_run = source_run_raw if isinstance(source_run_raw, Mapping) else {}
+        provenance = provenance_raw if isinstance(provenance_raw, Mapping) else {}
+        cited_sources: list[KnowledgeSourceFact] = []
+        if isinstance(sources_raw, list):
+            for item in sources_raw:
+                if isinstance(item, Mapping):
+                    source = KnowledgeSourceFact.from_mapping(item)
+                    if source is not None:
+                        cited_sources.append(source)
+
+        return cls(
+            source_run_tainted=bool(source_run.get("tainted")),
+            source_run_resolution=_text(source_run.get("resolution")) or RESOLUTION_INDETERMINATE,
+            provenance_resolution=_text(provenance.get("resolution")) or RESOLUTION_INDETERMINATE,
+            cited_sources=tuple(cited_sources),
+        )
+
+
+@dataclass(frozen=True)
+class KnowledgeSummaryVerdict:
+    status: str
+    rank: str
+    reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        data: dict[str, object] = {
+            "status": self.status,
+            "rank": self.rank,
+        }
+        if self.reasons:
+            data["reasons"] = list(self.reasons)
+        return data
+
+
+def missing_verdict() -> KnowledgeSummaryVerdict:
+    return KnowledgeSummaryVerdict(
+        status=STATUS_INADMISSIBLE,
+        rank=RANK_EXCLUDED,
+        reasons=(REASON_NO_VERDICT,),
+    )
+
+
+def interpret_persisted_verdict(raw: Any) -> KnowledgeSummaryVerdict:
+    """Return a safe verdict for persisted data, failing closed on absence/shape."""
+    if not isinstance(raw, Mapping):
+        return missing_verdict()
+
+    status = _text(raw.get("status"))
+    rank = _text(raw.get("rank"))
+    reasons_raw = raw.get("reasons")
+    reasons: list[str] = []
+    if isinstance(reasons_raw, list):
+        for item in reasons_raw:
+            reason = _text(item)
+            if reason:
+                reasons.append(reason)
+
+    if not status or not rank:
+        return missing_verdict()
+
+    return KnowledgeSummaryVerdict(status=status, rank=rank, reasons=tuple(reasons))
+
+
+def _summary_cited_paths(summary: Mapping[str, Any]) -> frozenset[str]:
+    """Return the file-path citations named directly by the persisted summary."""
+    cited: set[str] = set()
+    learned = summary.get("what_was_learned")
+    if not isinstance(learned, list):
+        return frozenset()
+
+    for claim in learned:
+        if not isinstance(claim, Mapping):
+            continue
+        evidence = claim.get("evidence")
+        if not isinstance(evidence, list):
+            continue
+        for item in evidence:
+            if not isinstance(item, Mapping):
+                continue
+            if _text(item.get("type")).lower() != "file":
+                continue
+            path = _text(item.get("path") or item.get("reference"))
+            if path:
+                cited.add(path)
+    return frozenset(cited)
+
+
+def evaluate_summary_admissibility(
+    summary: Mapping[str, Any],
+    facts: KnowledgeSummaryFacts,
+) -> KnowledgeSummaryVerdict:
+    """Evaluate one persisted summary from its own content plus deterministic facts."""
+
+    reasons: list[str] = []
+
+    summary_paths = _summary_cited_paths(summary)
+    fact_paths = {source.cited_path for source in facts.cited_sources}
+    if not summary_paths.issubset(fact_paths):
+        reasons.append(REASON_SOUNDNESS_INDETERMINATE)
+
+    if facts.source_run_resolution == RESOLUTION_INDETERMINATE:
+        reasons.append(REASON_SOUNDNESS_INDETERMINATE)
+    if facts.source_run_tainted:
+        reasons.append(REASON_SOURCE_RUN_TAINTED)
+
+    if facts.provenance_resolution == RESOLUTION_INDETERMINATE:
+        reasons.append(REASON_SOUNDNESS_INDETERMINATE)
+    elif facts.provenance_resolution == RESOLUTION_UNRESOLVED:
+        reasons.append(REASON_PROVENANCE_UNRESOLVED)
+
+    for source in facts.cited_sources:
+        if source.state == SOURCE_STATE_CHANGED:
+            reasons.append(REASON_SOURCES_CHANGED)
+        elif source.state == SOURCE_STATE_MOVED:
+            reasons.append(REASON_SOURCES_MOVED)
+        elif source.state == SOURCE_STATE_DELETED:
+            reasons.append(REASON_CITED_SOURCE_DELETED)
+        elif source.state == SOURCE_STATE_RELEVANCE_INDETERMINATE:
+            reasons.append(REASON_RELEVANCE_INDETERMINATE)
+        elif source.state == SOURCE_STATE_SOUNDNESS_INDETERMINATE:
+            reasons.append(REASON_SOUNDNESS_INDETERMINATE)
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    if any(reason in _INADMISSIBLE_REASONS for reason in unique_reasons):
+        return KnowledgeSummaryVerdict(
+            status=STATUS_INADMISSIBLE,
+            rank=RANK_EXCLUDED,
+            reasons=unique_reasons,
+        )
+    if unique_reasons:
+        return KnowledgeSummaryVerdict(
+            status=STATUS_ADMISSIBLE_WITH_REDUCED_RANK,
+            rank=RANK_REDUCED,
+            reasons=unique_reasons,
+        )
+    return KnowledgeSummaryVerdict(status=STATUS_ADMISSIBLE, rank=RANK_FULL)

--- a/src/theforge/knowledge_index.py
+++ b/src/theforge/knowledge_index.py
@@ -1,23 +1,51 @@
 """Deterministic index over persisted run summaries.
 
-This module builds Layer 3a from Layer 2 artifacts only: a disposable,
-rebuildable materialized view over ``.forge/knowledge/summaries/*.yaml``.
-It never reads audits and never calls a model. If a consumer needs an
-authoritative fact, it must follow the summary's backlink to the run record.
+This module builds Layer 3a as a disposable, rebuildable materialized view over
+``.forge/knowledge/summaries/*.yaml`` and the deterministic facts needed to
+judge those summaries before any consumer uses them. Schema v2 therefore reads:
+
+- the persisted summary artifact itself;
+- the summary's authoritative run record for trust/provenance facts; and
+- repository history / tree state for cited-source movement facts.
+
+It never calls a model and never depends on context assembly.
 """
 
 from __future__ import annotations
 
+import json
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-from theforge.knowledge_summary import SUMMARIES_DIR
+from theforge.coordinator.trust_status import derive_trust_status, is_tainted
+from theforge.knowledge_admissibility import (
+    RESOLUTION_INDETERMINATE,
+    RESOLUTION_RESOLVED,
+    RESOLUTION_UNRESOLVED,
+    SOURCE_STATE_CHANGED,
+    SOURCE_STATE_DELETED,
+    SOURCE_STATE_MOVED,
+    SOURCE_STATE_RELEVANCE_INDETERMINATE,
+    SOURCE_STATE_SOUNDNESS_INDETERMINATE,
+    SOURCE_STATE_UNCHANGED,
+    KnowledgeSourceFact,
+    KnowledgeSummaryFacts,
+    evaluate_summary_admissibility,
+)
+from theforge.knowledge_summary import (
+    EVIDENCE_REFERENCE_KEYS,
+    SUMMARIES_DIR,
+    extract_anchors,
+)
 
 KNOWLEDGE_INDEX_PATH = Path(".forge") / "knowledge" / "index.yaml"
-KNOWLEDGE_INDEX_SCHEMA_VERSION = 1
+KNOWLEDGE_INDEX_SCHEMA_VERSION = 2
+_DEFAULT_RUN_RECORD_DIR = Path(".forge") / "audits" / "runs"
+_GENERIC_REFERENCE_KEY = "reference"
 
 
 @dataclass(frozen=True)
@@ -140,7 +168,14 @@ def rebuild_knowledge_index(project_root: Path) -> KnowledgeIndexBuildResult:
             diagnostics.append(KnowledgeIndexDiagnostic(path=rel_path, reason=str(exc)))
             continue
 
-        entries.append(_build_entry(validated, summary_path=rel_path))
+        entries.append(
+            _build_entry_with_facts(
+                project_root,
+                summary,
+                validated,
+                summary_path=rel_path,
+            )
+        )
 
     entries.sort(key=_summary_sort_key)
     payload: dict[str, object] = {
@@ -160,4 +195,344 @@ def rebuild_knowledge_index(project_root: Path) -> KnowledgeIndexBuildResult:
         path=index_path,
         payload=payload,
         diagnostics=tuple(diagnostics),
+    )
+
+
+def _build_entry_with_facts(
+    project_root: Path,
+    raw_summary: dict[str, Any],
+    validated_summary: dict[str, Any],
+    *,
+    summary_path: str,
+) -> dict[str, object]:
+    entry = _build_entry(validated_summary, summary_path=summary_path)
+    facts = _build_admissibility_facts(raw_summary, project_root=project_root)
+    verdict = evaluate_summary_admissibility(raw_summary, facts)
+    entry["admissibility_facts"] = facts.to_dict()
+    entry["admissibility_verdict"] = verdict.to_dict()
+    return entry
+
+
+def _build_admissibility_facts(
+    summary: dict[str, Any],
+    *,
+    project_root: Path | None = None,
+) -> KnowledgeSummaryFacts:
+    run_record = None
+    source_run_resolution = RESOLUTION_INDETERMINATE
+    source_run_tainted = False
+    provenance_resolution = RESOLUTION_INDETERMINATE
+    cited_sources: tuple[KnowledgeSourceFact, ...] = ()
+
+    if project_root is not None:
+        run_record = _load_run_record(project_root, summary)
+        if run_record is not None:
+            source_run_resolution = RESOLUTION_RESOLVED
+            source_run_tainted = _run_record_is_tainted(run_record)
+            provenance_resolution = _provenance_resolution(summary, run_record)
+            cited_sources = _cited_source_facts(project_root, summary, run_record)
+        else:
+            provenance_resolution = RESOLUTION_INDETERMINATE
+
+    return KnowledgeSummaryFacts(
+        source_run_tainted=source_run_tainted,
+        source_run_resolution=source_run_resolution,
+        provenance_resolution=provenance_resolution,
+        cited_sources=cited_sources,
+    )
+
+
+def _summary_run_record_path(project_root: Path, summary: dict[str, Any]) -> Path:
+    raw = summary.get("authoritative_run_record")
+    run_id = str(summary.get("run_id") or "").strip()
+    if isinstance(raw, str) and raw.strip():
+        return project_root / raw
+    return project_root / _DEFAULT_RUN_RECORD_DIR / f"{run_id}.json"
+
+
+def _load_run_record(project_root: Path, summary: dict[str, Any]) -> dict[str, Any] | None:
+    path = _summary_run_record_path(project_root, summary)
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _run_record_is_tainted(run_record: dict[str, Any]) -> bool:
+    trust_status = run_record.get("trust_status")
+    if isinstance(trust_status, str):
+        return is_tainted(trust_status)
+    return is_tainted(derive_trust_status(run_record.get("trust_checks")))
+
+
+def _provenance_resolution(summary: dict[str, Any], run_record: dict[str, Any]) -> str:
+    anchors = extract_anchors(run_record)
+    learned = summary.get("what_was_learned")
+    if not isinstance(learned, list):
+        return RESOLUTION_INDETERMINATE
+
+    unresolved = False
+    for claim in learned:
+        if not isinstance(claim, dict):
+            return RESOLUTION_INDETERMINATE
+        evidence = claim.get("evidence")
+        if not isinstance(evidence, list):
+            return RESOLUTION_INDETERMINATE
+        for item in evidence:
+            if not isinstance(item, dict):
+                return RESOLUTION_INDETERMINATE
+            evidence_type = str(item.get("type") or "").strip().lower()
+            key = EVIDENCE_REFERENCE_KEYS.get(evidence_type)
+            if key is None:
+                return RESOLUTION_INDETERMINATE
+            reference = str(item.get(key) or item.get(_GENERIC_REFERENCE_KEY) or "").strip()
+            if not reference:
+                return RESOLUTION_INDETERMINATE
+            if not anchors.resolves(evidence_type, reference):
+                unresolved = True
+    return RESOLUTION_UNRESOLVED if unresolved else RESOLUTION_RESOLVED
+
+
+def _summary_file_citations(summary: dict[str, Any]) -> tuple[str, ...]:
+    learned = summary.get("what_was_learned")
+    if not isinstance(learned, list):
+        return ()
+
+    cited: set[str] = set()
+    for claim in learned:
+        if not isinstance(claim, dict):
+            continue
+        evidence = claim.get("evidence")
+        if not isinstance(evidence, list):
+            continue
+        for item in evidence:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("type") or "").strip().lower() != "file":
+                continue
+            path = str(item.get("path") or item.get(_GENERIC_REFERENCE_KEY) or "").strip()
+            if path:
+                cited.add(path)
+    return tuple(sorted(cited))
+
+
+def _cited_source_facts(
+    project_root: Path,
+    summary: dict[str, Any],
+    run_record: dict[str, Any],
+) -> tuple[KnowledgeSourceFact, ...]:
+    citations = _summary_file_citations(summary)
+    if not citations:
+        return ()
+
+    if not _git_history_available(project_root):
+        return tuple(
+            KnowledgeSourceFact(
+                cited_path=path,
+                state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
+                current_path=path if (project_root / path).exists() else None,
+            )
+            for path in citations
+        )
+
+    changed = run_record.get("changed_files")
+    changed_block = changed if isinstance(changed, dict) else {}
+    base_ref = _git_ref_text(changed_block.get("base_ref"))
+    head_ref = _git_ref_text(changed_block.get("head_ref"))
+
+    facts: list[KnowledgeSourceFact] = []
+    for cited_path in citations:
+        baseline = _resolve_source_baseline(
+            project_root,
+            cited_path,
+            head_ref=head_ref,
+            base_ref=base_ref,
+        )
+        if baseline is None:
+            facts.append(
+                KnowledgeSourceFact(
+                    cited_path=cited_path,
+                    state=SOURCE_STATE_SOUNDNESS_INDETERMINATE,
+                )
+            )
+            continue
+        baseline_ref, path_at_baseline = baseline
+        if not _git_is_ancestor(project_root, baseline_ref, "HEAD"):
+            facts.append(
+                KnowledgeSourceFact(
+                    cited_path=cited_path,
+                    state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
+                    current_path=cited_path if (project_root / cited_path).exists() else None,
+                )
+            )
+            continue
+
+        facts.append(
+            _materialize_source_fact(
+                project_root,
+                cited_path,
+                baseline_ref=baseline_ref,
+                path_at_baseline=path_at_baseline,
+            )
+        )
+
+    facts.sort(key=lambda item: (item.cited_path, item.current_path or "", item.state))
+    return tuple(facts)
+
+
+def _git_ref_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _resolve_source_baseline(
+    project_root: Path,
+    cited_path: str,
+    *,
+    head_ref: str | None,
+    base_ref: str | None,
+) -> tuple[str, str] | None:
+    for ref in (head_ref, base_ref):
+        if ref is None or not _git_ref_exists(project_root, ref):
+            continue
+        exists = _git_path_exists_at_ref(project_root, ref, cited_path)
+        if exists:
+            return ref, cited_path
+    return None
+
+
+def _materialize_source_fact(
+    project_root: Path,
+    cited_path: str,
+    *,
+    baseline_ref: str,
+    path_at_baseline: str,
+) -> KnowledgeSourceFact:
+    rename_target = _git_rename_target(project_root, baseline_ref, path_at_baseline)
+    if rename_target is not None:
+        return KnowledgeSourceFact(
+            cited_path=cited_path,
+            state=SOURCE_STATE_MOVED,
+            current_path=rename_target,
+            commits_since_summary=_git_commit_count(
+                project_root,
+                baseline_ref,
+                [path_at_baseline, rename_target],
+            ),
+        )
+
+    current_path = project_root / cited_path
+    if current_path.exists():
+        commits_since_summary = _git_commit_count(project_root, baseline_ref, [cited_path])
+        if commits_since_summary is None:
+            return KnowledgeSourceFact(
+                cited_path=cited_path,
+                state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
+                current_path=cited_path,
+            )
+        state = SOURCE_STATE_UNCHANGED if commits_since_summary == 0 else SOURCE_STATE_CHANGED
+        return KnowledgeSourceFact(
+            cited_path=cited_path,
+            state=state,
+            current_path=cited_path,
+            commits_since_summary=commits_since_summary,
+        )
+
+    status = _git_diff_status(project_root, baseline_ref, path_at_baseline)
+    if status == "deleted":
+        return KnowledgeSourceFact(
+            cited_path=cited_path,
+            state=SOURCE_STATE_DELETED,
+            commits_since_summary=_git_commit_count(
+                project_root,
+                baseline_ref,
+                [path_at_baseline],
+            ),
+        )
+    if status == "unknown":
+        return KnowledgeSourceFact(
+            cited_path=cited_path,
+            state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
+        )
+    return KnowledgeSourceFact(
+        cited_path=cited_path,
+        state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
+    )
+
+
+def _git_history_available(project_root: Path) -> bool:
+    result = _run_git(project_root, ["rev-parse", "--verify", "HEAD^{commit}"])
+    return result.returncode == 0
+
+
+def _git_ref_exists(project_root: Path, ref: str) -> bool:
+    result = _run_git(project_root, ["rev-parse", "--verify", f"{ref}^{{commit}}"])
+    return result.returncode == 0
+
+
+def _git_is_ancestor(project_root: Path, older: str, newer: str) -> bool:
+    result = _run_git(project_root, ["merge-base", "--is-ancestor", older, newer])
+    return result.returncode == 0
+
+
+def _git_path_exists_at_ref(project_root: Path, ref: str, path: str) -> bool:
+    result = _run_git(project_root, ["cat-file", "-e", f"{ref}:{path}"])
+    return result.returncode == 0
+
+
+def _git_rename_target(project_root: Path, baseline_ref: str, path: str) -> str | None:
+    result = _run_git(
+        project_root,
+        [
+            "-c",
+            "core.quotePath=false",
+            "diff",
+            "--name-status",
+            "-M",
+            "--find-renames",
+            baseline_ref,
+            "HEAD",
+        ],
+    )
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) == 3 and parts[0].startswith("R") and parts[1] == path:
+            return parts[2]
+    return None
+
+
+def _git_diff_status(project_root: Path, baseline_ref: str, path: str) -> str:
+    result = _run_git(
+        project_root,
+        ["-c", "core.quotePath=false", "diff", "--name-status", baseline_ref, "HEAD", "--", path],
+    )
+    if result.returncode != 0:
+        return "unknown"
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0] == "D" and parts[1] == path:
+            return "deleted"
+    return "missing"
+
+
+def _git_commit_count(project_root: Path, baseline_ref: str, paths: list[str]) -> int | None:
+    if not paths:
+        return 0
+    result = _run_git(project_root, ["rev-list", "--count", f"{baseline_ref}..HEAD", "--", *paths])
+    if result.returncode != 0:
+        return None
+    text = result.stdout.strip()
+    return int(text) if text.isdigit() else None
+
+
+def _run_git(project_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        ["git", *args],
+        cwd=project_root,
+        check=False,
+        capture_output=True,
+        text=True,
     )

--- a/src/theforge/knowledge_index.py
+++ b/src/theforge/knowledge_index.py
@@ -35,6 +35,7 @@ from theforge.knowledge_admissibility import (
     KnowledgeSourceFact,
     KnowledgeSummaryFacts,
     evaluate_summary_admissibility,
+    extract_summary_cited_paths,
 )
 from theforge.knowledge_summary import (
     EVIDENCE_REFERENCE_KEYS,
@@ -46,6 +47,10 @@ KNOWLEDGE_INDEX_PATH = Path(".forge") / "knowledge" / "index.yaml"
 KNOWLEDGE_INDEX_SCHEMA_VERSION = 2
 _DEFAULT_RUN_RECORD_DIR = Path(".forge") / "audits" / "runs"
 _GENERIC_REFERENCE_KEY = "reference"
+_GIT_TIMEOUT_SECONDS = 5.0
+_BASELINE_RESOLVED = "resolved"
+_BASELINE_HISTORY_INDETERMINATE = "history_indeterminate"
+_BASELINE_SOURCE_IDENTITY_UNRESOLVED = "source_identity_unresolved"
 
 
 @dataclass(frozen=True)
@@ -59,6 +64,19 @@ class KnowledgeIndexBuildResult:
     path: Path
     payload: dict[str, object]
     diagnostics: tuple[KnowledgeIndexDiagnostic, ...]
+
+
+@dataclass(frozen=True)
+class _SourceBaseline:
+    status: str
+    baseline_ref: str | None = None
+    path_at_baseline: str | None = None
+
+
+@dataclass(frozen=True)
+class _GitDiffSnapshot:
+    deleted_paths: frozenset[str]
+    rename_targets: dict[str, str]
 
 
 def _summary_sort_key(entry: dict[str, object]) -> tuple[str, str, str]:
@@ -294,38 +312,16 @@ def _provenance_resolution(summary: dict[str, Any], run_record: dict[str, Any]) 
     return RESOLUTION_UNRESOLVED if unresolved else RESOLUTION_RESOLVED
 
 
-def _summary_file_citations(summary: dict[str, Any]) -> tuple[str, ...]:
-    learned = summary.get("what_was_learned")
-    if not isinstance(learned, list):
-        return ()
-
-    cited: set[str] = set()
-    for claim in learned:
-        if not isinstance(claim, dict):
-            continue
-        evidence = claim.get("evidence")
-        if not isinstance(evidence, list):
-            continue
-        for item in evidence:
-            if not isinstance(item, dict):
-                continue
-            if str(item.get("type") or "").strip().lower() != "file":
-                continue
-            path = str(item.get("path") or item.get(_GENERIC_REFERENCE_KEY) or "").strip()
-            if path:
-                cited.add(path)
-    return tuple(sorted(cited))
-
-
 def _cited_source_facts(
     project_root: Path,
     summary: dict[str, Any],
     run_record: dict[str, Any],
 ) -> tuple[KnowledgeSourceFact, ...]:
-    citations = _summary_file_citations(summary)
+    citations = extract_summary_cited_paths(summary)
     if not citations:
         return ()
 
+    changed_paths = _run_record_changed_paths(run_record)
     if not _git_history_available(project_root):
         return tuple(
             KnowledgeSourceFact(
@@ -340,6 +336,7 @@ def _cited_source_facts(
     changed_block = changed if isinstance(changed, dict) else {}
     base_ref = _git_ref_text(changed_block.get("base_ref"))
     head_ref = _git_ref_text(changed_block.get("head_ref"))
+    diff_cache: dict[str, _GitDiffSnapshot | None] = {}
 
     facts: list[KnowledgeSourceFact] = []
     for cited_path in citations:
@@ -349,7 +346,16 @@ def _cited_source_facts(
             head_ref=head_ref,
             base_ref=base_ref,
         )
-        if baseline is None:
+        if baseline.status == _BASELINE_HISTORY_INDETERMINATE and cited_path in changed_paths:
+            facts.append(
+                KnowledgeSourceFact(
+                    cited_path=cited_path,
+                    state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
+                    current_path=_tracked_head_path(project_root, cited_path),
+                )
+            )
+            continue
+        if baseline.status != _BASELINE_RESOLVED:
             facts.append(
                 KnowledgeSourceFact(
                     cited_path=cited_path,
@@ -357,13 +363,16 @@ def _cited_source_facts(
                 )
             )
             continue
-        baseline_ref, path_at_baseline = baseline
+        assert baseline.baseline_ref is not None
+        assert baseline.path_at_baseline is not None
+        baseline_ref = baseline.baseline_ref
+        path_at_baseline = baseline.path_at_baseline
         if not _git_is_ancestor(project_root, baseline_ref, "HEAD"):
             facts.append(
                 KnowledgeSourceFact(
                     cited_path=cited_path,
                     state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
-                    current_path=cited_path if (project_root / cited_path).exists() else None,
+                    current_path=_tracked_head_path(project_root, cited_path),
                 )
             )
             continue
@@ -374,6 +383,7 @@ def _cited_source_facts(
                 cited_path,
                 baseline_ref=baseline_ref,
                 path_at_baseline=path_at_baseline,
+                diff_cache=diff_cache,
             )
         )
 
@@ -392,14 +402,26 @@ def _resolve_source_baseline(
     *,
     head_ref: str | None,
     base_ref: str | None,
-) -> tuple[str, str] | None:
+) -> _SourceBaseline:
+    saw_candidate_ref = False
+    saw_unavailable_ref = False
     for ref in (head_ref, base_ref):
-        if ref is None or not _git_ref_exists(project_root, ref):
+        if ref is None:
+            continue
+        saw_candidate_ref = True
+        if not _git_ref_exists(project_root, ref):
+            saw_unavailable_ref = True
             continue
         exists = _git_path_exists_at_ref(project_root, ref, cited_path)
         if exists:
-            return ref, cited_path
-    return None
+            return _SourceBaseline(
+                status=_BASELINE_RESOLVED,
+                baseline_ref=ref,
+                path_at_baseline=cited_path,
+            )
+    if saw_unavailable_ref or not saw_candidate_ref:
+        return _SourceBaseline(status=_BASELINE_HISTORY_INDETERMINATE)
+    return _SourceBaseline(status=_BASELINE_SOURCE_IDENTITY_UNRESOLVED)
 
 
 def _materialize_source_fact(
@@ -408,8 +430,10 @@ def _materialize_source_fact(
     *,
     baseline_ref: str,
     path_at_baseline: str,
+    diff_cache: dict[str, _GitDiffSnapshot | None],
 ) -> KnowledgeSourceFact:
-    rename_target = _git_rename_target(project_root, baseline_ref, path_at_baseline)
+    snapshot = _git_diff_snapshot(project_root, baseline_ref, diff_cache=diff_cache)
+    rename_target = snapshot.rename_targets.get(path_at_baseline) if snapshot is not None else None
     if rename_target is not None:
         return KnowledgeSourceFact(
             cited_path=cited_path,
@@ -422,8 +446,8 @@ def _materialize_source_fact(
             ),
         )
 
-    current_path = project_root / cited_path
-    if current_path.exists():
+    current_path = _tracked_head_path(project_root, cited_path)
+    if current_path is not None:
         commits_since_summary = _git_commit_count(project_root, baseline_ref, [cited_path])
         if commits_since_summary is None:
             return KnowledgeSourceFact(
@@ -439,8 +463,12 @@ def _materialize_source_fact(
             commits_since_summary=commits_since_summary,
         )
 
-    status = _git_diff_status(project_root, baseline_ref, path_at_baseline)
-    if status == "deleted":
+    if snapshot is None:
+        return KnowledgeSourceFact(
+            cited_path=cited_path,
+            state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
+        )
+    if path_at_baseline in snapshot.deleted_paths:
         return KnowledgeSourceFact(
             cited_path=cited_path,
             state=SOURCE_STATE_DELETED,
@@ -450,15 +478,27 @@ def _materialize_source_fact(
                 [path_at_baseline],
             ),
         )
-    if status == "unknown":
-        return KnowledgeSourceFact(
-            cited_path=cited_path,
-            state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
-        )
     return KnowledgeSourceFact(
         cited_path=cited_path,
         state=SOURCE_STATE_RELEVANCE_INDETERMINATE,
     )
+
+
+def _run_record_changed_paths(run_record: dict[str, Any]) -> frozenset[str]:
+    changed = run_record.get("changed_files")
+    changed_block = changed if isinstance(changed, dict) else {}
+    raw_files = changed_block.get("files")
+    if not isinstance(raw_files, list):
+        return frozenset()
+
+    paths = {
+        path
+        for entry in raw_files
+        if isinstance(entry, dict)
+        for path in (str(entry.get("path") or "").strip(),)
+        if path
+    }
+    return frozenset(paths)
 
 
 def _git_history_available(project_root: Path) -> bool:
@@ -481,7 +521,20 @@ def _git_path_exists_at_ref(project_root: Path, ref: str, path: str) -> bool:
     return result.returncode == 0
 
 
-def _git_rename_target(project_root: Path, baseline_ref: str, path: str) -> str | None:
+def _tracked_head_path(project_root: Path, path: str) -> str | None:
+    return path if _git_path_exists_at_ref(project_root, "HEAD", path) else None
+
+
+def _git_diff_snapshot(
+    project_root: Path,
+    baseline_ref: str,
+    *,
+    diff_cache: dict[str, _GitDiffSnapshot | None],
+) -> _GitDiffSnapshot | None:
+    cached = diff_cache.get(baseline_ref)
+    if baseline_ref in diff_cache:
+        return cached
+
     result = _run_git(
         project_root,
         [
@@ -496,26 +549,25 @@ def _git_rename_target(project_root: Path, baseline_ref: str, path: str) -> str 
         ],
     )
     if result.returncode != 0:
+        diff_cache[baseline_ref] = None
         return None
+
+    deleted_paths: set[str] = set()
+    rename_targets: dict[str, str] = {}
     for line in result.stdout.splitlines():
         parts = line.split("\t")
-        if len(parts) == 3 and parts[0].startswith("R") and parts[1] == path:
-            return parts[2]
-    return None
+        if len(parts) == 3 and parts[0].startswith("R"):
+            rename_targets[parts[1]] = parts[2]
+            continue
+        if len(parts) >= 2 and parts[0] == "D":
+            deleted_paths.add(parts[1])
 
-
-def _git_diff_status(project_root: Path, baseline_ref: str, path: str) -> str:
-    result = _run_git(
-        project_root,
-        ["-c", "core.quotePath=false", "diff", "--name-status", baseline_ref, "HEAD", "--", path],
+    snapshot = _GitDiffSnapshot(
+        deleted_paths=frozenset(deleted_paths),
+        rename_targets=rename_targets,
     )
-    if result.returncode != 0:
-        return "unknown"
-    for line in result.stdout.splitlines():
-        parts = line.split("\t")
-        if len(parts) >= 2 and parts[0] == "D" and parts[1] == path:
-            return "deleted"
-    return "missing"
+    diff_cache[baseline_ref] = snapshot
+    return snapshot
 
 
 def _git_commit_count(project_root: Path, baseline_ref: str, paths: list[str]) -> int | None:
@@ -529,10 +581,20 @@ def _git_commit_count(project_root: Path, baseline_ref: str, paths: list[str]) -
 
 
 def _run_git(project_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(  # noqa: S603
-        ["git", *args],
-        cwd=project_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    command = ["git", *args]
+    try:
+        return subprocess.run(  # noqa: S603
+            command,
+            cwd=project_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=124,
+            stdout="",
+            stderr=str(exc),
+        )

--- a/tests/test_knowledge_admissibility.py
+++ b/tests/test_knowledge_admissibility.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from theforge.knowledge_admissibility import (
+    REASON_NO_VERDICT,
+    REASON_SOURCES_CHANGED,
+    RESOLUTION_RESOLVED,
+    SOURCE_STATE_CHANGED,
+    STATUS_ADMISSIBLE_WITH_REDUCED_RANK,
+    STATUS_INADMISSIBLE,
+    KnowledgeSourceFact,
+    KnowledgeSummaryFacts,
+    evaluate_summary_admissibility,
+    interpret_persisted_verdict,
+)
+
+
+def test_missing_verdict_fails_closed() -> None:
+    verdict = interpret_persisted_verdict(None)
+
+    assert verdict.status == STATUS_INADMISSIBLE
+    assert verdict.rank == "excluded"
+    assert verdict.reasons == (REASON_NO_VERDICT,)
+
+
+def test_same_summary_and_facts_yield_the_same_verdict() -> None:
+    summary = {
+        "what_was_learned": [
+            {
+                "claim": "keep retry logic close to the client",
+                "evidence": [{"type": "file", "path": "src/client.py"}],
+            }
+        ]
+    }
+    facts = KnowledgeSummaryFacts(
+        source_run_tainted=False,
+        source_run_resolution=RESOLUTION_RESOLVED,
+        provenance_resolution=RESOLUTION_RESOLVED,
+        cited_sources=(
+            KnowledgeSourceFact(
+                cited_path="src/client.py",
+                state=SOURCE_STATE_CHANGED,
+                current_path="src/client.py",
+                commits_since_summary=2,
+            ),
+        ),
+    )
+
+    first = evaluate_summary_admissibility(summary, facts)
+    second = evaluate_summary_admissibility(summary, facts)
+
+    assert first == second
+    assert first.status == STATUS_ADMISSIBLE_WITH_REDUCED_RANK
+    assert first.rank == "reduced"
+    assert first.reasons == (REASON_SOURCES_CHANGED,)

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -1,10 +1,87 @@
 from __future__ import annotations
 
+import json
+import subprocess
 from pathlib import Path
 
 import yaml
 
+from theforge.knowledge_admissibility import (
+    REASON_CITED_SOURCE_DELETED,
+    REASON_PROVENANCE_UNRESOLVED,
+    REASON_RELEVANCE_INDETERMINATE,
+    REASON_SOUNDNESS_INDETERMINATE,
+    REASON_SOURCE_RUN_TAINTED,
+    REASON_SOURCES_CHANGED,
+    REASON_SOURCES_MOVED,
+    STATUS_ADMISSIBLE,
+    STATUS_ADMISSIBLE_WITH_REDUCED_RANK,
+    STATUS_INADMISSIBLE,
+)
 from theforge.knowledge_index import KNOWLEDGE_INDEX_PATH, rebuild_knowledge_index
+
+
+def _git(project_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_git_repo(project_root: Path) -> None:
+    _git(project_root, "init", "-q", "-b", "main")
+    _git(project_root, "config", "user.email", "test@example.com")
+    _git(project_root, "config", "user.name", "Test")
+
+
+def _commit_all(project_root: Path, message: str) -> str:
+    _git(project_root, "add", ".")
+    _git(project_root, "commit", "-q", "-m", message)
+    return _git(project_root, "rev-parse", "HEAD")
+
+
+def _write_run_record(
+    project_root: Path,
+    run_id: str,
+    *,
+    trust_status: str = "trusted",
+    base_ref: str | None = None,
+    head_ref: str | None = None,
+    finding_ids: tuple[str, ...] = ("f-001",),
+    file_paths: tuple[str, ...] = ("src/client.py",),
+) -> Path:
+    path = project_root / ".forge" / "audits" / "runs" / f"{run_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "run_id": run_id,
+        "trust_status": trust_status,
+        "trust_checks": [],
+        "finding_registry": [
+            {
+                "finding_id": finding_id,
+                "cycle_first_seen": 1,
+                "cycle_last_seen": 1,
+                "file": file_paths[0] if file_paths else "",
+                "severity": "P1",
+                "description": f"finding {finding_id}",
+                "disposition": "resolved",
+            }
+            for finding_id in finding_ids
+        ],
+        "reviews": [{"cycle": 1}],
+        "phases": {"plan": {"plan_structured": {"steps": [{"id": "s-1", "description": "step"}]}}},
+        "changed_files": {
+            "base_ref": base_ref,
+            "head_ref": head_ref,
+            "files": [{"path": path} for path in file_paths],
+        },
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
 
 
 def _write_summary(
@@ -22,6 +99,8 @@ def _write_summary(
     domains: list[str],
     changed_files: list[str],
     learned_patterns: list[str],
+    what_was_learned: list[dict] | None = None,
+    authoritative_run_record: str | None = None,
 ) -> Path:
     path = project_root / ".forge" / "knowledge" / "summaries" / f"{run_id}.yaml"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -44,6 +123,10 @@ def _write_summary(
         "changed_files": changed_files,
         "learned_patterns": learned_patterns,
     }
+    if authoritative_run_record is not None:
+        payload["authoritative_run_record"] = authoritative_run_record
+    if what_was_learned is not None:
+        payload["what_was_learned"] = what_was_learned
     path.write_text(
         yaml.safe_dump(payload, sort_keys=False, default_flow_style=False),
         encoding="utf-8",
@@ -55,6 +138,16 @@ def _entry_ids(payload: dict[str, object]) -> list[str]:
     entries = payload["entries"]
     assert isinstance(entries, list)
     return [entry["run_id"] for entry in entries]
+
+
+def _entry_map(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    entries = payload["entries"]
+    assert isinstance(entries, list)
+    return {entry["run_id"]: entry for entry in entries if isinstance(entry, dict)}
+
+
+def _summary_claim(*evidence: dict[str, object]) -> list[dict[str, object]]:
+    return [{"claim": "learned something real", "evidence": list(evidence)}]
 
 
 def test_rebuild_is_deterministic_and_order_is_stable(tmp_path: Path) -> None:
@@ -245,7 +338,7 @@ def test_unreadable_or_non_utf8_summaries_are_skipped_with_diagnostics(tmp_path:
     assert "unreadable summary:" in result.diagnostics[0].reason
 
 
-def test_entries_expose_lookup_fields_needed_by_next_story(tmp_path: Path) -> None:
+def test_entries_expose_lookup_fields_and_fail_closed_verdicts(tmp_path: Path) -> None:
     _write_summary(
         tmp_path,
         "run-api-retry",
@@ -266,7 +359,7 @@ def test_entries_expose_lookup_fields_needed_by_next_story(tmp_path: Path) -> No
 
     assert result.path == tmp_path / KNOWLEDGE_INDEX_PATH
     assert result.diagnostics == ()
-    assert result.payload["schema_version"] == 1
+    assert result.payload["schema_version"] == 2
     assert result.payload["source_count"] == 1
     assert result.payload["indexed_count"] == 1
     assert result.payload["skipped_count"] == 0
@@ -289,5 +382,342 @@ def test_entries_expose_lookup_fields_needed_by_next_story(tmp_path: Path) -> No
             "changed_files": ["src/client.py", "tests/test_client.py"],
             "learned_patterns": ["retry", "timeout"],
             "summary_path": ".forge/knowledge/summaries/run-api-retry.yaml",
+            "admissibility_facts": {
+                "source_run": {"tainted": False, "resolution": "indeterminate"},
+                "provenance": {"resolution": "indeterminate"},
+                "cited_sources": [],
+            },
+            "admissibility_verdict": {
+                "status": STATUS_INADMISSIBLE,
+                "rank": "excluded",
+                "reasons": [REASON_SOUNDNESS_INDETERMINATE],
+            },
         }
     ]
+
+
+def test_unchanged_cited_source_is_admissible(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    src = tmp_path / "src" / "client.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("value = 1\n", encoding="utf-8")
+    head_ref = _commit_all(tmp_path, "seed")
+
+    _write_run_record(tmp_path, "run-unchanged", base_ref=head_ref, head_ref=head_ref)
+    _write_summary(
+        tmp_path,
+        "run-unchanged",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-unchanged.json",
+        what_was_learned=_summary_claim(
+            {"type": "file", "path": "src/client.py"},
+            {"type": "review_finding", "finding_id": "f-001"},
+        ),
+    )
+
+    result = rebuild_knowledge_index(tmp_path)
+    entry = _entry_map(result.payload)["run-unchanged"]
+
+    assert entry["admissibility_verdict"] == {"status": STATUS_ADMISSIBLE, "rank": "full"}
+    assert entry["admissibility_facts"]["cited_sources"] == [
+        {
+            "cited_path": "src/client.py",
+            "state": "unchanged",
+            "current_path": "src/client.py",
+            "commits_since_summary": 0,
+        }
+    ]
+
+
+def test_changed_cited_source_is_down_ranked(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    src = tmp_path / "src" / "client.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("value = 1\n", encoding="utf-8")
+    baseline = _commit_all(tmp_path, "seed")
+    _write_run_record(tmp_path, "run-changed", base_ref=baseline, head_ref=baseline)
+    _write_summary(
+        tmp_path,
+        "run-changed",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-changed.json",
+        what_was_learned=_summary_claim(
+            {"type": "file", "path": "src/client.py"},
+            {"type": "review_finding", "finding_id": "f-001"},
+        ),
+    )
+    src.write_text("value = 2\n", encoding="utf-8")
+    _commit_all(tmp_path, "follow-up")
+
+    result = rebuild_knowledge_index(tmp_path)
+    verdict = _entry_map(result.payload)["run-changed"]["admissibility_verdict"]
+
+    assert verdict == {
+        "status": STATUS_ADMISSIBLE_WITH_REDUCED_RANK,
+        "rank": "reduced",
+        "reasons": [REASON_SOURCES_CHANGED],
+    }
+
+
+def test_rename_with_continuity_is_down_ranked(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    old_path = tmp_path / "src" / "client.py"
+    old_path.parent.mkdir(parents=True)
+    old_path.write_text("value = 1\n", encoding="utf-8")
+    baseline = _commit_all(tmp_path, "seed")
+    _write_run_record(tmp_path, "run-moved", base_ref=baseline, head_ref=baseline)
+    _write_summary(
+        tmp_path,
+        "run-moved",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-moved.json",
+        what_was_learned=_summary_claim(
+            {"type": "file", "path": "src/client.py"},
+            {"type": "review_finding", "finding_id": "f-001"},
+        ),
+    )
+    new_path = tmp_path / "src" / "phases" / "client.py"
+    new_path.parent.mkdir(parents=True)
+    _git(tmp_path, "mv", "src/client.py", "src/phases/client.py")
+    _commit_all(tmp_path, "rename")
+
+    result = rebuild_knowledge_index(tmp_path)
+    entry = _entry_map(result.payload)["run-moved"]
+
+    assert entry["admissibility_verdict"] == {
+        "status": STATUS_ADMISSIBLE_WITH_REDUCED_RANK,
+        "rank": "reduced",
+        "reasons": [REASON_SOURCES_MOVED],
+    }
+    assert entry["admissibility_facts"]["cited_sources"] == [
+        {
+            "cited_path": "src/client.py",
+            "state": "moved",
+            "current_path": "src/phases/client.py",
+            "commits_since_summary": 1,
+        }
+    ]
+
+
+def test_deleted_cited_source_is_inadmissible(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    src = tmp_path / "src" / "client.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("value = 1\n", encoding="utf-8")
+    baseline = _commit_all(tmp_path, "seed")
+    _write_run_record(tmp_path, "run-deleted", base_ref=baseline, head_ref=baseline)
+    _write_summary(
+        tmp_path,
+        "run-deleted",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-deleted.json",
+        what_was_learned=_summary_claim(
+            {"type": "file", "path": "src/client.py"},
+            {"type": "review_finding", "finding_id": "f-001"},
+        ),
+    )
+    src.unlink()
+    _commit_all(tmp_path, "delete")
+
+    result = rebuild_knowledge_index(tmp_path)
+    verdict = _entry_map(result.payload)["run-deleted"]["admissibility_verdict"]
+
+    assert verdict == {
+        "status": STATUS_INADMISSIBLE,
+        "rank": "excluded",
+        "reasons": [REASON_CITED_SOURCE_DELETED],
+    }
+
+
+def test_tainted_source_run_is_inadmissible(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    src = tmp_path / "src" / "client.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("value = 1\n", encoding="utf-8")
+    head_ref = _commit_all(tmp_path, "seed")
+
+    _write_run_record(
+        tmp_path,
+        "run-tainted",
+        trust_status="tainted",
+        base_ref=head_ref,
+        head_ref=head_ref,
+    )
+    _write_summary(
+        tmp_path,
+        "run-tainted",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-tainted.json",
+        what_was_learned=_summary_claim(
+            {"type": "file", "path": "src/client.py"},
+            {"type": "review_finding", "finding_id": "f-001"},
+        ),
+    )
+
+    result = rebuild_knowledge_index(tmp_path)
+    verdict = _entry_map(result.payload)["run-tainted"]["admissibility_verdict"]
+
+    assert verdict == {
+        "status": STATUS_INADMISSIBLE,
+        "rank": "excluded",
+        "reasons": [REASON_SOURCE_RUN_TAINTED],
+    }
+
+
+def test_unresolved_provenance_is_inadmissible(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    src = tmp_path / "src" / "client.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("value = 1\n", encoding="utf-8")
+    head_ref = _commit_all(tmp_path, "seed")
+
+    _write_run_record(tmp_path, "run-unresolved", base_ref=head_ref, head_ref=head_ref)
+    _write_summary(
+        tmp_path,
+        "run-unresolved",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-unresolved.json",
+        what_was_learned=_summary_claim({"type": "review_finding", "finding_id": "f-missing"}),
+    )
+
+    result = rebuild_knowledge_index(tmp_path)
+    verdict = _entry_map(result.payload)["run-unresolved"]["admissibility_verdict"]
+
+    assert verdict == {
+        "status": STATUS_INADMISSIBLE,
+        "rank": "excluded",
+        "reasons": [REASON_PROVENANCE_UNRESOLVED],
+    }
+
+
+def test_non_git_history_absence_down_ranks_relevance(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "client.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("value = 1\n", encoding="utf-8")
+
+    _write_run_record(tmp_path, "run-no-history", file_paths=("src/client.py",))
+    _write_summary(
+        tmp_path,
+        "run-no-history",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-no-history.json",
+        what_was_learned=_summary_claim(
+            {"type": "file", "path": "src/client.py"},
+            {"type": "review_finding", "finding_id": "f-001"},
+        ),
+    )
+
+    result = rebuild_knowledge_index(tmp_path)
+    entry = _entry_map(result.payload)["run-no-history"]
+
+    assert entry["admissibility_verdict"] == {
+        "status": STATUS_ADMISSIBLE_WITH_REDUCED_RANK,
+        "rank": "reduced",
+        "reasons": [REASON_RELEVANCE_INDETERMINATE],
+    }
+    assert entry["admissibility_facts"]["cited_sources"] == [
+        {
+            "cited_path": "src/client.py",
+            "state": "relevance_indeterminate",
+            "current_path": "src/client.py",
+        }
+    ]
+
+
+def test_missing_run_record_is_soundness_indeterminate(tmp_path: Path) -> None:
+    _write_summary(
+        tmp_path,
+        "run-missing-record",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-missing-record.json",
+        what_was_learned=_summary_claim({"type": "review_finding", "finding_id": "f-001"}),
+    )
+
+    result = rebuild_knowledge_index(tmp_path)
+    verdict = _entry_map(result.payload)["run-missing-record"]["admissibility_verdict"]
+
+    assert verdict == {
+        "status": STATUS_INADMISSIBLE,
+        "rank": "excluded",
+        "reasons": [REASON_SOUNDNESS_INDETERMINATE],
+    }

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -694,6 +694,160 @@ def test_non_git_history_absence_down_ranks_relevance(tmp_path: Path) -> None:
     ]
 
 
+def test_unresolvable_history_refs_for_resolved_file_down_rank_relevance(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    src = tmp_path / "src" / "client.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("value = 1\n", encoding="utf-8")
+    _commit_all(tmp_path, "seed")
+
+    _write_run_record(
+        tmp_path,
+        "run-missing-history-refs",
+        base_ref="deadbeef",
+        head_ref="cafebabe",
+        file_paths=("src/client.py",),
+    )
+    _write_summary(
+        tmp_path,
+        "run-missing-history-refs",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-missing-history-refs.json",
+        what_was_learned=_summary_claim(
+            {"type": "file", "path": "src/client.py"},
+            {"type": "review_finding", "finding_id": "f-001"},
+        ),
+    )
+
+    result = rebuild_knowledge_index(tmp_path)
+    entry = _entry_map(result.payload)["run-missing-history-refs"]
+
+    assert entry["admissibility_verdict"] == {
+        "status": STATUS_ADMISSIBLE_WITH_REDUCED_RANK,
+        "rank": "reduced",
+        "reasons": [REASON_RELEVANCE_INDETERMINATE],
+    }
+    assert entry["admissibility_facts"]["cited_sources"] == [
+        {
+            "cited_path": "src/client.py",
+            "state": "relevance_indeterminate",
+            "current_path": "src/client.py",
+        }
+    ]
+
+
+def test_created_file_with_missing_head_ref_down_ranks_relevance(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _git(tmp_path, "commit", "--allow-empty", "-q", "-m", "seed")
+    baseline = _git(tmp_path, "rev-parse", "HEAD")
+    src = tmp_path / "src" / "client.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("value = 1\n", encoding="utf-8")
+    _commit_all(tmp_path, "create file")
+
+    _write_run_record(
+        tmp_path,
+        "run-created-file-missing-head",
+        base_ref=baseline,
+        head_ref="pruned-head-ref",
+        file_paths=("src/client.py",),
+    )
+    _write_summary(
+        tmp_path,
+        "run-created-file-missing-head",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-created-file-missing-head.json",
+        what_was_learned=_summary_claim(
+            {"type": "file", "path": "src/client.py"},
+            {"type": "review_finding", "finding_id": "f-001"},
+        ),
+    )
+
+    result = rebuild_knowledge_index(tmp_path)
+    entry = _entry_map(result.payload)["run-created-file-missing-head"]
+
+    assert entry["admissibility_verdict"] == {
+        "status": STATUS_ADMISSIBLE_WITH_REDUCED_RANK,
+        "rank": "reduced",
+        "reasons": [REASON_RELEVANCE_INDETERMINATE],
+    }
+    assert entry["admissibility_facts"]["cited_sources"] == [
+        {
+            "cited_path": "src/client.py",
+            "state": "relevance_indeterminate",
+            "current_path": "src/client.py",
+        }
+    ]
+
+
+def test_deleted_cited_source_ignores_untracked_leftover_copy(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    src = tmp_path / "src" / "client.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("value = 1\n", encoding="utf-8")
+    baseline = _commit_all(tmp_path, "seed")
+    _write_run_record(tmp_path, "run-deleted-leftover", base_ref=baseline, head_ref=baseline)
+    _write_summary(
+        tmp_path,
+        "run-deleted-leftover",
+        generated_at="2026-08-15T09:00:00+00:00",
+        slug="retry-client",
+        name="Retry client",
+        github_issue=1,
+        work_type="feature",
+        complexity="small",
+        complexity_score=2,
+        contract_change=False,
+        domains=["backend"],
+        changed_files=["src/client.py"],
+        learned_patterns=["retry"],
+        authoritative_run_record=".forge/audits/runs/run-deleted-leftover.json",
+        what_was_learned=_summary_claim(
+            {"type": "file", "path": "src/client.py"},
+            {"type": "review_finding", "finding_id": "f-001"},
+        ),
+    )
+    src.unlink()
+    _commit_all(tmp_path, "delete")
+    src.write_text("stale untracked copy\n", encoding="utf-8")
+
+    result = rebuild_knowledge_index(tmp_path)
+    entry = _entry_map(result.payload)["run-deleted-leftover"]
+
+    assert entry["admissibility_verdict"] == {
+        "status": STATUS_INADMISSIBLE,
+        "rank": "excluded",
+        "reasons": [REASON_CITED_SOURCE_DELETED],
+    }
+    assert entry["admissibility_facts"]["cited_sources"] == [
+        {
+            "cited_path": "src/client.py",
+            "state": "deleted",
+            "commits_since_summary": 1,
+        }
+    ]
+
+
 def test_missing_run_record_is_soundness_indeterminate(tmp_path: Path) -> None:
     _write_summary(
         tmp_path,


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Cycle 1 P1 fixes are verified, focused knowledge tests pass, and I found no blocking regressions. | [anthropic-opus-cli] Both cycle-1 P1s are fixed and independently reproduced as resolved (unavailable history refs and a run-created file with a pruned head_ref now yield relevance_indeterminate reduced-rank rather than inadmissible); prior P2s on duplicated citation extraction, git timeouts, and working-tree-based deletion detection were also addressed, all 45 knowledge tests pass, and the iteration introduced no regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $7.28
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Knowledge summary admissibility and staleness filtering (GitHub Issue #1866)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1866