### PR TITLE
The gate CPU oversubscription warning fires for every parallelism above 1, so it reports that parallelism was used rather than that contention is likely

### DIFF
--- a/src/theforge/sprint/gate_timeout_resolver.py
+++ b/src/theforge/sprint/gate_timeout_resolver.py
@@ -29,6 +29,7 @@ class GateTimeoutResolution:
     running_stories: int = 0
     actual_parallel: int = 0
     observed_host_load: float | None = None
+    warning_host_load: float | None = None
 
 
 def resolve_effective_gate_timeout(
@@ -48,7 +49,11 @@ def resolve_effective_gate_timeout(
         demand            = gate_demand_cores * actual_parallel
         factor            = max(1.0, demand / host_cores)
         effective         = baseline if mode == "fixed" else ceil(baseline * factor)
-        overcommit        = observed_host_load > host_cores when load is available
+        warning_host_load = max(0.0, observed_host_load - running_stories) so
+                            inherited stories already counted into
+                            ``actual_parallel`` do not also read as external
+                            host pressure
+        overcommit        = warning_host_load > host_cores when load is available
                             and the operator is actually using parallelism
 
     ``running_stories`` is the count of stories already executing when the
@@ -64,6 +69,9 @@ def resolve_effective_gate_timeout(
     safe_running = max(0, int(running_stories or 0))
     actual_parallel = safe_parallel + safe_running
     safe_observed_load = float(observed_host_load) if observed_host_load is not None else None
+    warning_host_load = (
+        max(0.0, safe_observed_load - safe_running) if safe_observed_load is not None else None
+    )
     gate_demand_cores = gate_cpu_cores if gate_cpu_cores and gate_cpu_cores > 0 else safe_host
     demand = gate_demand_cores * actual_parallel
     factor = max(1.0, demand / safe_host)
@@ -77,7 +85,7 @@ def resolve_effective_gate_timeout(
     else:
         effective = int(math.ceil(baseline * factor))
     overcommit = (
-        safe_observed_load is not None and actual_parallel > 1 and safe_observed_load > safe_host
+        warning_host_load is not None and actual_parallel > 1 and warning_host_load > safe_host
     )
     # Field order is appended-to, never reordered: the reason line is an
     # operator-facing diagnostic that is grepped and asserted on by prefix.
@@ -89,6 +97,8 @@ def resolve_effective_gate_timeout(
     )
     if safe_observed_load is not None:
         reason = f"{reason} observed_host_load={safe_observed_load:.2f}"
+    if warning_host_load is not None and warning_host_load != safe_observed_load:
+        reason = f"{reason} warning_host_load={warning_host_load:.2f}"
     return GateTimeoutResolution(
         effective_timeout=effective,
         baseline=int(baseline),
@@ -102,4 +112,5 @@ def resolve_effective_gate_timeout(
         running_stories=safe_running,
         actual_parallel=actual_parallel,
         observed_host_load=safe_observed_load,
+        warning_host_load=warning_host_load,
     )

--- a/src/theforge/sprint/gate_timeout_resolver.py
+++ b/src/theforge/sprint/gate_timeout_resolver.py
@@ -28,6 +28,7 @@ class GateTimeoutResolution:
     reason: str
     running_stories: int = 0
     actual_parallel: int = 0
+    observed_host_load: float | None = None
 
 
 def resolve_effective_gate_timeout(
@@ -37,6 +38,7 @@ def resolve_effective_gate_timeout(
     gate_cpu_cores: int | None,
     mode: str,
     running_stories: int = 0,
+    observed_host_load: float | None = None,
 ) -> GateTimeoutResolution:
     """Resolve the effective gate timeout given contention conditions.
 
@@ -46,7 +48,8 @@ def resolve_effective_gate_timeout(
         demand            = gate_demand_cores * actual_parallel
         factor            = max(1.0, demand / host_cores)
         effective         = baseline if mode == "fixed" else ceil(baseline * factor)
-        overcommit        = demand > host_cores * 1.5
+        overcommit        = observed_host_load > host_cores when load is available
+                            and the operator is actually using parallelism
 
     ``running_stories`` is the count of stories already executing when the
     timeout is resolved — non-zero only on a continuation (a mid-run re-exec
@@ -60,6 +63,7 @@ def resolve_effective_gate_timeout(
     safe_parallel = max(1, max_parallel)
     safe_running = max(0, int(running_stories or 0))
     actual_parallel = safe_parallel + safe_running
+    safe_observed_load = float(observed_host_load) if observed_host_load is not None else None
     gate_demand_cores = gate_cpu_cores if gate_cpu_cores and gate_cpu_cores > 0 else safe_host
     demand = gate_demand_cores * actual_parallel
     factor = max(1.0, demand / safe_host)
@@ -72,7 +76,9 @@ def resolve_effective_gate_timeout(
         effective = int(baseline)
     else:
         effective = int(math.ceil(baseline * factor))
-    overcommit = demand > safe_host * 1.5
+    overcommit = (
+        safe_observed_load is not None and actual_parallel > 1 and safe_observed_load > safe_host
+    )
     # Field order is appended-to, never reordered: the reason line is an
     # operator-facing diagnostic that is grepped and asserted on by prefix.
     reason = (
@@ -81,6 +87,8 @@ def resolve_effective_gate_timeout(
         f"demand={demand} factor={factor:.2f} effective={effective}s "
         f"running_stories={safe_running} actual_parallel={actual_parallel}"
     )
+    if safe_observed_load is not None:
+        reason = f"{reason} observed_host_load={safe_observed_load:.2f}"
     return GateTimeoutResolution(
         effective_timeout=effective,
         baseline=int(baseline),
@@ -93,4 +101,5 @@ def resolve_effective_gate_timeout(
         reason=reason,
         running_stories=safe_running,
         actual_parallel=actual_parallel,
+        observed_host_load=safe_observed_load,
     )

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -4441,6 +4441,10 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
     _host_cores = os.cpu_count() or 1
     _gate_cpu_raw = _ctx.config.validation.gate_cpu_cores
     _gate_cpu_cores = int(_gate_cpu_raw) if _gate_cpu_raw else None
+    try:
+        _observed_host_load = float(os.getloadavg()[0])
+    except (AttributeError, OSError):
+        _observed_host_load = None
     _mode_raw = _ctx.config.validation.gate_timeout_scale
     if _mode_raw is None:
         _mode = "adaptive"
@@ -4463,6 +4467,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
         gate_cpu_cores=_gate_cpu_cores,
         mode=_mode,
         running_stories=len(_live_story_slugs),
+        observed_host_load=_observed_host_load,
     )
     if _gate_timeout_resolution is not None:
         print(
@@ -4471,13 +4476,12 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
             flush=True,
         )
     if _gate_timeout_resolution is not None and _gate_timeout_resolution.overcommit:
-        _gpc = _gate_timeout_resolution.gate_cpu_cores
-        _mp = _gate_timeout_resolution.actual_parallel or _gate_timeout_resolution.max_parallel
+        _observed = _gate_timeout_resolution.observed_host_load
         _hc = _gate_timeout_resolution.host_cores
         print(
-            f"[sprint] WARNING: gate CPU demand ({_gpc} cores × parallel {_mp} = "
-            f"{_gpc * _mp} cores) exceeds host capacity ({_hc} cores) by >50%; "
-            "consider lowering --parallel to avoid contention-driven gate timeouts",
+            f"[sprint] WARNING: gate CPU observed host load ({_observed:.2f} 1m / {_hc} cores) "
+            "already indicates contention; adaptive gate_timeout scaling was applied, "
+            "but concurrent work on this host may still stretch gate completion",
             file=sys.stderr,
             flush=True,
         )

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -4477,11 +4477,28 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
         )
     if _gate_timeout_resolution is not None and _gate_timeout_resolution.overcommit:
         _observed = _gate_timeout_resolution.observed_host_load
+        _warning_load = _gate_timeout_resolution.warning_host_load
         _hc = _gate_timeout_resolution.host_cores
+        if _gate_timeout_resolution.mode == "fixed":
+            _warning_suffix = (
+                "already indicates contention; fixed gate_timeout leaves the baseline "
+                "unchanged, so concurrent work on this host may still stretch gate completion"
+            )
+        else:
+            _warning_suffix = (
+                "already indicates contention; the expanded gate_timeout may still be "
+                "insufficient while concurrent work on this host persists"
+            )
+        _warning_load_fragment = ""
+        if _warning_load is not None and _warning_load != _observed:
+            _story_noun = "story" if _gate_timeout_resolution.running_stories == 1 else "stories"
+            _warning_load_fragment = (
+                f" after discounting {_gate_timeout_resolution.running_stories} inherited "
+                f"{_story_noun} ({_warning_load:.2f} effective)"
+            )
         print(
             f"[sprint] WARNING: gate CPU observed host load ({_observed:.2f} 1m / {_hc} cores) "
-            "already indicates contention; adaptive gate_timeout scaling was applied, "
-            "but concurrent work on this host may still stretch gate completion",
+            f"{_warning_load_fragment} {_warning_suffix}".lstrip(),
             file=sys.stderr,
             flush=True,
         )

--- a/tests/test_sprint_gate_timeout_reexec_load.py
+++ b/tests/test_sprint_gate_timeout_reexec_load.py
@@ -99,10 +99,12 @@ def test_running_stories_warns_only_with_high_observed_load() -> None:
         gate_cpu_cores=10,
         mode="adaptive",
         running_stories=2,
-        observed_host_load=10.2,
+        observed_host_load=12.2,
     )
     assert r.overcommit is True
-    assert "observed_host_load=10.20" in r.reason
+    assert r.warning_host_load == 10.2
+    assert "observed_host_load=12.20" in r.reason
+    assert "warning_host_load=10.20" in r.reason
 
 
 # ── Seam: runner supplies the actual load ────────────────────────────
@@ -211,8 +213,35 @@ def test_continuation_timeout_counts_inherited_running_stories(tmp_path: Path, c
         )
 
     err = capsys.readouterr().err
-    assert "running_stories=1 actual_parallel=3 observed_host_load=10.20" in err
-    assert "WARNING: gate CPU observed host load (10.20 1m / 10 cores)" in err
+    assert (
+        "running_stories=1 actual_parallel=3 observed_host_load=10.20 "
+        "warning_host_load=9.20" in err
+    )
+    assert "WARNING: gate CPU" not in err
     # 60s baseline × (10 cores × 3) / 10 host cores = 180s, not the 120s a model
     # blind to the inherited agent would have produced.
     assert captured["gate_timeout"] == 180
+
+
+def test_continuation_warning_requires_load_beyond_inherited_stories(
+    tmp_path: Path, capsys
+) -> None:
+    manifest_path = _make_manifest(tmp_path, ["story-a", "story-b"], max_parallel=2)
+    config = _make_config(tmp_path, gate_timeout=60, gate_cpu_cores=10)
+
+    with (
+        patch("theforge.sprint.runner.run_task", return_value=_ok_result()),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("os.cpu_count", return_value=10),
+        patch("os.getloadavg", return_value=(11.2, 10.9, 10.6)),
+    ):
+        run_sprint_ctx(
+            config,
+            manifest_path,
+            reexec=True,
+            live_story_slugs={"story-a"},
+        )
+
+    err = capsys.readouterr().err
+    assert "WARNING: gate CPU observed host load (11.20 1m / 10 cores)" in err
+    assert "after discounting 1 inherited story (10.20 effective)" in err

--- a/tests/test_sprint_gate_timeout_reexec_load.py
+++ b/tests/test_sprint_gate_timeout_reexec_load.py
@@ -70,7 +70,7 @@ def test_running_stories_raises_demand_and_timeout() -> None:
     assert r.actual_parallel == 4
     assert r.factor == 4.0
     assert r.effective_timeout == 240
-    assert r.overcommit is True
+    assert r.overcommit is False
     # Configured parallelism is still reported as itself — the two numbers are
     # different facts and the diagnostic keeps both.
     assert r.max_parallel == 2
@@ -89,6 +89,20 @@ def test_fixed_mode_ignores_inherited_load() -> None:
     )
     assert r.effective_timeout == 60
     assert r.running_stories == 3
+
+
+def test_running_stories_warns_only_with_high_observed_load() -> None:
+    r = resolve_effective_gate_timeout(
+        baseline=60,
+        max_parallel=2,
+        host_cores=10,
+        gate_cpu_cores=10,
+        mode="adaptive",
+        running_stories=2,
+        observed_host_load=10.2,
+    )
+    assert r.overcommit is True
+    assert "observed_host_load=10.20" in r.reason
 
 
 # ── Seam: runner supplies the actual load ────────────────────────────
@@ -162,12 +176,14 @@ def test_fresh_start_timeout_derives_from_configured_parallel(tmp_path: Path, ca
     with (
         patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
         patch("os.cpu_count", return_value=10),
+        patch("os.getloadavg", return_value=(6.68, 7.0, 5.52)),
     ):
         run_sprint_ctx(config, manifest_path)
 
     err = capsys.readouterr().err
-    assert "running_stories=0 actual_parallel=2" in err
+    assert "running_stories=0 actual_parallel=2 observed_host_load=6.68" in err
     assert captured["gate_timeout"] == 120
+    assert "WARNING: gate CPU" not in err
 
 
 def test_continuation_timeout_counts_inherited_running_stories(tmp_path: Path, capsys) -> None:
@@ -185,6 +201,7 @@ def test_continuation_timeout_counts_inherited_running_stories(tmp_path: Path, c
         patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
         patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
         patch("os.cpu_count", return_value=10),
+        patch("os.getloadavg", return_value=(10.2, 10.0, 9.8)),
     ):
         run_sprint_ctx(
             config,
@@ -194,7 +211,8 @@ def test_continuation_timeout_counts_inherited_running_stories(tmp_path: Path, c
         )
 
     err = capsys.readouterr().err
-    assert "running_stories=1 actual_parallel=3" in err
+    assert "running_stories=1 actual_parallel=3 observed_host_load=10.20" in err
+    assert "WARNING: gate CPU observed host load (10.20 1m / 10 cores)" in err
     # 60s baseline × (10 cores × 3) / 10 host cores = 180s, not the 120s a model
     # blind to the inherited agent would have produced.
     assert captured["gate_timeout"] == 180

--- a/tests/test_sprint_gate_timeout_scaling.py
+++ b/tests/test_sprint_gate_timeout_scaling.py
@@ -49,7 +49,7 @@ class TestResolveEffectiveGateTimeout:
         # demand = 21, factor = 2.1, effective = ceil(45*2.1) = 95
         assert r.factor == 2.1
         assert r.effective_timeout == 95
-        assert r.overcommit is True
+        assert r.overcommit is False
 
     def test_fixed_mode_preserves_baseline(self) -> None:
         r = resolve_effective_gate_timeout(
@@ -58,27 +58,49 @@ class TestResolveEffectiveGateTimeout:
         assert r.effective_timeout == 45
         assert r.mode == "fixed"
 
-    def test_overcommit_threshold_is_1_5x_host(self) -> None:
-        # demand = 12, host = 10, ratio = 1.2 → not overcommit
+    def test_observed_host_load_controls_overcommit(self) -> None:
+        # demand still scales the timeout, but warning eligibility follows observed host load.
         r = resolve_effective_gate_timeout(
-            baseline=60, max_parallel=2, host_cores=10, gate_cpu_cores=6, mode="adaptive"
+            baseline=60,
+            max_parallel=2,
+            host_cores=10,
+            gate_cpu_cores=6,
+            mode="adaptive",
+            observed_host_load=6.68,
         )
         assert r.overcommit is False
 
-        # demand = 16, host = 10, ratio = 1.6 → overcommit
         r2 = resolve_effective_gate_timeout(
-            baseline=60, max_parallel=2, host_cores=10, gate_cpu_cores=8, mode="adaptive"
+            baseline=60,
+            max_parallel=2,
+            host_cores=10,
+            gate_cpu_cores=8,
+            mode="adaptive",
+            observed_host_load=10.1,
         )
         assert r2.overcommit is True
 
-    def test_gate_cpu_cores_none_defaults_to_host_cores(self) -> None:
+    def test_gate_cpu_cores_none_defaults_to_host_cores_without_warning_on_low_load(self) -> None:
         r = resolve_effective_gate_timeout(
-            baseline=30, max_parallel=2, host_cores=8, gate_cpu_cores=None, mode="adaptive"
+            baseline=30,
+            max_parallel=2,
+            host_cores=10,
+            gate_cpu_cores=None,
+            mode="adaptive",
+            observed_host_load=6.68,
         )
-        # demand = 8 * 2 = 16, factor = 2.0
-        assert r.gate_cpu_cores == 8
+        # demand = 10 * 2 = 20, factor = 2.0
+        assert r.gate_cpu_cores == 10
         assert r.factor == 2.0
         assert r.effective_timeout == 60
+        assert r.overcommit is False
+
+    def test_load_unavailable_suppresses_overcommit_warning(self) -> None:
+        r = resolve_effective_gate_timeout(
+            baseline=30, max_parallel=4, host_cores=10, gate_cpu_cores=10, mode="adaptive"
+        )
+        assert r.overcommit is False
+        assert r.observed_host_load is None
 
     def test_unknown_mode_raises(self) -> None:
         with pytest.raises(ValueError, match="gate_timeout_scale must be 'adaptive' or 'fixed'"):
@@ -195,7 +217,7 @@ def test_sprint_fixed_mode_keeps_baseline(tmp_path: Path) -> None:
 
 
 def test_sprint_emits_overcommit_warning(tmp_path: Path, capsys) -> None:
-    """When demand exceeds 1.5× host cores, an overcommit WARNING is logged."""
+    """Observed host contention, not synthetic demand alone, triggers the warning."""
     _make_spec_file(tmp_path, "story-a")
     manifest_path = _make_manifest(tmp_path, ["story-a"], max_parallel=3)
     config = _make_config(tmp_path, gate_timeout=45, gate_cpu_cores=7)
@@ -203,14 +225,32 @@ def test_sprint_emits_overcommit_warning(tmp_path: Path, capsys) -> None:
     with (
         patch("theforge.sprint.runner.run_task", return_value=_ok_result()),
         patch("os.cpu_count", return_value=10),
+        patch("os.getloadavg", return_value=(10.1, 9.8, 9.4)),
     ):
         run_sprint_ctx(config, manifest_path)
 
     err = capsys.readouterr().err
     assert "WARNING" in err
-    assert "overcommit" in err.lower() or "consider lowering --parallel" in err
+    assert "observed host load (10.10 1m / 10 cores)" in err
     # And the resolution reasoning line:
     assert "gate_timeout: baseline=45s" in err
+
+
+def test_sprint_skips_overcommit_warning_when_load_is_low(tmp_path: Path, capsys) -> None:
+    _make_spec_file(tmp_path, "story-a")
+    manifest_path = _make_manifest(tmp_path, ["story-a"], max_parallel=2)
+    config = _make_config(tmp_path, gate_timeout=45, gate_cpu_cores=None)
+
+    with (
+        patch("theforge.sprint.runner.run_task", return_value=_ok_result()),
+        patch("os.cpu_count", return_value=10),
+        patch("os.getloadavg", return_value=(6.68, 7.0, 5.52)),
+    ):
+        run_sprint_ctx(config, manifest_path)
+
+    err = capsys.readouterr().err
+    assert "gate_timeout: baseline=45s mode=adaptive parallel=2 gate_cpu_cores=10" in err
+    assert "WARNING: gate CPU" not in err
 
 
 def test_sprint_invalid_gate_timeout_scale_fails_fast(tmp_path: Path) -> None:

--- a/tests/test_sprint_gate_timeout_scaling.py
+++ b/tests/test_sprint_gate_timeout_scaling.py
@@ -69,6 +69,7 @@ class TestResolveEffectiveGateTimeout:
             observed_host_load=6.68,
         )
         assert r.overcommit is False
+        assert r.warning_host_load == 6.68
 
         r2 = resolve_effective_gate_timeout(
             baseline=60,
@@ -79,6 +80,7 @@ class TestResolveEffectiveGateTimeout:
             observed_host_load=10.1,
         )
         assert r2.overcommit is True
+        assert r2.warning_host_load == 10.1
 
     def test_gate_cpu_cores_none_defaults_to_host_cores_without_warning_on_low_load(self) -> None:
         r = resolve_effective_gate_timeout(
@@ -232,8 +234,25 @@ def test_sprint_emits_overcommit_warning(tmp_path: Path, capsys) -> None:
     err = capsys.readouterr().err
     assert "WARNING" in err
     assert "observed host load (10.10 1m / 10 cores)" in err
-    # And the resolution reasoning line:
+    assert "expanded gate_timeout may still be insufficient" in err
     assert "gate_timeout: baseline=45s" in err
+
+
+def test_sprint_fixed_mode_warning_mentions_unchanged_baseline(tmp_path: Path, capsys) -> None:
+    _make_spec_file(tmp_path, "story-a")
+    manifest_path = _make_manifest(tmp_path, ["story-a"], max_parallel=3)
+    config = _make_config(tmp_path, gate_timeout=45, gate_cpu_cores=7, mode="fixed")
+
+    with (
+        patch("theforge.sprint.runner.run_task", return_value=_ok_result()),
+        patch("os.cpu_count", return_value=10),
+        patch("os.getloadavg", return_value=(10.1, 9.8, 9.4)),
+    ):
+        run_sprint_ctx(config, manifest_path)
+
+    err = capsys.readouterr().err
+    assert "WARNING: gate CPU observed host load (10.10 1m / 10 cores)" in err
+    assert "fixed gate_timeout leaves the baseline unchanged" in err
 
 
 def test_sprint_skips_overcommit_warning_when_load_is_low(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The warning no longer fires merely because parallelism is greater than one; it is now driven by observed host load, with focused resolver and runner tests passing. | [anthropic-opus-cli] Cycle 2 refinement discounts inherited stories from the warning load and makes the text mode-aware; verified against source, all 20 gate-timeout tests pass locally, no regression found — one cosmetic double-space P2 in the warning string.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $3.91
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:4500`** The gate contention WARNING renders with two consecutive spaces after the core-count parenthetical in both the fresh-start and continuation forms, because the leading space of the optional discount fragment is added to a prefix that already ends in a space and the trailing lstrip only affects the start of the full line.
- **[P2] `src/theforge/sprint/gate_timeout_resolver.py:72`** The warning load subtracts the raw count of inherited running stories from the one-minute load average, so on a continuation carrying several stories a host that is genuinely oversubscribed by external work can fall below the host-core threshold and emit no warning at all.

## Story

The gate CPU oversubscription warning fires for every parallelism above 1, so it reports that parallelism was used rather than that contention is likely (GitHub Issue #2085)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2085