### PR TITLE
Phase-specific prior-knowledge injection

### DIFF
--- a/docs/adr/0002-audit-substrate-and-queryable-run-history.md
+++ b/docs/adr/0002-audit-substrate-and-queryable-run-history.md
@@ -104,7 +104,7 @@ The router's trust surface is exactly the substrate. Anything else is advisory.
 
 Summaries are advisory. Specifically:
 
-- **May influence:** prompt construction for plan, dev, and review phases. Context manifests that select which summaries are relevant for the current story. Operator-facing search and discovery.
+- **May influence:** prompt construction for plan, dev, and review phases; audit-derived signal renderings for preflight; context manifests that select which summaries are relevant for the current story; operator-facing search and discovery.
 - **MUST NOT influence:** routing decisions, budget enforcement, refusal verdicts, gate pass/fail outcomes, or any mechanical action the coordinator takes. Those decisions belong to the per-run records and the deterministic gates.
 
 This is the *"LLMs propose, the coordinator decides"* invariant applied to history. Mechanical control flow stays on telemetry; LLM-generated text stays on context.

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -1055,12 +1055,14 @@ spent after the run's own cost accounting has closed.
 
 `knowledge.prior_run_context` enables Layer 3 consumption: context assembly may
 then offer indexed prior summaries to the **plan, dev, and review** phases as
-advisory, droppable context items. It never offers them to preflight, whose
-output drives coordinator control flow (ADR-0002 clause 5), and it only offers a
-summary the knowledge index carries an *admissible* verdict for — a summary with
-an inadmissible verdict, or with no verdict at all, is never injected. Relevance
-is scored from deterministic index fields only (file overlap, domain, story
-shape, indexed patterns, recency), so summary prose can never select itself in.
+advisory, droppable context items, and to **preflight** only as audit-derived
+signal renderings with no summary prose. Preflight's output still drives
+coordinator control flow (ADR-0002 clause 5), so only bounded mechanical signals
+may appear there. A summary is offered only when the knowledge index carries an
+*admissible* verdict for it — a summary with an inadmissible verdict, or with no
+verdict at all, is never injected. Relevance is scored from deterministic index
+fields only (file overlap, domain, story shape, indexed patterns, recency), so
+summary prose can never select itself in.
 
 Every decision is recorded per phase in the audit record under
 `context_manifests[].prior_run_context` — what was included and why, what was

--- a/src/theforge/knowledge_effectiveness_signals.py
+++ b/src/theforge/knowledge_effectiveness_signals.py
@@ -94,10 +94,10 @@ def _cost(value: object) -> float | None:
 def classify_cohort(record: dict) -> str:
     """Which cohort a run belongs to, decided only by its context manifests.
 
-    Manifests for phases prior-run context is never injected into (preflight)
-    are skipped: they record ``enabled: True`` with nothing included on every
-    run of an enabled project, and counting them would put every such run in the
-    control group.
+    Only prose-eligible plan/dev/review manifests classify cohorts. Preflight's
+    signal-only manifest is advisory visibility, not treatment/control evidence,
+    so preflight-only records stay ``unclassified`` rather than inflating the
+    control cohort.
     """
     manifests = record.get("context_manifests")
     if not isinstance(manifests, list):

--- a/src/theforge/task/prior_run_manifest.py
+++ b/src/theforge/task/prior_run_manifest.py
@@ -8,13 +8,15 @@ selector never asks: was nothing known, or was something known and withheld?
 
 from __future__ import annotations
 
-from .prior_run_selector import ELIGIBLE_PHASES, PriorRunSelection
+from .prior_run_selector import SUPPORTED_PHASES, PriorRunSelection
 
 
 def disabled_manifest() -> dict:
     """The manifest payload for a run whose ``knowledge.prior_run_context`` is off."""
     return {
         "enabled": False,
+        "phase": "",
+        "rendering_mode": "",
         "included": [],
         "dropped": [],
         "note": "prior-run context disabled (knowledge.prior_run_context)",
@@ -39,6 +41,8 @@ def build_manifest(
     for candidate in selection.candidates:
         record = {
             "run_id": candidate.run_id,
+            "phase": candidate.phase,
+            "rendering_mode": candidate.rendering_mode,
             "reason": candidate.reason,
             "score": candidate.score,
             "verdict": candidate.verdict.to_dict(),
@@ -49,13 +53,20 @@ def build_manifest(
             dropped.append({**record, "reason": "budget_pressure"})
 
     for exclusion in selection.excluded:
-        record = {"run_id": exclusion.run_id, "reason": exclusion.reason}
+        record = {
+            "run_id": exclusion.run_id,
+            "phase": selection.phase or phase,
+            "rendering_mode": selection.rendering_mode,
+            "reason": exclusion.reason,
+        }
         if exclusion.verdict is not None:
             record["verdict"] = exclusion.verdict.to_dict()
         dropped.append(record)
 
     return {
         "enabled": True,
+        "phase": selection.phase or phase,
+        "rendering_mode": selection.rendering_mode,
         "included": included,
         "dropped": dropped,
         "note": _build_note(
@@ -83,7 +94,7 @@ def _build_note(
     if not selection.phase_eligible:
         return (
             f"prior-run context is not injected in the {phase} phase "
-            f"(eligible phases: {', '.join(sorted(ELIGIBLE_PHASES))})"
+            f"(supported phases: {', '.join(sorted(SUPPORTED_PHASES))})"
         )
     if selection.entry_count == 0:
         return "no relevant prior knowledge exists (no indexed summaries)"

--- a/src/theforge/task/prior_run_selector.py
+++ b/src/theforge/task/prior_run_selector.py
@@ -49,6 +49,8 @@ PRIOR_RUN_KIND = "prior_run_summary"
 #: review agents. It must never reach preflight, whose output (sufficiency,
 #: complexity, likely files, refusal) drives coordinator control flow.
 ELIGIBLE_PHASES = frozenset({"plan", "dev", "review"})
+SIGNAL_ONLY_PHASES = frozenset({"preflight"})
+SUPPORTED_PHASES = ELIGIBLE_PHASES | SIGNAL_ONLY_PHASES
 
 #: Most prior summaries a single assembly will ever offer, before budget.
 _MAX_CANDIDATES = 3
@@ -115,6 +117,8 @@ class PriorRunCandidate:
     reason: str
     verdict: KnowledgeSummaryVerdict
     content: str
+    phase: str
+    rendering_mode: str
 
     @property
     def source(self) -> str:
@@ -139,6 +143,8 @@ class PriorRunSelection:
     excluded: tuple[PriorRunExclusion, ...] = ()
     entry_count: int = 0
     phase_eligible: bool = True
+    phase: str = ""
+    rendering_mode: str = ""
 
 
 def select_prior_runs(
@@ -155,8 +161,9 @@ def select_prior_runs(
     the index is absent/malformed, or nothing scores above zero.
     """
     normalized_phase = (phase or "").lower()
-    if normalized_phase not in ELIGIBLE_PHASES:
-        return PriorRunSelection(phase_eligible=False)
+    rendering_mode = _rendering_mode_for_phase(normalized_phase)
+    if not rendering_mode:
+        return PriorRunSelection(phase_eligible=False, phase=normalized_phase)
 
     entries = _load_index_entries(Path(project_root))
     if not entries:
@@ -228,7 +235,16 @@ def select_prior_runs(
             score -= _PENALTY_REDUCED_RANK
             reasons.append("reduced_rank")
 
-        content = _render_summary(Path(project_root), entry, run_id=run_id, verdict=verdict)
+        content = _render_summary(
+            Path(project_root),
+            entry,
+            run_id=run_id,
+            verdict=verdict,
+            phase=normalized_phase,
+            rendering_mode=rendering_mode,
+            touched_files=touched_files,
+            touched_dirs=touched_dirs,
+        )
         if not content:
             excluded.append(
                 PriorRunExclusion(run_id=run_id, reason="summary_unreadable", verdict=verdict)
@@ -243,6 +259,8 @@ def select_prior_runs(
                 reason=", ".join(reasons),
                 verdict=verdict,
                 content=content,
+                phase=normalized_phase,
+                rendering_mode=rendering_mode,
             )
         )
 
@@ -265,6 +283,8 @@ def select_prior_runs(
         excluded=tuple(excluded),
         entry_count=len(entries),
         phase_eligible=True,
+        phase=normalized_phase,
+        rendering_mode=rendering_mode,
     )
 
 
@@ -383,6 +403,10 @@ def _render_summary(
     *,
     run_id: str,
     verdict: KnowledgeSummaryVerdict,
+    phase: str,
+    rendering_mode: str,
+    touched_files: set[str],
+    touched_dirs: set[str],
 ) -> str:
     """Render bounded advisory prose from the referenced summary artifact."""
     rel_path = _text(entry.get("summary_path"))
@@ -404,36 +428,266 @@ def _render_summary(
         ),
         "",
     ]
-
-    what_changed = summary.get("what_changed")
-    if isinstance(what_changed, Mapping):
-        description = _text(what_changed.get("description"), limit=_MAX_FIELD_CHARS)
-        approach = _text(what_changed.get("approach"), limit=_MAX_FIELD_CHARS)
-        if description:
-            lines.append(f"- What changed: {description}")
-        if approach:
-            lines.append(f"- Approach: {approach}")
-
-    learned = summary.get("what_was_learned")
-    if isinstance(learned, list):
-        claims = [
-            _text(item.get("claim"), limit=_MAX_FIELD_CHARS)
-            for item in learned
-            if isinstance(item, Mapping)
-        ]
-        claims = [claim for claim in claims if claim][:_MAX_RENDERED_CLAIMS]
-        if claims:
-            lines.append("- Learned:")
-            lines.extend(f"  - {claim}" for claim in claims)
-
-    patterns = _string_list(entry.get("learned_patterns"))[:_MAX_RENDERED_PATTERNS]
-    if patterns:
-        lines.append(f"- Patterns: {', '.join(patterns)}")
+    phase_lines = _phase_lines(
+        phase,
+        summary=summary,
+        entry=entry,
+        rendering_mode=rendering_mode,
+        touched_files=touched_files,
+        touched_dirs=touched_dirs,
+    )
+    lines.extend(phase_lines)
 
     if verdict.reasons:
         lines.append(f"- Verdict caveats: {', '.join(verdict.reasons)}")
 
     return "\n".join(lines).strip()
+
+
+def _phase_lines(
+    phase: str,
+    *,
+    summary: Mapping[str, Any],
+    entry: Mapping[str, Any],
+    rendering_mode: str,
+    touched_files: set[str],
+    touched_dirs: set[str],
+) -> list[str]:
+    if rendering_mode == "signal_only":
+        return _render_preflight_signals(summary)
+    if phase == "plan":
+        return _render_plan_summary(summary)
+    if phase == "dev":
+        return _render_dev_summary(
+            summary,
+            entry=entry,
+            touched_files=touched_files,
+            touched_dirs=touched_dirs,
+        )
+    if phase == "review":
+        return _render_review_summary(summary)
+    return []
+
+
+def _render_preflight_signals(summary: Mapping[str, Any]) -> list[str]:
+    lines = [
+        (
+            "- Preflight note: Advisory prior-run signals only. "
+            "Use these as risk context, not as control-flow input."
+        ),
+    ]
+    story_shape = summary.get("story_shape")
+    if isinstance(story_shape, Mapping):
+        shape_parts = [
+            f"{key}={value}"
+            for key in ("work_type", "complexity", "complexity_score", "contract_change")
+            if (value := story_shape.get(key)) is not None and _text(value)
+        ]
+        if shape_parts:
+            lines.append(f"- Story shape: {', '.join(shape_parts)}")
+
+    complexity = summary.get("complexity_signal")
+    if isinstance(complexity, Mapping):
+        metrics = []
+        for key in ("actual_iterations", "review_cycles", "plan_regenerations", "cost_usd"):
+            value = complexity.get(key)
+            if value is None:
+                continue
+            metrics.append(f"{key}={value}")
+        if metrics:
+            lines.append(f"- Run signals: {', '.join(metrics)}")
+
+    insights = summary.get("review_insights")
+    if isinstance(insights, Mapping):
+        recurring = _finding_metadata(insights.get("recurring_findings"))
+        resolved = _finding_metadata(insights.get("resolved_findings"))
+        if recurring:
+            lines.append(f"- Recurring findings: count={len(recurring)}; {', '.join(recurring)}")
+        if resolved:
+            lines.append(f"- Resolved findings: count={len(resolved)}; {', '.join(resolved)}")
+    return lines
+
+
+def _render_plan_summary(summary: Mapping[str, Any]) -> list[str]:
+    lines: list[str] = []
+    what_changed = summary.get("what_changed")
+    if isinstance(what_changed, Mapping):
+        approach = _text(what_changed.get("approach"), limit=_MAX_FIELD_CHARS)
+        if approach:
+            lines.append(f"- Prior approach: {approach}")
+    claims = _evidenced_claims(summary)
+    if claims:
+        lines.append("- Lessons with resolved evidence:")
+        lines.extend(f"  - {claim}" for claim in claims[:_MAX_RENDERED_CLAIMS])
+    return lines
+
+
+def _render_dev_summary(
+    summary: Mapping[str, Any],
+    *,
+    entry: Mapping[str, Any],
+    touched_files: set[str],
+    touched_dirs: set[str],
+) -> list[str]:
+    lines: list[str] = []
+    changed_files = _string_list(summary.get("changed_files")) or _string_list(
+        entry.get("changed_files")
+    )
+    if changed_files:
+        lines.append(
+            f"- Related changed files: {', '.join(changed_files[:_MAX_RENDERED_PATTERNS])}"
+        )
+
+    claims = _dev_grounded_claims(summary, touched_files=touched_files, touched_dirs=touched_dirs)
+    if claims:
+        lines.append("- Evidence-backed implementation patterns:")
+        lines.extend(f"  - {claim}" for claim in claims[:_MAX_RENDERED_CLAIMS])
+    return lines
+
+
+def _render_review_summary(summary: Mapping[str, Any]) -> list[str]:
+    lines: list[str] = []
+    insights = summary.get("review_insights")
+    if isinstance(insights, Mapping):
+        recurring = _finding_descriptions(insights.get("recurring_findings"))
+        resolved = _finding_descriptions(insights.get("resolved_findings"))
+        observations = [
+            _text(item, limit=_MAX_FIELD_CHARS)
+            for item in _string_list(insights.get("observations"))
+        ]
+        if recurring:
+            lines.append("- Recurring findings to re-check:")
+            lines.extend(f"  - {item}" for item in recurring[:_MAX_RENDERED_CLAIMS])
+        if resolved:
+            lines.append("- Resolved findings worth verifying stayed fixed:")
+            lines.extend(f"  - {item}" for item in resolved[:_MAX_RENDERED_CLAIMS])
+        if observations:
+            lines.append("- Verification concerns:")
+            lines.extend(f"  - {item}" for item in observations[:_MAX_RENDERED_CLAIMS])
+
+    complexity = summary.get("complexity_signal")
+    if isinstance(complexity, Mapping):
+        metrics = []
+        for key in ("review_cycles", "actual_iterations", "plan_regenerations"):
+            value = complexity.get(key)
+            if value is not None:
+                metrics.append(f"{key}={value}")
+        if metrics:
+            lines.append(f"- Review-cycle signals: {', '.join(metrics)}")
+    return lines
+
+
+def _evidenced_claims(summary: Mapping[str, Any]) -> list[str]:
+    learned = summary.get("what_was_learned")
+    if not isinstance(learned, list):
+        return []
+    claims: list[str] = []
+    for item in learned:
+        if not isinstance(item, Mapping):
+            continue
+        evidence = item.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            continue
+        claim = _text(item.get("claim"), limit=_MAX_FIELD_CHARS)
+        if claim:
+            claims.append(claim)
+    return claims
+
+
+def _dev_grounded_claims(
+    summary: Mapping[str, Any],
+    *,
+    touched_files: set[str],
+    touched_dirs: set[str],
+) -> list[str]:
+    learned = summary.get("what_was_learned")
+    if not isinstance(learned, list):
+        return []
+    claims: list[str] = []
+    for item in learned:
+        if not isinstance(item, Mapping):
+            continue
+        if not _claim_has_dev_relevant_evidence(
+            item.get("evidence"),
+            touched_files=touched_files,
+            touched_dirs=touched_dirs,
+        ):
+            continue
+        claim = _text(item.get("claim"), limit=_MAX_FIELD_CHARS)
+        if claim:
+            claims.append(claim)
+    return claims
+
+
+def _claim_has_dev_relevant_evidence(
+    evidence: Any,
+    *,
+    touched_files: set[str],
+    touched_dirs: set[str],
+) -> bool:
+    if not isinstance(evidence, list) or not evidence:
+        return False
+    for item in evidence:
+        if not isinstance(item, Mapping):
+            continue
+        evidence_type = _text(item.get("type"))
+        if evidence_type in {"review_finding", "plan_step", "diff"}:
+            return True
+        if evidence_type != "file":
+            continue
+        path = _text(item.get("path"))
+        if not path:
+            continue
+        if path in touched_files or str(Path(path).parent) in touched_dirs:
+            return True
+    return False
+
+
+def _finding_metadata(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    metadata: list[str] = []
+    for item in value[:_MAX_RENDERED_CLAIMS]:
+        if not isinstance(item, Mapping):
+            continue
+        parts = []
+        finding_id = _text(item.get("finding_id"))
+        if finding_id:
+            parts.append(f"id={finding_id}")
+        cycles_seen = item.get("cycles_seen")
+        if cycles_seen is not None:
+            parts.append(f"cycles_seen={cycles_seen}")
+        if parts:
+            metadata.append(", ".join(parts))
+    return metadata
+
+
+def _finding_descriptions(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    findings: list[str] = []
+    for item in value[:_MAX_RENDERED_CLAIMS]:
+        if not isinstance(item, Mapping):
+            continue
+        finding_id = _text(item.get("finding_id"))
+        description = _text(item.get("description"), limit=_MAX_FIELD_CHARS)
+        cycles_seen = item.get("cycles_seen")
+        resolution = _text(item.get("resolution"), limit=_MAX_FIELD_CHARS)
+        detail = description or resolution
+        if not detail:
+            continue
+        prefix = f"{finding_id}: " if finding_id else ""
+        suffix = f" (cycles_seen={cycles_seen})" if cycles_seen is not None else ""
+        findings.append(f"{prefix}{detail}{suffix}")
+    return findings
+
+
+def _rendering_mode_for_phase(phase: str) -> str:
+    if phase in SIGNAL_ONLY_PHASES:
+        return "signal_only"
+    if phase in ELIGIBLE_PHASES:
+        return "phase_summary"
+    return ""
 
 
 # ── Reason strings ────────────────────────────────────────────────────────────

--- a/src/theforge/task/prior_run_selector.py
+++ b/src/theforge/task/prior_run_selector.py
@@ -46,8 +46,9 @@ from theforge.knowledge_index import KNOWLEDGE_INDEX_PATH, KNOWLEDGE_INDEX_SCHEM
 PRIOR_RUN_KIND = "prior_run_summary"
 
 #: ADR-0002 clause 5: summary prose may advise the planning, development, and
-#: review agents. It must never reach preflight, whose output (sufficiency,
-#: complexity, likely files, refusal) drives coordinator control flow.
+#: review agents. Preflight may receive only audit-derived signal renderings,
+#: never summary prose, because its output (sufficiency, complexity, likely
+#: files, refusal) drives coordinator control flow.
 ELIGIBLE_PHASES = frozenset({"plan", "dev", "review"})
 SIGNAL_ONLY_PHASES = frozenset({"preflight"})
 SUPPORTED_PHASES = ELIGIBLE_PHASES | SIGNAL_ONLY_PHASES
@@ -499,12 +500,14 @@ def _render_preflight_signals(summary: Mapping[str, Any]) -> list[str]:
 
     insights = summary.get("review_insights")
     if isinstance(insights, Mapping):
-        recurring = _finding_metadata(insights.get("recurring_findings"))
-        resolved = _finding_metadata(insights.get("resolved_findings"))
-        if recurring:
-            lines.append(f"- Recurring findings: count={len(recurring)}; {', '.join(recurring)}")
-        if resolved:
-            lines.append(f"- Resolved findings: count={len(resolved)}; {', '.join(resolved)}")
+        recurring_count, recurring = _finding_metadata(insights.get("recurring_findings"))
+        resolved_count, resolved = _finding_metadata(insights.get("resolved_findings"))
+        if recurring_count:
+            detail = f"; {', '.join(recurring)}" if recurring else ""
+            lines.append(f"- Recurring findings: count={recurring_count}{detail}")
+        if resolved_count:
+            detail = f"; {', '.join(resolved)}" if resolved else ""
+            lines.append(f"- Resolved findings: count={resolved_count}{detail}")
     return lines
 
 
@@ -643,9 +646,10 @@ def _claim_has_dev_relevant_evidence(
     return False
 
 
-def _finding_metadata(value: Any) -> list[str]:
+def _finding_metadata(value: Any) -> tuple[int, list[str]]:
     if not isinstance(value, list):
-        return []
+        return (0, [])
+    total = sum(1 for item in value if isinstance(item, Mapping))
     metadata: list[str] = []
     for item in value[:_MAX_RENDERED_CLAIMS]:
         if not isinstance(item, Mapping):
@@ -659,7 +663,7 @@ def _finding_metadata(value: Any) -> list[str]:
             parts.append(f"cycles_seen={cycles_seen}")
         if parts:
             metadata.append(", ".join(parts))
-    return metadata
+    return total, metadata
 
 
 def _finding_descriptions(value: Any) -> list[str]:

--- a/tests/test_context_assembler.py
+++ b/tests/test_context_assembler.py
@@ -67,8 +67,44 @@ def _write_prior_run_corpus(
                 "what_changed": {
                     "description": "reworked the sprint runner retry loop",
                     "approach": "extracted a bounded helper",
+                    "files_modified": ["src/theforge/sprint/runner.py"],
                 },
-                "what_was_learned": [{"claim": "retries need a jitter cap", "evidence": []}],
+                "what_was_learned": [
+                    {
+                        "claim": "retries need a jitter cap",
+                        "evidence": [{"type": "file", "path": "src/theforge/sprint/runner.py"}],
+                    }
+                ],
+                "review_insights": {
+                    "recurring_findings": [
+                        {
+                            "finding_id": "f-007",
+                            "description": "missing timeout coverage",
+                            "cycles_seen": 2,
+                        }
+                    ],
+                    "resolved_findings": [
+                        {
+                            "finding_id": "f-003",
+                            "description": "race condition",
+                            "resolution": "guarded helper",
+                        }
+                    ],
+                    "observations": ["verify the timeout branch"],
+                },
+                "complexity_signal": {
+                    "actual_iterations": 2,
+                    "review_cycles": 2,
+                    "plan_regenerations": 1,
+                    "cost_usd": 4.25,
+                    "dominant_difficulty": "edge case coverage",
+                },
+                "story_shape": {
+                    "work_type": "refactor",
+                    "complexity": "medium",
+                    "complexity_score": 6,
+                    "contract_change": False,
+                },
             },
             sort_keys=False,
         ),
@@ -273,7 +309,8 @@ def test_prior_run_summary_is_included_when_enabled_and_relevant(tmp_path: Path)
         phase="dev", story_text=_PRIOR_STORY, file_list=_PRIOR_FILES, budget=100
     )
 
-    assert "reworked the sprint runner retry loop" in pack.content
+    assert "Related changed files: src/theforge/sprint/runner.py" in pack.content
+    assert "Evidence-backed implementation patterns:" in pack.content
     assert any(entry.kind == "prior_run_summary" for entry in pack.included)
     assert all(
         entry.item_type == "advisory"
@@ -304,7 +341,9 @@ def test_prior_run_summary_is_disabled_by_default(tmp_path: Path) -> None:
         assert pack.prior_run_context["enabled"] is False
 
 
-def test_prior_run_summary_never_reaches_preflight_even_when_enabled(tmp_path: Path) -> None:
+def test_prior_run_summary_reaches_preflight_as_signal_only_advisory_context(
+    tmp_path: Path,
+) -> None:
     _write_prior_run_corpus(tmp_path)
     config = _config_with_prior_run_context(tmp_path, enabled=True)
 
@@ -312,9 +351,18 @@ def test_prior_run_summary_never_reaches_preflight_even_when_enabled(tmp_path: P
         phase="preflight", story_text=_PRIOR_STORY, file_list=_PRIOR_FILES, budget=100
     )
 
-    assert "sprint runner retry loop" not in pack.content
-    assert not any(entry.kind == "prior_run_summary" for entry in pack.included)
-    assert "not injected in the preflight phase" in pack.prior_run_context["note"]
+    assert "Preflight note: Advisory prior-run signals only." in pack.content
+    assert (
+        "Run signals: actual_iterations=2, review_cycles=2, plan_regenerations=1, cost_usd=4.25"
+    ) in pack.content
+    assert any(entry.kind == "prior_run_summary" for entry in pack.included)
+    manifest = pack.prior_run_context
+    assert manifest["phase"] == "preflight"
+    assert manifest["rendering_mode"] == "signal_only"
+    assert manifest["included"][0]["phase"] == "preflight"
+    assert manifest["included"][0]["rendering_mode"] == "signal_only"
+    assert "reworked the sprint runner retry loop" not in pack.content
+    assert "edge case coverage" not in pack.content
 
 
 def test_inadmissible_prior_summary_is_excluded_with_verdict_in_manifest(tmp_path: Path) -> None:
@@ -352,6 +400,8 @@ def test_prior_run_summary_is_dropped_before_required_context(tmp_path: Path) ->
     manifest = pack.prior_run_context
     assert manifest["included"] == []
     assert manifest["dropped"][0]["reason"] == "budget_pressure"
+    assert manifest["dropped"][0]["phase"] == "dev"
+    assert manifest["dropped"][0]["rendering_mode"] == "phase_summary"
     assert "dropped under budget pressure" in manifest["note"]
 
 

--- a/tests/test_coord_context_assembly.py
+++ b/tests/test_coord_context_assembly.py
@@ -302,8 +302,44 @@ def _write_prior_run_corpus(root, run_id="4f2a91c"):
                 "what_changed": {
                     "description": "prior run reworked the thing",
                     "approach": "extracted a helper",
+                    "files_modified": ["src/app.py"],
                 },
-                "what_was_learned": [{"claim": "the thing needs a guard", "evidence": []}],
+                "what_was_learned": [
+                    {
+                        "claim": "the thing needs a guard",
+                        "evidence": [{"type": "file", "path": "src/app.py"}],
+                    }
+                ],
+                "review_insights": {
+                    "recurring_findings": [
+                        {
+                            "finding_id": "f-007",
+                            "description": "sentinel recurring prose",
+                            "cycles_seen": 2,
+                        }
+                    ],
+                    "resolved_findings": [
+                        {
+                            "finding_id": "f-003",
+                            "description": "sentinel resolved prose",
+                            "resolution": "sentinel resolution prose",
+                        }
+                    ],
+                    "observations": ["sentinel observation prose"],
+                },
+                "complexity_signal": {
+                    "actual_iterations": 2,
+                    "review_cycles": 2,
+                    "plan_regenerations": 1,
+                    "cost_usd": 4.25,
+                    "dominant_difficulty": "sentinel difficulty prose",
+                },
+                "story_shape": {
+                    "work_type": "feature",
+                    "complexity": "medium",
+                    "complexity_score": 6,
+                    "contract_change": False,
+                },
             },
             sort_keys=False,
         ),
@@ -322,8 +358,8 @@ def test_prior_run_context_flows_through_phase_seams_into_audit_state(
     """The config gate must survive the whole phase flow, not just the assembler.
 
     Each phase records the ContextPack it actually used, so an operator reading
-    the audit sees the prior-run decision per phase — including that preflight
-    was never offered prior knowledge (ADR-0002 clause 5).
+    the audit sees the prior-run decision per phase — including preflight's
+    signal-only advisory rendering.
     """
     config = replace(
         _make_plan_config(tmp_path),
@@ -368,11 +404,22 @@ def test_prior_run_context_flows_through_phase_seams_into_audit_state(
         captured.setdefault(entry["phase"], entry["manifest"])
 
     assert captured["preflight"].prior_run_context["enabled"] is True
-    assert captured["preflight"].prior_run_context["included"] == []
-    assert "not injected in the preflight phase" in captured["preflight"].prior_run_context["note"]
+    assert captured["preflight"].prior_run_context["phase"] == "preflight"
+    assert captured["preflight"].prior_run_context["rendering_mode"] == "signal_only"
+    assert [item["run_id"] for item in captured["preflight"].prior_run_context["included"]] == [
+        "4f2a91c"
+    ]
+    assert "Preflight note: Advisory prior-run signals only." in captured["preflight"].content
+    assert (
+        "Run signals: actual_iterations=2, review_cycles=2, plan_regenerations=1, cost_usd=4.25"
+    ) in captured["preflight"].content
+    assert "prior run reworked the thing" not in captured["preflight"].content
+    assert "sentinel difficulty prose" not in captured["preflight"].content
+    assert "sentinel recurring prose" not in captured["preflight"].content
 
     dev_prior = captured["dev"].prior_run_context
     assert dev_prior["enabled"] is True
     assert [item["run_id"] for item in dev_prior["included"]] == ["4f2a91c"]
     assert "file_overlap(src/app.py)" in dev_prior["included"][0]["reason"]
-    assert "prior run reworked the thing" in captured["dev"].content
+    assert "Evidence-backed implementation patterns:" in captured["dev"].content
+    assert "the thing needs a guard" in captured["dev"].content

--- a/tests/test_knowledge_effectiveness_signals.py
+++ b/tests/test_knowledge_effectiveness_signals.py
@@ -42,9 +42,9 @@ class TestCohortClassification:
         assert classify_cohort(entry) == COHORT_UNCLASSIFIED
 
     def test_ineligible_phase_manifest_does_not_create_a_control(self) -> None:
-        """Preflight never receives prior-run context, so its manifest proves nothing."""
+        """Preflight is signal-only, so its manifest still proves nothing for cohorts."""
         entry = record("r")
-        entry["context_manifests"] = manifests("without", phase="preflight")
+        entry["context_manifests"] = manifests("with", phase="preflight")
         assert classify_cohort(entry) == COHORT_UNCLASSIFIED
 
     def test_one_eligible_phase_with_an_inclusion_settles_the_cohort(self) -> None:

--- a/tests/test_knowledge_effectiveness_signals.py
+++ b/tests/test_knowledge_effectiveness_signals.py
@@ -41,10 +41,15 @@ class TestCohortClassification:
         entry["context_manifests"] = "not-a-list"
         assert classify_cohort(entry) == COHORT_UNCLASSIFIED
 
-    def test_ineligible_phase_manifest_does_not_create_a_control(self) -> None:
-        """Preflight is signal-only, so its manifest still proves nothing for cohorts."""
+    def test_preflight_only_inclusion_stays_unclassified(self) -> None:
+        """Signal-only preflight visibility is not treatment or control evidence."""
         entry = record("r")
         entry["context_manifests"] = manifests("with", phase="preflight")
+        assert classify_cohort(entry) == COHORT_UNCLASSIFIED
+
+    def test_preflight_only_empty_manifest_stays_unclassified(self) -> None:
+        entry = record("r")
+        entry["context_manifests"] = manifests("without", phase="preflight")
         assert classify_cohort(entry) == COHORT_UNCLASSIFIED
 
     def test_one_eligible_phase_with_an_inclusion_settles_the_cohort(self) -> None:

--- a/tests/test_prior_run_manifest.py
+++ b/tests/test_prior_run_manifest.py
@@ -67,9 +67,45 @@ def _write_summary(root: Path, run_id: str, **overrides) -> None:
         "what_changed": {
             "description": f"run {run_id} reworked the retry loop",
             "approach": "extracted a helper",
+            "files_modified": ["src/theforge/sprint/runner.py"],
         },
-        "what_was_learned": [{"claim": "retries need a jitter cap", "evidence": []}],
+        "what_was_learned": [
+            {
+                "claim": "retries need a jitter cap",
+                "evidence": [{"type": "file", "path": "src/theforge/sprint/runner.py"}],
+            }
+        ],
         "learned_patterns": ["retry-decorator"],
+        "review_insights": {
+            "recurring_findings": [
+                {
+                    "finding_id": "f-007",
+                    "description": "missing timeout",
+                    "cycles_seen": 2,
+                }
+            ],
+            "resolved_findings": [
+                {
+                    "finding_id": "f-003",
+                    "description": "race condition",
+                    "resolution": "guarded helper",
+                }
+            ],
+            "observations": ["verify the timeout path"],
+        },
+        "complexity_signal": {
+            "actual_iterations": 2,
+            "review_cycles": 2,
+            "plan_regenerations": 1,
+            "cost_usd": 4.25,
+            "dominant_difficulty": "edge case coverage",
+        },
+        "story_shape": {
+            "work_type": "refactor",
+            "complexity": "medium",
+            "complexity_score": 6,
+            "contract_change": False,
+        },
     }
     artifact.update(overrides)
     path.write_text(yaml.safe_dump(artifact, sort_keys=False), encoding="utf-8")
@@ -100,7 +136,11 @@ def test_manifest_note_separates_admissibility_from_absence(tmp_path: Path) -> N
     manifest = build_manifest(selection, included_run_ids={"4f2a91c"}, phase="dev")
 
     assert manifest["enabled"] is True
+    assert manifest["phase"] == "dev"
+    assert manifest["rendering_mode"] == "phase_summary"
     assert [item["run_id"] for item in manifest["included"]] == ["4f2a91c"]
+    assert manifest["included"][0]["phase"] == "dev"
+    assert manifest["included"][0]["rendering_mode"] == "phase_summary"
     dropped = {item["run_id"]: item["reason"] for item in manifest["dropped"]}
     assert dropped["71bd334"] == "inadmissible(cited_source_deleted)"
     assert dropped["0ae5f92"] == "inadmissible(no_verdict)"
@@ -117,12 +157,26 @@ def test_manifest_note_reports_absence_when_nothing_is_indexed(tmp_path: Path) -
     assert "no relevant prior knowledge exists" in manifest["note"]
 
 
-def test_manifest_note_reports_phase_ineligibility(tmp_path: Path) -> None:
+def test_manifest_note_reports_unsupported_phase_ineligibility(tmp_path: Path) -> None:
     _corpus(tmp_path, [_entry("4f2a91c")])
-    selection = select_prior_runs(tmp_path, phase="preflight", story_text=_STORY, file_list=_FILES)
-    manifest = build_manifest(selection, included_run_ids=set(), phase="preflight")
+    selection = select_prior_runs(tmp_path, phase="validate", story_text=_STORY, file_list=_FILES)
+    manifest = build_manifest(selection, included_run_ids=set(), phase="validate")
 
-    assert "not injected in the preflight phase" in manifest["note"]
+    assert "not injected in the validate phase" in manifest["note"]
+    assert "supported phases: dev, plan, preflight, review" in manifest["note"]
+
+
+def test_manifest_surfaces_signal_only_preflight_rendering(tmp_path: Path) -> None:
+    _corpus(tmp_path, [_entry("4f2a91c")])
+
+    selection = select_prior_runs(tmp_path, phase="preflight", story_text=_STORY, file_list=_FILES)
+    manifest = build_manifest(selection, included_run_ids={"4f2a91c"}, phase="preflight")
+
+    assert manifest["phase"] == "preflight"
+    assert manifest["rendering_mode"] == "signal_only"
+    assert manifest["included"][0]["phase"] == "preflight"
+    assert manifest["included"][0]["rendering_mode"] == "signal_only"
+    assert manifest["included"][0]["reason"].startswith("file_overlap(")
 
 
 def test_note_does_not_claim_unrelated_inadmissible_summaries_as_withheld(

--- a/tests/test_prior_run_selector.py
+++ b/tests/test_prior_run_selector.py
@@ -8,6 +8,15 @@ from theforge.task.prior_run_selector import select_prior_runs
 
 _STORY = "Refactor the sprint runner retry loop"
 _FILES = ["src/theforge/sprint/runner.py"]
+_PREFLIGHT_FORBIDDEN = [
+    "SENTINEL what changed description",
+    "SENTINEL dominant difficulty prose",
+    "SENTINEL recurring finding prose",
+    "SENTINEL resolved finding prose",
+    "SENTINEL review observation prose",
+    "SENTINEL learned pattern tag",
+    "SENTINEL plan-step lesson",
+]
 
 
 def _verdict(status: str = "admissible", rank: str = "full", reasons: list[str] | None = None):
@@ -64,11 +73,51 @@ def _write_summary(root: Path, run_id: str, **overrides) -> None:
         "schema_version": 1,
         "run_id": run_id,
         "what_changed": {
-            "description": f"run {run_id} reworked the retry loop",
-            "approach": "extracted a helper",
+            "description": "SENTINEL what changed description",
+            "approach": "Use a bounded helper before touching retry call sites",
+            "files_modified": ["src/theforge/sprint/runner.py"],
         },
-        "what_was_learned": [{"claim": "retries need a jitter cap", "evidence": []}],
-        "learned_patterns": ["retry-decorator"],
+        "what_was_learned": [
+            {
+                "claim": "Prefer a helper seam around the retry loop",
+                "evidence": [{"type": "file", "path": "src/theforge/sprint/runner.py"}],
+            },
+            {
+                "claim": "SENTINEL plan-step lesson",
+                "evidence": [{"type": "plan_step", "step_id": "s-2"}],
+            },
+        ],
+        "learned_patterns": ["SENTINEL learned pattern tag"],
+        "review_insights": {
+            "recurring_findings": [
+                {
+                    "finding_id": "f-007",
+                    "description": "SENTINEL recurring finding prose",
+                    "cycles_seen": 3,
+                }
+            ],
+            "resolved_findings": [
+                {
+                    "finding_id": "f-003",
+                    "description": "SENTINEL resolved finding prose",
+                    "resolution": "SENTINEL resolution prose",
+                }
+            ],
+            "observations": ["SENTINEL review observation prose"],
+        },
+        "complexity_signal": {
+            "actual_iterations": 2,
+            "review_cycles": 3,
+            "plan_regenerations": 1,
+            "cost_usd": 4.25,
+            "dominant_difficulty": "SENTINEL dominant difficulty prose",
+        },
+        "story_shape": {
+            "work_type": "refactor",
+            "complexity": "medium",
+            "complexity_score": 6,
+            "contract_change": False,
+        },
     }
     artifact.update(overrides)
     path.write_text(yaml.safe_dump(artifact, sort_keys=False), encoding="utf-8")
@@ -90,7 +139,8 @@ def test_relevant_summary_is_selected_with_deterministic_reasons(tmp_path: Path)
     assert "file_overlap(src/theforge/sprint/runner.py)" in candidate.reason
     assert "domain_match(sprint)" in candidate.reason
     assert candidate.score > 0
-    assert "reworked the retry loop" in candidate.content
+    assert "Related changed files: src/theforge/sprint/runner.py" in candidate.content
+    assert "Evidence-backed implementation patterns:" in candidate.content
     assert not selection.excluded
 
 
@@ -153,13 +203,53 @@ def test_malformed_verdict_block_fails_closed(tmp_path: Path) -> None:
     assert selection.excluded[0].reason == "inadmissible(no_verdict)"
 
 
-def test_preflight_phase_is_never_offered_prior_knowledge(tmp_path: Path) -> None:
+def test_preflight_phase_gets_signal_only_advisory_context(tmp_path: Path) -> None:
     _corpus(tmp_path, [_entry("4f2a91c")])
 
     selection = select_prior_runs(tmp_path, phase="preflight", story_text=_STORY, file_list=_FILES)
 
-    assert selection.candidates == ()
-    assert selection.phase_eligible is False
+    assert selection.phase_eligible is True
+    assert selection.rendering_mode == "signal_only"
+    assert [c.run_id for c in selection.candidates] == ["4f2a91c"]
+    content = selection.candidates[0].content
+    assert "Preflight note" in content
+    assert "Story shape: work_type=refactor, complexity=medium, complexity_score=6" in content
+    assert (
+        "Run signals: actual_iterations=2, review_cycles=3, plan_regenerations=1, cost_usd=4.25"
+    ) in content
+    assert "Recurring findings: count=1; id=f-007, cycles_seen=3" in content
+    assert "Resolved findings: count=1; id=f-003" in content
+    for sentinel in _PREFLIGHT_FORBIDDEN:
+        assert sentinel not in content
+
+
+def test_phase_specific_rendering_changes_by_phase(tmp_path: Path) -> None:
+    _corpus(tmp_path, [_entry("4f2a91c")])
+
+    plan = select_prior_runs(tmp_path, phase="plan", story_text=_STORY, file_list=_FILES)
+    dev = select_prior_runs(tmp_path, phase="dev", story_text=_STORY, file_list=_FILES)
+    review = select_prior_runs(tmp_path, phase="review", story_text=_STORY, file_list=_FILES)
+
+    plan_content = plan.candidates[0].content
+    dev_content = dev.candidates[0].content
+    review_content = review.candidates[0].content
+
+    assert "Prior approach: Use a bounded helper before touching retry call sites" in plan_content
+    assert "Lessons with resolved evidence:" in plan_content
+    assert "SENTINEL plan-step lesson" in plan_content
+
+    assert "Related changed files: src/theforge/sprint/runner.py" in dev_content
+    assert "Evidence-backed implementation patterns:" in dev_content
+    assert "Prefer a helper seam around the retry loop" in dev_content
+    assert "SENTINEL learned pattern tag" not in dev_content
+
+    assert "Recurring findings to re-check:" in review_content
+    assert "f-007: SENTINEL recurring finding prose (cycles_seen=3)" in review_content
+    assert "Resolved findings worth verifying stayed fixed:" in review_content
+    assert "SENTINEL review observation prose" in review_content
+    assert (
+        "Review-cycle signals: review_cycles=3, actual_iterations=2, plan_regenerations=1"
+    ) in review_content
 
 
 def test_missing_index_yields_no_candidates(tmp_path: Path) -> None:

--- a/tests/test_prior_run_selector.py
+++ b/tests/test_prior_run_selector.py
@@ -223,6 +223,37 @@ def test_preflight_phase_gets_signal_only_advisory_context(tmp_path: Path) -> No
         assert sentinel not in content
 
 
+def test_preflight_finding_counts_use_full_totals_not_render_cap(tmp_path: Path) -> None:
+    _write_index(tmp_path, [_entry("4f2a91c")])
+    _write_summary(
+        tmp_path,
+        "4f2a91c",
+        review_insights={
+            "recurring_findings": [
+                {
+                    "finding_id": f"f-{index:03d}",
+                    "description": f"detail {index}",
+                    "cycles_seen": 2,
+                }
+                for index in range(1, 8)
+            ],
+            "resolved_findings": [
+                {"finding_id": f"r-{index:03d}", "description": f"resolved {index}"}
+                for index in range(1, 7)
+            ],
+            "observations": ["SENTINEL review observation prose"],
+        },
+    )
+
+    selection = select_prior_runs(tmp_path, phase="preflight", story_text=_STORY, file_list=_FILES)
+
+    content = selection.candidates[0].content
+    assert "Recurring findings: count=7;" in content
+    assert "Resolved findings: count=6;" in content
+    assert "id=f-006" not in content
+    assert "id=r-006" not in content
+
+
 def test_phase_specific_rendering_changes_by_phase(tmp_path: Path) -> None:
     _corpus(tmp_path, [_entry("4f2a91c")])
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Phase-specific prior-run rendering is implemented, budget/audit-visible, and covered through selector, assembler, and coordinator seam tests. | [anthropic-opus-cli] Cycle-2 fixes are clean: preflight finding counts now report full totals (with a dedicated over-cap test), the ADR-0002 clause 5 text, inputs-reference guide and in-module comment now describe the audit-derived signal-only preflight channel, and the cohort docstring matches the unchanged skip-preflight logic; both _finding_metadata callers were updated for the new tuple return and all 68 tests across the five touched test modules pass at the authoritative gate commit 00f5e3df (gate verdict PASS).

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $5.36
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Phase-specific prior-knowledge injection (GitHub Issue #1868)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1868