### PR TITLE
Sprint log directory name is truncated, splitting one run's artifacts across two directories

### DIFF
--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -66,6 +66,17 @@ def _backstop_run_ended(run_id: str, project_root: Path) -> None:
     )
 
 
+def _derive_query_sprint_name(
+    *,
+    name: str | None,
+    milestone: str | None,
+    label: str | None,
+    issues_arg: str | None,
+) -> str:
+    """Return the canonical query-mode sprint name used across launch and runtime."""
+    return name or milestone or label or f"issues-{issues_arg}"
+
+
 def cmd_sprint(args: object) -> int:
     """Run multiple stories via a sprint manifest or GitHub query.
 
@@ -194,13 +205,12 @@ def _cmd_sprint(args: object) -> int:
         issues_arg_local: str | None = getattr(args, "issues", None)
         query_mode_local = bool(milestone_local or label_local or issues_arg_local)
         if query_mode_local:
-            sprint_name_local = (
-                getattr(args, "name", None)
-                or milestone_local
-                or label_local
-                or f"issues-{issues_arg_local}"
+            launch_slug = _derive_query_sprint_name(
+                name=getattr(args, "name", None),
+                milestone=milestone_local,
+                label=label_local,
+                issues_arg=issues_arg_local,
             )
-            launch_slug = sprint_name_local.replace(" ", "-").replace("/", "-").lower()[:50]
         else:
             launch_slug = Path(manifest_arg_local).stem if manifest_arg_local else "sprint"
 
@@ -996,7 +1006,12 @@ def _run_query_mode(
         from theforge import process_group as _process_group  # noqa: PLC0415
 
         _process_group.reap_orphan_agents(config.project_root)
-    gate_sprint_name = getattr(args, "name", None) or milestone or label or f"issues-{issues_arg}"
+    gate_sprint_name = _derive_query_sprint_name(
+        name=getattr(args, "name", None),
+        milestone=milestone,
+        label=label,
+        issues_arg=issues_arg,
+    )
     # Carry-across-re-exec: a prior process may have intake-remediated some
     # issues and stashed their numbers in the environment before re-exec.
     # Consume them here so the post-re-exec gate treats the async-lagging
@@ -1128,10 +1143,12 @@ def _run_query_mode(
             )
             _emit_all_skipped_audit(
                 config=config,
-                sprint_name=getattr(args, "name", None)
-                or milestone
-                or label
-                or f"issues-{issues_arg}",
+                sprint_name=_derive_query_sprint_name(
+                    name=getattr(args, "name", None),
+                    milestone=milestone,
+                    label=label,
+                    issues_arg=issues_arg,
+                ),
                 budget_usd=budget_usd,
                 skipped_issues=skipped_issues,
                 intake_outcomes=entry_intake_outcomes,
@@ -1139,7 +1156,12 @@ def _run_query_mode(
             )
             return 0
 
-    sprint_name: str = getattr(args, "name", None) or milestone or label or f"issues-{issues_arg}"
+    sprint_name = _derive_query_sprint_name(
+        name=getattr(args, "name", None),
+        milestone=milestone,
+        label=label,
+        issues_arg=issues_arg,
+    )
 
     # Build full ResolvedSprint (fetches individual issue bodies via gh)
     try:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -480,6 +480,77 @@ class TestFgFlag:
             cmd_sprint(args)
             mock_daemonize.assert_not_called()
 
+    def test_sprint_query_detach_parent_uses_full_derived_name(self, tmp_path):
+        """Detached query-mode launch must not truncate the sprint log directory name."""
+        from theforge.cli import cmd_sprint
+
+        config = _make_forge_config(tmp_path)
+        args = _make_sprint_args(
+            tmp_path,
+            fg=False,
+            manifest="",
+            milestone=None,
+            label=None,
+            budget="10",
+        )
+        args.issues = "2164,2160,2139,1993,1980,1945,2169,2156,1108"
+        expected_name = f"issues-{args.issues}"
+
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=config),
+            patch(
+                "theforge.detach.daemonize_run", side_effect=RuntimeError("detach stop")
+            ) as mock_daemonize,
+            patch("theforge.detach.is_detached_child", return_value=False),
+        ):
+            try:
+                cmd_sprint(args)
+            except RuntimeError as exc:
+                assert str(exc) == "detach stop"
+            else:
+                raise AssertionError("cmd_sprint should stop at daemonize_run in parent mode")
+
+        mock_daemonize.assert_called_once()
+        daemonize_args = mock_daemonize.call_args.args
+        assert daemonize_args[1] == expected_name
+        assert len(daemonize_args[1]) > 50
+
+    def test_sprint_query_detached_child_uses_full_derived_name(self, tmp_path, monkeypatch):
+        """Detached child setup must reuse the same full query-mode sprint name."""
+        from theforge.cli import cmd_sprint
+
+        config = _make_forge_config(tmp_path)
+        args = _make_sprint_args(
+            tmp_path,
+            fg=False,
+            manifest="",
+            milestone=None,
+            label=None,
+            budget="10",
+        )
+        args.issues = "2164,2160,2139,1993,1980,1945,2169,2156,1108"
+        expected_name = f"issues-{args.issues}"
+
+        monkeypatch.setenv("FORGE_DETACHED", "1")
+        monkeypatch.setenv("FORGE_DETACHED_RUN_ID", "child-run-id")
+
+        with (
+            patch("theforge.cli.sprint.load_config", return_value=config),
+            patch("theforge.detach.is_detached_child", return_value=True),
+            patch("theforge.detach.setup_detached_child") as mock_setup,
+            patch("theforge.detach.install_cleanup_handler"),
+            patch("theforge.detach.remove_pid"),
+            patch("theforge.sprint.query.fetch_issues_by_numbers", return_value=[]),
+        ):
+            rc = cmd_sprint(args)
+
+        assert rc == 0
+        mock_setup.assert_called_once()
+        setup_args = mock_setup.call_args.args
+        assert setup_args[0] == "child-run-id"
+        assert setup_args[1] == expected_name
+        assert len(setup_args[1]) > 50
+
 
 class TestCmdSprintQueryMode:
     def test_query_mode_defaults_to_sequential_when_parallel_omitted(self, tmp_path):


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change removes the query-mode detach truncation, routes parent and child log setup through the same derived sprint name used at runtime, and the focused regression tests pass. | [google-gemini-3.5-flash-api] The 50-character truncation has been successfully eliminated by unifying the launch slug and runtime resolved name through a single helper, and comprehensive integration tests have been added.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $2.06
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Sprint log directory name is truncated, splitting one run's artifacts across two directories (GitHub Issue #2190)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2190