### PR TITLE
Knowledge-loop effectiveness metrics

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -864,6 +864,41 @@ exists to measure.
 
 ---
 
+## `forge knowledge-report`
+
+Is the knowledge feed-forward loop earning its keep? Compares stories that
+actually received prior-run summaries against comparable stories that did not,
+on plan regeneration rate, review restated-finding rate, dev/review iteration
+counts, and cost per completed story / stories per dollar.
+
+```bash
+forge knowledge-report                          # all recorded runs, terminal report
+forge knowledge-report --recent-run-count 30    # bound by run count
+forge knowledge-report --since 2026-08-01 --until 2026-08-31
+forge knowledge-report --format json            # structured payload (also: yaml)
+```
+
+Cohorts come from the audit record's context manifests, never from config: a
+run is **with_prior_summary** only when an eligible phase (plan / dev / review)
+recorded `prior_run_context.enabled: true` *and* included at least one summary.
+Enabled with nothing included is the control cohort. Disabled or unrecorded is
+`unclassified` and never enters a comparison — a run from before the feature
+existed is not evidence about the feature.
+
+Comparisons are bucketed by preflight work type, complexity band, and domains,
+and only buckets holding both cohorts contribute; "stories with prior knowledge
+did better" means nothing if those stories were also smaller.
+
+The report distinguishes **insufficient_data** (cohorts or metric denominators
+too thin to compare) from **no_observed_improvement** (enough data, and the
+with-prior cohort did not do better). Missing telemetry is reported as an
+unavailable denominator, never as a zero: a run with no `plan_review` block is
+not a run with zero regenerations, and a run with null `cost.total_usd` is a
+delivery of unknown spend, counted in its cohort and excluded from both cost
+denominators.
+
+---
+
 ## `forge audits`
 
 Manage the SQLite audit substrate (distinct from `forge audit`, which renders a

--- a/src/theforge/cli/knowledge_report.py
+++ b/src/theforge/cli/knowledge_report.py
@@ -1,0 +1,193 @@
+"""``forge knowledge-report`` — is the knowledge feed-forward loop earning its keep?
+
+Thin command layer over :mod:`theforge.knowledge_effectiveness`: resolve config,
+open the audit substrate, bound the record window, hand the records to the pure
+report, render it. Every judgment — cohort classification, comparability
+bucketing, the insufficient-data threshold — lives in the core module so the
+terminal view and the structured payload cannot diverge from what the tests
+assert.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from pathlib import Path
+
+from theforge.cli.shared import _find_config
+from theforge.coordinator import audit_read_model, audit_storage
+
+
+def cmd_knowledge_report(args: argparse.Namespace) -> int:
+    """Render the knowledge-effectiveness report over a bounded run window."""
+    import yaml  # noqa: PLC0415
+
+    from theforge.knowledge_effectiveness import build_report  # noqa: PLC0415
+    from theforge.knowledge_effectiveness_render import (  # noqa: PLC0415
+        render_terminal,
+        report_payload,
+    )
+
+    config_path = _find_config(Path(args.config).resolve() if args.config else None)
+    if config_path is None:
+        print(
+            "forge.yaml not found. Run 'forge init' to create one, "
+            "or pass --config path/to/forge.yaml",
+            file=sys.stderr,
+        )
+        return 1
+    project_root = config_path.parent
+
+    try:
+        since = _parse_bound(args.since, "--since")
+        until = _parse_bound(args.until, "--until", end_of_day=True)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    recent_run_count: int | None = args.recent_run_count
+    if recent_run_count is not None and recent_run_count < 1:
+        print("--recent-run-count must be at least 1", file=sys.stderr)
+        return 1
+
+    try:
+        records = _load_records(
+            project_root, since=since, until=until, recent_run_count=recent_run_count
+        )
+    except audit_storage.SubstrateMissingError as exc:
+        print(f"No audit history found: {exc}", file=sys.stderr)
+        return 1
+    except audit_storage.SubstrateCorruptError as exc:
+        print(f"Audit substrate is corrupt: {exc}", file=sys.stderr)
+        return 1
+
+    report = build_report(
+        records,
+        since=args.since,
+        until=args.until,
+        recent_run_count=recent_run_count,
+    )
+
+    if args.format == "terminal":
+        print(render_terminal(report), end="")
+        return 0
+
+    payload = report_payload(report)
+    if args.format == "json":
+        print(json.dumps(payload, indent=2))
+    else:
+        print(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True), end="")
+    return 0
+
+
+def _load_records(
+    project_root: Path,
+    *,
+    since: datetime.datetime | None,
+    until: datetime.datetime | None,
+    recent_run_count: int | None,
+) -> list[dict]:
+    """Read the bounded record window from the substrate.
+
+    ``--recent-run-count`` bounds by position and the date flags bound by time;
+    when both are given the date filter is applied first and the count then
+    takes the most recent survivors, so the two never fight over which window
+    won.
+    """
+    conn = audit_storage.require_substrate(project_root)
+    try:
+        records = [
+            record
+            for record in audit_read_model.iter_records(conn, order_by_started=True)
+            if _in_window(record, since=since, until=until)
+        ]
+    finally:
+        conn.close()
+    if recent_run_count is not None:
+        return records[-recent_run_count:]
+    return records
+
+
+def _in_window(
+    record: dict,
+    *,
+    since: datetime.datetime | None,
+    until: datetime.datetime | None,
+) -> bool:
+    """A record with no parseable start time is kept — bounds exclude, not guess."""
+    if since is None and until is None:
+        return True
+    timing = record.get("timing")
+    started = timing.get("started_at") if isinstance(timing, dict) else None
+    if not isinstance(started, str) or not started:
+        return True
+    try:
+        stamp = datetime.datetime.fromisoformat(started)
+    except ValueError:
+        return True
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=datetime.timezone.utc)
+    if since is not None and stamp < since:
+        return False
+    return not (until is not None and stamp > until)
+
+
+def _parse_bound(
+    value: str | None, flag: str, *, end_of_day: bool = False
+) -> datetime.datetime | None:
+    """Parse a window bound, treating a bare ``--until`` date as inclusive.
+
+    ``--until 2026-08-04`` means "through the 4th": parsed as midnight it would
+    silently drop every run that day, which reads as data loss rather than as a
+    bound. A bound given with an explicit time is honoured as written.
+    """
+    if not value:
+        return None
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid {flag} value: {value!r} (expected YYYY-MM-DD or ISO-8601 timestamp)"
+        ) from exc
+    if end_of_day and len(value.strip()) == len("YYYY-MM-DD"):
+        parsed = parsed.replace(hour=23, minute=59, second=59, microsecond=999999)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed
+
+
+def register_parser(subparsers: object) -> None:
+    """Register the ``knowledge-report`` subcommand parser."""
+    p = subparsers.add_parser(
+        "knowledge-report",
+        help=(
+            "Knowledge-loop effectiveness: do stories that received prior run "
+            "summaries regenerate plans, repeat review findings, iterate, and "
+            "cost less than comparable stories that did not"
+        ),
+    )
+    p.add_argument("--config", help="Path to forge.yaml (default: auto-detect)")
+    p.add_argument(
+        "--since",
+        metavar="DATE",
+        help="Only include runs started on or after this date (YYYY-MM-DD or ISO-8601)",
+    )
+    p.add_argument(
+        "--until",
+        metavar="DATE",
+        help="Only include runs started on or before this date (YYYY-MM-DD or ISO-8601)",
+    )
+    p.add_argument(
+        "--recent-run-count",
+        type=int,
+        metavar="N",
+        help="Only include the most recent N runs in the window (default: all)",
+    )
+    p.add_argument(
+        "--format",
+        choices=("terminal", "yaml", "json"),
+        default="terminal",
+        help="Output format (default: terminal)",
+    )

--- a/src/theforge/cli/main.py
+++ b/src/theforge/cli/main.py
@@ -18,6 +18,7 @@ from theforge.cli import (
     hooks,
     ideate,
     index,
+    knowledge_report,
     migrate_profiles,
     profiles,
     providers,
@@ -89,6 +90,7 @@ def build_parser() -> argparse.ArgumentParser:
     diagnose.register_parser(subparsers)
     rca.register_parser(subparsers)
     batch_report.register_parser(subparsers)
+    knowledge_report.register_parser(subparsers)
     shape.register_parser(subparsers)
     groom.register_parser(subparsers)
     migrate_profiles.register_parser(subparsers)
@@ -132,6 +134,7 @@ def main() -> None:
         "diagnose": diagnose.cmd_diagnose,
         "rca": rca.cmd_rca,
         "batch-report": batch_report.cmd_batch_report,
+        "knowledge-report": knowledge_report.cmd_knowledge_report,
         "shape": shape.cmd_shape,
         "groom": groom.cmd_groom,
         "migrate-profiles": migrate_profiles.cmd_migrate_profiles,

--- a/src/theforge/knowledge_effectiveness.py
+++ b/src/theforge/knowledge_effectiveness.py
@@ -1,0 +1,460 @@
+"""Does the knowledge feed-forward loop earn its keep? (#1867)
+
+Layer 4 of ``docs/plans/knowledge-capture.md``: the measurement that decides
+whether Layers 1-3 compound or are merely maintained. Every input is recorded
+telemetry, read by :mod:`theforge.knowledge_effectiveness_signals` — the audit
+record's ``context_manifests``, ``plan_review.regenerated``,
+``iterations.review_loop``, ``cost.total_usd`` and ``outcome.success``. No
+sentence a model wrote is admitted as evidence, which is the whole point: a
+knowledge layer that reports on itself in prose proves nothing.
+
+Two ideas carry this half:
+
+1. **Comparisons are bucketed before they are made.** "Stories that had prior
+   summaries did better" is worthless if those stories were also smaller. Runs
+   are bucketed by preflight work type, complexity band and domains, and only
+   buckets holding *both* cohorts contribute to the matched comparison.
+
+2. **Each metric carries its own denominator.** A record with no ``plan_review``
+   block does not mean "zero regenerations", and a successful run with
+   ``cost.total_usd`` null is a delivery of unknown spend — counted in its
+   cohort, excluded from both cost denominators. A metric whose denominator is
+   too small reports ``insufficient_data`` rather than a number nobody should
+   act on, which is the distinction the whole report exists to make: "we cannot
+   tell yet" is not "it did not help".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from theforge.knowledge_effectiveness_signals import (
+    COHORT_UNCLASSIFIED,
+    COHORT_WITH,
+    COHORT_WITHOUT,
+    RunSignals,
+    classify_cohort,
+    extract_signals,
+)
+
+__all__ = [
+    "COHORT_UNCLASSIFIED",
+    "COHORT_WITH",
+    "COHORT_WITHOUT",
+    "MIN_COHORT_RUNS",
+    "MIN_METRIC_SAMPLES",
+    "METRIC_COST_PER_STORY",
+    "METRIC_DEV_ITERATIONS",
+    "METRIC_DIRECTION",
+    "METRIC_NAMES",
+    "METRIC_PLAN_REGENERATION",
+    "METRIC_REVIEW_CYCLES",
+    "METRIC_REVIEW_RECURRENCE",
+    "METRIC_STORIES_PER_DOLLAR",
+    "STATUS_INSUFFICIENT_DATA",
+    "STATUS_NO_OBSERVED_IMPROVEMENT",
+    "STATUS_OBSERVED_IMPROVEMENT",
+    "CohortMetrics",
+    "KnowledgeEffectivenessReport",
+    "MatchedBucket",
+    "Metric",
+    "MetricComparison",
+    "RunSignals",
+    "TrendPoint",
+    "build_report",
+    "classify_cohort",
+    "compute_cohort_metrics",
+    "extract_signals",
+]
+
+# ── Statuses ─────────────────────────────────────────────────────────────────
+
+STATUS_INSUFFICIENT_DATA = "insufficient_data"
+STATUS_NO_OBSERVED_IMPROVEMENT = "no_observed_improvement"
+STATUS_OBSERVED_IMPROVEMENT = "observed_improvement"
+
+#: Runs each cohort must contribute to the matched buckets before any comparison
+#: is reported. Deliberately small — the plan's own bar is 20-30 runs, and a
+#: report that stays silent until then teaches nothing about its own shape — but
+#: never 1, where a single run would decide the verdict.
+MIN_COHORT_RUNS = 3
+
+#: Observations a single metric needs on *both* sides before it is compared.
+#: A metric can be under-sampled while its cohort is not: plan_review telemetry
+#: is missing from more records than cost telemetry is.
+MIN_METRIC_SAMPLES = 3
+
+
+# ── Metrics ──────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Metric:
+    """A value and the denominator it was computed over.
+
+    ``value is None`` means the metric could not be computed at all; a value
+    with a small ``sample_size`` means it could, but should not be compared.
+    """
+
+    name: str
+    value: float | None
+    sample_size: int
+    lower_is_better: bool
+
+    @property
+    def available(self) -> bool:
+        return self.value is not None and self.sample_size > 0
+
+    @property
+    def comparable(self) -> bool:
+        return self.available and self.sample_size >= MIN_METRIC_SAMPLES
+
+
+@dataclass(frozen=True)
+class CohortMetrics:
+    """Rollup of one cohort over one population of runs."""
+
+    cohort: str
+    run_count: int
+    metrics: tuple[Metric, ...]
+
+    def metric(self, name: str) -> Metric | None:
+        for item in self.metrics:
+            if item.name == name:
+                return item
+        return None
+
+
+METRIC_PLAN_REGENERATION = "plan_regeneration_rate"
+METRIC_REVIEW_RECURRENCE = "review_recurrence_rate"
+METRIC_DEV_ITERATIONS = "avg_dev_iterations"
+METRIC_REVIEW_CYCLES = "avg_review_cycles"
+METRIC_COST_PER_STORY = "cost_per_completed_story"
+METRIC_STORIES_PER_DOLLAR = "stories_per_dollar"
+
+#: Ordered for rendering; also the set the status verdict reads. Direction is
+#: declared here so "improved" is never inferred from a metric's name.
+METRIC_DIRECTION: dict[str, bool] = {
+    METRIC_PLAN_REGENERATION: True,
+    METRIC_REVIEW_RECURRENCE: True,
+    METRIC_DEV_ITERATIONS: True,
+    METRIC_REVIEW_CYCLES: True,
+    METRIC_COST_PER_STORY: True,
+    METRIC_STORIES_PER_DOLLAR: False,
+}
+METRIC_NAMES = tuple(METRIC_DIRECTION)
+
+
+def _rate(numerator: float, denominator: int) -> float | None:
+    return round(numerator / denominator, 4) if denominator > 0 else None
+
+
+def _mean(values: list[int]) -> float | None:
+    return round(sum(values) / len(values), 4) if values else None
+
+
+def compute_cohort_metrics(cohort: str, runs: list[RunSignals]) -> CohortMetrics:
+    """Roll one cohort's runs up into the six reported metrics."""
+    regen = [run.plan_regenerated for run in runs if run.plan_regenerated is not None]
+    recurrence_runs = [
+        run for run in runs if run.total_findings is not None and run.total_findings > 0
+    ]
+    restated_total = sum(run.restated_findings or 0 for run in recurrence_runs)
+    findings_total = sum(run.total_findings or 0 for run in recurrence_runs)
+    dev_iters = [run.dev_iterations for run in runs if run.dev_iterations is not None]
+    review_cycles = [run.review_cycles for run in runs if run.review_cycles is not None]
+
+    # Completed stories with *measured* cost. A successful run whose cost is
+    # null is a real delivery with unknown spend: it stays in ``run_count`` and
+    # out of both cost denominators, so it can never understate cost per story.
+    delivered = [run for run in runs if run.success and run.cost_usd is not None]
+    spend = sum(run.cost_usd or 0.0 for run in delivered)
+
+    values: dict[str, tuple[float | None, int]] = {
+        METRIC_PLAN_REGENERATION: (
+            _rate(sum(1 for flag in regen if flag), len(regen)),
+            len(regen),
+        ),
+        METRIC_REVIEW_RECURRENCE: (
+            _rate(restated_total, findings_total),
+            len(recurrence_runs),
+        ),
+        METRIC_DEV_ITERATIONS: (_mean(dev_iters), len(dev_iters)),
+        METRIC_REVIEW_CYCLES: (_mean(review_cycles), len(review_cycles)),
+        METRIC_COST_PER_STORY: (
+            round(spend / len(delivered), 4) if delivered else None,
+            len(delivered),
+        ),
+        # Zero measured spend across delivered stories is not an infinite
+        # velocity — it is an unusable denominator.
+        METRIC_STORIES_PER_DOLLAR: (
+            round(len(delivered) / spend, 4) if delivered and spend > 0 else None,
+            len(delivered),
+        ),
+    }
+    return CohortMetrics(
+        cohort=cohort,
+        run_count=len(runs),
+        metrics=tuple(
+            Metric(
+                name=name,
+                value=values[name][0],
+                sample_size=values[name][1],
+                lower_is_better=METRIC_DIRECTION[name],
+            )
+            for name in METRIC_NAMES
+        ),
+    )
+
+
+# ── Comparison and report ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class MetricComparison:
+    """One metric held side by side across the two cohorts."""
+
+    name: str
+    lower_is_better: bool
+    with_prior: Metric
+    without_prior: Metric
+
+    @property
+    def comparable(self) -> bool:
+        return self.with_prior.comparable and self.without_prior.comparable
+
+    @property
+    def delta(self) -> float | None:
+        if not self.comparable:
+            return None
+        with_value = self.with_prior.value
+        without_value = self.without_prior.value
+        if (
+            with_value is None or without_value is None
+        ):  # pragma: no cover - comparable implies set
+            return None
+        return round(with_value - without_value, 4)
+
+    @property
+    def improved(self) -> bool | None:
+        """True when the with-prior cohort is better on this metric."""
+        delta = self.delta
+        if delta is None:
+            return None
+        return delta < 0 if self.lower_is_better else delta > 0
+
+
+@dataclass(frozen=True)
+class MatchedBucket:
+    """A comparability bucket holding runs from both cohorts."""
+
+    work_type: str
+    complexity: str
+    domains: tuple[str, ...]
+    with_prior_runs: int
+    without_prior_runs: int
+
+
+@dataclass(frozen=True)
+class TrendPoint:
+    """Stories-per-dollar for one half of the classified window."""
+
+    label: str
+    stories_per_dollar: float | None
+    completed_stories: int
+    measured_cost_usd: float
+
+
+@dataclass(frozen=True)
+class KnowledgeEffectivenessReport:
+    """The full report: window, cohorts, matched comparison, verdict."""
+
+    since: str | None
+    until: str | None
+    recent_run_count: int | None
+    records_considered: int
+    cohort_counts: dict[str, int]
+    matched_buckets: tuple[MatchedBucket, ...]
+    overall: tuple[CohortMetrics, ...]
+    matched: tuple[CohortMetrics, ...]
+    comparisons: tuple[MetricComparison, ...]
+    stories_per_dollar_trend: tuple[TrendPoint, ...]
+    status: str
+    status_reason: str
+
+    def cohort(self, name: str, *, matched: bool = True) -> CohortMetrics | None:
+        for item in self.matched if matched else self.overall:
+            if item.cohort == name:
+                return item
+        return None
+
+    def comparison(self, name: str) -> MetricComparison | None:
+        for item in self.comparisons:
+            if item.name == name:
+                return item
+        return None
+
+
+def build_report(
+    records: list[dict],
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    recent_run_count: int | None = None,
+) -> KnowledgeEffectivenessReport:
+    """Build the effectiveness report from already-windowed audit records.
+
+    ``since`` / ``until`` / ``recent_run_count`` are recorded verbatim so the
+    rendered report states the window it measured; filtering itself belongs to
+    the caller, which holds the substrate.
+    """
+    signals = [extract_signals(record) for record in records]
+    cohort_counts = {
+        COHORT_WITH: sum(1 for s in signals if s.cohort == COHORT_WITH),
+        COHORT_WITHOUT: sum(1 for s in signals if s.cohort == COHORT_WITHOUT),
+        COHORT_UNCLASSIFIED: sum(1 for s in signals if s.cohort == COHORT_UNCLASSIFIED),
+    }
+
+    matched_buckets, matched_runs = _match_buckets(signals)
+    overall = tuple(
+        compute_cohort_metrics(name, [s for s in signals if s.cohort == name])
+        for name in (COHORT_WITH, COHORT_WITHOUT)
+    )
+    matched = tuple(
+        compute_cohort_metrics(name, [s for s in matched_runs if s.cohort == name])
+        for name in (COHORT_WITH, COHORT_WITHOUT)
+    )
+    with_metrics, without_metrics = matched
+    comparisons = _compare(with_metrics, without_metrics)
+    status, reason = _verdict(with_metrics, without_metrics, comparisons)
+
+    return KnowledgeEffectivenessReport(
+        since=since,
+        until=until,
+        recent_run_count=recent_run_count,
+        records_considered=len(signals),
+        cohort_counts=cohort_counts,
+        matched_buckets=matched_buckets,
+        overall=overall,
+        matched=matched,
+        comparisons=comparisons,
+        stories_per_dollar_trend=_trend([s for s in signals if s.classified]),
+        status=status,
+        status_reason=reason,
+    )
+
+
+def _compare(
+    with_metrics: CohortMetrics, without_metrics: CohortMetrics
+) -> tuple[MetricComparison, ...]:
+    """Hold every metric side by side. Both cohorts always carry all six."""
+    comparisons: list[MetricComparison] = []
+    for name in METRIC_NAMES:
+        with_metric = with_metrics.metric(name)
+        without_metric = without_metrics.metric(name)
+        if with_metric is None or without_metric is None:  # pragma: no cover - always present
+            continue
+        comparisons.append(
+            MetricComparison(
+                name=name,
+                lower_is_better=METRIC_DIRECTION[name],
+                with_prior=with_metric,
+                without_prior=without_metric,
+            )
+        )
+    return tuple(comparisons)
+
+
+def _match_buckets(
+    signals: list[RunSignals],
+) -> tuple[tuple[MatchedBucket, ...], list[RunSignals]]:
+    """Keep only buckets that hold both cohorts — the comparable population."""
+    grouped: dict[tuple[str, str, tuple[str, ...]], list[RunSignals]] = {}
+    for signal in signals:
+        if signal.bucket is None or not signal.classified:
+            continue
+        grouped.setdefault(signal.bucket, []).append(signal)
+
+    buckets: list[MatchedBucket] = []
+    matched_runs: list[RunSignals] = []
+    for key in sorted(grouped):
+        members = grouped[key]
+        with_count = sum(1 for s in members if s.cohort == COHORT_WITH)
+        without_count = len(members) - with_count
+        if with_count == 0 or without_count == 0:
+            continue
+        work_type, complexity, domains = key
+        buckets.append(
+            MatchedBucket(
+                work_type=work_type,
+                complexity=complexity,
+                domains=domains,
+                with_prior_runs=with_count,
+                without_prior_runs=without_count,
+            )
+        )
+        matched_runs.extend(members)
+    return tuple(buckets), matched_runs
+
+
+def _trend(classified: list[RunSignals]) -> tuple[TrendPoint, ...]:
+    """Stories-per-dollar for the earlier and later half of the window.
+
+    The cohort comparison answers "did prior knowledge help this story"; this
+    answers the plan's other question — "does the same budget buy more over
+    time" — from the same measured-cost denominator.
+    """
+    ordered = sorted(classified, key=lambda s: (s.started_at or "", s.run_id))
+    if len(ordered) < 2:
+        return ()
+    midpoint = len(ordered) // 2
+    return (
+        _trend_point("earlier", ordered[:midpoint]),
+        _trend_point("later", ordered[midpoint:]),
+    )
+
+
+def _trend_point(label: str, runs: list[RunSignals]) -> TrendPoint:
+    delivered = [run for run in runs if run.success and run.cost_usd is not None]
+    spend = sum(run.cost_usd or 0.0 for run in delivered)
+    return TrendPoint(
+        label=label,
+        stories_per_dollar=(round(len(delivered) / spend, 4) if delivered and spend > 0 else None),
+        completed_stories=len(delivered),
+        measured_cost_usd=round(spend, 4),
+    )
+
+
+def _verdict(
+    with_metrics: CohortMetrics,
+    without_metrics: CohortMetrics,
+    comparisons: tuple[MetricComparison, ...],
+) -> tuple[str, str]:
+    """Separate "we cannot tell yet" from "we can tell, and it did not help"."""
+    if with_metrics.run_count < MIN_COHORT_RUNS or without_metrics.run_count < MIN_COHORT_RUNS:
+        return (
+            STATUS_INSUFFICIENT_DATA,
+            f"matched cohorts hold {with_metrics.run_count} with-prior and "
+            f"{without_metrics.run_count} without-prior run(s); "
+            f"{MIN_COHORT_RUNS} of each are required before comparing",
+        )
+
+    comparable = [item for item in comparisons if item.comparable]
+    if not comparable:
+        return (
+            STATUS_INSUFFICIENT_DATA,
+            f"no metric has {MIN_METRIC_SAMPLES} observations in both cohorts; "
+            "the runs are matched but their telemetry is not recorded on both sides",
+        )
+
+    improved = [item.name for item in comparable if item.improved]
+    if improved:
+        return (
+            STATUS_OBSERVED_IMPROVEMENT,
+            f"{len(improved)} of {len(comparable)} comparable metric(s) improved "
+            f"with prior summaries: {', '.join(improved)}",
+        )
+    return (
+        STATUS_NO_OBSERVED_IMPROVEMENT,
+        f"{len(comparable)} comparable metric(s) and none improved with prior summaries",
+    )

--- a/src/theforge/knowledge_effectiveness_render.py
+++ b/src/theforge/knowledge_effectiveness_render.py
@@ -1,0 +1,227 @@
+"""Presentation for the knowledge-effectiveness report (#1867).
+
+Split from :mod:`theforge.knowledge_effectiveness` so the computation stays a
+pure function of audit records: the same report backs the terminal view, the
+structured payload, and the tests, and none of them can quietly disagree.
+
+The renderer's one editorial rule: never print a bare number for an
+under-sampled metric. ``n=1`` rendered as "0.00" reads like a finding; rendered
+as "insufficient" it reads like what it is.
+"""
+
+from __future__ import annotations
+
+from theforge.knowledge_effectiveness import (
+    COHORT_UNCLASSIFIED,
+    COHORT_WITH,
+    COHORT_WITHOUT,
+    METRIC_COST_PER_STORY,
+    METRIC_DEV_ITERATIONS,
+    METRIC_PLAN_REGENERATION,
+    METRIC_REVIEW_CYCLES,
+    METRIC_REVIEW_RECURRENCE,
+    METRIC_STORIES_PER_DOLLAR,
+    STATUS_INSUFFICIENT_DATA,
+    CohortMetrics,
+    KnowledgeEffectivenessReport,
+    Metric,
+    MetricComparison,
+)
+
+_METRIC_LABELS = {
+    METRIC_PLAN_REGENERATION: "plan regeneration rate",
+    METRIC_REVIEW_RECURRENCE: "review restated-finding rate",
+    METRIC_DEV_ITERATIONS: "avg dev iterations",
+    METRIC_REVIEW_CYCLES: "avg review cycles",
+    METRIC_COST_PER_STORY: "cost per completed story",
+    METRIC_STORIES_PER_DOLLAR: "stories per dollar",
+}
+
+_MONEY_METRICS = frozenset({METRIC_COST_PER_STORY})
+_RATE_METRICS = frozenset({METRIC_PLAN_REGENERATION, METRIC_REVIEW_RECURRENCE})
+
+
+# ── Structured payload ───────────────────────────────────────────────────────
+
+
+def report_payload(report: KnowledgeEffectivenessReport) -> dict:
+    """JSON/YAML-serializable view of the report."""
+    return {
+        "window": {
+            "since": report.since,
+            "until": report.until,
+            "recent_run_count": report.recent_run_count,
+            "records_considered": report.records_considered,
+        },
+        "status": report.status,
+        "status_reason": report.status_reason,
+        "cohorts": {
+            COHORT_WITH: report.cohort_counts.get(COHORT_WITH, 0),
+            COHORT_WITHOUT: report.cohort_counts.get(COHORT_WITHOUT, 0),
+            COHORT_UNCLASSIFIED: report.cohort_counts.get(COHORT_UNCLASSIFIED, 0),
+        },
+        "matched_buckets": [
+            {
+                "work_type": bucket.work_type,
+                "complexity": bucket.complexity,
+                "domains": list(bucket.domains),
+                "with_prior_runs": bucket.with_prior_runs,
+                "without_prior_runs": bucket.without_prior_runs,
+            }
+            for bucket in report.matched_buckets
+        ],
+        "matched_comparison": [_comparison_payload(item) for item in report.comparisons],
+        "overall": {item.cohort: _cohort_payload(item) for item in report.overall},
+        "matched": {item.cohort: _cohort_payload(item) for item in report.matched},
+        "stories_per_dollar_trend": [
+            {
+                "label": point.label,
+                "stories_per_dollar": point.stories_per_dollar,
+                "completed_stories": point.completed_stories,
+                "measured_cost_usd": point.measured_cost_usd,
+            }
+            for point in report.stories_per_dollar_trend
+        ],
+    }
+
+
+def _cohort_payload(cohort: CohortMetrics) -> dict:
+    return {
+        "run_count": cohort.run_count,
+        "metrics": {item.name: _metric_payload(item) for item in cohort.metrics},
+    }
+
+
+def _metric_payload(metric: Metric) -> dict:
+    return {
+        "value": metric.value,
+        "sample_size": metric.sample_size,
+        "available": metric.available,
+        "comparable": metric.comparable,
+        "lower_is_better": metric.lower_is_better,
+    }
+
+
+def _comparison_payload(comparison: MetricComparison) -> dict:
+    return {
+        "metric": comparison.name,
+        "lower_is_better": comparison.lower_is_better,
+        "comparable": comparison.comparable,
+        "with_prior_summary": _metric_payload(comparison.with_prior),
+        "without_prior_summary": _metric_payload(comparison.without_prior),
+        "delta": comparison.delta,
+        "improved": comparison.improved,
+    }
+
+
+# ── Terminal renderer ────────────────────────────────────────────────────────
+
+
+def render_terminal(report: KnowledgeEffectivenessReport) -> str:
+    """Operator-facing view: window, cohorts, matched comparison, verdict."""
+    lines: list[str] = []
+    _render_header(report, lines)
+    _render_buckets(report, lines)
+    _render_comparison(report, lines)
+    _render_trend(report, lines)
+    _render_verdict(report, lines)
+    return "\n".join(lines) + "\n"
+
+
+def _render_header(report: KnowledgeEffectivenessReport, lines: list[str]) -> None:
+    lines.append("Knowledge-loop effectiveness")
+    lines.append("=" * 60)
+    window = _window_label(report)
+    lines.append(f"Window:  {window}")
+    lines.append(f"Records: {report.records_considered}")
+    counts = report.cohort_counts
+    lines.append(
+        f"Cohorts: {counts.get(COHORT_WITH, 0)} with prior summaries, "
+        f"{counts.get(COHORT_WITHOUT, 0)} without, "
+        f"{counts.get(COHORT_UNCLASSIFIED, 0)} unclassified "
+        "(prior-run context disabled or not recorded)"
+    )
+    lines.append("")
+
+
+def _window_label(report: KnowledgeEffectivenessReport) -> str:
+    if report.recent_run_count is not None:
+        return f"most recent {report.recent_run_count} run(s)"
+    if report.since or report.until:
+        return f"{report.since or 'start'} → {report.until or 'now'}"
+    return "all recorded runs"
+
+
+def _render_buckets(report: KnowledgeEffectivenessReport, lines: list[str]) -> None:
+    lines.append("Matched comparability buckets (work type / complexity / domains)")
+    if not report.matched_buckets:
+        lines.append("  none — no bucket holds runs from both cohorts")
+        lines.append("")
+        return
+    for bucket in report.matched_buckets:
+        domains = ",".join(bucket.domains) if bucket.domains else "—"
+        lines.append(
+            f"  {bucket.work_type}/{bucket.complexity}/{domains}: "
+            f"{bucket.with_prior_runs} with, {bucket.without_prior_runs} without"
+        )
+    lines.append("")
+
+
+def _render_comparison(report: KnowledgeEffectivenessReport, lines: list[str]) -> None:
+    with_cohort = report.cohort(COHORT_WITH)
+    without_cohort = report.cohort(COHORT_WITHOUT)
+    with_n = with_cohort.run_count if with_cohort else 0
+    without_n = without_cohort.run_count if without_cohort else 0
+    lines.append(f"Matched cohorts: {with_n} with prior / {without_n} without prior")
+    header = f"  {'metric':<30} {'with':>12} {'without':>12}  verdict"
+    lines.append(header)
+    lines.append("  " + "-" * (len(header) - 2))
+    for comparison in report.comparisons:
+        label = _METRIC_LABELS.get(comparison.name, comparison.name)
+        with_cell = _cell(comparison.name, comparison.with_prior)
+        without_cell = _cell(comparison.name, comparison.without_prior)
+        lines.append(f"  {label:<30} {with_cell:>12} {without_cell:>12}  {_verdict(comparison)}")
+    lines.append("")
+
+
+def _cell(metric_name: str, metric: Metric) -> str:
+    if not metric.available:
+        return "—"
+    value = metric.value
+    if value is None:  # pragma: no cover - available implies a value
+        return "—"
+    if metric_name in _MONEY_METRICS:
+        rendered = f"${value:.2f}"
+    elif metric_name in _RATE_METRICS:
+        rendered = f"{value * 100:.0f}%"
+    else:
+        rendered = f"{value:.2f}"
+    return f"{rendered} (n={metric.sample_size})"
+
+
+def _verdict(comparison: MetricComparison) -> str:
+    if not comparison.comparable:
+        return "insufficient data"
+    if comparison.improved:
+        return f"improved ({comparison.delta:+})"
+    if comparison.delta == 0:
+        return "unchanged"
+    return f"not improved ({comparison.delta:+})"
+
+
+def _render_trend(report: KnowledgeEffectivenessReport, lines: list[str]) -> None:
+    if not report.stories_per_dollar_trend:
+        return
+    lines.append("Stories per dollar over the window (classified runs, measured cost only)")
+    for point in report.stories_per_dollar_trend:
+        value = f"{point.stories_per_dollar:.2f}" if point.stories_per_dollar is not None else "—"
+        lines.append(
+            f"  {point.label:<8} {value:>8}  "
+            f"({point.completed_stories} completed, ${point.measured_cost_usd:.2f} measured)"
+        )
+    lines.append("")
+
+
+def _render_verdict(report: KnowledgeEffectivenessReport, lines: list[str]) -> None:
+    marker = "?" if report.status == STATUS_INSUFFICIENT_DATA else "→"
+    lines.append(f"{marker} {report.status}: {report.status_reason}")

--- a/src/theforge/knowledge_effectiveness_signals.py
+++ b/src/theforge/knowledge_effectiveness_signals.py
@@ -1,0 +1,234 @@
+"""Reading one audit record into the facts the effectiveness report measures (#1867).
+
+The companion to :mod:`theforge.knowledge_effectiveness`, split from it because
+the two change for different reasons: this module changes when the *audit record
+schema* changes, that one when the *metric definitions* do. Everything here is
+schema knowledge — which block holds the plan-regeneration flag, which manifest
+phases can carry prior-run context, which field is measured cost — reduced to a
+:class:`RunSignals` the metric layer can compute over without knowing an audit
+record exists.
+
+Two rules hold throughout:
+
+- **Cohorts come from the manifest, not from configuration.** A run is
+  ``with_prior_summary`` only when an eligible phase's manifest says prior-run
+  context was enabled *and* something was actually included. Enabled with
+  nothing included is ``without_prior_summary`` — a genuine control. Disabled or
+  absent is ``unclassified``, because a run from before the feature existed is
+  not evidence about the feature.
+- **Absent telemetry is unavailable, never zero.** Every metric input is
+  ``None``-able, so "this record predates the telemetry" can never be read
+  downstream as "this record recorded a zero".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from theforge.task.prior_run_selector import ELIGIBLE_PHASES
+
+# ── Cohorts ──────────────────────────────────────────────────────────────────
+
+COHORT_WITH = "with_prior_summary"
+COHORT_WITHOUT = "without_prior_summary"
+COHORT_UNCLASSIFIED = "unclassified"
+
+_COMPLEXITY_BANDS = {
+    "small": "LOW",
+    "medium": "MEDIUM",
+    "large": "HIGH",
+    "low": "LOW",
+    "high": "HIGH",
+}
+
+
+@dataclass(frozen=True)
+class RunSignals:
+    """The deterministic facts one audit record contributes to the report.
+
+    Every metric input is ``None``-able: that is how "this record predates the
+    telemetry" stays distinguishable from "this record recorded a zero".
+    """
+
+    run_id: str
+    slug: str
+    started_at: str | None
+    cohort: str
+    bucket: tuple[str, str, tuple[str, ...]] | None
+    success: bool
+    plan_regenerated: bool | None
+    restated_findings: int | None
+    total_findings: int | None
+    dev_iterations: int | None
+    review_cycles: int | None
+    cost_usd: float | None
+
+    @property
+    def classified(self) -> bool:
+        return self.cohort in (COHORT_WITH, COHORT_WITHOUT)
+
+
+def _mapping(value: object) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def _text(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _count(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def _cost(value: object) -> float | None:
+    """Measured cost only. ``None`` stays ``None`` — never coerced to 0.0."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def classify_cohort(record: dict) -> str:
+    """Which cohort a run belongs to, decided only by its context manifests.
+
+    Manifests for phases prior-run context is never injected into (preflight)
+    are skipped: they record ``enabled: True`` with nothing included on every
+    run of an enabled project, and counting them would put every such run in the
+    control group.
+    """
+    manifests = record.get("context_manifests")
+    if not isinstance(manifests, list):
+        return COHORT_UNCLASSIFIED
+
+    enabled_somewhere = False
+    for entry in manifests:
+        manifest = _mapping(entry)
+        phase = (_text(manifest.get("phase")) or "").lower()
+        if phase not in ELIGIBLE_PHASES:
+            continue
+        prior = _mapping(manifest.get("prior_run_context"))
+        if prior.get("enabled") is not True:
+            continue
+        enabled_somewhere = True
+        included = prior.get("included")
+        if isinstance(included, list) and included:
+            return COHORT_WITH
+    return COHORT_WITHOUT if enabled_somewhere else COHORT_UNCLASSIFIED
+
+
+def _bucket(record: dict) -> tuple[str, str, tuple[str, ...]] | None:
+    """Comparability key: work type, complexity band, domains.
+
+    ``None`` when preflight recorded neither a work type nor a complexity — such
+    a run can still be counted in a cohort, but it cannot be matched against
+    anything, so it is excluded from the bucketed comparison.
+    """
+    preflight = _mapping(record.get("preflight"))
+    if not preflight:
+        return None
+    work_type = _text(preflight.get("work_type"))
+    band = _complexity_band(preflight)
+    if work_type is None and band is None:
+        return None
+    domains_raw = preflight.get("domains")
+    domains = (
+        tuple(sorted(d.strip() for d in domains_raw if isinstance(d, str) and d.strip()))
+        if isinstance(domains_raw, list)
+        else ()
+    )
+    return (work_type or "unknown", band or "UNKNOWN", domains)
+
+
+def _complexity_band(preflight: dict) -> str | None:
+    raw = _text(preflight.get("complexity"))
+    if raw is not None:
+        return _COMPLEXITY_BANDS.get(raw.lower(), raw.upper())
+    score = _count(preflight.get("complexity_score"))
+    if score is None:
+        return None
+    if score <= 3:
+        return "LOW"
+    if score <= 6:
+        return "MEDIUM"
+    return "HIGH"
+
+
+def _review_recurrence(record: dict) -> tuple[int | None, int | None]:
+    """Restated findings and total findings across this run's review cycles.
+
+    ``restated_findings`` / ``novel_findings`` are the primary signal. When an
+    iteration predates them, ``repeated_findings_by_severity`` against
+    ``finding_counts`` is the equivalent recurrence signal. A run whose
+    ``review_loop`` carries neither yields ``(None, None)`` — unavailable, not a
+    zero recurrence rate.
+    """
+    loop = _mapping(record.get("iterations")).get("review_loop")
+    if not isinstance(loop, list) or not loop:
+        return (None, None)
+
+    restated = 0
+    total = 0
+    observed = False
+    for entry in loop:
+        iteration = _mapping(entry)
+        restated_n = _count(iteration.get("restated_findings"))
+        novel_n = _count(iteration.get("novel_findings"))
+        if restated_n is not None and novel_n is not None:
+            restated += restated_n
+            total += restated_n + novel_n
+            observed = True
+            continue
+        repeated = _sum_severity(iteration.get("repeated_findings_by_severity"))
+        counted = _sum_severity(iteration.get("finding_counts"))
+        if repeated is None or counted is None:
+            continue
+        restated += repeated
+        total += max(counted, repeated)
+        observed = True
+    if not observed:
+        return (None, None)
+    return (restated, total)
+
+
+def _sum_severity(value: object) -> int | None:
+    counts = value if isinstance(value, dict) else None
+    if counts is None:
+        return None
+    total = 0
+    for count in counts.values():
+        parsed = _count(count)
+        if parsed is not None:
+            total += parsed
+    return total
+
+
+def extract_signals(record: dict) -> RunSignals:
+    """Reduce one migrated audit record to the facts the report needs."""
+    task = _mapping(record.get("task"))
+    iterations = _mapping(record.get("iterations"))
+    plan_review = record.get("plan_review")
+    restated, total_findings = _review_recurrence(record)
+
+    return RunSignals(
+        run_id=_text(record.get("run_id")) or "",
+        slug=_text(task.get("slug")) or _text(task.get("name")) or "",
+        started_at=_text(_mapping(record.get("timing")).get("started_at")),
+        cohort=classify_cohort(record),
+        bucket=_bucket(record),
+        success=bool(_mapping(record.get("outcome")).get("success")),
+        # A record with no plan_review block never reached plan review; that is
+        # an unavailable denominator, not a run with zero regenerations.
+        plan_regenerated=(
+            bool(_mapping(plan_review).get("regenerated"))
+            if isinstance(plan_review, dict)
+            else None
+        ),
+        restated_findings=restated,
+        total_findings=total_findings,
+        dev_iterations=_count(iterations.get("dev_iterations_productive")),
+        review_cycles=_count(iterations.get("review_cycles_total")),
+        cost_usd=_cost(_mapping(record.get("cost")).get("total_usd")),
+    )

--- a/tests/knowledge_effectiveness_test_helpers.py
+++ b/tests/knowledge_effectiveness_test_helpers.py
@@ -1,0 +1,97 @@
+"""Synthetic audit records for the knowledge-effectiveness tests (#1867).
+
+Shared by the signals, metrics, and renderer mirrors so all three describe the
+same record shape. A drift in what an audit record looks like should break one
+builder, not three copies of it.
+"""
+
+from __future__ import annotations
+
+
+def manifests(cohort: str, *, phase: str = "dev") -> list[dict]:
+    """Context manifests that put a run in the requested cohort."""
+    if cohort == "unclassified":
+        return [
+            {
+                "phase": phase,
+                "prior_run_context": {
+                    "enabled": False,
+                    "included": [],
+                    "dropped": [],
+                    "note": "prior-run context disabled (knowledge.prior_run_context)",
+                },
+            }
+        ]
+    included = (
+        [{"run_id": "prior-1", "reason": "file_overlap", "score": 14}] if cohort == "with" else []
+    )
+    return [
+        {
+            "phase": phase,
+            "prior_run_context": {
+                "enabled": True,
+                "included": included,
+                "dropped": [],
+                "note": "note",
+            },
+        }
+    ]
+
+
+def review_loop(*, restated: int, novel: int) -> list[dict]:
+    return [
+        {
+            "iteration": 1,
+            "verdict": "APPROVE",
+            "novel_findings": novel,
+            "restated_findings": restated,
+        }
+    ]
+
+
+def record(
+    run_id: str,
+    *,
+    cohort: str = "with",
+    success: bool = True,
+    cost: float | None = 4.0,
+    plan_regenerated: bool = False,
+    restated: int = 0,
+    novel: int = 2,
+    dev_iterations: int = 1,
+    review_cycles: int = 1,
+    work_type: str = "feature",
+    complexity: str = "medium",
+    domains: tuple[str, ...] = ("backend",),
+    started_at: str = "2026-08-01T10:00:00+00:00",
+) -> dict:
+    """One migrated audit record, shaped like ``generate_audit_log`` emits."""
+    return {
+        "run_id": run_id,
+        "task": {"slug": run_id, "name": run_id},
+        "timing": {"started_at": started_at},
+        "outcome": {"success": success, "final_phase": "DONE"},
+        "cost": {"total_usd": cost},
+        "preflight": {
+            "work_type": work_type,
+            "complexity": complexity,
+            "complexity_score": 5,
+            "domains": list(domains),
+        },
+        "context_manifests": manifests(cohort),
+        "plan_review": {"decision": "approve", "regenerated": plan_regenerated},
+        "iterations": {
+            "dev_iterations_productive": dev_iterations,
+            "review_cycles_total": review_cycles,
+            "review_loop": review_loop(restated=restated, novel=novel),
+        },
+    }
+
+
+def cohorts(with_kwargs: dict, without_kwargs: dict, *, count: int = 3) -> list[dict]:
+    """``count`` runs per cohort, all sharing one comparability bucket."""
+    records: list[dict] = []
+    for i in range(count):
+        records.append(record(f"with-{i}", cohort="with", **with_kwargs))
+        records.append(record(f"without-{i}", cohort="without", **without_kwargs))
+    return records

--- a/tests/test_cli_knowledge_report.py
+++ b/tests/test_cli_knowledge_report.py
@@ -1,0 +1,161 @@
+"""Tests for ``forge knowledge-report`` — window bounds over the audit substrate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from theforge.cli.knowledge_report import cmd_knowledge_report
+from theforge.coordinator import audit_storage
+
+
+def _record(run_id: str, *, started_at: str, included: bool = True) -> dict:
+    return {
+        "run_id": run_id,
+        "task": {"slug": run_id, "name": run_id},
+        "timing": {"started_at": started_at},
+        "outcome": {"success": True, "final_phase": "DONE"},
+        "cost": {"total_usd": 3.0},
+        "preflight": {
+            "work_type": "feature",
+            "complexity": "medium",
+            "complexity_score": 5,
+            "domains": ["backend"],
+        },
+        "context_manifests": [
+            {
+                "phase": "dev",
+                "prior_run_context": {
+                    "enabled": True,
+                    "included": [{"run_id": "prior-1", "reason": "file_overlap"}]
+                    if included
+                    else [],
+                    "dropped": [],
+                    "note": "note",
+                },
+            }
+        ],
+        "plan_review": {"decision": "approve", "regenerated": False},
+        "iterations": {
+            "dev_iterations_productive": 1,
+            "review_cycles_total": 1,
+            "review_loop": [{"iteration": 1, "novel_findings": 1, "restated_findings": 0}],
+        },
+    }
+
+
+def _args(project_root: Path, **overrides: object) -> SimpleNamespace:
+    base = {
+        "config": str(project_root / "forge.yaml"),
+        "since": None,
+        "until": None,
+        "recent_run_count": None,
+        "format": "json",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _project(tmp_path: Path, records: list[dict]) -> Path:
+    (tmp_path / "forge.yaml").write_text("project: test\n", encoding="utf-8")
+    audit_storage.seed_records(tmp_path, records)
+    return tmp_path
+
+
+def _payload(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+class TestWindowBounds:
+    def test_recent_run_count_bounds_the_window(self, tmp_path: Path, capsys) -> None:
+        records = [
+            _record(f"run-{i}", started_at=f"2026-08-{i + 1:02d}T10:00:00+00:00") for i in range(5)
+        ]
+        root = _project(tmp_path, records)
+
+        assert cmd_knowledge_report(_args(root)) == 0
+        assert _payload(capsys)["window"]["records_considered"] == 5
+
+        assert cmd_knowledge_report(_args(root, recent_run_count=2)) == 0
+        payload = _payload(capsys)
+        assert payload["window"]["records_considered"] == 2
+        assert payload["window"]["recent_run_count"] == 2
+
+    def test_since_and_until_bound_the_window(self, tmp_path: Path, capsys) -> None:
+        records = [
+            _record(f"run-{i}", started_at=f"2026-08-{i + 1:02d}T10:00:00+00:00") for i in range(5)
+        ]
+        root = _project(tmp_path, records)
+
+        assert cmd_knowledge_report(_args(root, since="2026-08-03")) == 0
+        assert _payload(capsys)["window"]["records_considered"] == 3
+
+        assert cmd_knowledge_report(_args(root, since="2026-08-02", until="2026-08-04")) == 0
+        payload = _payload(capsys)
+        assert payload["window"]["records_considered"] == 3
+        assert payload["window"]["since"] == "2026-08-02"
+        assert payload["window"]["until"] == "2026-08-04"
+
+    def test_invalid_since_is_a_clean_failure(self, tmp_path: Path, capsys) -> None:
+        root = _project(tmp_path, [_record("run-0", started_at="2026-08-01T10:00:00+00:00")])
+
+        assert cmd_knowledge_report(_args(root, since="last-tuesday")) == 1
+        assert "Invalid --since" in capsys.readouterr().err
+
+    def test_zero_recent_run_count_is_rejected(self, tmp_path: Path, capsys) -> None:
+        root = _project(tmp_path, [_record("run-0", started_at="2026-08-01T10:00:00+00:00")])
+
+        assert cmd_knowledge_report(_args(root, recent_run_count=0)) == 1
+        assert "--recent-run-count" in capsys.readouterr().err
+
+
+class TestOutput:
+    def test_cohorts_are_reported_from_the_manifests(self, tmp_path: Path, capsys) -> None:
+        records = [
+            _record(f"with-{i}", started_at=f"2026-08-0{i + 1}T10:00:00+00:00", included=True)
+            for i in range(3)
+        ] + [
+            _record(f"without-{i}", started_at=f"2026-08-0{i + 4}T10:00:00+00:00", included=False)
+            for i in range(3)
+        ]
+        root = _project(tmp_path, records)
+
+        assert cmd_knowledge_report(_args(root)) == 0
+        payload = _payload(capsys)
+
+        assert payload["cohorts"]["with_prior_summary"] == 3
+        assert payload["cohorts"]["without_prior_summary"] == 3
+        assert payload["status"] == "no_observed_improvement"
+        assert payload["matched_buckets"][0]["with_prior_runs"] == 3
+
+    def test_terminal_format_renders_the_verdict(self, tmp_path: Path, capsys) -> None:
+        root = _project(tmp_path, [_record("run-0", started_at="2026-08-01T10:00:00+00:00")])
+
+        assert cmd_knowledge_report(_args(root, format="terminal")) == 0
+        out = capsys.readouterr().out
+        assert "Knowledge-loop effectiveness" in out
+        assert "insufficient_data" in out
+
+    def test_yaml_format_is_accepted(self, tmp_path: Path, capsys) -> None:
+        import yaml
+
+        root = _project(tmp_path, [_record("run-0", started_at="2026-08-01T10:00:00+00:00")])
+
+        assert cmd_knowledge_report(_args(root, format="yaml")) == 0
+        assert yaml.safe_load(capsys.readouterr().out)["status"] == "insufficient_data"
+
+
+class TestFailureModes:
+    def test_missing_config_returns_error(self, tmp_path: Path, capsys) -> None:
+        args = _args(tmp_path / "nowhere")
+        args.config = str(tmp_path / "nowhere" / "forge.yaml")
+
+        assert cmd_knowledge_report(args) == 1
+        assert "forge.yaml not found" in capsys.readouterr().err
+
+    def test_missing_substrate_returns_error(self, tmp_path: Path, capsys) -> None:
+        (tmp_path / "forge.yaml").write_text("project: test\n", encoding="utf-8")
+
+        assert cmd_knowledge_report(_args(tmp_path)) == 1
+        assert "No audit history found" in capsys.readouterr().err

--- a/tests/test_cli_knowledge_report.py
+++ b/tests/test_cli_knowledge_report.py
@@ -6,43 +6,14 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+from tests.knowledge_effectiveness_test_helpers import record
 from theforge.cli.knowledge_report import cmd_knowledge_report
 from theforge.coordinator import audit_storage
 
 
 def _record(run_id: str, *, started_at: str, included: bool = True) -> dict:
-    return {
-        "run_id": run_id,
-        "task": {"slug": run_id, "name": run_id},
-        "timing": {"started_at": started_at},
-        "outcome": {"success": True, "final_phase": "DONE"},
-        "cost": {"total_usd": 3.0},
-        "preflight": {
-            "work_type": "feature",
-            "complexity": "medium",
-            "complexity_score": 5,
-            "domains": ["backend"],
-        },
-        "context_manifests": [
-            {
-                "phase": "dev",
-                "prior_run_context": {
-                    "enabled": True,
-                    "included": [{"run_id": "prior-1", "reason": "file_overlap"}]
-                    if included
-                    else [],
-                    "dropped": [],
-                    "note": "note",
-                },
-            }
-        ],
-        "plan_review": {"decision": "approve", "regenerated": False},
-        "iterations": {
-            "dev_iterations_productive": 1,
-            "review_cycles_total": 1,
-            "review_loop": [{"iteration": 1, "novel_findings": 1, "restated_findings": 0}],
-        },
-    }
+    """One seeded run, in or out of the with-prior cohort."""
+    return record(run_id, cohort="with" if included else "without", started_at=started_at)
 
 
 def _args(project_root: Path, **overrides: object) -> SimpleNamespace:

--- a/tests/test_knowledge_effectiveness.py
+++ b/tests/test_knowledge_effectiveness.py
@@ -1,13 +1,15 @@
-"""Tests for the knowledge-loop effectiveness report (#1867).
+"""Tests for the knowledge-loop effectiveness metrics (#1867).
 
-Every input here is a synthetic audit record: the report is a pure function of
-recorded telemetry, so the tests assert on cohort classification, metric
-denominators, and the insufficient-data / no-improvement boundary without
-touching a substrate or an agent.
+This mirror covers the metric half: cohort rollups, comparability matching,
+metric denominators, and the insufficient-data / no-improvement boundary. Record
+reading is covered by ``test_knowledge_effectiveness_signals.py``; every input
+here is still a synthetic audit record, because the report is a pure function of
+recorded telemetry and never touches a substrate or an agent.
 """
 
 from __future__ import annotations
 
+from tests.knowledge_effectiveness_test_helpers import cohorts, record
 from theforge.knowledge_effectiveness import (
     COHORT_UNCLASSIFIED,
     COHORT_WITH,
@@ -22,141 +24,7 @@ from theforge.knowledge_effectiveness import (
     STATUS_NO_OBSERVED_IMPROVEMENT,
     STATUS_OBSERVED_IMPROVEMENT,
     build_report,
-    classify_cohort,
-    extract_signals,
 )
-
-# ── Record builders ───────────────────────────────────────────────────
-
-
-def _manifests(cohort: str, *, phase: str = "dev") -> list[dict]:
-    """Context manifests that put a run in the requested cohort."""
-    if cohort == "unclassified":
-        return [
-            {
-                "phase": phase,
-                "prior_run_context": {
-                    "enabled": False,
-                    "included": [],
-                    "dropped": [],
-                    "note": "prior-run context disabled (knowledge.prior_run_context)",
-                },
-            }
-        ]
-    included = (
-        [{"run_id": "prior-1", "reason": "file_overlap", "score": 14}] if cohort == "with" else []
-    )
-    return [
-        {
-            "phase": phase,
-            "prior_run_context": {
-                "enabled": True,
-                "included": included,
-                "dropped": [],
-                "note": "note",
-            },
-        }
-    ]
-
-
-def _review_loop(*, restated: int, novel: int) -> list[dict]:
-    return [
-        {
-            "iteration": 1,
-            "verdict": "APPROVE",
-            "novel_findings": novel,
-            "restated_findings": restated,
-        }
-    ]
-
-
-def _record(
-    run_id: str,
-    *,
-    cohort: str = "with",
-    success: bool = True,
-    cost: float | None = 4.0,
-    plan_regenerated: bool = False,
-    restated: int = 0,
-    novel: int = 2,
-    dev_iterations: int = 1,
-    review_cycles: int = 1,
-    work_type: str = "feature",
-    complexity: str = "medium",
-    domains: tuple[str, ...] = ("backend",),
-    started_at: str = "2026-08-01T10:00:00+00:00",
-) -> dict:
-    return {
-        "run_id": run_id,
-        "task": {"slug": run_id, "name": run_id},
-        "timing": {"started_at": started_at},
-        "outcome": {"success": success, "final_phase": "DONE"},
-        "cost": {"total_usd": cost},
-        "preflight": {
-            "work_type": work_type,
-            "complexity": complexity,
-            "complexity_score": 5,
-            "domains": list(domains),
-        },
-        "context_manifests": _manifests(cohort),
-        "plan_review": {"decision": "approve", "regenerated": plan_regenerated},
-        "iterations": {
-            "dev_iterations_productive": dev_iterations,
-            "review_cycles_total": review_cycles,
-            "review_loop": _review_loop(restated=restated, novel=novel),
-        },
-    }
-
-
-def _cohorts(with_kwargs: dict, without_kwargs: dict, *, count: int = 3) -> list[dict]:
-    """``count`` runs per cohort, all sharing one comparability bucket."""
-    records = []
-    for i in range(count):
-        records.append(_record(f"with-{i}", cohort="with", **with_kwargs))
-        records.append(_record(f"without-{i}", cohort="without", **without_kwargs))
-    return records
-
-
-# ── Cohort classification ─────────────────────────────────────────────
-
-
-class TestCohortClassification:
-    def test_included_prior_summary_is_with_cohort(self) -> None:
-        assert classify_cohort(_record("r", cohort="with")) == COHORT_WITH
-
-    def test_enabled_but_nothing_included_is_control_cohort(self) -> None:
-        """Enabled with an empty manifest is a genuine control, not unclassified."""
-        assert classify_cohort(_record("r", cohort="without")) == COHORT_WITHOUT
-
-    def test_disabled_manifest_is_unclassified(self) -> None:
-        assert classify_cohort(_record("r", cohort="unclassified")) == COHORT_UNCLASSIFIED
-
-    def test_missing_context_manifests_is_unclassified(self) -> None:
-        record = _record("r")
-        del record["context_manifests"]
-        assert classify_cohort(record) == COHORT_UNCLASSIFIED
-
-    def test_ineligible_phase_manifest_does_not_create_a_control(self) -> None:
-        """Preflight never receives prior-run context, so its manifest proves nothing."""
-        record = _record("r")
-        record["context_manifests"] = _manifests("without", phase="preflight")
-        assert classify_cohort(record) == COHORT_UNCLASSIFIED
-
-    def test_unclassified_runs_never_enter_a_cohort_metric(self) -> None:
-        records = [
-            *_cohorts({}, {}),
-            _record("legacy-1", cohort="unclassified", dev_iterations=99),
-        ]
-        report = build_report(records)
-
-        assert report.cohort_counts[COHORT_UNCLASSIFIED] == 1
-        with_cohort = report.cohort(COHORT_WITH)
-        without_cohort = report.cohort(COHORT_WITHOUT)
-        assert with_cohort is not None and without_cohort is not None
-        assert with_cohort.run_count == 3
-        assert without_cohort.run_count == 3
-        assert without_cohort.metric(METRIC_DEV_ITERATIONS).value == 1.0
-
 
 # ── Comparability bucketing ───────────────────────────────────────────
 
@@ -164,9 +32,9 @@ class TestCohortClassification:
 class TestBucketMatching:
     def test_only_buckets_holding_both_cohorts_are_matched(self) -> None:
         records = [
-            *_cohorts({}, {}),
+            *cohorts({}, {}),
             # A with-prior run in a bucket with no control counterpart.
-            _record("lonely", cohort="with", work_type="bug", complexity="small"),
+            record("lonely", cohort="with", work_type="bug", complexity="small"),
         ]
         report = build_report(records)
 
@@ -182,13 +50,28 @@ class TestBucketMatching:
         assert report.cohort(COHORT_WITH, matched=False).run_count == 4
 
     def test_differing_domains_are_not_comparable(self) -> None:
-        records = [_record(f"with-{i}", cohort="with", domains=("backend",)) for i in range(3)] + [
-            _record(f"without-{i}", cohort="without", domains=("cli",)) for i in range(3)
+        records = [record(f"with-{i}", cohort="with", domains=("backend",)) for i in range(3)] + [
+            record(f"without-{i}", cohort="without", domains=("cli",)) for i in range(3)
         ]
         report = build_report(records)
 
         assert report.matched_buckets == ()
         assert report.status == STATUS_INSUFFICIENT_DATA
+
+    def test_unclassified_runs_never_enter_a_cohort_metric(self) -> None:
+        records = [
+            *cohorts({}, {}),
+            record("legacy-1", cohort="unclassified", dev_iterations=99),
+        ]
+        report = build_report(records)
+
+        assert report.cohort_counts[COHORT_UNCLASSIFIED] == 1
+        with_cohort = report.cohort(COHORT_WITH)
+        without_cohort = report.cohort(COHORT_WITHOUT)
+        assert with_cohort is not None and without_cohort is not None
+        assert with_cohort.run_count == 3
+        assert without_cohort.run_count == 3
+        assert without_cohort.metric(METRIC_DEV_ITERATIONS).value == 1.0
 
 
 # ── Metric computation ────────────────────────────────────────────────
@@ -197,10 +80,10 @@ class TestBucketMatching:
 class TestMetricComputation:
     def test_plan_regeneration_rate_uses_recorded_flag(self) -> None:
         records = [
-            _record("with-0", cohort="with", plan_regenerated=False),
-            _record("with-1", cohort="with", plan_regenerated=False),
-            _record("with-2", cohort="with", plan_regenerated=True),
-            *(_record(f"without-{i}", cohort="without", plan_regenerated=True) for i in range(3)),
+            record("with-0", cohort="with", plan_regenerated=False),
+            record("with-1", cohort="with", plan_regenerated=False),
+            record("with-2", cohort="with", plan_regenerated=True),
+            *(record(f"without-{i}", cohort="without", plan_regenerated=True) for i in range(3)),
         ]
         report = build_report(records)
         comparison = report.comparison(METRIC_PLAN_REGENERATION)
@@ -210,7 +93,7 @@ class TestMetricComputation:
         assert comparison.improved is True
 
     def test_review_recurrence_rate_pools_findings(self) -> None:
-        records = _cohorts(
+        records = cohorts(
             {"restated": 1, "novel": 3},
             {"restated": 2, "novel": 2},
         )
@@ -222,21 +105,17 @@ class TestMetricComputation:
         assert comparison.with_prior.sample_size == 3
         assert comparison.improved is True
 
-    def test_repeated_findings_by_severity_is_the_fallback_signal(self) -> None:
-        record = _record("r")
-        record["iterations"]["review_loop"] = [
-            {
-                "iteration": 1,
-                "finding_counts": {"P1": 2, "P2": 2},
-                "repeated_findings_by_severity": {"P1": 1},
-            }
-        ]
-        signals = extract_signals(record)
+    def test_runs_with_no_findings_leave_the_recurrence_denominator_empty(self) -> None:
+        """Zero findings is no evidence about recurrence, not a 0% recurrence rate."""
+        report = build_report(cohorts({"restated": 0, "novel": 0}, {"restated": 1, "novel": 1}))
+        comparison = report.comparison(METRIC_REVIEW_RECURRENCE)
 
-        assert (signals.restated_findings, signals.total_findings) == (1, 4)
+        assert comparison.with_prior.sample_size == 0
+        assert comparison.with_prior.value is None
+        assert comparison.comparable is False
 
     def test_iteration_averages_come_from_recorded_counts(self) -> None:
-        records = _cohorts(
+        records = cohorts(
             {"dev_iterations": 1, "review_cycles": 1},
             {"dev_iterations": 3, "review_cycles": 2},
         )
@@ -247,7 +126,7 @@ class TestMetricComputation:
         assert report.comparison(METRIC_REVIEW_CYCLES).improved is True
 
     def test_cost_per_completed_story_and_stories_per_dollar(self) -> None:
-        records = _cohorts({"cost": 2.0}, {"cost": 8.0})
+        records = cohorts({"cost": 2.0}, {"cost": 8.0})
         report = build_report(records)
 
         assert report.comparison(METRIC_COST_PER_STORY).with_prior.value == 2.0
@@ -257,8 +136,8 @@ class TestMetricComputation:
         assert report.comparison(METRIC_STORIES_PER_DOLLAR).improved is True
 
     def test_failed_runs_are_excluded_from_cost_denominators(self) -> None:
-        records = _cohorts({"cost": 2.0}, {"cost": 8.0})
-        records.append(_record("with-failed", cohort="with", success=False, cost=50.0))
+        records = cohorts({"cost": 2.0}, {"cost": 8.0})
+        records.append(record("with-failed", cohort="with", success=False, cost=50.0))
         report = build_report(records)
 
         assert report.cohort(COHORT_WITH).run_count == 4
@@ -271,8 +150,8 @@ class TestMetricComputation:
         It stays in the cohort head-count and out of both cost denominators —
         counting it as $0.00 would understate cost per completed story.
         """
-        records = _cohorts({"cost": 2.0}, {"cost": 8.0})
-        records.append(_record("with-unmeasured", cohort="with", cost=None))
+        records = cohorts({"cost": 2.0}, {"cost": 8.0})
+        records.append(record("with-unmeasured", cohort="with", cost=None))
         report = build_report(records)
 
         with_cohort = report.cohort(COHORT_WITH)
@@ -282,11 +161,21 @@ class TestMetricComputation:
         assert with_cohort.metric(METRIC_STORIES_PER_DOLLAR).value == 0.5
 
     def test_zero_measured_spend_yields_no_stories_per_dollar(self) -> None:
-        records = _cohorts({"cost": 0.0}, {"cost": 8.0})
+        records = cohorts({"cost": 0.0}, {"cost": 8.0})
         report = build_report(records)
 
         assert report.cohort(COHORT_WITH).metric(METRIC_STORIES_PER_DOLLAR).value is None
         assert report.comparison(METRIC_STORIES_PER_DOLLAR).comparable is False
+
+    def test_a_cohort_with_no_successful_runs_has_no_cost_metrics(self) -> None:
+        records = cohorts({"success": False}, {})
+        report = build_report(records)
+        with_cohort = report.cohort(COHORT_WITH)
+
+        assert with_cohort.run_count == 3
+        assert with_cohort.metric(METRIC_COST_PER_STORY).value is None
+        assert with_cohort.metric(METRIC_COST_PER_STORY).sample_size == 0
+        assert with_cohort.metric(METRIC_STORIES_PER_DOLLAR).value is None
 
 
 # ── Missing telemetry ─────────────────────────────────────────────────
@@ -295,15 +184,10 @@ class TestMetricComputation:
 class TestMissingTelemetry:
     def test_missing_plan_review_block_makes_the_denominator_unavailable(self) -> None:
         """No plan_review block means "not recorded", never "zero regenerations"."""
-        record = _record("r")
-        del record["plan_review"]
-        signals = extract_signals(record)
-        assert signals.plan_regenerated is None
-
-        records = [_record(f"with-{i}", cohort="with") for i in range(3)]
+        records = [record(f"with-{i}", cohort="with") for i in range(3)]
         for entry in records:
             del entry["plan_review"]
-        records.extend(_record(f"without-{i}", cohort="without") for i in range(3))
+        records.extend(record(f"without-{i}", cohort="without") for i in range(3))
         report = build_report(records)
         comparison = report.comparison(METRIC_PLAN_REGENERATION)
 
@@ -311,22 +195,8 @@ class TestMissingTelemetry:
         assert comparison.with_prior.value is None
         assert comparison.with_prior.available is False
         assert comparison.comparable is False
-
-    def test_record_without_manifests_or_plan_review_is_unclassified(self) -> None:
-        record = _record("legacy")
-        del record["plan_review"]
-        del record["context_manifests"]
-        signals = extract_signals(record)
-
-        assert signals.cohort == COHORT_UNCLASSIFIED
-        assert signals.plan_regenerated is None
-
-    def test_missing_review_loop_leaves_recurrence_unavailable(self) -> None:
-        record = _record("r")
-        del record["iterations"]["review_loop"]
-        signals = extract_signals(record)
-
-        assert (signals.restated_findings, signals.total_findings) == (None, None)
+        assert comparison.delta is None
+        assert comparison.improved is None
 
     def test_empty_record_set_is_insufficient_data(self) -> None:
         report = build_report([])
@@ -341,43 +211,61 @@ class TestMissingTelemetry:
 
 class TestStatusSemantics:
     def test_thin_cohorts_are_insufficient_data_not_no_improvement(self) -> None:
-        report = build_report(_cohorts({"cost": 2.0}, {"cost": 8.0}, count=2))
+        report = build_report(cohorts({"cost": 2.0}, {"cost": 8.0}, count=2))
 
         assert report.status == STATUS_INSUFFICIENT_DATA
         assert "required before comparing" in report.status_reason
 
     def test_identical_cohorts_are_no_observed_improvement(self) -> None:
-        report = build_report(_cohorts({}, {}))
+        report = build_report(cohorts({}, {}))
 
         assert report.status == STATUS_NO_OBSERVED_IMPROVEMENT
         assert "none improved" in report.status_reason
 
     def test_worse_with_prior_is_no_observed_improvement(self) -> None:
         report = build_report(
-            _cohorts({"dev_iterations": 4, "cost": 9.0}, {"dev_iterations": 1, "cost": 2.0})
+            cohorts({"dev_iterations": 4, "cost": 9.0}, {"dev_iterations": 1, "cost": 2.0})
         )
 
         assert report.status == STATUS_NO_OBSERVED_IMPROVEMENT
 
     def test_one_improved_metric_is_observed_improvement(self) -> None:
-        report = build_report(_cohorts({"dev_iterations": 1}, {"dev_iterations": 3}))
+        report = build_report(cohorts({"dev_iterations": 1}, {"dev_iterations": 3}))
 
         assert report.status == STATUS_OBSERVED_IMPROVEMENT
         assert METRIC_DEV_ITERATIONS in report.status_reason
 
+    def test_better_stories_per_dollar_alone_is_observed_improvement(self) -> None:
+        """The one higher-is-better metric must be read in its own direction."""
+        report = build_report(cohorts({"cost": 2.0}, {"cost": 8.0}))
+
+        assert report.status == STATUS_OBSERVED_IMPROVEMENT
+        assert METRIC_STORIES_PER_DOLLAR in report.status_reason
+
     def test_matched_runs_present_but_telemetry_absent_is_insufficient_data(self) -> None:
         """Cohorts are big enough, but no metric has observations on both sides."""
-        records = _cohorts({}, {})
-        for record in records:
-            del record["plan_review"]
-            del record["iterations"]["review_loop"]
-            record["iterations"]["dev_iterations_productive"] = None
-            record["iterations"]["review_cycles_total"] = None
-            record["cost"]["total_usd"] = None
+        records = cohorts({}, {})
+        for entry in records:
+            del entry["plan_review"]
+            del entry["iterations"]["review_loop"]
+            entry["iterations"]["dev_iterations_productive"] = None
+            entry["iterations"]["review_cycles_total"] = None
+            entry["cost"]["total_usd"] = None
         report = build_report(records)
 
         assert report.status == STATUS_INSUFFICIENT_DATA
         assert "telemetry is not recorded on both sides" in report.status_reason
+
+    def test_unbucketed_runs_cannot_carry_the_verdict(self) -> None:
+        """Plenty of classified runs, none comparable — still insufficient data."""
+        records = cohorts({}, {})
+        for entry in records:
+            del entry["preflight"]
+        report = build_report(records)
+
+        assert report.cohort_counts[COHORT_WITH] == 3
+        assert report.matched_buckets == ()
+        assert report.status == STATUS_INSUFFICIENT_DATA
 
 
 # ── Window metadata and trend ─────────────────────────────────────────
@@ -386,7 +274,7 @@ class TestStatusSemantics:
 class TestWindowAndTrend:
     def test_window_bounds_are_carried_into_the_report(self) -> None:
         report = build_report(
-            _cohorts({}, {}), since="2026-08-01", until="2026-08-31", recent_run_count=25
+            cohorts({}, {}), since="2026-08-01", until="2026-08-31", recent_run_count=25
         )
 
         assert (report.since, report.until, report.recent_run_count) == (
@@ -398,17 +286,27 @@ class TestWindowAndTrend:
 
     def test_stories_per_dollar_trend_splits_the_window_chronologically(self) -> None:
         records = [
-            _record(
-                "early-0", cohort="without", cost=10.0, started_at="2026-08-01T00:00:00+00:00"
-            ),
-            _record(
-                "early-1", cohort="without", cost=10.0, started_at="2026-08-02T00:00:00+00:00"
-            ),
-            _record("late-0", cohort="with", cost=2.0, started_at="2026-08-03T00:00:00+00:00"),
-            _record("late-1", cohort="with", cost=2.0, started_at="2026-08-04T00:00:00+00:00"),
+            record("early-0", cohort="without", cost=10.0, started_at="2026-08-01T00:00:00+00:00"),
+            record("early-1", cohort="without", cost=10.0, started_at="2026-08-02T00:00:00+00:00"),
+            record("late-0", cohort="with", cost=2.0, started_at="2026-08-03T00:00:00+00:00"),
+            record("late-1", cohort="with", cost=2.0, started_at="2026-08-04T00:00:00+00:00"),
         ]
         earlier, later = build_report(records).stories_per_dollar_trend
 
         assert (earlier.label, earlier.stories_per_dollar) == ("earlier", 0.1)
         assert (later.label, later.stories_per_dollar) == ("later", 0.5)
         assert later.measured_cost_usd == 4.0
+
+    def test_trend_excludes_unclassified_runs_and_unmeasured_spend(self) -> None:
+        records = [
+            record("early", cohort="with", cost=4.0, started_at="2026-08-01T00:00:00+00:00"),
+            record(
+                "noise", cohort="unclassified", cost=99.0, started_at="2026-08-02T00:00:00+00:00"
+            ),
+            record("late", cohort="with", cost=None, started_at="2026-08-03T00:00:00+00:00"),
+        ]
+        earlier, later = build_report(records).stories_per_dollar_trend
+
+        assert earlier.measured_cost_usd == 4.0
+        assert later.completed_stories == 0
+        assert later.stories_per_dollar is None

--- a/tests/test_knowledge_effectiveness.py
+++ b/tests/test_knowledge_effectiveness.py
@@ -1,0 +1,414 @@
+"""Tests for the knowledge-loop effectiveness report (#1867).
+
+Every input here is a synthetic audit record: the report is a pure function of
+recorded telemetry, so the tests assert on cohort classification, metric
+denominators, and the insufficient-data / no-improvement boundary without
+touching a substrate or an agent.
+"""
+
+from __future__ import annotations
+
+from theforge.knowledge_effectiveness import (
+    COHORT_UNCLASSIFIED,
+    COHORT_WITH,
+    COHORT_WITHOUT,
+    METRIC_COST_PER_STORY,
+    METRIC_DEV_ITERATIONS,
+    METRIC_PLAN_REGENERATION,
+    METRIC_REVIEW_CYCLES,
+    METRIC_REVIEW_RECURRENCE,
+    METRIC_STORIES_PER_DOLLAR,
+    STATUS_INSUFFICIENT_DATA,
+    STATUS_NO_OBSERVED_IMPROVEMENT,
+    STATUS_OBSERVED_IMPROVEMENT,
+    build_report,
+    classify_cohort,
+    extract_signals,
+)
+
+# ── Record builders ───────────────────────────────────────────────────
+
+
+def _manifests(cohort: str, *, phase: str = "dev") -> list[dict]:
+    """Context manifests that put a run in the requested cohort."""
+    if cohort == "unclassified":
+        return [
+            {
+                "phase": phase,
+                "prior_run_context": {
+                    "enabled": False,
+                    "included": [],
+                    "dropped": [],
+                    "note": "prior-run context disabled (knowledge.prior_run_context)",
+                },
+            }
+        ]
+    included = (
+        [{"run_id": "prior-1", "reason": "file_overlap", "score": 14}] if cohort == "with" else []
+    )
+    return [
+        {
+            "phase": phase,
+            "prior_run_context": {
+                "enabled": True,
+                "included": included,
+                "dropped": [],
+                "note": "note",
+            },
+        }
+    ]
+
+
+def _review_loop(*, restated: int, novel: int) -> list[dict]:
+    return [
+        {
+            "iteration": 1,
+            "verdict": "APPROVE",
+            "novel_findings": novel,
+            "restated_findings": restated,
+        }
+    ]
+
+
+def _record(
+    run_id: str,
+    *,
+    cohort: str = "with",
+    success: bool = True,
+    cost: float | None = 4.0,
+    plan_regenerated: bool = False,
+    restated: int = 0,
+    novel: int = 2,
+    dev_iterations: int = 1,
+    review_cycles: int = 1,
+    work_type: str = "feature",
+    complexity: str = "medium",
+    domains: tuple[str, ...] = ("backend",),
+    started_at: str = "2026-08-01T10:00:00+00:00",
+) -> dict:
+    return {
+        "run_id": run_id,
+        "task": {"slug": run_id, "name": run_id},
+        "timing": {"started_at": started_at},
+        "outcome": {"success": success, "final_phase": "DONE"},
+        "cost": {"total_usd": cost},
+        "preflight": {
+            "work_type": work_type,
+            "complexity": complexity,
+            "complexity_score": 5,
+            "domains": list(domains),
+        },
+        "context_manifests": _manifests(cohort),
+        "plan_review": {"decision": "approve", "regenerated": plan_regenerated},
+        "iterations": {
+            "dev_iterations_productive": dev_iterations,
+            "review_cycles_total": review_cycles,
+            "review_loop": _review_loop(restated=restated, novel=novel),
+        },
+    }
+
+
+def _cohorts(with_kwargs: dict, without_kwargs: dict, *, count: int = 3) -> list[dict]:
+    """``count`` runs per cohort, all sharing one comparability bucket."""
+    records = []
+    for i in range(count):
+        records.append(_record(f"with-{i}", cohort="with", **with_kwargs))
+        records.append(_record(f"without-{i}", cohort="without", **without_kwargs))
+    return records
+
+
+# ── Cohort classification ─────────────────────────────────────────────
+
+
+class TestCohortClassification:
+    def test_included_prior_summary_is_with_cohort(self) -> None:
+        assert classify_cohort(_record("r", cohort="with")) == COHORT_WITH
+
+    def test_enabled_but_nothing_included_is_control_cohort(self) -> None:
+        """Enabled with an empty manifest is a genuine control, not unclassified."""
+        assert classify_cohort(_record("r", cohort="without")) == COHORT_WITHOUT
+
+    def test_disabled_manifest_is_unclassified(self) -> None:
+        assert classify_cohort(_record("r", cohort="unclassified")) == COHORT_UNCLASSIFIED
+
+    def test_missing_context_manifests_is_unclassified(self) -> None:
+        record = _record("r")
+        del record["context_manifests"]
+        assert classify_cohort(record) == COHORT_UNCLASSIFIED
+
+    def test_ineligible_phase_manifest_does_not_create_a_control(self) -> None:
+        """Preflight never receives prior-run context, so its manifest proves nothing."""
+        record = _record("r")
+        record["context_manifests"] = _manifests("without", phase="preflight")
+        assert classify_cohort(record) == COHORT_UNCLASSIFIED
+
+    def test_unclassified_runs_never_enter_a_cohort_metric(self) -> None:
+        records = [
+            *_cohorts({}, {}),
+            _record("legacy-1", cohort="unclassified", dev_iterations=99),
+        ]
+        report = build_report(records)
+
+        assert report.cohort_counts[COHORT_UNCLASSIFIED] == 1
+        with_cohort = report.cohort(COHORT_WITH)
+        without_cohort = report.cohort(COHORT_WITHOUT)
+        assert with_cohort is not None and without_cohort is not None
+        assert with_cohort.run_count == 3
+        assert without_cohort.run_count == 3
+        assert without_cohort.metric(METRIC_DEV_ITERATIONS).value == 1.0
+
+
+# ── Comparability bucketing ───────────────────────────────────────────
+
+
+class TestBucketMatching:
+    def test_only_buckets_holding_both_cohorts_are_matched(self) -> None:
+        records = [
+            *_cohorts({}, {}),
+            # A with-prior run in a bucket with no control counterpart.
+            _record("lonely", cohort="with", work_type="bug", complexity="small"),
+        ]
+        report = build_report(records)
+
+        assert report.cohort_counts[COHORT_WITH] == 4
+        assert len(report.matched_buckets) == 1
+        bucket = report.matched_buckets[0]
+        assert (bucket.work_type, bucket.complexity, bucket.domains) == (
+            "feature",
+            "MEDIUM",
+            ("backend",),
+        )
+        assert report.cohort(COHORT_WITH).run_count == 3
+        assert report.cohort(COHORT_WITH, matched=False).run_count == 4
+
+    def test_differing_domains_are_not_comparable(self) -> None:
+        records = [_record(f"with-{i}", cohort="with", domains=("backend",)) for i in range(3)] + [
+            _record(f"without-{i}", cohort="without", domains=("cli",)) for i in range(3)
+        ]
+        report = build_report(records)
+
+        assert report.matched_buckets == ()
+        assert report.status == STATUS_INSUFFICIENT_DATA
+
+
+# ── Metric computation ────────────────────────────────────────────────
+
+
+class TestMetricComputation:
+    def test_plan_regeneration_rate_uses_recorded_flag(self) -> None:
+        records = [
+            _record("with-0", cohort="with", plan_regenerated=False),
+            _record("with-1", cohort="with", plan_regenerated=False),
+            _record("with-2", cohort="with", plan_regenerated=True),
+            *(_record(f"without-{i}", cohort="without", plan_regenerated=True) for i in range(3)),
+        ]
+        report = build_report(records)
+        comparison = report.comparison(METRIC_PLAN_REGENERATION)
+
+        assert comparison.with_prior.value == 0.3333
+        assert comparison.without_prior.value == 1.0
+        assert comparison.improved is True
+
+    def test_review_recurrence_rate_pools_findings(self) -> None:
+        records = _cohorts(
+            {"restated": 1, "novel": 3},
+            {"restated": 2, "novel": 2},
+        )
+        report = build_report(records)
+        comparison = report.comparison(METRIC_REVIEW_RECURRENCE)
+
+        assert comparison.with_prior.value == 0.25
+        assert comparison.without_prior.value == 0.5
+        assert comparison.with_prior.sample_size == 3
+        assert comparison.improved is True
+
+    def test_repeated_findings_by_severity_is_the_fallback_signal(self) -> None:
+        record = _record("r")
+        record["iterations"]["review_loop"] = [
+            {
+                "iteration": 1,
+                "finding_counts": {"P1": 2, "P2": 2},
+                "repeated_findings_by_severity": {"P1": 1},
+            }
+        ]
+        signals = extract_signals(record)
+
+        assert (signals.restated_findings, signals.total_findings) == (1, 4)
+
+    def test_iteration_averages_come_from_recorded_counts(self) -> None:
+        records = _cohorts(
+            {"dev_iterations": 1, "review_cycles": 1},
+            {"dev_iterations": 3, "review_cycles": 2},
+        )
+        report = build_report(records)
+
+        assert report.comparison(METRIC_DEV_ITERATIONS).with_prior.value == 1.0
+        assert report.comparison(METRIC_DEV_ITERATIONS).without_prior.value == 3.0
+        assert report.comparison(METRIC_REVIEW_CYCLES).improved is True
+
+    def test_cost_per_completed_story_and_stories_per_dollar(self) -> None:
+        records = _cohorts({"cost": 2.0}, {"cost": 8.0})
+        report = build_report(records)
+
+        assert report.comparison(METRIC_COST_PER_STORY).with_prior.value == 2.0
+        assert report.comparison(METRIC_COST_PER_STORY).without_prior.value == 8.0
+        assert report.comparison(METRIC_COST_PER_STORY).improved is True
+        assert report.comparison(METRIC_STORIES_PER_DOLLAR).with_prior.value == 0.5
+        assert report.comparison(METRIC_STORIES_PER_DOLLAR).improved is True
+
+    def test_failed_runs_are_excluded_from_cost_denominators(self) -> None:
+        records = _cohorts({"cost": 2.0}, {"cost": 8.0})
+        records.append(_record("with-failed", cohort="with", success=False, cost=50.0))
+        report = build_report(records)
+
+        assert report.cohort(COHORT_WITH).run_count == 4
+        assert report.comparison(METRIC_COST_PER_STORY).with_prior.sample_size == 3
+        assert report.comparison(METRIC_COST_PER_STORY).with_prior.value == 2.0
+
+    def test_unmeasured_cost_is_not_coerced_to_zero(self) -> None:
+        """A successful run with null cost is a delivery of unknown spend.
+
+        It stays in the cohort head-count and out of both cost denominators —
+        counting it as $0.00 would understate cost per completed story.
+        """
+        records = _cohorts({"cost": 2.0}, {"cost": 8.0})
+        records.append(_record("with-unmeasured", cohort="with", cost=None))
+        report = build_report(records)
+
+        with_cohort = report.cohort(COHORT_WITH)
+        assert with_cohort.run_count == 4
+        assert with_cohort.metric(METRIC_COST_PER_STORY).sample_size == 3
+        assert with_cohort.metric(METRIC_COST_PER_STORY).value == 2.0
+        assert with_cohort.metric(METRIC_STORIES_PER_DOLLAR).value == 0.5
+
+    def test_zero_measured_spend_yields_no_stories_per_dollar(self) -> None:
+        records = _cohorts({"cost": 0.0}, {"cost": 8.0})
+        report = build_report(records)
+
+        assert report.cohort(COHORT_WITH).metric(METRIC_STORIES_PER_DOLLAR).value is None
+        assert report.comparison(METRIC_STORIES_PER_DOLLAR).comparable is False
+
+
+# ── Missing telemetry ─────────────────────────────────────────────────
+
+
+class TestMissingTelemetry:
+    def test_missing_plan_review_block_makes_the_denominator_unavailable(self) -> None:
+        """No plan_review block means "not recorded", never "zero regenerations"."""
+        record = _record("r")
+        del record["plan_review"]
+        signals = extract_signals(record)
+        assert signals.plan_regenerated is None
+
+        records = [_record(f"with-{i}", cohort="with") for i in range(3)]
+        for entry in records:
+            del entry["plan_review"]
+        records.extend(_record(f"without-{i}", cohort="without") for i in range(3))
+        report = build_report(records)
+        comparison = report.comparison(METRIC_PLAN_REGENERATION)
+
+        assert comparison.with_prior.sample_size == 0
+        assert comparison.with_prior.value is None
+        assert comparison.with_prior.available is False
+        assert comparison.comparable is False
+
+    def test_record_without_manifests_or_plan_review_is_unclassified(self) -> None:
+        record = _record("legacy")
+        del record["plan_review"]
+        del record["context_manifests"]
+        signals = extract_signals(record)
+
+        assert signals.cohort == COHORT_UNCLASSIFIED
+        assert signals.plan_regenerated is None
+
+    def test_missing_review_loop_leaves_recurrence_unavailable(self) -> None:
+        record = _record("r")
+        del record["iterations"]["review_loop"]
+        signals = extract_signals(record)
+
+        assert (signals.restated_findings, signals.total_findings) == (None, None)
+
+    def test_empty_record_set_is_insufficient_data(self) -> None:
+        report = build_report([])
+
+        assert report.status == STATUS_INSUFFICIENT_DATA
+        assert report.records_considered == 0
+        assert report.stories_per_dollar_trend == ()
+
+
+# ── Status semantics ──────────────────────────────────────────────────
+
+
+class TestStatusSemantics:
+    def test_thin_cohorts_are_insufficient_data_not_no_improvement(self) -> None:
+        report = build_report(_cohorts({"cost": 2.0}, {"cost": 8.0}, count=2))
+
+        assert report.status == STATUS_INSUFFICIENT_DATA
+        assert "required before comparing" in report.status_reason
+
+    def test_identical_cohorts_are_no_observed_improvement(self) -> None:
+        report = build_report(_cohorts({}, {}))
+
+        assert report.status == STATUS_NO_OBSERVED_IMPROVEMENT
+        assert "none improved" in report.status_reason
+
+    def test_worse_with_prior_is_no_observed_improvement(self) -> None:
+        report = build_report(
+            _cohorts({"dev_iterations": 4, "cost": 9.0}, {"dev_iterations": 1, "cost": 2.0})
+        )
+
+        assert report.status == STATUS_NO_OBSERVED_IMPROVEMENT
+
+    def test_one_improved_metric_is_observed_improvement(self) -> None:
+        report = build_report(_cohorts({"dev_iterations": 1}, {"dev_iterations": 3}))
+
+        assert report.status == STATUS_OBSERVED_IMPROVEMENT
+        assert METRIC_DEV_ITERATIONS in report.status_reason
+
+    def test_matched_runs_present_but_telemetry_absent_is_insufficient_data(self) -> None:
+        """Cohorts are big enough, but no metric has observations on both sides."""
+        records = _cohorts({}, {})
+        for record in records:
+            del record["plan_review"]
+            del record["iterations"]["review_loop"]
+            record["iterations"]["dev_iterations_productive"] = None
+            record["iterations"]["review_cycles_total"] = None
+            record["cost"]["total_usd"] = None
+        report = build_report(records)
+
+        assert report.status == STATUS_INSUFFICIENT_DATA
+        assert "telemetry is not recorded on both sides" in report.status_reason
+
+
+# ── Window metadata and trend ─────────────────────────────────────────
+
+
+class TestWindowAndTrend:
+    def test_window_bounds_are_carried_into_the_report(self) -> None:
+        report = build_report(
+            _cohorts({}, {}), since="2026-08-01", until="2026-08-31", recent_run_count=25
+        )
+
+        assert (report.since, report.until, report.recent_run_count) == (
+            "2026-08-01",
+            "2026-08-31",
+            25,
+        )
+        assert report.records_considered == 6
+
+    def test_stories_per_dollar_trend_splits_the_window_chronologically(self) -> None:
+        records = [
+            _record(
+                "early-0", cohort="without", cost=10.0, started_at="2026-08-01T00:00:00+00:00"
+            ),
+            _record(
+                "early-1", cohort="without", cost=10.0, started_at="2026-08-02T00:00:00+00:00"
+            ),
+            _record("late-0", cohort="with", cost=2.0, started_at="2026-08-03T00:00:00+00:00"),
+            _record("late-1", cohort="with", cost=2.0, started_at="2026-08-04T00:00:00+00:00"),
+        ]
+        earlier, later = build_report(records).stories_per_dollar_trend
+
+        assert (earlier.label, earlier.stories_per_dollar) == ("earlier", 0.1)
+        assert (later.label, later.stories_per_dollar) == ("later", 0.5)
+        assert later.measured_cost_usd == 4.0

--- a/tests/test_knowledge_effectiveness_render.py
+++ b/tests/test_knowledge_effectiveness_render.py
@@ -1,0 +1,209 @@
+"""Tests for the knowledge-effectiveness payload and terminal view (#1867).
+
+The renderer's contract is narrow but load-bearing: the structured payload must
+carry every fact the terminal view shows (so a JSON consumer and an operator
+never disagree), and an under-sampled metric must never be printed as a bare
+number an operator would read as a finding.
+"""
+
+from __future__ import annotations
+
+from tests.knowledge_effectiveness_test_helpers import cohorts, record
+from theforge.knowledge_effectiveness import (
+    METRIC_COST_PER_STORY,
+    METRIC_DEV_ITERATIONS,
+    METRIC_NAMES,
+    METRIC_PLAN_REGENERATION,
+    METRIC_STORIES_PER_DOLLAR,
+    build_report,
+)
+from theforge.knowledge_effectiveness_render import render_terminal, report_payload
+
+# ── Structured payload ────────────────────────────────────────────────
+
+
+class TestReportPayload:
+    def test_payload_carries_the_window_and_cohort_counts(self) -> None:
+        records = [*cohorts({}, {}), record("legacy", cohort="unclassified")]
+        payload = report_payload(
+            build_report(records, since="2026-08-01", until="2026-08-31", recent_run_count=25)
+        )
+
+        assert payload["window"] == {
+            "since": "2026-08-01",
+            "until": "2026-08-31",
+            "recent_run_count": 25,
+            "records_considered": 7,
+        }
+        assert payload["cohorts"] == {
+            "with_prior_summary": 3,
+            "without_prior_summary": 3,
+            "unclassified": 1,
+        }
+
+    def test_payload_reports_every_metric_on_both_sides(self) -> None:
+        payload = report_payload(build_report(cohorts({"cost": 2.0}, {"cost": 8.0})))
+
+        assert [item["metric"] for item in payload["matched_comparison"]] == list(METRIC_NAMES)
+        for item in payload["matched_comparison"]:
+            assert set(item["with_prior_summary"]) == {
+                "value",
+                "sample_size",
+                "available",
+                "comparable",
+                "lower_is_better",
+            }
+        cost = next(
+            item
+            for item in payload["matched_comparison"]
+            if item["metric"] == METRIC_COST_PER_STORY
+        )
+        assert cost["with_prior_summary"]["value"] == 2.0
+        assert cost["without_prior_summary"]["value"] == 8.0
+        assert cost["delta"] == -6.0
+        assert cost["improved"] is True
+
+    def test_payload_separates_overall_from_matched_populations(self) -> None:
+        records = [
+            *cohorts({}, {}),
+            # Unmatched: no control counterpart in this bucket.
+            record("lonely", cohort="with", work_type="bug", complexity="small"),
+        ]
+        payload = report_payload(build_report(records))
+
+        assert payload["overall"]["with_prior_summary"]["run_count"] == 4
+        assert payload["matched"]["with_prior_summary"]["run_count"] == 3
+        assert payload["matched_buckets"] == [
+            {
+                "work_type": "feature",
+                "complexity": "MEDIUM",
+                "domains": ["backend"],
+                "with_prior_runs": 3,
+                "without_prior_runs": 3,
+            }
+        ]
+
+    def test_payload_states_the_status_and_its_reason(self) -> None:
+        payload = report_payload(
+            build_report(cohorts({"dev_iterations": 1}, {"dev_iterations": 3}))
+        )
+
+        assert payload["status"] == "observed_improvement"
+        assert METRIC_DEV_ITERATIONS in payload["status_reason"]
+
+    def test_payload_carries_the_trend_points(self) -> None:
+        records = [
+            record("early", cohort="without", cost=10.0, started_at="2026-08-01T00:00:00+00:00"),
+            record("late", cohort="with", cost=2.0, started_at="2026-08-04T00:00:00+00:00"),
+        ]
+        payload = report_payload(build_report(records))
+
+        assert [point["label"] for point in payload["stories_per_dollar_trend"]] == [
+            "earlier",
+            "later",
+        ]
+        assert payload["stories_per_dollar_trend"][1]["stories_per_dollar"] == 0.5
+
+    def test_payload_is_json_serializable(self) -> None:
+        import json
+
+        payload = report_payload(build_report(cohorts({}, {})))
+
+        assert json.loads(json.dumps(payload))["status"] == "no_observed_improvement"
+
+
+# ── Terminal renderer ─────────────────────────────────────────────────
+
+
+class TestRenderTerminal:
+    def test_header_states_the_window_and_cohort_split(self) -> None:
+        records = [*cohorts({}, {}), record("legacy", cohort="unclassified")]
+        out = render_terminal(build_report(records, recent_run_count=30))
+
+        assert "Knowledge-loop effectiveness" in out
+        assert "most recent 30 run(s)" in out
+        assert "3 with prior summaries, 3 without, 1 unclassified" in out
+        assert out.endswith("\n")
+
+    def test_window_label_falls_back_to_dates_then_to_all_runs(self) -> None:
+        dated = render_terminal(build_report(cohorts({}, {}), since="2026-08-01"))
+        undated = render_terminal(build_report(cohorts({}, {})))
+
+        assert "2026-08-01 → now" in dated
+        assert "all recorded runs" in undated
+
+    def test_metric_rows_are_formatted_by_kind(self) -> None:
+        out = render_terminal(
+            build_report(cohorts({"cost": 2.0, "plan_regenerated": False}, {"cost": 8.0}))
+        )
+
+        assert "$2.00 (n=3)" in out  # money
+        assert "0% (n=3)" in out  # rate
+        assert "1.00 (n=3)" in out  # plain average
+
+    def test_under_sampled_metrics_read_as_insufficient_not_as_zero(self) -> None:
+        """A metric nobody should act on must not render as a number."""
+        out = render_terminal(build_report(cohorts({}, {}, count=1)))
+
+        assert "insufficient data" in out
+        assert "insufficient_data" in out
+        assert "0.00" not in out
+
+    def test_missing_denominator_renders_as_a_dash(self) -> None:
+        records = cohorts({}, {})
+        for entry in records:
+            del entry["plan_review"]
+        out = render_terminal(build_report(records))
+
+        plan_row = next(line for line in out.splitlines() if "plan regeneration rate" in line)
+        assert "—" in plan_row
+        assert "insufficient data" in plan_row
+
+    def test_improvement_and_regression_are_labelled_with_the_delta(self) -> None:
+        improved = render_terminal(
+            build_report(cohorts({"dev_iterations": 1}, {"dev_iterations": 3}))
+        )
+        regressed = render_terminal(
+            build_report(cohorts({"dev_iterations": 3}, {"dev_iterations": 1}))
+        )
+
+        assert "improved (-2.0)" in improved
+        assert "not improved (+2.0)" in regressed
+        assert "unchanged" in improved  # metrics equal on both sides
+
+    def test_unmatched_buckets_are_stated_rather_than_left_blank(self) -> None:
+        records = [record(f"with-{i}", cohort="with") for i in range(3)]
+        out = render_terminal(build_report(records))
+
+        assert "none — no bucket holds runs from both cohorts" in out
+
+    def test_matched_buckets_are_listed(self) -> None:
+        out = render_terminal(build_report(cohorts({}, {})))
+
+        assert "feature/MEDIUM/backend: 3 with, 3 without" in out
+
+    def test_trend_section_is_omitted_when_there_is_nothing_to_trend(self) -> None:
+        single = render_terminal(build_report([record("only", cohort="with")]))
+        paired = render_terminal(build_report(cohorts({"cost": 2.0}, {"cost": 8.0})))
+
+        assert "Stories per dollar over the window" not in single
+        assert "Stories per dollar over the window" in paired
+
+    def test_stories_per_dollar_is_rendered_when_measurable(self) -> None:
+        out = render_terminal(build_report(cohorts({"cost": 2.0}, {"cost": 8.0})))
+
+        stories_row = next(
+            line for line in out.splitlines() if "stories per dollar" in line.lower()
+        )
+        assert "0.50 (n=3)" in stories_row
+        # The table row is labelled in prose; the metric key appears only in the
+        # verdict line, which names the metrics that moved.
+        assert METRIC_STORIES_PER_DOLLAR not in stories_row
+        assert METRIC_STORIES_PER_DOLLAR in out.splitlines()[-1]
+
+    def test_empty_report_renders_without_raising(self) -> None:
+        out = render_terminal(build_report([]))
+
+        assert "Records: 0" in out
+        assert "insufficient_data" in out
+        assert METRIC_PLAN_REGENERATION not in out

--- a/tests/test_knowledge_effectiveness_signals.py
+++ b/tests/test_knowledge_effectiveness_signals.py
@@ -1,0 +1,204 @@
+"""Tests for reading an audit record into effectiveness signals (#1867).
+
+This mirror covers the schema-reading half: which block a fact comes from, how a
+cohort is decided from the context manifests, how a comparability bucket is
+derived, and — the rule the whole report rests on — that absent telemetry
+becomes ``None`` rather than a zero.
+"""
+
+from __future__ import annotations
+
+from tests.knowledge_effectiveness_test_helpers import manifests, record
+from theforge.knowledge_effectiveness_signals import (
+    COHORT_UNCLASSIFIED,
+    COHORT_WITH,
+    COHORT_WITHOUT,
+    classify_cohort,
+    extract_signals,
+)
+
+# ── Cohort classification ─────────────────────────────────────────────
+
+
+class TestCohortClassification:
+    def test_included_prior_summary_is_with_cohort(self) -> None:
+        assert classify_cohort(record("r", cohort="with")) == COHORT_WITH
+
+    def test_enabled_but_nothing_included_is_control_cohort(self) -> None:
+        """Enabled with an empty manifest is a genuine control, not unclassified."""
+        assert classify_cohort(record("r", cohort="without")) == COHORT_WITHOUT
+
+    def test_disabled_manifest_is_unclassified(self) -> None:
+        assert classify_cohort(record("r", cohort="unclassified")) == COHORT_UNCLASSIFIED
+
+    def test_missing_context_manifests_is_unclassified(self) -> None:
+        entry = record("r")
+        del entry["context_manifests"]
+        assert classify_cohort(entry) == COHORT_UNCLASSIFIED
+
+    def test_malformed_context_manifests_is_unclassified(self) -> None:
+        entry = record("r")
+        entry["context_manifests"] = "not-a-list"
+        assert classify_cohort(entry) == COHORT_UNCLASSIFIED
+
+    def test_ineligible_phase_manifest_does_not_create_a_control(self) -> None:
+        """Preflight never receives prior-run context, so its manifest proves nothing."""
+        entry = record("r")
+        entry["context_manifests"] = manifests("without", phase="preflight")
+        assert classify_cohort(entry) == COHORT_UNCLASSIFIED
+
+    def test_one_eligible_phase_with_an_inclusion_settles_the_cohort(self) -> None:
+        """Plan saw a summary, review saw none — the run was still advised."""
+        entry = record("r")
+        entry["context_manifests"] = [
+            *manifests("with", phase="plan"),
+            *manifests("without", phase="review"),
+        ]
+        assert classify_cohort(entry) == COHORT_WITH
+
+
+# ── Comparability bucket ──────────────────────────────────────────────
+
+
+class TestBucketDerivation:
+    def test_bucket_is_work_type_complexity_band_and_sorted_domains(self) -> None:
+        signals = extract_signals(
+            record("r", work_type="feature", complexity="large", domains=("cli", "backend"))
+        )
+
+        assert signals.bucket == ("feature", "HIGH", ("backend", "cli"))
+
+    def test_complexity_score_is_the_fallback_band(self) -> None:
+        entry = record("r")
+        del entry["preflight"]["complexity"]
+        entry["preflight"]["complexity_score"] = 9
+
+        assert extract_signals(entry).bucket == ("feature", "HIGH", ("backend",))
+
+    def test_missing_preflight_leaves_the_run_unbucketed(self) -> None:
+        entry = record("r")
+        del entry["preflight"]
+
+        assert extract_signals(entry).bucket is None
+
+    def test_preflight_without_work_type_or_complexity_is_unbucketed(self) -> None:
+        entry = record("r")
+        entry["preflight"] = {"domains": ["backend"]}
+
+        assert extract_signals(entry).bucket is None
+
+    def test_non_list_domains_degrade_to_empty(self) -> None:
+        entry = record("r")
+        entry["preflight"]["domains"] = "backend"
+
+        assert extract_signals(entry).bucket == ("feature", "MEDIUM", ())
+
+
+# ── Recurrence extraction ─────────────────────────────────────────────
+
+
+class TestRecurrenceExtraction:
+    def test_restated_and_novel_findings_are_the_primary_signal(self) -> None:
+        signals = extract_signals(record("r", restated=2, novel=6))
+
+        assert (signals.restated_findings, signals.total_findings) == (2, 8)
+
+    def test_repeated_findings_by_severity_is_the_fallback_signal(self) -> None:
+        entry = record("r")
+        entry["iterations"]["review_loop"] = [
+            {
+                "iteration": 1,
+                "finding_counts": {"P1": 2, "P2": 2},
+                "repeated_findings_by_severity": {"P1": 1},
+            }
+        ]
+        signals = extract_signals(entry)
+
+        assert (signals.restated_findings, signals.total_findings) == (1, 4)
+
+    def test_iterations_accumulate_across_the_review_loop(self) -> None:
+        entry = record("r")
+        entry["iterations"]["review_loop"] = [
+            {"iteration": 1, "novel_findings": 3, "restated_findings": 0},
+            {"iteration": 2, "novel_findings": 1, "restated_findings": 2},
+        ]
+        signals = extract_signals(entry)
+
+        assert (signals.restated_findings, signals.total_findings) == (2, 6)
+
+    def test_missing_review_loop_leaves_recurrence_unavailable(self) -> None:
+        entry = record("r")
+        del entry["iterations"]["review_loop"]
+        signals = extract_signals(entry)
+
+        assert (signals.restated_findings, signals.total_findings) == (None, None)
+
+    def test_review_loop_without_any_recurrence_fields_is_unavailable(self) -> None:
+        """An iteration that recorded neither signal is not a zero-recurrence run."""
+        entry = record("r")
+        entry["iterations"]["review_loop"] = [{"iteration": 1, "verdict": "APPROVE"}]
+        signals = extract_signals(entry)
+
+        assert (signals.restated_findings, signals.total_findings) == (None, None)
+
+
+# ── Absent telemetry stays absent ─────────────────────────────────────
+
+
+class TestAbsentTelemetry:
+    def test_missing_plan_review_block_is_not_zero_regenerations(self) -> None:
+        entry = record("r")
+        del entry["plan_review"]
+
+        assert extract_signals(entry).plan_regenerated is None
+
+    def test_recorded_plan_review_flag_is_read_verbatim(self) -> None:
+        assert extract_signals(record("r", plan_regenerated=True)).plan_regenerated is True
+        assert extract_signals(record("r", plan_regenerated=False)).plan_regenerated is False
+
+    def test_record_without_manifests_or_plan_review_is_unclassified(self) -> None:
+        entry = record("legacy")
+        del entry["plan_review"]
+        del entry["context_manifests"]
+        signals = extract_signals(entry)
+
+        assert signals.cohort == COHORT_UNCLASSIFIED
+        assert signals.plan_regenerated is None
+        assert signals.classified is False
+
+    def test_null_cost_is_not_coerced_to_zero(self) -> None:
+        assert extract_signals(record("r", cost=None)).cost_usd is None
+        assert extract_signals(record("r", cost=0.0)).cost_usd == 0.0
+
+    def test_missing_iteration_counts_stay_none(self) -> None:
+        entry = record("r")
+        entry["iterations"]["dev_iterations_productive"] = None
+        del entry["iterations"]["review_cycles_total"]
+        signals = extract_signals(entry)
+
+        assert signals.dev_iterations is None
+        assert signals.review_cycles is None
+
+    def test_booleans_are_never_read_as_counts(self) -> None:
+        """``True`` is an ``int`` in Python; it is not an iteration count."""
+        entry = record("r")
+        entry["iterations"]["dev_iterations_productive"] = True
+
+        assert extract_signals(entry).dev_iterations is None
+
+    def test_identity_and_timing_survive_extraction(self) -> None:
+        signals = extract_signals(record("run-7", started_at="2026-08-09T12:00:00+00:00"))
+
+        assert (signals.run_id, signals.slug) == ("run-7", "run-7")
+        assert signals.started_at == "2026-08-09T12:00:00+00:00"
+        assert signals.success is True
+
+    def test_an_empty_record_yields_all_unavailable_signals(self) -> None:
+        signals = extract_signals({})
+
+        assert signals.cohort == COHORT_UNCLASSIFIED
+        assert signals.bucket is None
+        assert signals.success is False
+        assert signals.plan_regenerated is None
+        assert signals.cost_usd is None
+        assert (signals.dev_iterations, signals.review_cycles) == (None, None)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] No blocking issues found; the focused knowledge-effectiveness test suite passed with 75 tests. | [google-gemini-3.5-flash-api] The implementation of the knowledge-loop effectiveness metrics is robust, cleanly modularized, and fully compliant with all acceptance criteria. | [anthropic-claude-haiku-4-5-cli] Implementation fully satisfies spec and acceptance criteria. Three-way module split (signals/metrics/render) follows project single-purpose convention with tests mirrored to match. CLI command properly integrated. All six metrics computed with correct denominator guards. Cohort classification, bucketing, and insufficient-data vs. no-improvement verdict logic are sound. 75 tests cover metric computation, boundary conditions, and cohort separation. One justified convention deviation (stdlib-only import in signals module) is P2 and outweighed by duplication prevention.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $13.05
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/knowledge_effectiveness_signals.py:27`** The signals module imports ELIGIBLE_PHASES from theforge.task.prior_run_selector, violating the project convention to keep pure-data types in low-dependency modules with stdlib-only imports.

## Story

Knowledge-loop effectiveness metrics (GitHub Issue #1867)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1867