### PR TITLE
Invariant index spike: authoritative project invariants as selective context

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -669,12 +669,16 @@ principle stands regardless of which model wins the cheap-bucket tie-break.)
 Changes that affect coordinator phase boundaries, state handoff between phases, or adaptive routing/config propagation must include seam-level integration tests covering the touched boundary. Unit tests alone are insufficient when correctness depends on cross-phase state flow.
 
 ### No LLM in the loop for process decisions
+<!-- forge-invariant id="coordinator-pure-python" scope="area:coordinator phase:plan,dev,review files:src/theforge/coordinator/*.py" enforcement="review" -->
 The coordinator is pure Python. If you find yourself writing code where an LLM
 decides whether to retry or escalate, stop — that decision belongs in the coordinator.
+<!-- /forge-invariant -->
 
 ### Schema enforcement is mandatory
+<!-- forge-invariant id="schema-integrity-boundary" scope="area:schema area:review phase:plan,dev,review files:src/theforge/schemas.py" enforcement="gate" -->
 The review output schema in `schemas.py` is the integrity boundary. Do not relax
 cross-validation rules (APPROVE+P1 or REQUEST_CHANGES+no P1 are always errors).
+<!-- /forge-invariant -->
 
 ### Review YAML structure
 ```yaml

--- a/docs/adr/0002-audit-substrate-and-queryable-run-history.md
+++ b/docs/adr/0002-audit-substrate-and-queryable-run-history.md
@@ -102,10 +102,12 @@ The router's trust surface is exactly the substrate. Anything else is advisory.
 
 `.forge/knowledge/summaries/{run_id}.yaml` (knowledge-capture Layer 2) are LLM-generated condensations of run history. They feed Layer 3 — the future-runs context-assembly machinery — so agents stop rediscovering the same conventions and failure modes.
 
+<!-- forge-invariant id="summaries-advisory" scope="area:audit area:knowledge phase:plan,dev,review files:src/theforge/knowledge_*.py,src/theforge/task/*_selector.py" enforcement="review" -->
 Summaries are advisory. Specifically:
 
 - **May influence:** prompt construction for plan, dev, and review phases; audit-derived signal renderings for preflight; context manifests that select which summaries are relevant for the current story; operator-facing search and discovery.
 - **MUST NOT influence:** routing decisions, budget enforcement, refusal verdicts, gate pass/fail outcomes, or any mechanical action the coordinator takes. Those decisions belong to the per-run records and the deterministic gates.
+<!-- /forge-invariant -->
 
 This is the *"LLMs propose, the coordinator decides"* invariant applied to history. Mechanical control flow stays on telemetry; LLM-generated text stays on context.
 

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -789,6 +789,18 @@ detection read to reason about the repository.
 forge index
 ```
 
+Two derived-index modes share the command:
+
+```bash
+forge index --knowledge    # .forge/knowledge/index.yaml from persisted run summaries
+forge index --invariants   # .forge/knowledge/invariants/index.yaml from forge-invariant markers
+```
+
+`--invariants` scans the Markdown globs in `knowledge.invariant_sources`, prints
+`path:line: reason` diagnostics for malformed annotations on stderr, and writes
+provenance metadata only — never invariant prose. See
+`docs/plans/1875-invariant-index-spike.md`.
+
 ---
 
 ## `forge check-story-config`

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -1078,7 +1078,7 @@ marked in the project's own authoritative docs:
 ```yaml
 knowledge:
   invariant_context: false
-  invariant_sources: ["*.md", "docs/**/*.md", "**/CONVENTIONS.md"]
+  invariant_sources: ["**/*.md"]   # default: every Markdown file; narrow if you like
 ```
 
 ```md

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -1070,6 +1070,34 @@ dropped, and a `note` that distinguishes "no relevant prior knowledge exists"
 from "prior knowledge existed but was withheld as inadmissible or stale". Design
 doctrine lives in `docs/plans/knowledge-capture.md`.
 
+`knowledge.invariant_context` (default `false`) gates the #1875 invariant-index
+spike, and `knowledge.invariant_sources` lists the Markdown globs the extractor
+scans — source locations only, never invariant prose. Project invariants are
+marked in the project's own authoritative docs:
+
+```yaml
+knowledge:
+  invariant_context: false
+  invariant_sources: ["*.md", "docs/**/*.md", "**/CONVENTIONS.md"]
+```
+
+```md
+<!-- forge-invariant id="summaries-advisory" scope="area:audit phase:plan,dev,review files:src/theforge/knowledge_*.py" enforcement="review" -->
+LLM-generated summaries advise agents; they never drive coordinator control flow.
+<!-- /forge-invariant -->
+```
+
+`forge index --invariants` rebuilds the derived index at
+`.forge/knowledge/invariants/index.yaml`, which stores provenance and
+applicability metadata only — the source document stays authoritative and is
+re-read when text is injected. When the gate is on, plan and dev may receive
+narrow capsules while **review always receives the broader enclosing source
+section**, and preflight receives nothing at all (ADR-0002 clause 5). When scope
+confidence is low, the broader source is included rather than the rule dropped.
+Every decision is recorded per phase under `context_manifests[].invariant_context`
+with `included`, `dropped`, and `uncertain` entries. Design doctrine and the
+adoption decision live in `docs/plans/1875-invariant-index-spike.md`.
+
 ### Adaptive assignment (`assignment:`)
 
 Config mechanics for the v0.13 adaptive routing surface. Behavior and doctrine

--- a/docs/plans/1875-invariant-index-spike.md
+++ b/docs/plans/1875-invariant-index-spike.md
@@ -39,6 +39,11 @@ LLM-generated summaries advise agents; they never drive coordinator control flow
 | `scope` | no | Whitespace-separated `key:value` tokens. Known keys: `area`, `phase`, `files` (comma-separated values). |
 | `enforcement` | no | `advisory` (default), `review`, or `gate`. Declares how the project enforces the rule; TheForge uses it only for ranking. |
 
+A marker inside a fenced code block is ignored. An example shown while
+*documenting* the convention is a marker about the convention, not an assertion
+of a rule — without that exemption this very document would file its own
+illustrations as live invariants, duplicate-id diagnostics and all.
+
 The convention is **portable**: nothing in it names TheForge's own doc culture.
 A target project points `knowledge.invariant_sources` at whatever Markdown it
 keeps its rules in.
@@ -47,12 +52,18 @@ Configuration is source locations only — never invariant prose:
 
 ```yaml
 knowledge:
-  invariant_context: false           # off by default
+  invariant_context: false      # off by default
   invariant_sources:
-    - "*.md"
-    - "docs/**/*.md"
-    - "**/CONVENTIONS.md"
+    - "**/*.md"                 # the default
 ```
+
+The default is deliberately **every Markdown file in the repository**. A default
+naming `docs/` would presume one project's layout, and the whole point is that
+this works on a target project whose rules live in `handbook/`, `rfcs/`, or the
+repository root. Discovery skips hidden directories and the usual vendored/build
+names (`node_modules`, `vendor`, `build`, `dist`, …), and only files containing
+the literal `forge-invariant` are parsed at all, so the broad default costs a
+substring scan. Projects with a settled documentation layout can narrow it.
 
 ## The derived index
 

--- a/docs/plans/1875-invariant-index-spike.md
+++ b/docs/plans/1875-invariant-index-spike.md
@@ -81,6 +81,12 @@ Each entry records **provenance and applicability metadata only**:
 | `enforcement` | The project's declared enforcement level |
 | `source_digest` | SHA-256 of the marked body, for staleness reporting |
 
+The body span begins after the opening marker *ends*, which matters because an
+opening marker may wrap across lines — the convention's own documented example
+does. The digest is taken over exactly the line span consumers re-read, so an
+unchanged source can never report as stale over text the render drops. A rule
+sharing a line with its markers is a diagnostic rather than a guess.
+
 The index deliberately **does not copy the rule text**. Consumers re-read the
 source document. That is what keeps the ADR authoritative and the index merely
 useful: an index that drifts is *visibly* stale (digest mismatch, reported in

--- a/docs/plans/1875-invariant-index-spike.md
+++ b/docs/plans/1875-invariant-index-spike.md
@@ -1,0 +1,229 @@
+# Invariant index spike: authoritative project invariants as selective context
+
+**Issue:** #1875 · **Status:** spike complete, adoption decision below ·
+**Depends on:** #1860 (prior-run context assembly), #1866, #1867
+
+## What this spike asked
+
+After the v0.14/v0.15 knowledge feed-forward loop, TheForge can put *prior-run
+lessons* into future context. This spike asks the next question: can **stable
+project invariants** — the rules a project already wrote down and already
+believes — be extracted, indexed, and selectively injected in a way that reduces
+churn (plan regenerations, review cycles, restated findings)?
+
+The dangerous version of this feature is obvious, so the spike was built to make
+it structurally impossible:
+
+- an `invariants.yaml` that restates project rules becomes a **second source of
+  truth** that drifts from the doc it paraphrased; and
+- narrow scope selection produces **correlated misses** — the plan agent and the
+  reviewer both blind to the same rule, because the same bad scope tag decided
+  for both.
+
+## The annotation convention
+
+A project marks a rule *inside the document that already owns it* — an ADR,
+`CONVENTIONS.md`, a policy doc, anything Markdown:
+
+```md
+<!-- forge-invariant id="summaries-advisory"
+     scope="area:audit phase:plan,dev,review files:src/theforge/knowledge_*.py"
+     enforcement="review" -->
+LLM-generated summaries advise agents; they never drive coordinator control flow.
+<!-- /forge-invariant -->
+```
+
+| Attribute | Required | Meaning |
+| --- | --- | --- |
+| `id` | yes | Stable identity, `[a-z0-9][a-z0-9._-]*`. Duplicates across sources are a diagnostic; the first wins. |
+| `scope` | no | Whitespace-separated `key:value` tokens. Known keys: `area`, `phase`, `files` (comma-separated values). |
+| `enforcement` | no | `advisory` (default), `review`, or `gate`. Declares how the project enforces the rule; TheForge uses it only for ranking. |
+
+The convention is **portable**: nothing in it names TheForge's own doc culture.
+A target project points `knowledge.invariant_sources` at whatever Markdown it
+keeps its rules in.
+
+Configuration is source locations only — never invariant prose:
+
+```yaml
+knowledge:
+  invariant_context: false           # off by default
+  invariant_sources:
+    - "*.md"
+    - "docs/**/*.md"
+    - "**/CONVENTIONS.md"
+```
+
+## The derived index
+
+`forge index --invariants` writes `.forge/knowledge/invariants/index.yaml`.
+It is derived, rebuildable, disposable, and gitignored — the same status as
+`.forge/knowledge/index.yaml`.
+
+Each entry records **provenance and applicability metadata only**:
+
+| Field | Purpose |
+| --- | --- |
+| `id`, `source_path`, `source_anchor` | Identity and where the rule actually lives |
+| `start_line` / `end_line` / `body_*_line` | The span consumers re-read at render time |
+| `scope_raw`, `scope`, `applicability` | Declared scope verbatim, parsed, plus `scope_completeness` and any `unparsed_scope_keys` |
+| `enforcement` | The project's declared enforcement level |
+| `source_digest` | SHA-256 of the marked body, for staleness reporting |
+
+The index deliberately **does not copy the rule text**. Consumers re-read the
+source document. That is what keeps the ADR authoritative and the index merely
+useful: an index that drifts is *visibly* stale (digest mismatch, reported in
+the manifest) rather than quietly wrong.
+
+Extraction is deterministic and stdlib-light. Every malformed marker —
+unterminated block, missing/invalid id, unknown enforcement, unparsed scope key,
+empty body, duplicate id, unreadable file — becomes a diagnostic printed by the
+command, never an exception. One broken annotation does not cost a project its
+index.
+
+## Selection and the conservative fallback
+
+`ContextAssembler` consults `task/invariant_selector.py` only when
+`knowledge.invariant_context` is on. Disabled means the index is never read at
+all, so no marked prose can reach a prompt by any later path.
+
+**Preflight is excluded outright.** Preflight's output (sufficiency, complexity,
+likely files, refusal) drives coordinator control flow, so it may not receive
+invariant prose — the same ADR-0002 clause 5 boundary that governs prior-run
+summaries. The preflight manifest still records the decision, so the exclusion
+is auditable rather than invisible.
+
+The concrete confidence triggers:
+
+| Declared scope | File list known? | Decision |
+| --- | --- | --- |
+| `full` (file globs) | yes, a glob matches | **high** → capsule (the marked region only) |
+| `full` (file globs) | yes, no glob matches | **high** → the one confident drop (`files_out_of_scope`) |
+| `full` (file globs) | no | **low** → broad source section |
+| `partial` (areas only) | area token found in a touched path or the story | **high** → capsule |
+| `partial` (areas only) | not found | **low** → broad source section |
+| `none` | — | **low** → broad source section |
+| any, with `unparsed_scope_keys` | — | **low** → broad source section |
+
+"Broad" means the **enclosing Markdown section** — from the nearest heading
+through the next heading of the same or higher level, bounded at 120 lines with
+a pointer to the file for the remainder. Bounded, but strictly more than the
+marked lines: the surrounding paragraphs a human would read to understand the
+rule.
+
+Uncertainty therefore *widens*. The only narrowing a low-confidence path can
+produce is nothing at all.
+
+### Review is deliberately broader than plan/dev
+
+Review always renders source sections, and — the part that matters — review does
+**not** apply the confident `files_out_of_scope` drop. A rule that plan/dev
+narrowed away still reaches the reviewer, tagged
+`broad_phase_override(files_out_of_scope(...))`.
+
+This is the asymmetry the story asks for: a bad scope tag can cost the producer
+a rule without also blinding the reviewer who would catch the resulting mistake.
+It costs review tokens, and that is the intended trade for the length of the
+proof.
+
+## What the manifest shows
+
+Every assembly records `invariant_context` in the audit record under
+`context_manifests[]`:
+
+```yaml
+invariant_context:
+  enabled: true
+  phase: dev
+  selection_mode: selective
+  included:  [{id, source_path, source_anchor, enforcement, rendering_mode,
+               scope_confidence, reason, score, source_digest_matches}]
+  dropped:   [{id, source_path, reason}]      # files_out_of_scope | phase_not_applicable | budget_pressure
+  uncertain: [...]                            # the subset of `included` that widened
+  note: "2 of 4 indexed invariants included; 1 included as full source sections
+         because scope confidence was low"
+```
+
+`uncertain` is the field the adoption decision hangs on. It is not a failure
+count — it is the measure of how much of the proof was carried by the fallback
+rather than by real scope matching.
+
+## Measurement
+
+`forge knowledge-report` gains an **invariant-context proof** section
+(`knowledge_invariant_proof.py`, rendered into both the terminal view and the
+structured payload under `invariant_context_proof`).
+
+Cohorts come from the manifest, never from config: included-something is
+treatment, enabled-but-nothing-included is a genuine control, disabled or absent
+is unclassified. Preflight manifests never classify.
+
+It reports **four churn metrics only** — plan regeneration rate, review
+restated-finding rate, average dev iterations, average review cycles — reusing
+the existing `knowledge_effectiveness` cohort machinery. Cost per story and
+stories per dollar are **deliberately excluded from the churn comparison**:
+the story's success claim is churn reduction, and prompt-size or spend movement
+must not be able to carry the verdict. Token and cost movement remain visible in
+the surrounding knowledge report as secondary telemetry.
+
+Below three runs per cohort the section reports `insufficient_data` with the
+counts that produced it. That is the expected output today, and saying so is the
+point — a spike that reports a number off two runs has proved nothing.
+
+## Adoption decision
+
+**Revise and continue as opt-in proof machinery. Do not promote to a default,
+and do not claim a benefit yet.**
+
+What the spike settled:
+
+- The **derived-metadata shape works.** Storing provenance rather than prose
+  removes the second-source-of-truth risk entirely, and re-reading at render
+  time makes the source document authoritative by construction rather than by
+  convention.
+- The **conservative fallback is cheap to state and cheap to verify.** Every
+  low-confidence path widens; the single narrowing path requires an explicit
+  project-declared file glob *and* a known file list.
+- The **review asymmetry is implementable** without a second selection engine —
+  one flag on the same selector.
+
+What it did **not** settle, and what would decide promotion:
+
+1. **No churn evidence exists yet.** Zero runs have executed with
+   `invariant_context: true`. The proof section will report `insufficient_data`
+   until at least three runs per cohort accumulate. Until then the honest claim
+   is "the mechanism exists and is measurable", not "it helps".
+2. **`uncertain_share` is the real risk.** If most inclusions arrive through the
+   fallback, this feature is a verbose way to paste documentation into prompts.
+   Marked-scope quality, not selection cleverness, is what would fix that — and
+   that is a cost borne by the adopting project, not by TheForge.
+3. **Marking discipline is unproven at scale.** Four markers exist in this
+   repository. Whether a project keeps `scope` tags accurate as code moves is
+   the same maintenance question that makes most annotation conventions rot.
+   The digest-mismatch signal in the manifest is the early-warning surface for
+   this; it has never fired in anger.
+
+Concrete next step before any promotion: run a bounded cohort (≥3 runs each
+side, matched work type and complexity) with `invariant_context: true`, then
+read the proof section. Drop the feature if `uncertain_share` stays high while
+churn does not move; keep it opt-in either way until it does.
+
+## Non-goals honoured
+
+- No LLM-authored invariant is authoritative — extraction is pure Python and
+  reads only human-written markers.
+- No standalone `invariants.yaml` restating rules — the index is metadata over
+  spans in the project's own docs.
+- No knowledge graph or ERD generation.
+- No mechanical coordinator decision reads invariant prose — the coordinator
+  reads only the manifest's counts, and only for reporting.
+
+## References
+
+- `src/theforge/invariant_index.py` — extractor and derived index
+- `src/theforge/task/invariant_selector.py` — selection, confidence, rendering
+- `src/theforge/task/invariant_manifest.py` — audit-visible decision record
+- `src/theforge/knowledge_invariant_proof.py` — churn proof
+- `docs/adr/0002-audit-substrate-and-queryable-run-history.md` clause 5
+- `docs/plans/knowledge-capture.md` (sibling: prior-run knowledge)
+- `docs/plans/forge-storage-layout.md` (derived-artifact status)

--- a/docs/plans/forge-storage-layout.md
+++ b/docs/plans/forge-storage-layout.md
@@ -79,13 +79,14 @@ Four categories, enforced by both `.gitignore` and runtime checks:
 |----------|----------|----------|---------------------|
 | **Secrets** | `.env`, `secrets.yaml` | Never | Leak credentials |
 | **Machine-local runtime** | `worktrees/`, `locks/`, `merge.lock`, `daemon.json`, `pending/`, `runs/` (the execution state dir, not the audit dir), root `handoff.yaml` | Never | Break runs: stale PIDs, nested git repos, cross-machine lock false-positives |
-| **Noise / derived views** | `logs/`, `index/`, `audits/history.jsonl`, `audits/index.sqlite`, `knowledge/index.yaml`, `assignment_history.yaml` (derived) | Never (derived or ephemeral) | Create churn or merge conflicts; regenerable |
+| **Noise / derived views** | `logs/`, `index/`, `audits/history.jsonl`, `audits/index.sqlite`, `knowledge/index.yaml`, `knowledge/invariants/index.yaml`, `assignment_history.yaml` (derived) | Never (derived or ephemeral) | Create churn or merge conflicts; regenerable |
 | **Project memory + config** | `hooks/`, `.env.example`, `audits/runs/{run_id}.json`, `knowledge/summaries/{run_id}.yaml` | **Default on** (opt out via `forge init --local-memory`) | Nothing — this is the working memory of the project |
 
 The third category is important: **derived views are never tracked, even
 though they contain tracked data.** `history.jsonl`, `index.sqlite`,
-`knowledge/index.yaml`, and `assignment_history.yaml` are rebuildable from
-per-run files. Tracking them would create merge-conflict bait without adding
+`knowledge/index.yaml`, `knowledge/invariants/index.yaml`, and
+`assignment_history.yaml` are rebuildable from per-run files or, for the
+invariant index (#1875), from the marked Markdown sources it derives from. Tracking them would create merge-conflict bait without adding
 information the per-run files don't already have.
 
 ### Naming collision note

--- a/src/theforge/cli/index.py
+++ b/src/theforge/cli/index.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from theforge.cli.shared import _find_config
 from theforge.indexer import INDEX_PATH, generate_index
+from theforge.invariant_index import rebuild_invariant_index
 from theforge.knowledge_index import rebuild_knowledge_index
 
 
@@ -22,6 +23,19 @@ def cmd_index(args: argparse.Namespace) -> int:
         return 1
 
     project_root = config_path.parent
+    if getattr(args, "invariants", False):
+        from theforge.config.load import load_config  # noqa: PLC0415
+
+        config = load_config(config_path)
+        result = rebuild_invariant_index(project_root, config.knowledge.invariant_sources)
+        for diagnostic in result.diagnostics:
+            print(
+                f"{diagnostic.path}:{diagnostic.line}: {diagnostic.reason}",
+                file=sys.stderr,
+            )
+        print(str(result.path))
+        return 0
+
     if getattr(args, "knowledge", False):
         result = rebuild_knowledge_index(project_root)
         for diagnostic in result.diagnostics:
@@ -41,4 +55,12 @@ def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPars
         "--knowledge",
         action="store_true",
         help="Rebuild .forge/knowledge/index.yaml from persisted summaries",
+    )
+    parser.add_argument(
+        "--invariants",
+        action="store_true",
+        help=(
+            "Rebuild .forge/knowledge/invariants/index.yaml from forge-invariant "
+            "markers in the configured Markdown sources"
+        ),
     )

--- a/src/theforge/cli/knowledge_report.py
+++ b/src/theforge/cli/knowledge_report.py
@@ -29,6 +29,9 @@ def cmd_knowledge_report(args: argparse.Namespace) -> int:
         render_terminal,
         report_payload,
     )
+    from theforge.knowledge_invariant_proof import (  # noqa: PLC0415
+        build_invariant_proof_from_records,
+    )
 
     config_path = _find_config(Path(args.config).resolve() if args.config else None)
     if config_path is None:
@@ -70,11 +73,13 @@ def cmd_knowledge_report(args: argparse.Namespace) -> int:
         recent_run_count=recent_run_count,
     )
 
+    proof = build_invariant_proof_from_records(records)
+
     if args.format == "terminal":
-        print(render_terminal(report), end="")
+        print(render_terminal(report, proof), end="")
         return 0
 
-    payload = report_payload(report)
+    payload = report_payload(report, proof)
     if args.format == "json":
         print(json.dumps(payload, indent=2))
     else:

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -1627,12 +1627,30 @@ def load_config(config_path: Path) -> ForgeConfig:
     if not isinstance(knowledge_data, dict):
         raise ValueError(f"forge.yaml 'knowledge' must be a mapping, got {knowledge_data!r}")
     _knowledge_values: dict[str, bool] = {}
-    for _key in ("run_summaries", "prior_run_context"):
+    for _key in ("run_summaries", "prior_run_context", "invariant_context"):
         _value = knowledge_data.get(_key, getattr(KnowledgeConfig, _key))
         if not isinstance(_value, bool):
             raise ValueError(f"forge.yaml 'knowledge.{_key}' must be a bool, got {_value!r}")
         _knowledge_values[_key] = _value
-    knowledge_cfg = KnowledgeConfig(**_knowledge_values)
+    # Source globs are a list, not a gate, so they are parsed off the bool loop.
+    _invariant_sources_raw = knowledge_data.get(
+        "invariant_sources", list(KnowledgeConfig.invariant_sources)
+    )
+    if not isinstance(_invariant_sources_raw, list):
+        raise ValueError(
+            "forge.yaml 'knowledge.invariant_sources' must be a list of glob strings,"
+            f" got {_invariant_sources_raw!r}"
+        )
+    for _glob in _invariant_sources_raw:
+        if not isinstance(_glob, str) or not _glob.strip():
+            raise ValueError(
+                "forge.yaml 'knowledge.invariant_sources' items must be non-empty strings,"
+                f" got {_glob!r}"
+            )
+    knowledge_cfg = KnowledgeConfig(
+        **_knowledge_values,
+        invariant_sources=tuple(_glob.strip() for _glob in _invariant_sources_raw),
+    )
 
     context_data = raw.get("context", {})
     context_cfg = ContextConfig(

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -1254,10 +1254,20 @@ class KnowledgeConfig:
     and never without an admissible verdict in the knowledge index. It is
     deliberately not advertised in the generated starter config: it is only
     useful once a project has a corpus of summaries to draw on.
+
+    ``invariant_context`` gates the #1875 invariant-index spike: when on,
+    ``ContextAssembler`` offers project invariants marked in the project's own
+    authoritative Markdown to the plan, dev, and review phases — never to
+    preflight, for the same ADR-0002 clause 5 reason. ``invariant_sources`` is
+    the list of Markdown globs the deterministic extractor scans; it holds
+    *source locations only*, never invariant prose, because the marked document
+    stays the single source of truth.
     """
 
     run_summaries: bool = False
     prior_run_context: bool = False
+    invariant_context: bool = False
+    invariant_sources: tuple[str, ...] = ("*.md", "docs/**/*.md", "**/CONVENTIONS.md")
 
 
 @dataclass(frozen=True)

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -1262,12 +1262,19 @@ class KnowledgeConfig:
     the list of Markdown globs the deterministic extractor scans; it holds
     *source locations only*, never invariant prose, because the marked document
     stays the single source of truth.
+
+    The default glob is every Markdown file in the repository, deliberately: a
+    default naming particular directories would presume one project's layout,
+    and this feature has to work on any target project that marks its own rules.
+    The extractor skips derived and vendored trees and only parses files that
+    actually contain a marker, so the broad default costs a substring scan.
+    Projects with a settled documentation layout can narrow it here.
     """
 
     run_summaries: bool = False
     prior_run_context: bool = False
     invariant_context: bool = False
-    invariant_sources: tuple[str, ...] = ("*.md", "docs/**/*.md", "**/CONVENTIONS.md")
+    invariant_sources: tuple[str, ...] = ("**/*.md",)
 
 
 @dataclass(frozen=True)

--- a/src/theforge/coordinator/audit.py
+++ b/src/theforge/coordinator/audit.py
@@ -673,6 +673,7 @@ def generate_audit_log(config: ForgeConfig, task: TaskStory, result: Coordinator
                 for item in entry["manifest"].dropped
             ],
             "prior_run_context": entry["manifest"].prior_run_context,
+            "invariant_context": entry["manifest"].invariant_context,
         }
         for entry in state.context_manifests
     ]

--- a/src/theforge/invariant_index.py
+++ b/src/theforge/invariant_index.py
@@ -60,11 +60,23 @@ _OPEN_MARKER = re.compile(r"<!--\s*forge-invariant\b(?P<attrs>.*?)-->", re.DOTAL
 _CLOSE_MARKER = re.compile(r"<!--\s*/\s*forge-invariant\s*-->")
 _ATTR_PATTERN = re.compile(r"(?P<key>[A-Za-z_][A-Za-z0-9_-]*)\s*=\s*\"(?P<value>[^\"]*)\"")
 _HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(?P<title>.+?)\s*$")
+_FENCE_PATTERN = re.compile(r"^(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
 
-#: Directories never scanned for invariant sources regardless of the configured
-#: globs. ``.forge`` is excluded because the derived index lives there.
+#: Vendored and build directories never scanned for invariant sources, whatever
+#: the configured globs say. Kept to names that mean the same thing in any
+#: ecosystem — a project's *own* layout is never assumed here, because the
+#: default glob is the whole repository.
 _EXCLUDED_DIRS = frozenset(
-    {".git", ".forge", ".venv", "venv", "node_modules", "__pycache__", ".tox", ".mypy_cache"}
+    {
+        "venv",
+        "node_modules",
+        "__pycache__",
+        "vendor",
+        "target",
+        "build",
+        "dist",
+        "site-packages",
+    }
 )
 
 
@@ -100,6 +112,11 @@ def discover_sources(project_root: Path, globs: tuple[str, ...] | list[str]) -> 
 
     Ordering is total and content-independent so two rebuilds of an unchanged
     tree produce byte-identical indexes.
+
+    Hidden directories are skipped along with the vendored/build names above.
+    That single rule keeps tooling state — caches, VCS metadata, ``.forge``'s own
+    derived index — out of the corpus without naming any project's layout, which
+    matters because the default glob is every Markdown file in the repository.
     """
     found: set[Path] = set()
     for pattern in globs:
@@ -116,7 +133,7 @@ def discover_sources(project_root: Path, globs: tuple[str, ...] | list[str]) -> 
                 rel = match.relative_to(project_root)
             except ValueError:  # pragma: no cover - glob results are always under root
                 continue
-            if any(part in _EXCLUDED_DIRS for part in rel.parts):
+            if any(part in _EXCLUDED_DIRS or part.startswith(".") for part in rel.parts[:-1]):
                 continue
             found.add(rel)
     return sorted(found)
@@ -135,13 +152,21 @@ def extract_from_text(
 
     Returns metadata entries and diagnostics. The invariant prose is hashed for
     staleness detection and then discarded — the source document keeps it.
+
+    Markers inside fenced code blocks are ignored. A project that documents this
+    convention writes example markers in its own docs, and an example is a marker
+    *about* the convention rather than an application of it; without this,
+    documenting the feature would file its own illustrations as live invariants.
     """
     entries: list[dict[str, Any]] = []
     diagnostics: list[InvariantIndexDiagnostic] = []
     lines = text.splitlines()
+    fenced = _fenced_lines(lines)
 
     for match in _OPEN_MARKER.finditer(text):
         open_line = _line_number(text, match.start())
+        if open_line in fenced:
+            continue
         attrs, attr_errors = _parse_attributes(match.group("attrs"))
         for error in attr_errors:
             diagnostics.append(InvariantIndexDiagnostic(source_path, open_line, error))
@@ -224,6 +249,30 @@ def extract_from_text(
         )
 
     return entries, diagnostics
+
+
+def _fenced_lines(lines: list[str]) -> frozenset[int]:
+    """1-based line numbers that sit inside a fenced code block.
+
+    Fence delimiters themselves count as inside, so a marker sharing a line with
+    one cannot slip through. An unterminated fence swallows the rest of the file,
+    which is the conservative reading: text a Markdown renderer would show as
+    code is not a rule the project is asserting.
+    """
+    inside: set[int] = set()
+    fence: str | None = None
+    for index, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        match = _FENCE_PATTERN.match(stripped)
+        if fence is None:
+            if match:
+                fence = match.group("fence")[:3]
+                inside.add(index)
+            continue
+        inside.add(index)
+        if match and match.group("fence").startswith(fence) and not match.group("info").strip():
+            fence = None
+    return frozenset(inside)
 
 
 def _parse_attributes(raw: str) -> tuple[dict[str, str], list[str]]:

--- a/src/theforge/invariant_index.py
+++ b/src/theforge/invariant_index.py
@@ -1,0 +1,394 @@
+"""Deterministic index over project invariants marked in authoritative docs (#1875).
+
+The spike's central bet is that a project's "do not break this" rules are already
+written down somewhere authoritative — an ADR, ``CONVENTIONS.md``, a policy doc —
+and the only thing missing is a way to *find the relevant ones* at prompt-build
+time. So this module builds a derived, rebuildable, disposable view over marked
+regions of the project's own Markdown. It is not a second source of truth:
+
+- The index stores **provenance and applicability metadata only** — id, source
+  path, source anchor, line span, scope, enforcement, digest. It deliberately
+  does not copy the invariant prose, so an index that drifts from its source is
+  visibly stale (digest mismatch) rather than quietly authoritative.
+- Consumers re-read the source document to render text. See
+  :mod:`theforge.task.invariant_selector`.
+- Nothing here calls a model, and nothing here decides coordinator control flow.
+
+The annotation convention is portable — a target project marks its own rules::
+
+    <!-- forge-invariant id="summaries-advisory"
+         scope="area:audit phase:plan,dev,review files:src/knowledge_*.py"
+         enforcement="review" -->
+    LLM-generated summaries advise agents; they never drive coordinator control flow.
+    <!-- /forge-invariant -->
+
+Every malformed marker becomes a diagnostic, never an exception: a project with
+one broken annotation still gets an index of the rest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+INVARIANT_INDEX_PATH = Path(".forge") / "knowledge" / "invariants" / "index.yaml"
+INVARIANT_INDEX_SCHEMA_VERSION = 1
+
+#: Enforcement levels a project may declare. ``advisory`` is the default so an
+#: unmarked level never silently claims gate authority.
+ENFORCEMENT_LEVELS = ("advisory", "review", "gate")
+DEFAULT_ENFORCEMENT = "advisory"
+
+#: Scope keys the extractor understands. An unknown key is recorded verbatim in
+#: ``scope_raw`` and reported as a diagnostic — it never narrows applicability,
+#: because a scope nobody parsed cannot be evidence that a rule does not apply.
+SCOPE_KEYS = ("area", "phase", "files")
+
+#: How completely a project narrowed a rule's applicability. Consumers read this
+#: to decide between a narrow capsule and conservative broad inclusion.
+COMPLETENESS_FULL = "full"
+COMPLETENESS_PARTIAL = "partial"
+COMPLETENESS_NONE = "none"
+
+_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_OPEN_MARKER = re.compile(r"<!--\s*forge-invariant\b(?P<attrs>.*?)-->", re.DOTALL)
+_CLOSE_MARKER = re.compile(r"<!--\s*/\s*forge-invariant\s*-->")
+_ATTR_PATTERN = re.compile(r"(?P<key>[A-Za-z_][A-Za-z0-9_-]*)\s*=\s*\"(?P<value>[^\"]*)\"")
+_HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(?P<title>.+?)\s*$")
+
+#: Directories never scanned for invariant sources regardless of the configured
+#: globs. ``.forge`` is excluded because the derived index lives there.
+_EXCLUDED_DIRS = frozenset(
+    {".git", ".forge", ".venv", "venv", "node_modules", "__pycache__", ".tox", ".mypy_cache"}
+)
+
+
+@dataclass(frozen=True)
+class InvariantIndexDiagnostic:
+    """One annotation the extractor could not use, and why."""
+
+    path: str
+    line: int
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"path": self.path, "line": self.line, "reason": self.reason}
+
+
+@dataclass(frozen=True)
+class InvariantIndexBuildResult:
+    path: Path
+    payload: dict[str, Any]
+    diagnostics: tuple[InvariantIndexDiagnostic, ...]
+
+    @property
+    def entries(self) -> list[dict[str, Any]]:
+        invariants = self.payload.get("invariants")
+        return invariants if isinstance(invariants, list) else []
+
+
+# ── Source discovery ─────────────────────────────────────────────────────────
+
+
+def discover_sources(project_root: Path, globs: tuple[str, ...] | list[str]) -> list[Path]:
+    """Repo-relative Markdown paths matching ``globs``, deduped and sorted.
+
+    Ordering is total and content-independent so two rebuilds of an unchanged
+    tree produce byte-identical indexes.
+    """
+    found: set[Path] = set()
+    for pattern in globs:
+        if not pattern or not pattern.strip():
+            continue
+        try:
+            matches = project_root.glob(pattern.strip())
+        except (ValueError, NotImplementedError):
+            continue
+        for match in matches:
+            if not match.is_file():
+                continue
+            try:
+                rel = match.relative_to(project_root)
+            except ValueError:  # pragma: no cover - glob results are always under root
+                continue
+            if any(part in _EXCLUDED_DIRS for part in rel.parts):
+                continue
+            found.add(rel)
+    return sorted(found)
+
+
+# ── Extraction ───────────────────────────────────────────────────────────────
+
+
+def extract_from_text(
+    text: str, source_path: str
+) -> tuple[
+    list[dict[str, Any]],
+    list[InvariantIndexDiagnostic],
+]:
+    """Parse every ``forge-invariant`` region in one document.
+
+    Returns metadata entries and diagnostics. The invariant prose is hashed for
+    staleness detection and then discarded — the source document keeps it.
+    """
+    entries: list[dict[str, Any]] = []
+    diagnostics: list[InvariantIndexDiagnostic] = []
+    lines = text.splitlines()
+
+    for match in _OPEN_MARKER.finditer(text):
+        open_line = _line_number(text, match.start())
+        attrs, attr_errors = _parse_attributes(match.group("attrs"))
+        for error in attr_errors:
+            diagnostics.append(InvariantIndexDiagnostic(source_path, open_line, error))
+
+        close = _CLOSE_MARKER.search(text, match.end())
+        if close is None:
+            diagnostics.append(
+                InvariantIndexDiagnostic(
+                    source_path, open_line, "unterminated forge-invariant block"
+                )
+            )
+            continue
+
+        invariant_id = attrs.get("id", "").strip()
+        if not invariant_id:
+            diagnostics.append(
+                InvariantIndexDiagnostic(source_path, open_line, "missing required attribute 'id'")
+            )
+            continue
+        if not _ID_PATTERN.match(invariant_id):
+            diagnostics.append(
+                InvariantIndexDiagnostic(
+                    source_path,
+                    open_line,
+                    f"invalid id {invariant_id!r} (expected [a-z0-9][a-z0-9._-]*)",
+                )
+            )
+            continue
+
+        enforcement = (attrs.get("enforcement") or DEFAULT_ENFORCEMENT).strip().lower()
+        if enforcement not in ENFORCEMENT_LEVELS:
+            diagnostics.append(
+                InvariantIndexDiagnostic(
+                    source_path,
+                    open_line,
+                    f"unknown enforcement {enforcement!r}; using {DEFAULT_ENFORCEMENT!r}",
+                )
+            )
+            enforcement = DEFAULT_ENFORCEMENT
+
+        scope_raw = (attrs.get("scope") or "").strip()
+        scope, scope_errors = _parse_scope(scope_raw)
+        for error in scope_errors:
+            diagnostics.append(InvariantIndexDiagnostic(source_path, open_line, error))
+
+        body = text[match.end() : close.start()]
+        close_line = _line_number(text, close.start())
+        body_start = open_line + 1
+        body_end = max(body_start, close_line - 1)
+        if not body.strip():
+            diagnostics.append(
+                InvariantIndexDiagnostic(
+                    source_path, open_line, f"empty invariant body for id {invariant_id!r}"
+                )
+            )
+            continue
+
+        entries.append(
+            {
+                "id": invariant_id,
+                "source_path": source_path,
+                "source_anchor": _nearest_heading(lines, open_line),
+                "start_line": open_line,
+                "end_line": close_line,
+                "body_start_line": body_start,
+                "body_end_line": body_end,
+                "body_lines": len([line for line in body.strip().splitlines()]),
+                "enforcement": enforcement,
+                "scope_raw": scope_raw,
+                "scope": scope,
+                "applicability": {
+                    "phases": list(scope["phases"]),
+                    "areas": list(scope["areas"]),
+                    "file_globs": list(scope["files"]),
+                    "scope_completeness": _completeness(scope, bool(scope_errors)),
+                    "unparsed_scope_keys": list(scope["unknown_keys"]),
+                },
+                "source_digest": _digest(body),
+            }
+        )
+
+    return entries, diagnostics
+
+
+def _parse_attributes(raw: str) -> tuple[dict[str, str], list[str]]:
+    attrs: dict[str, str] = {}
+    errors: list[str] = []
+    consumed = 0
+    for match in _ATTR_PATTERN.finditer(raw):
+        key = match.group("key").lower()
+        if key in attrs:
+            errors.append(f"duplicate attribute {key!r}; keeping first value")
+            consumed += len(match.group(0))
+            continue
+        attrs[key] = match.group("value")
+        consumed += len(match.group(0))
+    leftover = re.sub(r"\s+", "", raw)
+    if consumed == 0 and leftover:
+        errors.append('could not parse any key="value" attributes')
+    for key in attrs:
+        if key not in {"id", "scope", "enforcement"}:
+            errors.append(f"unknown attribute {key!r}; ignored")
+    return attrs, errors
+
+
+def _parse_scope(raw: str) -> tuple[dict[str, list[str]], list[str]]:
+    scope: dict[str, list[str]] = {"areas": [], "phases": [], "files": [], "unknown_keys": []}
+    errors: list[str] = []
+    for token in raw.split():
+        if ":" not in token:
+            errors.append(f"scope token {token!r} is not key:value; ignored")
+            scope["unknown_keys"].append(token)
+            continue
+        key, _, values = token.partition(":")
+        key = key.strip().lower()
+        parsed = [value.strip() for value in values.split(",") if value.strip()]
+        if key == "area":
+            scope["areas"].extend(parsed)
+        elif key == "phase":
+            scope["phases"].extend(value.lower() for value in parsed)
+        elif key == "files":
+            scope["files"].extend(parsed)
+        else:
+            errors.append(f"unknown scope key {key!r} (known: {', '.join(SCOPE_KEYS)})")
+            scope["unknown_keys"].append(key)
+    for key in ("areas", "phases", "files", "unknown_keys"):
+        scope[key] = sorted(dict.fromkeys(scope[key]))
+    return scope, errors
+
+
+def _completeness(scope: dict[str, list[str]], had_errors: bool) -> str:
+    """How confidently this rule's applicability can be narrowed.
+
+    An annotation with unparsed scope tokens is never reported as ``full``: a
+    scope nobody understood must widen inclusion, not narrow it.
+    """
+    if scope["unknown_keys"] or had_errors:
+        return COMPLETENESS_PARTIAL if (scope["areas"] or scope["files"]) else COMPLETENESS_NONE
+    if scope["files"]:
+        return COMPLETENESS_FULL
+    if scope["areas"]:
+        return COMPLETENESS_PARTIAL
+    return COMPLETENESS_NONE
+
+
+def _nearest_heading(lines: list[str], line_number: int) -> str:
+    """The Markdown heading a marker sits under — the human-readable anchor."""
+    for index in range(min(line_number, len(lines)) - 1, -1, -1):
+        match = _HEADING_PATTERN.match(lines[index])
+        if match:
+            return match.group("title").strip()
+    return ""
+
+
+def _line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _digest(body: str) -> str:
+    return "sha256:" + hashlib.sha256(body.strip().encode("utf-8")).hexdigest()
+
+
+# ── Build / load ─────────────────────────────────────────────────────────────
+
+
+def build_invariant_index(
+    project_root: Path, source_globs: tuple[str, ...] | list[str]
+) -> InvariantIndexBuildResult:
+    """Scan the configured sources and return the derived payload (no write)."""
+    entries: list[dict[str, Any]] = []
+    diagnostics: list[InvariantIndexDiagnostic] = []
+    seen_ids: dict[str, str] = {}
+
+    for rel_path in discover_sources(project_root, source_globs):
+        source_path = rel_path.as_posix()
+        try:
+            text = (project_root / rel_path).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            diagnostics.append(InvariantIndexDiagnostic(source_path, 0, f"unreadable: {exc}"))
+            continue
+        if "forge-invariant" not in text:
+            continue
+        found, problems = extract_from_text(text, source_path)
+        diagnostics.extend(problems)
+        for entry in found:
+            previous = seen_ids.get(entry["id"])
+            if previous is not None:
+                diagnostics.append(
+                    InvariantIndexDiagnostic(
+                        source_path,
+                        entry["start_line"],
+                        f"duplicate invariant id {entry['id']!r} (first defined in {previous})",
+                    )
+                )
+                continue
+            seen_ids[entry["id"]] = source_path
+            entries.append(entry)
+
+    entries.sort(key=lambda entry: (entry["source_path"], entry["start_line"], entry["id"]))
+    payload: dict[str, Any] = {
+        "schema_version": INVARIANT_INDEX_SCHEMA_VERSION,
+        "source_globs": [glob for glob in source_globs],
+        "invariant_count": len(entries),
+        "diagnostics": [diagnostic.to_dict() for diagnostic in sorted_diagnostics(diagnostics)],
+        "invariants": entries,
+    }
+    return InvariantIndexBuildResult(
+        path=project_root / INVARIANT_INDEX_PATH,
+        payload=payload,
+        diagnostics=tuple(sorted_diagnostics(diagnostics)),
+    )
+
+
+def sorted_diagnostics(
+    diagnostics: list[InvariantIndexDiagnostic],
+) -> list[InvariantIndexDiagnostic]:
+    return sorted(diagnostics, key=lambda item: (item.path, item.line, item.reason))
+
+
+def rebuild_invariant_index(
+    project_root: Path, source_globs: tuple[str, ...] | list[str]
+) -> InvariantIndexBuildResult:
+    """Build the index and write it to ``.forge/knowledge/invariants/index.yaml``."""
+    result = build_invariant_index(project_root, source_globs)
+    result.path.parent.mkdir(parents=True, exist_ok=True)
+    result.path.write_text(
+        yaml.safe_dump(result.payload, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    return result
+
+
+def load_invariant_index(project_root: Path) -> list[dict[str, Any]]:
+    """Read the derived index, degrading to ``[]`` on any problem.
+
+    A missing, unparseable, or wrong-schema index means "no invariants known",
+    never an exception: a run with nothing to be reminded of must proceed.
+    """
+    path = project_root / INVARIANT_INDEX_PATH
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(raw, dict):
+        return []
+    if raw.get("schema_version") != INVARIANT_INDEX_SCHEMA_VERSION:
+        return []
+    entries = raw.get("invariants")
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict) and entry.get("id")]

--- a/src/theforge/invariant_index.py
+++ b/src/theforge/invariant_index.py
@@ -37,7 +37,12 @@ from typing import Any
 import yaml
 
 INVARIANT_INDEX_PATH = Path(".forge") / "knowledge" / "invariants" / "index.yaml"
-INVARIANT_INDEX_SCHEMA_VERSION = 1
+#: v2 corrected ``body_start_line`` (and the digest computed over that span) for
+#: opening markers that wrap across lines. The field set is unchanged, but a v1
+#: entry's span points into the marker's own attributes, so a stale index would
+#: render attribute text as the rule. Rejecting v1 outright makes that a rebuild
+#: prompt rather than a silently wrong capsule.
+INVARIANT_INDEX_SCHEMA_VERSION = 2
 
 #: Enforcement levels a project may declare. ``advisory`` is the default so an
 #: unmarked level never silently claims gate authority.
@@ -212,10 +217,27 @@ def extract_from_text(
         for error in scope_errors:
             diagnostics.append(InvariantIndexDiagnostic(source_path, open_line, error))
 
-        body = text[match.end() : close.start()]
+        # The body begins after the opening marker *ends*, not after the line it
+        # starts on: an opening marker may wrap across lines, and the convention's
+        # own documented example does. Deriving the span from ``match.end()``
+        # keeps the recorded line range off the attribute continuation lines.
         close_line = _line_number(text, close.start())
-        body_start = open_line + 1
-        body_end = max(body_start, close_line - 1)
+        body_start = _line_number(text, match.end()) + 1
+        body_end = close_line - 1
+        if body_end < body_start:
+            diagnostics.append(
+                InvariantIndexDiagnostic(
+                    source_path,
+                    open_line,
+                    f"invariant body for id {invariant_id!r} shares a line with its markers; "
+                    "put the rule on its own lines",
+                )
+            )
+            continue
+
+        # Hash the same line span consumers re-read, so an unchanged source can
+        # never report as stale over a whitespace difference the render drops.
+        body = "\n".join(lines[body_start - 1 : body_end])
         if not body.strip():
             diagnostics.append(
                 InvariantIndexDiagnostic(

--- a/src/theforge/knowledge_effectiveness_render.py
+++ b/src/theforge/knowledge_effectiveness_render.py
@@ -27,6 +27,12 @@ from theforge.knowledge_effectiveness import (
     Metric,
     MetricComparison,
 )
+from theforge.knowledge_invariant_proof import (
+    INVARIANT_COHORT_WITH,
+    INVARIANT_COHORT_WITHOUT,
+    InvariantChurnComparison,
+    InvariantContextProof,
+)
 
 _METRIC_LABELS = {
     METRIC_PLAN_REGENERATION: "plan regeneration rate",
@@ -44,8 +50,23 @@ _RATE_METRICS = frozenset({METRIC_PLAN_REGENERATION, METRIC_REVIEW_RECURRENCE})
 # ── Structured payload ───────────────────────────────────────────────────────
 
 
-def report_payload(report: KnowledgeEffectivenessReport) -> dict:
-    """JSON/YAML-serializable view of the report."""
+def report_payload(
+    report: KnowledgeEffectivenessReport,
+    proof: "InvariantContextProof | None" = None,
+) -> dict:
+    """JSON/YAML-serializable view of the report.
+
+    ``proof`` is the #1875 invariant-context spike section. It is optional so
+    the spike's proof machinery can be removed without touching the shipped
+    knowledge-loop report.
+    """
+    payload = _report_payload(report)
+    if proof is not None:
+        payload["invariant_context_proof"] = invariant_proof_payload(proof)
+    return payload
+
+
+def _report_payload(report: KnowledgeEffectivenessReport) -> dict:
     return {
         "window": {
             "since": report.since,
@@ -117,7 +138,10 @@ def _comparison_payload(comparison: MetricComparison) -> dict:
 # ── Terminal renderer ────────────────────────────────────────────────────────
 
 
-def render_terminal(report: KnowledgeEffectivenessReport) -> str:
+def render_terminal(
+    report: KnowledgeEffectivenessReport,
+    proof: "InvariantContextProof | None" = None,
+) -> str:
     """Operator-facing view: window, cohorts, matched comparison, verdict."""
     lines: list[str] = []
     _render_header(report, lines)
@@ -125,6 +149,9 @@ def render_terminal(report: KnowledgeEffectivenessReport) -> str:
     _render_comparison(report, lines)
     _render_trend(report, lines)
     _render_verdict(report, lines)
+    if proof is not None:
+        lines.append("")
+        _render_invariant_proof(proof, lines)
     return "\n".join(lines) + "\n"
 
 
@@ -225,3 +252,70 @@ def _render_trend(report: KnowledgeEffectivenessReport, lines: list[str]) -> Non
 def _render_verdict(report: KnowledgeEffectivenessReport, lines: list[str]) -> None:
     marker = "?" if report.status == STATUS_INSUFFICIENT_DATA else "→"
     lines.append(f"{marker} {report.status}: {report.status_reason}")
+
+
+# ── Invariant-context proof section (#1875) ──────────────────────────────────
+
+
+def invariant_proof_payload(proof: InvariantContextProof) -> dict:
+    """JSON/YAML-serializable view of the invariant-context proof."""
+    counts = proof.selection_counts
+    return {
+        "status": proof.status,
+        "status_reason": proof.status_reason,
+        "cohorts": dict(proof.cohort_counts),
+        "selection": {
+            "runs_with_telemetry": counts.runs_with_telemetry,
+            "included": counts.included,
+            "uncertain": counts.uncertain,
+            "dropped": counts.dropped,
+            "uncertain_share": counts.uncertain_share,
+        },
+        "churn_comparison": [
+            {
+                "metric": item.name,
+                "lower_is_better": item.lower_is_better,
+                "comparable": item.comparable,
+                INVARIANT_COHORT_WITH: _metric_payload(item.with_invariants),
+                INVARIANT_COHORT_WITHOUT: _metric_payload(item.without_invariants),
+                "delta": item.delta,
+                "improved": item.improved,
+            }
+            for item in proof.comparisons
+        ],
+    }
+
+
+def _render_invariant_proof(proof: InvariantContextProof, lines: list[str]) -> None:
+    lines.append("Invariant-context proof (#1875 spike)")
+    lines.append("-" * 60)
+    counts = proof.cohort_counts
+    lines.append(
+        f"Runs:    {counts.get(INVARIANT_COHORT_WITH, 0)} with invariant context, "
+        f"{counts.get(INVARIANT_COHORT_WITHOUT, 0)} without, "
+        f"{counts.get(COHORT_UNCLASSIFIED, 0)} unclassified"
+    )
+    selection = proof.selection_counts
+    share = f"{selection.uncertain_share:.0%}" if selection.uncertain_share is not None else "—"
+    lines.append(
+        f"Scope:   {selection.included} invariants included "
+        f"({selection.uncertain} uncertain → broad source, {share} of inclusions), "
+        f"{selection.dropped} dropped"
+    )
+    lines.append("")
+    for item in proof.comparisons:
+        label = _METRIC_LABELS.get(item.name, item.name)
+        lines.append(f"  {label:<32} {_invariant_verdict(item)}")
+    lines.append("")
+    marker = "?" if proof.status == STATUS_INSUFFICIENT_DATA else "→"
+    lines.append(f"{marker} {proof.status}: {proof.status_reason}")
+
+
+def _invariant_verdict(comparison: InvariantChurnComparison) -> str:
+    if not comparison.comparable:
+        return "insufficient data"
+    if comparison.improved:
+        return f"improved ({comparison.delta:+})"
+    if comparison.delta == 0:
+        return "unchanged"
+    return f"not improved ({comparison.delta:+})"

--- a/src/theforge/knowledge_effectiveness_signals.py
+++ b/src/theforge/knowledge_effectiveness_signals.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from theforge.task.invariant_selector import ELIGIBLE_PHASES as INVARIANT_ELIGIBLE_PHASES
 from theforge.task.prior_run_selector import ELIGIBLE_PHASES
 
 # ── Cohorts ──────────────────────────────────────────────────────────────────
@@ -32,6 +33,12 @@ from theforge.task.prior_run_selector import ELIGIBLE_PHASES
 COHORT_WITH = "with_prior_summary"
 COHORT_WITHOUT = "without_prior_summary"
 COHORT_UNCLASSIFIED = "unclassified"
+
+#: Cohorts for the #1875 invariant-context spike. Same rule as above: the
+#: manifest decides, not configuration, and a run from before the feature
+#: existed is not evidence about the feature.
+INVARIANT_COHORT_WITH = "with_invariant_context"
+INVARIANT_COHORT_WITHOUT = "without_invariant_context"
 
 _COMPLEXITY_BANDS = {
     "small": "LOW",
@@ -62,10 +69,18 @@ class RunSignals:
     dev_iterations: int | None
     review_cycles: int | None
     cost_usd: float | None
+    invariant_cohort: str = COHORT_UNCLASSIFIED
+    invariant_included: int | None = None
+    invariant_uncertain: int | None = None
+    invariant_dropped: int | None = None
 
     @property
     def classified(self) -> bool:
         return self.cohort in (COHORT_WITH, COHORT_WITHOUT)
+
+    @property
+    def invariant_classified(self) -> bool:
+        return self.invariant_cohort in (INVARIANT_COHORT_WITH, INVARIANT_COHORT_WITHOUT)
 
 
 def _mapping(value: object) -> dict:
@@ -117,6 +132,68 @@ def classify_cohort(record: dict) -> str:
         if isinstance(included, list) and included:
             return COHORT_WITH
     return COHORT_WITHOUT if enabled_somewhere else COHORT_UNCLASSIFIED
+
+
+def classify_invariant_cohort(record: dict) -> str:
+    """Which invariant-context cohort a run belongs to (#1875).
+
+    Mirrors :func:`classify_cohort` deliberately: enabled somewhere *and*
+    something included is treatment; enabled with nothing included is a genuine
+    control; disabled or absent is unclassified. Preflight manifests never
+    classify — the selector refuses that phase, so a preflight manifest saying
+    "not injected here" is not evidence either way.
+    """
+    manifests = record.get("context_manifests")
+    if not isinstance(manifests, list):
+        return COHORT_UNCLASSIFIED
+
+    enabled_somewhere = False
+    for entry in manifests:
+        manifest = _mapping(entry)
+        phase = (_text(manifest.get("phase")) or "").lower()
+        if phase not in INVARIANT_ELIGIBLE_PHASES:
+            continue
+        invariants = _mapping(manifest.get("invariant_context"))
+        if invariants.get("enabled") is not True:
+            continue
+        enabled_somewhere = True
+        included = invariants.get("included")
+        if isinstance(included, list) and included:
+            return INVARIANT_COHORT_WITH
+    return INVARIANT_COHORT_WITHOUT if enabled_somewhere else COHORT_UNCLASSIFIED
+
+
+def _invariant_counts(record: dict) -> tuple[int | None, int | None, int | None]:
+    """Included / uncertain / dropped invariants across eligible manifests.
+
+    ``None`` when no eligible manifest carried an enabled ``invariant_context``
+    block — unavailable telemetry, never a zero.
+    """
+    manifests = record.get("context_manifests")
+    if not isinstance(manifests, list):
+        return (None, None, None)
+
+    included = uncertain = dropped = 0
+    observed = False
+    for entry in manifests:
+        manifest = _mapping(entry)
+        phase = (_text(manifest.get("phase")) or "").lower()
+        if phase not in INVARIANT_ELIGIBLE_PHASES:
+            continue
+        invariants = _mapping(manifest.get("invariant_context"))
+        if invariants.get("enabled") is not True:
+            continue
+        observed = True
+        included += _list_len(invariants.get("included"))
+        uncertain += _list_len(invariants.get("uncertain"))
+        dropped += _list_len(invariants.get("dropped"))
+    if not observed:
+        return (None, None, None)
+    return (included, uncertain, dropped)
+
+
+def _list_len(value: object) -> int:
+    return len(value) if isinstance(value, list) else 0
 
 
 def _bucket(record: dict) -> tuple[str, str, tuple[str, ...]] | None:
@@ -211,6 +288,7 @@ def extract_signals(record: dict) -> RunSignals:
     iterations = _mapping(record.get("iterations"))
     plan_review = record.get("plan_review")
     restated, total_findings = _review_recurrence(record)
+    inv_included, inv_uncertain, inv_dropped = _invariant_counts(record)
 
     return RunSignals(
         run_id=_text(record.get("run_id")) or "",
@@ -231,4 +309,8 @@ def extract_signals(record: dict) -> RunSignals:
         dev_iterations=_count(iterations.get("dev_iterations_productive")),
         review_cycles=_count(iterations.get("review_cycles_total")),
         cost_usd=_cost(_mapping(record.get("cost")).get("total_usd")),
+        invariant_cohort=classify_invariant_cohort(record),
+        invariant_included=inv_included,
+        invariant_uncertain=inv_uncertain,
+        invariant_dropped=inv_dropped,
     )

--- a/src/theforge/knowledge_invariant_proof.py
+++ b/src/theforge/knowledge_invariant_proof.py
@@ -1,0 +1,215 @@
+"""Did selective invariant context reduce churn? (#1875)
+
+The measurement half of the invariant-index spike, and deliberately a sibling of
+:mod:`theforge.knowledge_effectiveness` rather than a section inside it: the two
+measure different treatments over the same audit records, and a spike's proof
+machinery should be removable without touching the shipped knowledge loop.
+
+The proof reuses that module's cohort metrics wholesale, restricted to the four
+**churn** metrics the story names — plan regeneration, review cycles, dev
+iterations, restated-finding rate. Cost and stories-per-dollar are deliberately
+absent: the spike's success claim is churn reduction, and token or spend
+movement is secondary telemetry that must not be able to carry the verdict.
+
+The default answer is ``insufficient_data``. A spike that reports a number off
+two runs has proved nothing, and saying so is the point.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from theforge.knowledge_effectiveness import (
+    METRIC_DEV_ITERATIONS,
+    METRIC_DIRECTION,
+    METRIC_PLAN_REGENERATION,
+    METRIC_REVIEW_CYCLES,
+    METRIC_REVIEW_RECURRENCE,
+    MIN_COHORT_RUNS,
+    STATUS_INSUFFICIENT_DATA,
+    STATUS_NO_OBSERVED_IMPROVEMENT,
+    STATUS_OBSERVED_IMPROVEMENT,
+    CohortMetrics,
+    Metric,
+    compute_cohort_metrics,
+)
+from theforge.knowledge_effectiveness_signals import (
+    COHORT_UNCLASSIFIED,
+    INVARIANT_COHORT_WITH,
+    INVARIANT_COHORT_WITHOUT,
+    RunSignals,
+    classify_invariant_cohort,
+    extract_signals,
+)
+
+__all__ = [
+    "CHURN_METRICS",
+    "INVARIANT_COHORT_WITH",
+    "INVARIANT_COHORT_WITHOUT",
+    "InvariantChurnComparison",
+    "InvariantContextProof",
+    "InvariantSelectionCounts",
+    "build_invariant_proof",
+    "build_invariant_proof_from_records",
+    "classify_invariant_cohort",
+]
+
+#: The churn signals this proof reports. Token and cost movement are excluded on
+#: purpose — see the module docstring.
+CHURN_METRICS = (
+    METRIC_PLAN_REGENERATION,
+    METRIC_REVIEW_RECURRENCE,
+    METRIC_DEV_ITERATIONS,
+    METRIC_REVIEW_CYCLES,
+)
+
+
+@dataclass(frozen=True)
+class InvariantChurnComparison:
+    """One churn metric held side by side across the invariant cohorts."""
+
+    name: str
+    lower_is_better: bool
+    with_invariants: Metric
+    without_invariants: Metric
+
+    @property
+    def comparable(self) -> bool:
+        return self.with_invariants.comparable and self.without_invariants.comparable
+
+    @property
+    def delta(self) -> float | None:
+        if not self.comparable:
+            return None
+        with_value = self.with_invariants.value
+        without_value = self.without_invariants.value
+        # comparable implies both are set
+        if with_value is None or without_value is None:  # pragma: no cover
+            return None
+        return round(with_value - without_value, 4)
+
+    @property
+    def improved(self) -> bool | None:
+        delta = self.delta
+        if delta is None:
+            return None
+        return delta < 0 if self.lower_is_better else delta > 0
+
+
+@dataclass(frozen=True)
+class InvariantSelectionCounts:
+    """What the selector actually did, summed over the classified runs.
+
+    This is scope-decision telemetry, not a success measure: a high
+    ``uncertain`` share means the conservative fallback carried the proof, which
+    is exactly the thing the adoption decision needs to know.
+    """
+
+    runs_with_telemetry: int
+    included: int
+    uncertain: int
+    dropped: int
+
+    @property
+    def uncertain_share(self) -> float | None:
+        return round(self.uncertain / self.included, 4) if self.included else None
+
+
+@dataclass(frozen=True)
+class InvariantContextProof:
+    """The spike's proof section: cohorts, churn comparison, and a verdict."""
+
+    cohort_counts: dict[str, int]
+    with_metrics: CohortMetrics
+    without_metrics: CohortMetrics
+    comparisons: tuple[InvariantChurnComparison, ...]
+    selection_counts: InvariantSelectionCounts
+    status: str
+    status_reason: str
+
+    def comparison(self, name: str) -> InvariantChurnComparison | None:
+        for item in self.comparisons:
+            if item.name == name:
+                return item
+        return None
+
+
+def build_invariant_proof(signals: list[RunSignals]) -> InvariantContextProof:
+    """Build the invariant-context proof from already-extracted run signals."""
+    with_runs = [s for s in signals if s.invariant_cohort == INVARIANT_COHORT_WITH]
+    without_runs = [s for s in signals if s.invariant_cohort == INVARIANT_COHORT_WITHOUT]
+    cohort_counts = {
+        INVARIANT_COHORT_WITH: len(with_runs),
+        INVARIANT_COHORT_WITHOUT: len(without_runs),
+        COHORT_UNCLASSIFIED: sum(1 for s in signals if not s.invariant_classified),
+    }
+
+    with_metrics = compute_cohort_metrics(INVARIANT_COHORT_WITH, with_runs)
+    without_metrics = compute_cohort_metrics(INVARIANT_COHORT_WITHOUT, without_runs)
+    comparisons = tuple(
+        InvariantChurnComparison(
+            name=name,
+            lower_is_better=METRIC_DIRECTION[name],
+            with_invariants=with_metrics.metric(name),
+            without_invariants=without_metrics.metric(name),
+        )
+        for name in CHURN_METRICS
+        if with_metrics.metric(name) is not None and without_metrics.metric(name) is not None
+    )
+    status, reason = _verdict(with_metrics, without_metrics, comparisons)
+    return InvariantContextProof(
+        cohort_counts=cohort_counts,
+        with_metrics=with_metrics,
+        without_metrics=without_metrics,
+        comparisons=comparisons,
+        selection_counts=_selection_counts(signals),
+        status=status,
+        status_reason=reason,
+    )
+
+
+def build_invariant_proof_from_records(records: list[dict]) -> InvariantContextProof:
+    """Convenience for callers holding audit records rather than signals."""
+    return build_invariant_proof([extract_signals(record) for record in records])
+
+
+def _selection_counts(signals: list[RunSignals]) -> InvariantSelectionCounts:
+    observed = [s for s in signals if s.invariant_included is not None]
+    return InvariantSelectionCounts(
+        runs_with_telemetry=len(observed),
+        included=sum(s.invariant_included or 0 for s in observed),
+        uncertain=sum(s.invariant_uncertain or 0 for s in observed),
+        dropped=sum(s.invariant_dropped or 0 for s in observed),
+    )
+
+
+def _verdict(
+    with_metrics: CohortMetrics,
+    without_metrics: CohortMetrics,
+    comparisons: tuple[InvariantChurnComparison, ...],
+) -> tuple[str, str]:
+    """Report "we cannot tell yet" — the honest default for a spike this young."""
+    if with_metrics.run_count < MIN_COHORT_RUNS or without_metrics.run_count < MIN_COHORT_RUNS:
+        return (
+            STATUS_INSUFFICIENT_DATA,
+            f"invariant cohorts hold {with_metrics.run_count} with-invariant and "
+            f"{without_metrics.run_count} without-invariant run(s); "
+            f"{MIN_COHORT_RUNS} of each are required before comparing churn",
+        )
+    comparable = [item for item in comparisons if item.comparable]
+    if not comparable:
+        return (
+            STATUS_INSUFFICIENT_DATA,
+            "no churn metric has enough observations in both invariant cohorts",
+        )
+    improved = [item.name for item in comparable if item.improved]
+    if improved:
+        return (
+            STATUS_OBSERVED_IMPROVEMENT,
+            f"{len(improved)} of {len(comparable)} comparable churn metric(s) improved "
+            f"with invariant context: {', '.join(improved)}",
+        )
+    return (
+        STATUS_NO_OBSERVED_IMPROVEMENT,
+        f"{len(comparable)} comparable churn metric(s) and none improved with invariant context",
+    )

--- a/src/theforge/task/CONVENTIONS.md
+++ b/src/theforge/task/CONVENTIONS.md
@@ -10,9 +10,11 @@ construction layer, not the coordinator.
 
 - Keep prompt construction separate from coordinator control flow and separate
   from runner/provider execution details.
+<!-- forge-invariant id="acceptance-criteria-authoritative" scope="area:prompts area:story phase:plan,dev,review" enforcement="review" -->
 - Preserve the distinction between story requirements and advisory notes.
   Acceptance criteria are authoritative; notes are hints that must not be
   promoted into hard requirements by default.
+<!-- /forge-invariant -->
 - Story and plan parsing should remain strict enough to surface malformed agent
   output instead of papering over ambiguity.
 - Keep low-dependency data definitions lightweight; avoid pulling heavy runtime

--- a/src/theforge/task/context_assembler.py
+++ b/src/theforge/task/context_assembler.py
@@ -48,6 +48,13 @@ class ContextItem:
     content: str
     reason: str
     score: int = 0
+    # Identity of the indexed thing this item renders — a run id for prior-run
+    # summaries, an invariant id for project invariants. Carried explicitly
+    # because the budget loop later has to report *which* entries survived, and
+    # re-deriving an id by splitting ``source`` makes that decision depend on
+    # whether a project's own file paths happen to contain the delimiter.
+    # ``None`` for items that render no indexed entity (docs, structural index).
+    item_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -193,6 +200,7 @@ class ContextAssembler:
                         content=candidate.content,
                         reason=candidate.reason,
                         score=candidate.score,
+                        item_id=candidate.run_id,
                     )
                 )
 
@@ -210,6 +218,7 @@ class ContextAssembler:
                         content=invariant.content,
                         reason=invariant.reason,
                         score=invariant.score,
+                        item_id=invariant.invariant_id,
                     )
                 )
 
@@ -267,11 +276,7 @@ class ContextAssembler:
             prior_run_context=(
                 prior_run_manifest.build_manifest(
                     prior_selection,
-                    included_run_ids={
-                        item.source.split(":", 1)[1]
-                        for item in included_items
-                        if item.kind == PRIOR_RUN_KIND
-                    },
+                    included_run_ids=_included_ids(included_items, PRIOR_RUN_KIND),
                     phase=normalized_phase,
                 )
                 if prior_selection is not None
@@ -280,11 +285,7 @@ class ContextAssembler:
             invariant_context=(
                 invariant_manifest.build_manifest(
                     invariant_selection,
-                    included_ids={
-                        item.source.split("#", 1)[1]
-                        for item in included_items
-                        if item.kind == INVARIANT_KIND and "#" in item.source
-                    },
+                    included_ids=_included_ids(included_items, INVARIANT_KIND),
                     phase=normalized_phase,
                 )
                 if invariant_selection is not None
@@ -435,6 +436,18 @@ class ContextAssembler:
         ):
             score += 3
         return score
+
+
+def _included_ids(items: list[ContextItem], kind: str) -> set[str]:
+    """Ids of ``kind`` items that survived the budget, read off the item itself.
+
+    The manifest's "included vs dropped under budget pressure" split is only
+    trustworthy if it uses the same identity the selector used. Splitting the
+    display ``source`` string to recover it made that split depend on a
+    project's file naming, which is exactly the kind of coupling a portable
+    feature cannot carry.
+    """
+    return {item.item_id for item in items if item.kind == kind and item.item_id is not None}
 
 
 def _drop_reason(item: ContextItem) -> str:

--- a/src/theforge/task/context_assembler.py
+++ b/src/theforge/task/context_assembler.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from . import prior_run_manifest, prior_run_selector
+from . import invariant_manifest, invariant_selector, prior_run_manifest, prior_run_selector
+from .invariant_selector import INVARIANT_KIND
 from .prior_run_selector import PRIOR_RUN_KIND
 
 if TYPE_CHECKING:
@@ -74,6 +75,10 @@ class ContextPack:
     # Audit-visible record of the prior-run knowledge this assembly considered.
     # Defaulted so the many constructors that predate #1860 keep working.
     prior_run_context: dict = field(default_factory=prior_run_manifest.disabled_manifest)
+    # Audit-visible record of the project invariants this assembly considered,
+    # including the ones it could not confidently scope. Defaulted for the same
+    # reason as ``prior_run_context``: constructors predating #1875 keep working.
+    invariant_context: dict = field(default_factory=invariant_manifest.disabled_manifest)
 
 
 @dataclass(frozen=True)
@@ -90,12 +95,14 @@ class ContextAssembler:
         *,
         budgets: ContextBudgetConfig | None = None,
         prior_run_context: bool = False,
+        invariant_context: bool = False,
     ) -> None:
         self.project_root = project_root
         self.budgets = budgets or ContextBudgetConfig()
         # Off unless a config explicitly turns it on: a direct
         # ContextAssembler(project_root) never injects prior-run knowledge.
         self.prior_run_context = prior_run_context
+        self.invariant_context = invariant_context
 
     @classmethod
     def from_config(cls, config: "ForgeConfig") -> "ContextAssembler":
@@ -109,6 +116,7 @@ class ContextAssembler:
                 review_budget=ctx.review_budget,
             ),
             prior_run_context=config.knowledge.prior_run_context,
+            invariant_context=config.knowledge.invariant_context,
         )
 
     def assemble(
@@ -188,6 +196,23 @@ class ContextAssembler:
                     )
                 )
 
+        invariant_selection = self._select_invariants(
+            phase=normalized_phase, story_text=story_text, file_list=file_list
+        )
+        if invariant_selection is not None:
+            for invariant in invariant_selection.candidates:
+                advisory_items.append(
+                    ContextItem(
+                        source=invariant.source,
+                        kind=INVARIANT_KIND,
+                        required=False,
+                        lines=_count_lines(invariant.content),
+                        content=invariant.content,
+                        reason=invariant.reason,
+                        score=invariant.score,
+                    )
+                )
+
         included_items = list(required_items)
         dropped_items: list[ContextItem] = []
         used_lines = sum(item.lines for item in included_items)
@@ -252,6 +277,19 @@ class ContextAssembler:
                 if prior_selection is not None
                 else prior_run_manifest.disabled_manifest()
             ),
+            invariant_context=(
+                invariant_manifest.build_manifest(
+                    invariant_selection,
+                    included_ids={
+                        item.source.split("#", 1)[1]
+                        for item in included_items
+                        if item.kind == INVARIANT_KIND and "#" in item.source
+                    },
+                    phase=normalized_phase,
+                )
+                if invariant_selection is not None
+                else invariant_manifest.disabled_manifest()
+            ),
         )
 
     def _select_prior_runs(
@@ -265,6 +303,25 @@ class ContextAssembler:
         if not self.prior_run_context:
             return None
         return prior_run_selector.select_prior_runs(
+            self.project_root,
+            phase=phase,
+            story_text=story_text,
+            file_list=file_list,
+        )
+
+    def _select_invariants(
+        self, *, phase: str, story_text: str, file_list: list[str] | None
+    ) -> invariant_selector.InvariantSelection | None:
+        """Return the invariant selection, or ``None`` when injection is off.
+
+        Disabled means the derived index is never even read, so no marked prose
+        can reach a prompt through any later code path. Preflight is handled
+        inside the selector, which refuses it outright: preflight output drives
+        coordinator control flow (ADR-0002 clause 5).
+        """
+        if not self.invariant_context:
+            return None
+        return invariant_selector.select_invariants(
             self.project_root,
             phase=phase,
             story_text=story_text,
@@ -387,7 +444,9 @@ def _drop_reason(item: ContextItem) -> str:
     can tell "we knew something relevant but required context won" apart from the
     ordinary advisory truncation that has always read ``budget exceeded``.
     """
-    return "budget_pressure" if item.kind == PRIOR_RUN_KIND else "budget exceeded"
+    return (
+        "budget_pressure" if item.kind in (PRIOR_RUN_KIND, INVARIANT_KIND) else "budget exceeded"
+    )
 
 
 def _extract_section(text: str, heading: str) -> str:

--- a/src/theforge/task/invariant_manifest.py
+++ b/src/theforge/task/invariant_manifest.py
@@ -1,0 +1,112 @@
+"""The audit-visible record of which project invariants a run was offered (#1875).
+
+Split from :mod:`theforge.task.invariant_selector` for the same reason
+``prior_run_manifest`` is split from its selector: the selector answers *what an
+agent may read*, this answers *what an operator can later see*. For the
+invariant spike the operator question is sharper than usual, because the whole
+claim under test is about scope decisions — so the manifest reports not just
+included and dropped, but **uncertain**: the rules that were included broadly
+precisely because TheForge could not confidently narrow them.
+"""
+
+from __future__ import annotations
+
+from .invariant_selector import (
+    CONFIDENCE_LOW,
+    ELIGIBLE_PHASES,
+    InvariantCandidate,
+    InvariantSelection,
+)
+
+
+def disabled_manifest() -> dict:
+    """The payload for a run whose ``knowledge.invariant_context`` is off."""
+    return {
+        "enabled": False,
+        "phase": "",
+        "selection_mode": "",
+        "included": [],
+        "dropped": [],
+        "uncertain": [],
+        "note": "invariant context disabled (knowledge.invariant_context)",
+    }
+
+
+def build_manifest(
+    selection: InvariantSelection,
+    *,
+    included_ids: set[str],
+    phase: str,
+) -> dict:
+    """Render what invariant knowledge this assembly offered, and what it withheld.
+
+    Candidates absent from ``included_ids`` lost the context budget, so they are
+    reported as ``budget_pressure`` — distinct from the applicability exclusions
+    the selector already decided.
+    """
+    included: list[dict] = []
+    dropped: list[dict] = []
+    uncertain: list[dict] = []
+
+    for candidate in selection.candidates:
+        record = _record(candidate)
+        if candidate.invariant_id in included_ids:
+            included.append(record)
+            if candidate.scope_confidence == CONFIDENCE_LOW:
+                uncertain.append(record)
+        else:
+            dropped.append({**record, "reason": "budget_pressure"})
+
+    for exclusion in selection.excluded:
+        dropped.append(
+            {
+                "id": exclusion.invariant_id,
+                "source_path": exclusion.source_path,
+                "reason": exclusion.reason,
+            }
+        )
+
+    return {
+        "enabled": True,
+        "phase": selection.phase or phase,
+        "selection_mode": selection.selection_mode,
+        "included": included,
+        "dropped": dropped,
+        "uncertain": uncertain,
+        "note": _note(selection, included_count=len(included), uncertain_count=len(uncertain)),
+    }
+
+
+def _record(candidate: InvariantCandidate) -> dict:
+    return {
+        "id": candidate.invariant_id,
+        "source_path": candidate.source_path,
+        "source_anchor": candidate.source_anchor,
+        "enforcement": candidate.enforcement,
+        "rendering_mode": candidate.rendering_mode,
+        "scope_confidence": candidate.scope_confidence,
+        "reason": candidate.reason,
+        "score": candidate.score,
+        "source_digest_matches": candidate.source_digest_matches,
+    }
+
+
+def _note(selection: InvariantSelection, *, included_count: int, uncertain_count: int) -> str:
+    """Separate 'no invariants are marked' from 'invariants exist and were withheld'."""
+    if not selection.phase_eligible:
+        return (
+            f"invariant context is not injected in the {selection.phase} phase "
+            f"(eligible phases: {', '.join(sorted(ELIGIBLE_PHASES))})"
+        )
+    if selection.entry_count == 0:
+        return "no project invariants are indexed (run 'forge index --invariants')"
+
+    parts = [f"{included_count} of {selection.entry_count} indexed invariants included"]
+    if uncertain_count:
+        parts.append(
+            f"{uncertain_count} included as full source sections because scope confidence was low"
+        )
+    stale = sum(1 for candidate in selection.candidates if not candidate.source_digest_matches)
+    if stale:
+        parts.append(f"{stale} source regions changed since the index was built")
+    return "; ".join(parts)

--- a/src/theforge/task/invariant_selector.py
+++ b/src/theforge/task/invariant_selector.py
@@ -1,0 +1,373 @@
+"""Which project invariants a phase may see, and how narrowly (#1875).
+
+The consumer half of the invariant-index spike. :mod:`theforge.invariant_index`
+materializes provenance and applicability metadata over marked regions of the
+project's own Markdown; this module decides which of those regions reach a
+prompt, and — the part the spike actually exists to test — *how much of the
+source document comes with them*.
+
+Three rules shape everything here:
+
+1. **Uncertainty widens, never narrows.** A rule whose declared scope cannot be
+   matched against the story's files with confidence is included as its whole
+   enclosing source section, not dropped and not trimmed to a guess. The only
+   drop that narrowing may cause is the confident one: the project declared file
+   globs, the touched files are known, and none of them match.
+2. **Review is deliberately broader than plan/dev.** Plan and dev may receive
+   narrow capsules; review always receives the enclosing source section. A bad
+   scope decision then reaches the producer without also blinding the reviewer,
+   which is the correlated-miss failure this asymmetry exists to prevent.
+3. **The source document is authoritative; the index is not.** Text is always
+   re-read from the source file at render time. The indexed digest is compared
+   only to *report* staleness, never to suppress a rule.
+
+Preflight is excluded outright, on the same ground as prior-run summaries:
+preflight's output (sufficiency, complexity, likely files, refusal) drives
+coordinator control flow, so no marked prose may reach it (ADR-0002 clause 5).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from theforge.invariant_index import (
+    COMPLETENESS_FULL,
+    COMPLETENESS_NONE,
+    COMPLETENESS_PARTIAL,
+    load_invariant_index,
+)
+
+#: ``ContextItem.kind`` for an injected project invariant. Budget accounting and
+#: the audit manifest both branch on this value.
+INVARIANT_KIND = "project_invariant"
+
+#: Phases that may receive invariant prose at all.
+ELIGIBLE_PHASES = frozenset({"plan", "dev", "review"})
+
+#: Phases that always receive the broader source section, never a capsule.
+BROAD_SOURCE_PHASES = frozenset({"review"})
+
+RENDER_CAPSULE = "capsule"
+RENDER_SOURCE_SECTION = "source_section"
+
+CONFIDENCE_HIGH = "high"
+CONFIDENCE_LOW = "low"
+
+#: Lines of enclosing source a single broad inclusion may render before it is
+#: truncated with a pointer back to the file. Broad means "the section", not
+#: "the repository".
+_MAX_SECTION_LINES = 120
+
+_SCORE_BASE = 100
+_SCORE_ENFORCEMENT = {"gate": 15, "review": 8, "advisory": 0}
+_SCORE_CONFIDENT = 5
+
+_HEADING_PATTERN = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<title>.+?)\s*$")
+
+
+@dataclass(frozen=True)
+class InvariantCandidate:
+    """One invariant offered to a phase, already rendered from its source."""
+
+    invariant_id: str
+    source_path: str
+    source_anchor: str
+    enforcement: str
+    rendering_mode: str
+    scope_confidence: str
+    reason: str
+    content: str
+    score: int
+    source_digest_matches: bool
+
+    @property
+    def source(self) -> str:
+        """``ContextItem.source`` — carries the id so the manifest can round-trip."""
+        return f"{self.source_path}#{self.invariant_id}"
+
+
+@dataclass(frozen=True)
+class InvariantExclusion:
+    invariant_id: str
+    source_path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class InvariantSelection:
+    phase: str
+    phase_eligible: bool
+    entry_count: int
+    selection_mode: str
+    candidates: tuple[InvariantCandidate, ...] = ()
+    excluded: tuple[InvariantExclusion, ...] = ()
+
+    @property
+    def uncertain(self) -> tuple[InvariantCandidate, ...]:
+        """Candidates included broadly *because* scope confidence was low."""
+        return tuple(
+            candidate
+            for candidate in self.candidates
+            if candidate.scope_confidence == CONFIDENCE_LOW
+        )
+
+
+def select_invariants(
+    project_root: Path,
+    *,
+    phase: str,
+    story_text: str,
+    file_list: list[str] | None,
+) -> InvariantSelection:
+    """Choose the invariants this phase may see. Never raises."""
+    normalized_phase = phase.lower()
+    if normalized_phase not in ELIGIBLE_PHASES:
+        return InvariantSelection(
+            phase=normalized_phase,
+            phase_eligible=False,
+            entry_count=0,
+            selection_mode="",
+        )
+
+    entries = load_invariant_index(project_root)
+    broad_phase = normalized_phase in BROAD_SOURCE_PHASES
+    selection_mode = RENDER_SOURCE_SECTION if broad_phase else "selective"
+
+    candidates: list[InvariantCandidate] = []
+    excluded: list[InvariantExclusion] = []
+    sources = _SourceCache(project_root)
+
+    for entry in entries:
+        invariant_id = str(entry.get("id", ""))
+        source_path = str(entry.get("source_path", ""))
+        applicability = entry.get("applicability")
+        applicability = applicability if isinstance(applicability, dict) else {}
+        phases = _string_list(applicability.get("phases"))
+        if phases and normalized_phase not in phases:
+            excluded.append(
+                InvariantExclusion(
+                    invariant_id,
+                    source_path,
+                    f"phase_not_applicable({','.join(phases)})",
+                )
+            )
+            continue
+
+        confidence, reason, applies = _scope_confidence(
+            applicability, file_list=file_list, story_text=story_text
+        )
+        if not applies:
+            if not broad_phase:
+                excluded.append(InvariantExclusion(invariant_id, source_path, reason))
+                continue
+            # Review is broader on purpose: the one narrowing decision plan/dev
+            # is allowed to make must not also blind the reviewer, or a bad
+            # scope tag produces a correlated miss on both sides.
+            reason = f"broad_phase_override({reason})"
+
+        rendered = sources.render(entry, broad=broad_phase or confidence == CONFIDENCE_LOW)
+        if rendered is None:
+            excluded.append(InvariantExclusion(invariant_id, source_path, "source_unreadable"))
+            continue
+        content, mode, digest_matches = rendered
+
+        candidates.append(
+            InvariantCandidate(
+                invariant_id=invariant_id,
+                source_path=source_path,
+                source_anchor=str(entry.get("source_anchor") or ""),
+                enforcement=str(entry.get("enforcement") or "advisory"),
+                rendering_mode=mode,
+                scope_confidence=confidence,
+                reason=reason,
+                content=content,
+                score=_score(entry, confidence),
+                source_digest_matches=digest_matches,
+            )
+        )
+
+    candidates.sort(key=lambda item: (-item.score, item.source_path, item.invariant_id))
+    return InvariantSelection(
+        phase=normalized_phase,
+        phase_eligible=True,
+        entry_count=len(entries),
+        selection_mode=selection_mode,
+        candidates=tuple(candidates),
+        excluded=tuple(excluded),
+    )
+
+
+# ── Scope confidence ─────────────────────────────────────────────────────────
+
+
+def _scope_confidence(
+    applicability: dict,
+    *,
+    file_list: list[str] | None,
+    story_text: str,
+) -> tuple[str, str, bool]:
+    """Decide confidence, the reason for it, and whether the rule applies.
+
+    The concrete triggers, so no consumer has to infer them:
+
+    - ``full`` scope (file globs declared) **and** a known file list: a glob
+      match is high confidence; no match is the one confident *drop*.
+    - ``full`` scope with **no** known file list: low confidence — there is
+      nothing to match against, so the rule widens rather than guessing.
+    - ``partial`` scope (areas only): an area token appearing in a touched path
+      or in the story text is high confidence; otherwise low.
+    - ``none`` scope, or scope tokens the extractor could not parse: always low.
+    """
+    completeness = str(applicability.get("scope_completeness") or COMPLETENESS_NONE)
+    unparsed = _string_list(applicability.get("unparsed_scope_keys"))
+    globs = _string_list(applicability.get("file_globs"))
+    areas = _string_list(applicability.get("areas"))
+    files = [item for item in (file_list or []) if isinstance(item, str) and item.strip()]
+
+    if unparsed:
+        return (CONFIDENCE_LOW, f"unparsed_scope({','.join(unparsed)})", True)
+
+    if completeness == COMPLETENESS_FULL and globs:
+        if not files:
+            return (CONFIDENCE_LOW, "no_file_list_to_match_scope", True)
+        matched = [glob for glob in globs if _any_match(files, glob)]
+        if matched:
+            return (CONFIDENCE_HIGH, f"file_scope_match({','.join(sorted(matched)[:3])})", True)
+        return (CONFIDENCE_HIGH, f"files_out_of_scope({','.join(globs[:3])})", False)
+
+    if completeness == COMPLETENESS_PARTIAL and areas:
+        haystack = " ".join(files).lower() + " " + story_text.lower()
+        matched = [area for area in areas if area.lower() in haystack]
+        if matched:
+            return (CONFIDENCE_HIGH, f"area_match({','.join(sorted(matched)[:3])})", True)
+        return (CONFIDENCE_LOW, f"area_unmatched({','.join(areas[:3])})", True)
+
+    return (CONFIDENCE_LOW, "no_scope_metadata", True)
+
+
+def _any_match(files: list[str], glob: str) -> bool:
+    normalized = glob.strip()
+    for path in files:
+        candidate = path.strip().lstrip("./")
+        if fnmatch.fnmatch(candidate, normalized) or fnmatch.fnmatch(
+            candidate, f"*/{normalized.lstrip('/')}"
+        ):
+            return True
+        if normalized.endswith("/") and candidate.startswith(normalized):
+            return True
+    return False
+
+
+def _score(entry: dict, confidence: str) -> int:
+    enforcement = str(entry.get("enforcement") or "advisory")
+    score = _SCORE_BASE + _SCORE_ENFORCEMENT.get(enforcement, 0)
+    if confidence == CONFIDENCE_HIGH:
+        score += _SCORE_CONFIDENT
+    return score
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+# ── Rendering from the authoritative source ──────────────────────────────────
+
+
+@dataclass
+class _SourceCache:
+    """Re-reads source documents once per assembly. The index never holds prose."""
+
+    project_root: Path
+    _texts: dict[str, list[str] | None] = field(default_factory=dict)
+
+    def lines(self, source_path: str) -> list[str] | None:
+        if source_path not in self._texts:
+            try:
+                text = (self.project_root / source_path).read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                self._texts[source_path] = None
+            else:
+                self._texts[source_path] = text.splitlines()
+        return self._texts[source_path]
+
+    def render(self, entry: dict, *, broad: bool) -> tuple[str, str, bool] | None:
+        source_path = str(entry.get("source_path", ""))
+        lines = self.lines(source_path)
+        if not lines:
+            return None
+        body = _slice(lines, entry.get("body_start_line"), entry.get("body_end_line"))
+        if not body.strip():
+            return None
+        digest_matches = _digest_matches(body, entry.get("source_digest"))
+        header_scope = str(entry.get("scope_raw") or "unscoped")
+        enforcement = str(entry.get("enforcement") or "advisory")
+
+        if not broad:
+            header = (
+                f"### Project invariant `{entry.get('id')}` "
+                f"({source_path}:{entry.get('start_line')}, enforcement: {enforcement})"
+            )
+            return (f"{header}\n\n{body.strip()}", RENDER_CAPSULE, digest_matches)
+
+        section, start_line = _enclosing_section(lines, entry)
+        header = (
+            f"### Project invariant source `{entry.get('id')}` "
+            f"({source_path}:{start_line}, enforcement: {enforcement}, scope: {header_scope})\n"
+            "Included as the full enclosing section rather than a narrowed excerpt."
+        )
+        return (f"{header}\n\n{section.strip()}", RENDER_SOURCE_SECTION, digest_matches)
+
+
+def _slice(lines: list[str], start: object, end: object) -> str:
+    if not isinstance(start, int) or not isinstance(end, int):
+        return ""
+    first = max(start - 1, 0)
+    last = min(end, len(lines))
+    if first >= last:
+        return ""
+    return "\n".join(lines[first:last])
+
+
+def _enclosing_section(lines: list[str], entry: dict) -> tuple[str, int]:
+    """The Markdown section containing the marker, truncated to a bounded size."""
+    marker_line = entry.get("start_line")
+    marker_index = (marker_line - 1) if isinstance(marker_line, int) else 0
+    marker_index = max(0, min(marker_index, len(lines) - 1))
+
+    start = 0
+    level = 1
+    for index in range(marker_index, -1, -1):
+        match = _HEADING_PATTERN.match(lines[index])
+        if match:
+            start = index
+            level = len(match.group("hashes"))
+            break
+
+    end = len(lines)
+    for index in range(marker_index + 1, len(lines)):
+        match = _HEADING_PATTERN.match(lines[index])
+        if match and len(match.group("hashes")) <= level:
+            end = index
+            break
+
+    section_lines = lines[start:end]
+    if len(section_lines) > _MAX_SECTION_LINES:
+        section_lines = section_lines[:_MAX_SECTION_LINES]
+        section_lines.append(
+            f"[section truncated at {_MAX_SECTION_LINES} lines — "
+            f"read {entry.get('source_path')} for the rest]"
+        )
+    return ("\n".join(section_lines), start + 1)
+
+
+def _digest_matches(body: str, recorded: object) -> bool:
+    if not isinstance(recorded, str) or not recorded.startswith("sha256:"):
+        return False
+    import hashlib  # noqa: PLC0415
+
+    return recorded == "sha256:" + hashlib.sha256(body.strip().encode("utf-8")).hexdigest()

--- a/src/theforge/task/invariant_selector.py
+++ b/src/theforge/task/invariant_selector.py
@@ -85,7 +85,12 @@ class InvariantCandidate:
 
     @property
     def source(self) -> str:
-        """``ContextItem.source`` — carries the id so the manifest can round-trip."""
+        """Human-readable provenance label for the context manifest.
+
+        Display only. Identity travels separately as ``ContextItem.item_id`` —
+        source paths are project-controlled and may contain the delimiter, so
+        this string is not parseable back into a path and an id.
+        """
         return f"{self.source_path}#{self.invariant_id}"
 
 

--- a/tests/test_invariant_context.py
+++ b/tests/test_invariant_context.py
@@ -123,7 +123,8 @@ def test_config_defaults_keep_the_portable_source_globs(tmp_path: Path):
     config = load_config(path)
 
     assert config.knowledge.invariant_context is False
-    assert "docs/**/*.md" in config.knowledge.invariant_sources
+    # Layout-neutral: naming a docs/ directory would presume one project's shape.
+    assert config.knowledge.invariant_sources == ("**/*.md",)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_invariant_context.py
+++ b/tests/test_invariant_context.py
@@ -190,6 +190,29 @@ def test_dev_receives_a_capsule_when_file_scope_matches(project: Path):
     assert "Introductory prose" not in pack.content
 
 
+def test_a_capsule_from_a_multi_line_marker_renders_only_the_rule(project: Path):
+    """`coordinator-pure` wraps its opening marker, as the convention's example does.
+
+    The rendered capsule used to trail the scope and enforcement attribute lines
+    into the prompt, and the digest computed over the real body then reported the
+    unchanged source as stale.
+    """
+    selection = select_invariants(
+        project, phase="dev", story_text="retry loop", file_list=["src/coordinator/engine.py"]
+    )
+    capsule = next(c for c in selection.candidates if c.invariant_id == "coordinator-pure")
+
+    assert capsule.rendering_mode == RENDER_CAPSULE
+    body = capsule.content.split("\n\n", 1)[1]
+    assert body == "The coordinator is pure Python; no model decides retry or escalation."
+    assert capsule.source_digest_matches is True
+
+    pack = _assembler(project).assemble(
+        phase="dev", story_text="retry loop", file_list=["src/coordinator/engine.py"], budget=400
+    )
+    assert "source regions changed" not in pack.invariant_context["note"]
+
+
 def test_confident_file_scope_mismatch_is_the_only_drop(project: Path):
     manifest = (
         _assembler(project)

--- a/tests/test_invariant_context.py
+++ b/tests/test_invariant_context.py
@@ -1,0 +1,479 @@
+"""Selective invariant injection through context assembly (#1875).
+
+Covers the config gate, the plan/dev capsule path, the conservative fallback,
+the review asymmetry, the manifest's included/dropped/uncertain visibility, the
+preflight exclusion, and the coordinator phase seam into the audit record.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from coord_test_helpers import patch_gate_shell
+
+from tests.coord_test_helpers import (
+    APPROVE_REVIEW,
+    PREFLIGHT_PROCEED_MEDIUM,
+    _make_agent_result,
+    _make_plan_config,
+    _make_task,
+    _shell_with_gate,
+)
+from theforge.config.load import load_config
+from theforge.config.types import KnowledgeConfig
+from theforge.coordinator.audit import generate_audit_log
+from theforge.coordinator.engine import run_task
+from theforge.invariant_index import rebuild_invariant_index
+from theforge.task.context_assembler import ContextAssembler, ContextPack
+from theforge.task.invariant_selector import (
+    CONFIDENCE_HIGH,
+    CONFIDENCE_LOW,
+    INVARIANT_KIND,
+    RENDER_CAPSULE,
+    RENDER_SOURCE_SECTION,
+    select_invariants,
+)
+
+_GLOBS = ("*.md", "docs/**/*.md", "**/CONVENTIONS.md")
+
+_POLICY = """# Project policy
+
+## Coordinator rules
+
+Introductory prose that only the broad rendering should reach.
+
+<!-- forge-invariant id="coordinator-pure"
+     scope="area:coordinator phase:plan,dev,review files:src/coordinator/*.py"
+     enforcement="review" -->
+The coordinator is pure Python; no model decides retry or escalation.
+<!-- /forge-invariant -->
+
+## Schema rules
+
+<!-- forge-invariant id="schema-boundary"
+     scope="area:schema phase:plan,dev,review files:src/schemas.py"
+     enforcement="gate" -->
+The review schema is the integrity boundary; do not relax cross-validation.
+<!-- /forge-invariant -->
+
+## Prompt rules
+
+<!-- forge-invariant id="ac-authoritative"
+     scope="area:prompts phase:plan,dev,review" enforcement="review" -->
+Acceptance criteria are authoritative; notes are advisory hints.
+<!-- /forge-invariant -->
+
+## Review rules
+
+<!-- forge-invariant id="review-only" scope="area:review phase:review" enforcement="review" -->
+Reviewers evaluate the commit, not the plan.
+<!-- /forge-invariant -->
+"""
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    (tmp_path / "docs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "docs" / "policy.md").write_text(_POLICY, encoding="utf-8")
+    rebuild_invariant_index(tmp_path, _GLOBS)
+    return tmp_path
+
+
+def _assembler(root: Path, **kwargs) -> ContextAssembler:
+    return ContextAssembler(root, invariant_context=True, **kwargs)
+
+
+def _ids(manifest_section: list[dict]) -> list[str]:
+    return [item["id"] for item in manifest_section]
+
+
+# ── Config ───────────────────────────────────────────────────────────────────
+
+
+def test_invariant_context_is_off_by_default():
+    assert KnowledgeConfig().invariant_context is False
+
+
+def test_config_parses_the_gate_and_the_source_globs(tmp_path: Path):
+    path = tmp_path / "forge.yaml"
+    path.write_text(
+        "project:\n  name: demo\n  language: python\n"
+        "knowledge:\n"
+        "  invariant_context: true\n"
+        "  invariant_sources:\n"
+        "    - 'docs/**/*.md'\n"
+        "    - 'POLICY.md'\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(path)
+
+    assert config.knowledge.invariant_context is True
+    assert config.knowledge.invariant_sources == ("docs/**/*.md", "POLICY.md")
+
+
+def test_config_defaults_keep_the_portable_source_globs(tmp_path: Path):
+    path = tmp_path / "forge.yaml"
+    path.write_text("project:\n  name: demo\n  language: python\n", encoding="utf-8")
+
+    config = load_config(path)
+
+    assert config.knowledge.invariant_context is False
+    assert "docs/**/*.md" in config.knowledge.invariant_sources
+
+
+@pytest.mark.parametrize(
+    "block,message",
+    [
+        ("knowledge:\n  invariant_context: yes-please\n", "must be a bool"),
+        ("knowledge:\n  invariant_sources: 'docs/*.md'\n", "must be a list"),
+        ("knowledge:\n  invariant_sources:\n    - 7\n", "must be non-empty strings"),
+    ],
+)
+def test_config_rejects_malformed_invariant_settings(tmp_path: Path, block: str, message: str):
+    path = tmp_path / "forge.yaml"
+    path.write_text("project:\n  name: demo\n  language: python\n" + block, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        load_config(path)
+
+
+def test_from_config_propagates_the_gate(tmp_path: Path):
+    path = tmp_path / "forge.yaml"
+    path.write_text(
+        "project:\n  name: demo\n  language: python\nknowledge:\n  invariant_context: true\n",
+        encoding="utf-8",
+    )
+
+    assert ContextAssembler.from_config(load_config(path)).invariant_context is True
+
+
+def test_disabled_assembler_never_reads_the_index(project: Path):
+    pack = ContextAssembler(project).assemble(
+        phase="dev", story_text="coordinator retry", file_list=["src/coordinator/engine.py"]
+    )
+
+    assert pack.invariant_context["enabled"] is False
+    assert "coordinator is pure Python" not in pack.content
+
+
+# ── Selective injection for plan/dev ─────────────────────────────────────────
+
+
+def test_dev_receives_a_capsule_when_file_scope_matches(project: Path):
+    pack = _assembler(project).assemble(
+        phase="dev",
+        story_text="retry loop",
+        file_list=["src/coordinator/engine.py"],
+        budget=400,
+    )
+
+    manifest = pack.invariant_context
+    assert manifest["enabled"] is True
+    included = {item["id"]: item for item in manifest["included"]}
+    assert included["coordinator-pure"]["rendering_mode"] == RENDER_CAPSULE
+    assert included["coordinator-pure"]["scope_confidence"] == CONFIDENCE_HIGH
+    assert "file_scope_match" in included["coordinator-pure"]["reason"]
+    assert "The coordinator is pure Python" in pack.content
+    # A capsule is the marked region only — not the surrounding section.
+    assert "Introductory prose" not in pack.content
+
+
+def test_confident_file_scope_mismatch_is_the_only_drop(project: Path):
+    manifest = (
+        _assembler(project)
+        .assemble(
+            phase="dev",
+            story_text="retry loop",
+            file_list=["src/coordinator/engine.py"],
+            budget=400,
+        )
+        .invariant_context
+    )
+
+    dropped = {item["id"]: item["reason"] for item in manifest["dropped"]}
+    assert "files_out_of_scope" in dropped["schema-boundary"]
+    assert "phase_not_applicable" in dropped["review-only"]
+
+
+def test_included_items_are_visible_in_the_context_manifest(project: Path):
+    pack = _assembler(project).assemble(
+        phase="dev", story_text="retry loop", file_list=["src/coordinator/engine.py"], budget=400
+    )
+
+    entry = next(item for item in pack.included if item.kind == INVARIANT_KIND)
+    assert entry.source.endswith("#coordinator-pure") or "#" in entry.source
+    assert entry.included is True
+
+
+# ── Conservative fallback ────────────────────────────────────────────────────
+
+
+def test_area_only_scope_without_a_match_falls_back_to_the_broader_source(project: Path):
+    manifest = (
+        _assembler(project)
+        .assemble(
+            phase="dev",
+            story_text="retry loop",
+            file_list=["src/coordinator/engine.py"],
+            budget=400,
+        )
+        .invariant_context
+    )
+
+    uncertain = {item["id"]: item for item in manifest["uncertain"]}
+    assert "ac-authoritative" in uncertain
+    assert uncertain["ac-authoritative"]["rendering_mode"] == RENDER_SOURCE_SECTION
+    assert uncertain["ac-authoritative"]["scope_confidence"] == CONFIDENCE_LOW
+    assert "area_unmatched" in uncertain["ac-authoritative"]["reason"]
+    # Uncertain means included-broadly, never dropped.
+    assert "ac-authoritative" in _ids(manifest["included"])
+
+
+def test_no_file_list_widens_every_rule_instead_of_guessing(project: Path):
+    pack = _assembler(project).assemble(
+        phase="plan", story_text="an unclassifiable story", file_list=None, budget=600
+    )
+    manifest = pack.invariant_context
+
+    assert set(_ids(manifest["included"])) == {
+        "coordinator-pure",
+        "schema-boundary",
+        "ac-authoritative",
+    }
+    assert all(item["rendering_mode"] == RENDER_SOURCE_SECTION for item in manifest["included"])
+    assert set(_ids(manifest["uncertain"])) == set(_ids(manifest["included"]))
+    assert "no_file_list_to_match_scope" in manifest["included"][0]["reason"]
+    assert "Introductory prose" in pack.content
+
+
+def test_unparsable_scope_metadata_widens_rather_than_narrows(tmp_path: Path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "policy.md").write_text(
+        "## Odd\n\n"
+        '<!-- forge-invariant id="odd-scope" scope="module:coordinator files:src/other/*.py" -->\n'
+        "A rule with a scope key nobody parsed.\n"
+        "<!-- /forge-invariant -->\n",
+        encoding="utf-8",
+    )
+    rebuild_invariant_index(tmp_path, _GLOBS)
+
+    manifest = (
+        _assembler(tmp_path)
+        .assemble(phase="dev", story_text="story", file_list=["src/app.py"], budget=400)
+        .invariant_context
+    )
+
+    assert _ids(manifest["included"]) == ["odd-scope"]
+    assert "unparsed_scope" in manifest["included"][0]["reason"]
+    assert _ids(manifest["uncertain"]) == ["odd-scope"]
+
+
+def test_note_separates_nothing_indexed_from_something_withheld(project: Path):
+    unmarked = project / "unmarked"
+    unmarked.mkdir()
+    empty = (
+        _assembler(unmarked)
+        .assemble(phase="dev", story_text="story", file_list=["src/app.py"])
+        .invariant_context
+    )
+    assert "no project invariants are indexed" in empty["note"]
+
+    populated = (
+        _assembler(project)
+        .assemble(
+            phase="dev", story_text="story", file_list=["src/coordinator/engine.py"], budget=400
+        )
+        .invariant_context
+    )
+    assert "indexed invariants included" in populated["note"]
+    assert "scope confidence was low" in populated["note"]
+
+
+def test_budget_pressure_is_named_distinctly_from_scope_exclusion(project: Path):
+    manifest = (
+        _assembler(project)
+        .assemble(
+            phase="plan", story_text="story", file_list=["src/coordinator/engine.py"], budget=1
+        )
+        .invariant_context
+    )
+
+    assert manifest["included"] == []
+    assert {item["reason"] for item in manifest["dropped"]} >= {"budget_pressure"}
+
+
+def test_stale_source_regions_are_reported_not_suppressed(project: Path):
+    policy = project / "docs" / "policy.md"
+    policy.write_text(
+        policy.read_text(encoding="utf-8").replace(
+            "The coordinator is pure Python; no model decides retry or escalation.",
+            "The coordinator is pure Python. Amended after the index was built.",
+        ),
+        encoding="utf-8",
+    )
+
+    pack = _assembler(project).assemble(
+        phase="dev", story_text="retry", file_list=["src/coordinator/engine.py"], budget=400
+    )
+    manifest = pack.invariant_context
+
+    entry = next(item for item in manifest["included"] if item["id"] == "coordinator-pure")
+    assert entry["source_digest_matches"] is False
+    # The source document stays authoritative: the amended text is what is shown.
+    assert "Amended after the index was built" in pack.content
+    assert "source regions changed since the index was built" in manifest["note"]
+
+
+# ── Review is deliberately broader ───────────────────────────────────────────
+
+
+def test_review_gets_broader_context_than_dev(project: Path):
+    dev = (
+        _assembler(project)
+        .assemble(
+            phase="dev", story_text="retry", file_list=["src/coordinator/engine.py"], budget=900
+        )
+        .invariant_context
+    )
+    review = (
+        _assembler(project)
+        .assemble(
+            phase="review", story_text="retry", file_list=["src/coordinator/engine.py"], budget=900
+        )
+        .invariant_context
+    )
+
+    assert set(_ids(dev["included"])) < set(_ids(review["included"]))
+    assert "schema-boundary" in _ids(review["included"])
+    assert all(item["rendering_mode"] == RENDER_SOURCE_SECTION for item in review["included"])
+    override = next(item for item in review["included"] if item["id"] == "schema-boundary")
+    assert "broad_phase_override" in override["reason"]
+
+
+def test_review_still_honours_phase_scope(project: Path):
+    review = (
+        _assembler(project)
+        .assemble(
+            phase="review", story_text="retry", file_list=["src/coordinator/engine.py"], budget=900
+        )
+        .invariant_context
+    )
+
+    assert "review-only" in _ids(review["included"])
+
+    plan = (
+        _assembler(project)
+        .assemble(phase="plan", story_text="retry", file_list=None, budget=900)
+        .invariant_context
+    )
+    assert "review-only" not in _ids(plan["included"])
+
+
+# ── Preflight exclusion ──────────────────────────────────────────────────────
+
+
+def test_preflight_receives_no_invariant_prose(project: Path):
+    pack = _assembler(project).assemble(
+        phase="preflight",
+        story_text="coordinator retry escalation",
+        file_list=["src/coordinator/engine.py"],
+        budget=900,
+    )
+
+    manifest = pack.invariant_context
+    assert manifest["included"] == []
+    assert manifest["uncertain"] == []
+    assert "not injected in the preflight phase" in manifest["note"]
+    assert "The coordinator is pure Python" not in pack.content
+    assert all(item.kind != INVARIANT_KIND for item in pack.included)
+
+
+def test_selector_refuses_preflight_without_reading_the_index(project: Path):
+    selection = select_invariants(
+        project, phase="preflight", story_text="story", file_list=["src/coordinator/engine.py"]
+    )
+
+    assert selection.phase_eligible is False
+    assert selection.candidates == ()
+    assert selection.entry_count == 0
+
+
+# ── Coordinator seam ─────────────────────────────────────────────────────────
+
+
+@patch("theforge.coordinator.review_pool.run_agent_pool")
+@patch("theforge.coordinator.plan_flow.run_agent")
+@patch("theforge.coordinator.preflight_flow.run_agent")
+@patch("theforge.coordinator.dev_phase.run_agent")
+@patch_gate_shell()
+def test_invariant_context_flows_through_phase_seams_into_audit_state(
+    mock_shell, mock_dev, mock_preflight, mock_plan, mock_pool, tmp_path
+):
+    """The gate must survive the whole phase flow, and preflight must stay clean."""
+    config = replace(
+        _make_plan_config(tmp_path),
+        knowledge=KnowledgeConfig(invariant_context=True),
+    )
+    task = _make_task(tmp_path)
+    workspace = tmp_path / task.slug
+    workspace.mkdir()
+    (tmp_path / "docs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "docs" / "policy.md").write_text(_POLICY, encoding="utf-8")
+    rebuild_invariant_index(tmp_path, _GLOBS)
+
+    mock_shell.side_effect = _shell_with_gate(workspace, "PASS")
+    mock_preflight.return_value = _make_agent_result(
+        success=True, output=PREFLIGHT_PROCEED_MEDIUM, profile_name="preflight"
+    )
+    mock_plan.return_value = _make_agent_result(
+        success=True,
+        output=(
+            "```yaml\n"
+            "plan:\n"
+            "  approach: Update the thing.\n"
+            "  steps:\n"
+            "    - id: 1\n"
+            "      description: Update implementation\n"
+            "      files:\n"
+            "        - src/coordinator/engine.py\n"
+            "      action: modify\n"
+            "      details: Apply the behavior change.\n"
+            "```\n"
+        ),
+        profile_name="plan",
+    )
+    mock_dev.return_value = _make_agent_result(success=True, output="Done.", profile_name="dev")
+    mock_pool.return_value = [
+        _make_agent_result(success=True, output=APPROVE_REVIEW, profile_name="review")
+    ]
+
+    result = run_task(config, task)
+
+    assert result.success is True
+    captured: dict[str, ContextPack] = {}
+    for entry in result.state.context_manifests:
+        captured.setdefault(entry["phase"], entry["manifest"])
+
+    preflight = captured["preflight"].invariant_context
+    assert preflight["enabled"] is True
+    assert preflight["included"] == []
+    assert "The coordinator is pure Python" not in captured["preflight"].content
+
+    dev = captured["dev"].invariant_context
+    assert dev["enabled"] is True
+    assert "coordinator-pure" in _ids(dev["included"])
+
+    review = captured["review"].invariant_context
+    assert set(_ids(dev["included"])) <= set(_ids(review["included"]))
+
+    # The decision has to survive into the audit record, not just into state.
+    record = generate_audit_log(config, task, result)
+    by_phase = {entry["phase"]: entry for entry in record["context_manifests"]}
+    assert "coordinator-pure" in _ids(by_phase["dev"]["invariant_context"]["included"])
+    assert by_phase["preflight"]["invariant_context"]["included"] == []
+    assert yaml.safe_dump(record["context_manifests"])

--- a/tests/test_invariant_context.py
+++ b/tests/test_invariant_context.py
@@ -28,7 +28,12 @@ from theforge.config.types import KnowledgeConfig
 from theforge.coordinator.audit import generate_audit_log
 from theforge.coordinator.engine import run_task
 from theforge.invariant_index import rebuild_invariant_index
-from theforge.task.context_assembler import ContextAssembler, ContextPack
+from theforge.task.context_assembler import (
+    ContextAssembler,
+    ContextItem,
+    ContextPack,
+    _included_ids,
+)
 from theforge.task.invariant_selector import (
     CONFIDENCE_HIGH,
     CONFIDENCE_LOW,
@@ -37,6 +42,7 @@ from theforge.task.invariant_selector import (
     RENDER_SOURCE_SECTION,
     select_invariants,
 )
+from theforge.task.prior_run_selector import PRIOR_RUN_KIND
 
 _GLOBS = ("*.md", "docs/**/*.md", "**/CONVENTIONS.md")
 
@@ -209,6 +215,73 @@ def test_included_items_are_visible_in_the_context_manifest(project: Path):
     entry = next(item for item in pack.included if item.kind == INVARIANT_KIND)
     assert entry.source.endswith("#coordinator-pure") or "#" in entry.source
     assert entry.included is True
+
+
+def test_inclusion_is_recorded_against_the_selector_identity_not_the_path(tmp_path: Path):
+    """A project's own file naming must not move an invariant into `dropped`.
+
+    The manifest recovered the invariant id by splitting the display `source`,
+    so a source path containing the delimiter injected the rule into the prompt
+    while reporting it dropped under budget pressure.
+    """
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "rules#v2.md").write_text(
+        "## Rules\n\n"
+        '<!-- forge-invariant id="hash-path" scope="area:coordinator phase:dev" -->\n'
+        "A rule in a file whose name contains a hash.\n"
+        "<!-- /forge-invariant -->\n",
+        encoding="utf-8",
+    )
+    rebuild_invariant_index(tmp_path, _GLOBS)
+
+    pack = _assembler(tmp_path).assemble(
+        phase="dev",
+        story_text="coordinator retry",
+        file_list=["src/coordinator/engine.py"],
+        budget=400,
+    )
+
+    manifest = pack.invariant_context
+    assert "a hash" in pack.content
+    assert _ids(manifest["included"]) == ["hash-path"]
+    assert manifest["dropped"] == []
+
+
+def test_included_ids_reads_identity_off_the_item_never_off_the_source():
+    """Pins the contract the hash-path bug broke, for both indexed kinds."""
+    items = [
+        ContextItem(
+            source="docs/rules#v2.md#hash-path",
+            kind=INVARIANT_KIND,
+            required=False,
+            lines=1,
+            content="x",
+            reason="r",
+            item_id="hash-path",
+        ),
+        ContextItem(
+            source="knowledge:run:with:colons",
+            kind=PRIOR_RUN_KIND,
+            required=False,
+            lines=1,
+            content="x",
+            reason="r",
+            item_id="run:with:colons",
+        ),
+        # Renders no indexed entity, so it contributes no id.
+        ContextItem(
+            source="CONVENTIONS.md",
+            kind="claude_invariants",
+            required=True,
+            lines=1,
+            content="x",
+            reason="r",
+        ),
+    ]
+
+    assert _included_ids(items, INVARIANT_KIND) == {"hash-path"}
+    assert _included_ids(items, PRIOR_RUN_KIND) == {"run:with:colons"}
+    assert _included_ids(items, "claude_invariants") == set()
 
 
 # ── Conservative fallback ────────────────────────────────────────────────────

--- a/tests/test_invariant_index.py
+++ b/tests/test_invariant_index.py
@@ -82,6 +82,31 @@ def test_index_entry_carries_source_anchor_and_line_span_not_prose():
     assert "never drive coordinator control flow" not in serialized
 
 
+def test_body_span_starts_after_a_multi_line_opening_marker():
+    """_MARKED's opening marker wraps, as the documented convention example does.
+
+    Deriving the span from the marker's start line swept the scope and
+    enforcement attribute lines into the body.
+    """
+    (entry,) = extract_from_text(_MARKED, "docs/policy.md")[0]
+
+    lines = _MARKED.splitlines()
+    body = lines[entry["body_start_line"] - 1 : entry["body_end_line"]]
+
+    assert body == ["Summaries advise agents; they never drive coordinator control flow."]
+    assert entry["body_lines"] == 1
+    assert not any("scope=" in line or "enforcement=" in line for line in body)
+
+
+def test_a_body_sharing_a_line_with_its_markers_is_a_diagnostic():
+    entries, diagnostics = extract_from_text(
+        '<!-- forge-invariant id="inline" -->A rule.<!-- /forge-invariant -->\n', "docs/a.md"
+    )
+
+    assert entries == []
+    assert any("shares a line with its markers" in d.reason for d in diagnostics)
+
+
 def test_enforcement_defaults_to_advisory_and_scope_may_be_omitted():
     entries, diagnostics = extract_from_text(
         '<!-- forge-invariant id="bare" -->\nA rule.\n<!-- /forge-invariant -->\n',

--- a/tests/test_invariant_index.py
+++ b/tests/test_invariant_index.py
@@ -1,0 +1,315 @@
+"""Extractor and index-command coverage for the invariant-index spike (#1875)."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+from theforge.cli.index import cmd_index
+from theforge.invariant_index import (
+    COMPLETENESS_FULL,
+    COMPLETENESS_NONE,
+    COMPLETENESS_PARTIAL,
+    INVARIANT_INDEX_PATH,
+    INVARIANT_INDEX_SCHEMA_VERSION,
+    build_invariant_index,
+    discover_sources,
+    extract_from_text,
+    load_invariant_index,
+    rebuild_invariant_index,
+)
+
+_GLOBS = ("*.md", "docs/**/*.md", "**/CONVENTIONS.md")
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+_MARKED = """# Policy
+
+## Audit rules
+
+Some preamble.
+
+<!-- forge-invariant id="summaries-advisory"
+     scope="area:audit phase:plan,dev files:src/audit/*.py"
+     enforcement="review" -->
+Summaries advise agents; they never drive coordinator control flow.
+<!-- /forge-invariant -->
+
+Trailing prose.
+"""
+
+
+# ── Marker parsing ───────────────────────────────────────────────────────────
+
+
+def test_marker_parsing_records_identity_provenance_and_scope():
+    entries, diagnostics = extract_from_text(_MARKED, "docs/policy.md")
+
+    assert diagnostics == []
+    (entry,) = entries
+    assert entry["id"] == "summaries-advisory"
+    assert entry["source_path"] == "docs/policy.md"
+    assert entry["source_anchor"] == "Audit rules"
+    assert entry["enforcement"] == "review"
+    assert entry["scope"]["areas"] == ["audit"]
+    assert entry["scope"]["phases"] == ["dev", "plan"]
+    assert entry["scope"]["files"] == ["src/audit/*.py"]
+    assert entry["applicability"]["scope_completeness"] == COMPLETENESS_FULL
+    assert entry["source_digest"].startswith("sha256:")
+
+
+def test_index_entry_carries_source_anchor_and_line_span_not_prose():
+    entries, _ = extract_from_text(_MARKED, "docs/policy.md")
+    (entry,) = entries
+
+    lines = _MARKED.splitlines()
+    assert lines[entry["start_line"] - 1].startswith("<!-- forge-invariant")
+    assert lines[entry["end_line"] - 1].startswith("<!-- /forge-invariant")
+    body = "\n".join(lines[entry["body_start_line"] - 1 : entry["body_end_line"]])
+    assert "never drive coordinator control flow" in body
+
+    # The index is metadata only: the rule text itself is never copied into it.
+    serialized = yaml.safe_dump(entry)
+    assert "never drive coordinator control flow" not in serialized
+
+
+def test_enforcement_defaults_to_advisory_and_scope_may_be_omitted():
+    entries, diagnostics = extract_from_text(
+        '<!-- forge-invariant id="bare" -->\nA rule.\n<!-- /forge-invariant -->\n',
+        "docs/a.md",
+    )
+
+    assert diagnostics == []
+    assert entries[0]["enforcement"] == "advisory"
+    assert entries[0]["applicability"]["scope_completeness"] == COMPLETENESS_NONE
+
+
+def test_area_only_scope_is_partial_completeness():
+    entries, _ = extract_from_text(
+        '<!-- forge-invariant id="areas" scope="area:prompts" -->\nA rule.\n'
+        "<!-- /forge-invariant -->\n",
+        "docs/a.md",
+    )
+
+    assert entries[0]["applicability"]["scope_completeness"] == COMPLETENESS_PARTIAL
+
+
+# ── Malformed markers become diagnostics, never exceptions ───────────────────
+
+
+def test_unterminated_marker_is_a_diagnostic_and_skips_the_entry():
+    entries, diagnostics = extract_from_text(
+        '<!-- forge-invariant id="open" -->\nA rule with no close marker.\n', "docs/a.md"
+    )
+
+    assert entries == []
+    assert [d.reason for d in diagnostics] == ["unterminated forge-invariant block"]
+
+
+def test_missing_and_invalid_ids_are_diagnostics():
+    _, missing = extract_from_text(
+        "<!-- forge-invariant -->\nA rule.\n<!-- /forge-invariant -->\n", "docs/a.md"
+    )
+    _, invalid = extract_from_text(
+        '<!-- forge-invariant id="Not Valid" -->\nA rule.\n<!-- /forge-invariant -->\n',
+        "docs/a.md",
+    )
+
+    assert any("missing required attribute 'id'" in d.reason for d in missing)
+    assert any("invalid id" in d.reason for d in invalid)
+
+
+def test_unknown_enforcement_falls_back_to_advisory_with_a_diagnostic():
+    entries, diagnostics = extract_from_text(
+        '<!-- forge-invariant id="x" enforcement="mandatory" -->\nA rule.\n'
+        "<!-- /forge-invariant -->\n",
+        "docs/a.md",
+    )
+
+    assert entries[0]["enforcement"] == "advisory"
+    assert any("unknown enforcement" in d.reason for d in diagnostics)
+
+
+def test_unparsed_scope_key_never_reports_full_completeness():
+    entries, diagnostics = extract_from_text(
+        '<!-- forge-invariant id="x" scope="module:audit files:src/*.py" -->\nA rule.\n'
+        "<!-- /forge-invariant -->\n",
+        "docs/a.md",
+    )
+
+    assert any("unknown scope key" in d.reason for d in diagnostics)
+    applicability = entries[0]["applicability"]
+    assert applicability["scope_completeness"] != COMPLETENESS_FULL
+    assert applicability["unparsed_scope_keys"] == ["module"]
+
+
+def test_empty_body_is_a_diagnostic():
+    entries, diagnostics = extract_from_text(
+        '<!-- forge-invariant id="x" -->\n\n<!-- /forge-invariant -->\n', "docs/a.md"
+    )
+
+    assert entries == []
+    assert any("empty invariant body" in d.reason for d in diagnostics)
+
+
+def test_duplicate_ids_keep_the_first_and_report_the_second(tmp_path: Path):
+    marked = '<!-- forge-invariant id="dup" -->\n{}\n<!-- /forge-invariant -->\n'
+    _write(tmp_path, "a.md", marked.format("One."))
+    _write(tmp_path, "b.md", marked.format("Two."))
+
+    result = build_invariant_index(tmp_path, _GLOBS)
+
+    assert [entry["source_path"] for entry in result.entries] == ["a.md"]
+    assert any("duplicate invariant id" in d.reason for d in result.diagnostics)
+
+
+def test_unreadable_source_is_a_diagnostic_not_a_crash(tmp_path: Path, monkeypatch):
+    _write(tmp_path, "a.md", '<!-- forge-invariant id="x" -->\nRule.\n<!-- /forge-invariant -->\n')
+    original = Path.read_text
+
+    def _boom(self, *args, **kwargs):
+        if self.name == "a.md":
+            raise OSError("permission denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+    result = build_invariant_index(tmp_path, _GLOBS)
+
+    assert result.entries == []
+    assert any("unreadable" in d.reason for d in result.diagnostics)
+
+
+# ── Source discovery and determinism ─────────────────────────────────────────
+
+
+def test_configured_globs_bound_discovery(tmp_path: Path):
+    _write(tmp_path, "docs/adr/one.md", "x")
+    _write(tmp_path, "src/pkg/CONVENTIONS.md", "x")
+    _write(tmp_path, "src/pkg/notes.md", "x")
+
+    found = discover_sources(tmp_path, _GLOBS)
+
+    assert [p.as_posix() for p in found] == ["docs/adr/one.md", "src/pkg/CONVENTIONS.md"]
+
+
+def test_discovery_skips_derived_and_vendored_directories(tmp_path: Path):
+    _write(tmp_path, ".forge/knowledge/notes.md", "x")
+    _write(tmp_path, "node_modules/pkg/CONVENTIONS.md", "x")
+    _write(tmp_path, "keep.md", "x")
+
+    assert [p.as_posix() for p in discover_sources(tmp_path, ("**/*.md",))] == ["keep.md"]
+
+
+def test_ordering_is_deterministic_across_rebuilds(tmp_path: Path):
+    _write(tmp_path, "z.md", '<!-- forge-invariant id="z" -->\nZ.\n<!-- /forge-invariant -->\n')
+    _write(
+        tmp_path,
+        "docs/a.md",
+        '<!-- forge-invariant id="a2" -->\nA2.\n<!-- /forge-invariant -->\n'
+        '<!-- forge-invariant id="a1" -->\nA1.\n<!-- /forge-invariant -->\n',
+    )
+
+    first = build_invariant_index(tmp_path, _GLOBS).payload
+    second = build_invariant_index(tmp_path, _GLOBS).payload
+
+    assert first == second
+    assert [entry["id"] for entry in first["invariants"]] == ["a2", "a1", "z"]
+
+
+def test_rebuild_writes_the_derived_index_and_reloads_it(tmp_path: Path):
+    _write(tmp_path, "docs/policy.md", _MARKED)
+
+    result = rebuild_invariant_index(tmp_path, _GLOBS)
+
+    assert result.path == tmp_path / INVARIANT_INDEX_PATH
+    payload = yaml.safe_load(result.path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == INVARIANT_INDEX_SCHEMA_VERSION
+    assert payload["invariant_count"] == 1
+    assert [entry["id"] for entry in load_invariant_index(tmp_path)] == ["summaries-advisory"]
+
+
+def test_rebuild_drops_entries_whose_markers_were_removed(tmp_path: Path):
+    _write(tmp_path, "docs/policy.md", _MARKED)
+    rebuild_invariant_index(tmp_path, _GLOBS)
+
+    _write(tmp_path, "docs/policy.md", "# Policy\n\nNo markers any more.\n")
+    rebuild_invariant_index(tmp_path, _GLOBS)
+
+    assert load_invariant_index(tmp_path) == []
+
+
+def test_load_degrades_to_empty_on_missing_or_wrong_schema(tmp_path: Path):
+    assert load_invariant_index(tmp_path) == []
+
+    path = tmp_path / INVARIANT_INDEX_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("schema_version: 99\ninvariants: [{id: x}]\n", encoding="utf-8")
+    assert load_invariant_index(tmp_path) == []
+
+    path.write_text("{{ not yaml", encoding="utf-8")
+    assert load_invariant_index(tmp_path) == []
+
+
+# ── forge index --invariants ─────────────────────────────────────────────────
+
+
+def _forge_yaml(root: Path, extra: str = "") -> Path:
+    return _write(
+        root,
+        "forge.yaml",
+        "project:\n  name: demo\n  language: python\n" + extra,
+    )
+
+
+def test_index_invariants_command_writes_the_index(tmp_path: Path, capsys):
+    config_path = _forge_yaml(tmp_path)
+    _write(tmp_path, "docs/policy.md", _MARKED)
+
+    code = cmd_index(argparse.Namespace(config=str(config_path), knowledge=False, invariants=True))
+
+    assert code == 0
+    assert str(tmp_path / INVARIANT_INDEX_PATH) in capsys.readouterr().out
+    assert [entry["id"] for entry in load_invariant_index(tmp_path)] == ["summaries-advisory"]
+
+
+def test_index_invariants_command_prints_diagnostics(tmp_path: Path, capsys):
+    config_path = _forge_yaml(tmp_path)
+    _write(tmp_path, "docs/broken.md", '<!-- forge-invariant id="open" -->\nRule.\n')
+
+    code = cmd_index(argparse.Namespace(config=str(config_path), knowledge=False, invariants=True))
+
+    assert code == 0
+    assert "unterminated forge-invariant block" in capsys.readouterr().err
+
+
+def test_index_invariants_command_honours_configured_sources(tmp_path: Path):
+    config_path = _forge_yaml(
+        tmp_path, "knowledge:\n  invariant_sources:\n    - 'policies/*.md'\n"
+    )
+    _write(tmp_path, "docs/policy.md", _MARKED)
+    _write(
+        tmp_path,
+        "policies/rules.md",
+        '<!-- forge-invariant id="only-this" -->\nRule.\n<!-- /forge-invariant -->\n',
+    )
+
+    cmd_index(argparse.Namespace(config=str(config_path), knowledge=False, invariants=True))
+
+    assert [entry["id"] for entry in load_invariant_index(tmp_path)] == ["only-this"]
+
+
+def test_index_without_invariants_flag_leaves_the_invariant_index_alone(tmp_path: Path):
+    config_path = _forge_yaml(tmp_path)
+    _write(tmp_path, "docs/policy.md", _MARKED)
+
+    cmd_index(argparse.Namespace(config=str(config_path), knowledge=False, invariants=False))
+
+    assert not (tmp_path / INVARIANT_INDEX_PATH).exists()

--- a/tests/test_invariant_index.py
+++ b/tests/test_invariant_index.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import yaml
 
 from theforge.cli.index import cmd_index
+from theforge.config.types import KnowledgeConfig
 from theforge.invariant_index import (
     COMPLETENESS_FULL,
     COMPLETENESS_NONE,
@@ -202,10 +203,93 @@ def test_configured_globs_bound_discovery(tmp_path: Path):
 
 def test_discovery_skips_derived_and_vendored_directories(tmp_path: Path):
     _write(tmp_path, ".forge/knowledge/notes.md", "x")
+    _write(tmp_path, ".pytest_cache/README.md", "x")
     _write(tmp_path, "node_modules/pkg/CONVENTIONS.md", "x")
+    _write(tmp_path, "build/generated/notes.md", "x")
     _write(tmp_path, "keep.md", "x")
 
     assert [p.as_posix() for p in discover_sources(tmp_path, ("**/*.md",))] == ["keep.md"]
+
+
+def test_the_default_glob_names_no_project_layout():
+    # The feature has to work on any target project, so the shipped default
+    # cannot presume a docs/ directory exists.
+    assert KnowledgeConfig().invariant_sources == ("**/*.md",)
+
+
+def test_default_glob_finds_markers_wherever_a_project_keeps_them(tmp_path: Path):
+    _write(
+        tmp_path,
+        "POLICY.md",
+        '<!-- forge-invariant id="root" -->\nR.\n<!-- /forge-invariant -->\n',
+    )
+    _write(
+        tmp_path,
+        "handbook/rules/two.md",
+        '<!-- forge-invariant id="nested" -->\nN.\n<!-- /forge-invariant -->\n',
+    )
+
+    result = build_invariant_index(tmp_path, KnowledgeConfig().invariant_sources)
+
+    assert [entry["id"] for entry in result.entries] == ["root", "nested"]
+
+
+# ── Documentation examples are not invariants ────────────────────────────────
+
+
+def test_markers_inside_fenced_code_blocks_are_ignored(tmp_path: Path):
+    _write(
+        tmp_path,
+        "guide.md",
+        "# How to mark an invariant\n\n"
+        "```md\n"
+        '<!-- forge-invariant id="illustration" scope="area:x" enforcement="review" -->\n'
+        "An example a project shows while documenting the convention.\n"
+        "<!-- /forge-invariant -->\n"
+        "```\n\n"
+        "## A real rule\n\n"
+        '<!-- forge-invariant id="genuine" -->\n'
+        "An actual rule this project asserts.\n"
+        "<!-- /forge-invariant -->\n",
+    )
+
+    result = build_invariant_index(tmp_path, ("**/*.md",))
+
+    assert [entry["id"] for entry in result.entries] == ["genuine"]
+    assert result.diagnostics == ()
+
+
+def test_documenting_the_convention_does_not_file_duplicate_ids(tmp_path: Path):
+    """The repo's own docs illustrate real ids; that must not collide with them."""
+    _write(
+        tmp_path,
+        "rules.md",
+        '<!-- forge-invariant id="shared" -->\nThe real rule.\n<!-- /forge-invariant -->\n',
+    )
+    _write(
+        tmp_path,
+        "guide.md",
+        "~~~md\n"
+        '<!-- forge-invariant id="shared" -->\nThe same id, shown as an example.\n'
+        "<!-- /forge-invariant -->\n"
+        "~~~\n",
+    )
+
+    result = build_invariant_index(tmp_path, ("**/*.md",))
+
+    assert [entry["source_path"] for entry in result.entries] == ["rules.md"]
+    assert result.diagnostics == ()
+
+
+def test_an_unterminated_fence_suppresses_the_rest_of_the_file(tmp_path: Path):
+    _write(
+        tmp_path,
+        "guide.md",
+        "```md\n"
+        '<!-- forge-invariant id="never-closed-fence" -->\nExample.\n<!-- /forge-invariant -->\n',
+    )
+
+    assert build_invariant_index(tmp_path, ("**/*.md",)).entries == []
 
 
 def test_ordering_is_deterministic_across_rebuilds(tmp_path: Path):

--- a/tests/test_knowledge_invariant_proof.py
+++ b/tests/test_knowledge_invariant_proof.py
@@ -1,0 +1,227 @@
+"""Invariant-context churn proof over audit records (#1875)."""
+
+from __future__ import annotations
+
+from knowledge_effectiveness_test_helpers import record
+
+from theforge.knowledge_effectiveness import (
+    METRIC_COST_PER_STORY,
+    METRIC_DEV_ITERATIONS,
+    METRIC_PLAN_REGENERATION,
+    METRIC_REVIEW_CYCLES,
+    METRIC_REVIEW_RECURRENCE,
+    METRIC_STORIES_PER_DOLLAR,
+    STATUS_INSUFFICIENT_DATA,
+    STATUS_NO_OBSERVED_IMPROVEMENT,
+    STATUS_OBSERVED_IMPROVEMENT,
+)
+from theforge.knowledge_effectiveness_render import invariant_proof_payload, render_terminal
+from theforge.knowledge_effectiveness_signals import (
+    COHORT_UNCLASSIFIED,
+    INVARIANT_COHORT_WITH,
+    INVARIANT_COHORT_WITHOUT,
+    classify_invariant_cohort,
+    extract_signals,
+)
+from theforge.knowledge_invariant_proof import (
+    CHURN_METRICS,
+    build_invariant_proof_from_records,
+)
+
+
+def _manifest(
+    *,
+    enabled: bool,
+    included: int = 0,
+    uncertain: int = 0,
+    dropped: int = 0,
+    phase: str = "dev",
+) -> dict:
+    return {
+        "phase": phase,
+        "prior_run_context": {"enabled": False, "included": [], "dropped": []},
+        "invariant_context": {
+            "enabled": enabled,
+            "phase": phase,
+            "selection_mode": "selective",
+            "included": [{"id": f"inv-{i}"} for i in range(included)],
+            "uncertain": [{"id": f"inv-{i}"} for i in range(uncertain)],
+            "dropped": [{"id": f"drop-{i}"} for i in range(dropped)],
+            "note": "note",
+        },
+    }
+
+
+def _record(run_id: str, *, manifests: list[dict] | None, **kwargs) -> dict:
+    rec = record(run_id, **kwargs)
+    if manifests is None:
+        rec.pop("context_manifests")
+    else:
+        rec["context_manifests"] = manifests
+    return rec
+
+
+# ── Cohort classification ────────────────────────────────────────────────────
+
+
+def test_included_invariants_make_a_run_treatment():
+    rec = _record("a", manifests=[_manifest(enabled=True, included=2)])
+
+    assert classify_invariant_cohort(rec) == INVARIANT_COHORT_WITH
+
+
+def test_enabled_with_nothing_included_is_a_genuine_control():
+    rec = _record("a", manifests=[_manifest(enabled=True, included=0)])
+
+    assert classify_invariant_cohort(rec) == INVARIANT_COHORT_WITHOUT
+
+
+def test_disabled_or_absent_is_unclassified():
+    assert (
+        classify_invariant_cohort(_record("a", manifests=[_manifest(enabled=False)]))
+        == COHORT_UNCLASSIFIED
+    )
+    assert classify_invariant_cohort(_record("a", manifests=None)) == COHORT_UNCLASSIFIED
+
+
+def test_preflight_manifests_never_classify():
+    rec = _record("a", manifests=[_manifest(enabled=True, included=2, phase="preflight")])
+
+    assert classify_invariant_cohort(rec) == COHORT_UNCLASSIFIED
+
+
+def test_absent_invariant_telemetry_is_unavailable_not_zero():
+    signals = extract_signals(_record("a", manifests=[_manifest(enabled=False)]))
+
+    assert signals.invariant_included is None
+    assert signals.invariant_uncertain is None
+    assert signals.invariant_dropped is None
+
+
+# ── Churn proof ──────────────────────────────────────────────────────────────
+
+
+def _cohort_records(*, count: int = 3, with_kwargs: dict, without_kwargs: dict) -> list[dict]:
+    records: list[dict] = []
+    for i in range(count):
+        records.append(
+            _record(
+                f"with-{i}",
+                manifests=[_manifest(enabled=True, included=2, uncertain=1, dropped=1)],
+                **with_kwargs,
+            )
+        )
+        records.append(
+            _record(
+                f"without-{i}",
+                manifests=[_manifest(enabled=True, included=0)],
+                **without_kwargs,
+            )
+        )
+    return records
+
+
+def test_proof_reports_insufficient_data_below_the_cohort_floor():
+    proof = build_invariant_proof_from_records(
+        [_record("a", manifests=[_manifest(enabled=True, included=1)])]
+    )
+
+    assert proof.status == STATUS_INSUFFICIENT_DATA
+    assert "1 with-invariant" in proof.status_reason
+
+
+def test_proof_reports_churn_improvement_when_both_cohorts_are_populated():
+    records = _cohort_records(
+        with_kwargs={"plan_regenerated": False, "review_cycles": 1, "dev_iterations": 1},
+        without_kwargs={"plan_regenerated": True, "review_cycles": 3, "dev_iterations": 2},
+    )
+
+    proof = build_invariant_proof_from_records(records)
+
+    assert proof.status == STATUS_OBSERVED_IMPROVEMENT
+    assert proof.cohort_counts[INVARIANT_COHORT_WITH] == 3
+    assert proof.cohort_counts[INVARIANT_COHORT_WITHOUT] == 3
+    regen = proof.comparison(METRIC_PLAN_REGENERATION)
+    assert regen.improved is True
+    assert regen.delta == -1.0
+
+
+def test_proof_reports_no_observed_improvement_honestly():
+    records = _cohort_records(
+        with_kwargs={"plan_regenerated": True, "review_cycles": 3, "dev_iterations": 2},
+        without_kwargs={"plan_regenerated": True, "review_cycles": 3, "dev_iterations": 2},
+    )
+
+    proof = build_invariant_proof_from_records(records)
+
+    assert proof.status == STATUS_NO_OBSERVED_IMPROVEMENT
+
+
+def test_restated_finding_rate_is_a_reported_churn_signal():
+    records = _cohort_records(
+        with_kwargs={"restated": 0, "novel": 4},
+        without_kwargs={"restated": 3, "novel": 1},
+    )
+
+    proof = build_invariant_proof_from_records(records)
+
+    recurrence = proof.comparison(METRIC_REVIEW_RECURRENCE)
+    assert recurrence.comparable is True
+    assert recurrence.improved is True
+
+
+def test_cost_metrics_are_not_part_of_the_churn_claim():
+    assert set(CHURN_METRICS) == {
+        METRIC_PLAN_REGENERATION,
+        METRIC_REVIEW_RECURRENCE,
+        METRIC_DEV_ITERATIONS,
+        METRIC_REVIEW_CYCLES,
+    }
+    proof = build_invariant_proof_from_records(_cohort_records(with_kwargs={}, without_kwargs={}))
+    assert proof.comparison(METRIC_COST_PER_STORY) is None
+    assert proof.comparison(METRIC_STORIES_PER_DOLLAR) is None
+
+
+def test_selection_counts_surface_how_often_the_fallback_carried_the_proof():
+    proof = build_invariant_proof_from_records(_cohort_records(with_kwargs={}, without_kwargs={}))
+
+    counts = proof.selection_counts
+    assert counts.runs_with_telemetry == 6
+    assert counts.included == 6
+    assert counts.uncertain == 3
+    assert counts.dropped == 3
+    assert counts.uncertain_share == 0.5
+
+
+def test_unavailable_telemetry_never_counts_as_zero_selection():
+    proof = build_invariant_proof_from_records([_record("a", manifests=None)])
+
+    assert proof.selection_counts.runs_with_telemetry == 0
+    assert proof.selection_counts.uncertain_share is None
+
+
+# ── Rendering ────────────────────────────────────────────────────────────────
+
+
+def test_proof_payload_is_serializable_and_names_its_cohorts():
+    proof = build_invariant_proof_from_records(_cohort_records(with_kwargs={}, without_kwargs={}))
+
+    payload = invariant_proof_payload(proof)
+
+    assert payload["cohorts"][INVARIANT_COHORT_WITH] == 3
+    assert payload["selection"]["uncertain"] == 3
+    assert {item["metric"] for item in payload["churn_comparison"]} == set(CHURN_METRICS)
+    assert INVARIANT_COHORT_WITH in payload["churn_comparison"][0]
+
+
+def test_terminal_render_appends_the_proof_section_only_when_asked():
+    from theforge.knowledge_effectiveness import build_report
+
+    records = _cohort_records(with_kwargs={}, without_kwargs={})
+    report = build_report(records)
+    proof = build_invariant_proof_from_records(records)
+
+    assert "Invariant-context proof" not in render_terminal(report)
+    rendered = render_terminal(report, proof)
+    assert "Invariant-context proof" in rendered
+    assert "uncertain → broad source" in rendered


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior hash-path manifest bug is fixed; no P1 regressions found; targeted invariant tests passed. | [google-gemini-3.5-flash-api] Highly robust and elegant implementation of the invariant index spike, passing all test suites. | [anthropic-claude-haiku-4-5-cli] Cycle 1's P1 (invariant context manifest incorrectly reported dropped when source path contained hash) is confirmed fixed in ac0d64d8: ContextItem now carries explicit item_id; manifest building reads identity from item, not by parsing source string. The fix is surgical, backward-compatible (calls existing test locations), and regression-tested. Body-span fix in 798beb0c corrects digest computation and rendering for multi-line markers so digest never reports stale over unchanged content. Gate verdict is PASS; all ACs verified.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $37.14
- **Dev iterations:** 4
- **Tests:** N/A

## Findings

_No findings._

## Story

Invariant index spike: authoritative project invariants as selective context (GitHub Issue #1875)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #1875