### PR TITLE
An escalate-gate action an operator selects is recorded as resolving the escalation while none of the operation it names is performed

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -1007,12 +1007,12 @@ re-enter a stopped story, and they do different things:
 Those diverge whenever a story stopped with both a recorded escalate-gate
 decision and a review cycle it never ran — for example: gate PASS after a fix,
 review cycle 1 returned REQUEST_CHANGES, cycle 2 never ran, escalation decision
-`land_core_defer_edges` recorded.
+`accept` recorded.
 
 | You want | Use | What happens |
 |---|---|---|
 | The unrun review cycle to execute against the fix | `forge review <story>` | Review cycle 2 runs; the recorded decision is not consulted |
-| To honor the recorded pipeline state (the decision you already made) | `forge sprint --resume` / `forge run --resume` | Resume continues from `land_core_defer_edges` and proceeds to landing; **no review runs** |
+| To honor the recorded pipeline state (the decision you already made) | `forge sprint --resume` / `forge run --resume` | Resume continues from `accept` and proceeds to landing; **no review runs** |
 
 Neither is a default: choosing between them is choosing whether the work gets
 reviewed. Check `forge status` first — a story in this state prints an
@@ -1024,7 +1024,7 @@ anything, on its `↺ RESUME` lines — stated for the path you actually invoked
 
 ```
   ↺ RESUME   recovered phase record: escalation
-  ↺ RESUME   recovered escalation decision land_core / defer_edges (from run 20260807-...)
+  ↺ RESUME   recovered escalation decision accept (from run 20260807-...)
   ↺ RESUME   outstanding: REVIEW cycle 2 has not run (last verdict REQUEST_CHANGES, gate PASS)
   ↺ RESUME   this resume continues from that decision and will NOT run REVIEW —
              `forge review` runs REVIEW cycle 2 instead
@@ -1034,7 +1034,7 @@ anything, on its `↺ RESUME` lines — stated for the path you actually invoked
 
 ```
   ↺ RESUME   recovered phase record: escalation
-  ↺ RESUME   recovered escalation decision land_core / defer_edges (from run 20260807-...)
+  ↺ RESUME   recovered escalation decision accept (from run 20260807-...)
   ↺ RESUME   outstanding: REVIEW cycle 2 has not run (last verdict REQUEST_CHANGES, gate PASS)
   ↺ RESUME   `forge review` runs REVIEW cycle 2 now —
              `forge sprint --resume` would continue from that decision and skip it

--- a/src/theforge/coordinator/escalate_actions.py
+++ b/src/theforge/coordinator/escalate_actions.py
@@ -25,6 +25,13 @@ if TYPE_CHECKING:
 #: performability depends on run state rather than on the operator alone.
 ACCEPT_ACTION = "accept"
 
+#: Taxonomy actions that still name historical/manual forge operations but are
+#: not mechanically executable by this run. Keep them recognizable for parsing
+#: stale/manual selections, but do not offer them as real gate choices.
+NON_EXECUTABLE_NAMED_ACTIONS = frozenset(
+    {"land_core_defer_edges", "redirect", "decompose", "elevate"}
+)
+
 #: Reason text used when accept cannot be offered/performed. Rendered to the
 #: operator at the gate and recorded in the audit trail when a stale selection
 #: is declined, so "why wasn't this offered" and "why was this refused" read the
@@ -33,6 +40,8 @@ ACCEPT_UNAVAILABLE_REASON = (
     "no approvable reviewer result is retained for this run — "
     "there is no verdict the gate could finalize on"
 )
+
+NAMED_ACTION_UNAVAILABLE_REASON = "action is not executable by this run"
 
 
 def approvable_review_result(
@@ -79,6 +88,9 @@ def available_escalate_actions(
     for action in actions:
         if action == ACCEPT_ACTION and not accept_ok:
             omitted[action] = ACCEPT_UNAVAILABLE_REASON
+            continue
+        if action in NON_EXECUTABLE_NAMED_ACTIONS:
+            omitted[action] = NAMED_ACTION_UNAVAILABLE_REASON
             continue
         available.append(action)
     return available, omitted

--- a/src/theforge/coordinator/escalate_actions.py
+++ b/src/theforge/coordinator/escalate_actions.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from theforge.escalation_advisor import ACTION_TAXONOMY, action_disposition
+
 if TYPE_CHECKING:
     from theforge.review import ReviewResult
 
@@ -29,7 +31,7 @@ ACCEPT_ACTION = "accept"
 #: not mechanically executable by this run. Keep them recognizable for parsing
 #: stale/manual selections, but do not offer them as real gate choices.
 NON_EXECUTABLE_NAMED_ACTIONS = frozenset(
-    {"land_core_defer_edges", "redirect", "decompose", "elevate"}
+    action for action in ACTION_TAXONOMY if action_disposition(action) == "named"
 )
 
 #: Reason text used when accept cannot be offered/performed. Rendered to the

--- a/src/theforge/coordinator/escalation_advisor_flow.py
+++ b/src/theforge/coordinator/escalation_advisor_flow.py
@@ -22,6 +22,7 @@ from theforge.config import DEFAULT_INVESTIGATION_TOOLS
 from theforge.config.model_identity import KNOWN_PHASES
 from theforge.config.pricing import price_tiebreak_signal_for
 from theforge.escalation_advisor import (
+    ACTION_TAXONOMY,
     CycleEvidence,
     EvidencePacket,
     parse_advisory_report,
@@ -35,6 +36,7 @@ from theforge.model_capabilities import (
 from theforge.task.advisor_prompts import build_advisor_prompt
 
 from . import util as _cu
+from .escalate_actions import available_escalate_actions
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -344,7 +346,8 @@ def run_escalation_advisor(
     packet = build_evidence_packet(state, task, config, workspace_path)
     state.advisory_packet = packet.to_dict()
 
-    prompt = build_advisor_prompt(packet)
+    available_actions, _omitted_actions = available_escalate_actions(state, ACTION_TAXONOMY)
+    prompt = build_advisor_prompt(packet, available_actions)
     try:
         profile = _select_advisor_profile(config)
     except NoCapableCandidateError as exc:

--- a/src/theforge/coordinator/pending_hitl.py
+++ b/src/theforge/coordinator/pending_hitl.py
@@ -118,10 +118,10 @@ def _pending_escalate_gate(
 ) -> str:
     """Pending-file-based escalate gate with a fresh-context advisory report.
 
-    When ``advisory`` is a valid report, the pending file presents the action
-    taxonomy (Accept / Land-core-defer-edges / Redirect / Decompose / Elevate /
-    Defer-or-Abandon) as the options and embeds the report + evidence packet as
-    structured payload; the operator must select one of those actions.
+    When ``advisory`` is a valid report, the pending file presents the
+    executable subset of the action taxonomy as the options and embeds the
+    report + evidence packet as structured payload; the operator must select one
+    of those actions.
 
     The presented options are the taxonomy filtered to what the current state can
     actually perform (see :mod:`.escalate_actions`) — ``accept`` is withheld when

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -43,6 +43,7 @@ from .commit_guard import _has_commits_ahead_of_base
 from .completion import _append_cycle_history, _finalize_approve
 from .escalate_actions import (
     ACCEPT_UNAVAILABLE_REASON,
+    NAMED_ACTION_UNAVAILABLE_REASON,
     approvable_review_result,
     available_escalate_actions,
 )
@@ -628,26 +629,31 @@ def _run_escalate_gate_inner(
         return None
 
     if disposition == "named":
-        # A middle-taxonomy action (redirect / decompose / elevate /
-        # land-core-defer-edges): v1 names the concrete forge operation and
-        # preserves the worktree for the operator to run it — it is not an
-        # auto-reject that discards the work.
         op = ACTION_FORGE_OPERATIONS.get(norm, norm)
         label = ACTION_LABELS.get(norm, norm)
         by_advice = _decided_by_advice(state)
         how = "applied from the advisory on expiry" if by_advice else "selected"
-        _log(f"  Escalate gate: {label} {how} — next operation: {op}")
+        state.escalate_declined_action = norm
+        state.escalate_declined_reason = NAMED_ACTION_UNAVAILABLE_REASON
+        if not by_advice:
+            state.escalate_decision_source = ESCALATE_SOURCE_OPERATOR_DECLINED
+        _log(
+            f"  ⚠ Escalate gate: {label} {how} but was not carried out "
+            f"({state.escalate_declined_reason}) — DECLINED; named operation remains {op}"
+        )
         return _make_escalate_result(
-            norm,
+            None,
             message=(
-                f"Escalation resolved as {label}: {op}. "
+                f"Escalation preserved: the selected action {label} was not carried out "
+                f"({state.escalate_declined_reason}). "
                 + (
                     "The gate expired with no operator selection and the advisory "
-                    "recommendation was applied. "
+                    "recommendation was declined. "
                     if by_advice
                     else ""
                 )
-                + "Worktree preserved for the operator to run the named operation."
+                + f"The named operation remains {op}, and an operator action selection "
+                "is still required."
             ),
         )
 

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -631,14 +631,11 @@ def _run_escalate_gate_inner(
     if disposition == "named":
         op = ACTION_FORGE_OPERATIONS.get(norm, norm)
         label = ACTION_LABELS.get(norm, norm)
-        by_advice = _decided_by_advice(state)
-        how = "applied from the advisory on expiry" if by_advice else "selected"
         state.escalate_declined_action = norm
         state.escalate_declined_reason = NAMED_ACTION_UNAVAILABLE_REASON
-        if not by_advice:
-            state.escalate_decision_source = ESCALATE_SOURCE_OPERATOR_DECLINED
+        state.escalate_decision_source = ESCALATE_SOURCE_OPERATOR_DECLINED
         _log(
-            f"  ⚠ Escalate gate: {label} {how} but was not carried out "
+            f"  ⚠ Escalate gate: {label} selected but was not carried out "
             f"({state.escalate_declined_reason}) — DECLINED; named operation remains {op}"
         )
         return _make_escalate_result(
@@ -646,12 +643,6 @@ def _run_escalate_gate_inner(
             message=(
                 f"Escalation preserved: the selected action {label} was not carried out "
                 f"({state.escalate_declined_reason}). "
-                + (
-                    "The gate expired with no operator selection and the advisory "
-                    "recommendation was declined. "
-                    if by_advice
-                    else ""
-                )
                 + f"The named operation remains {op}, and an operator action selection "
                 "is still required."
             ),

--- a/src/theforge/task/advisor_prompts.py
+++ b/src/theforge/task/advisor_prompts.py
@@ -12,11 +12,14 @@ agent lives in ``theforge.coordinator.escalation_advisor_flow``.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from theforge.escalation_advisor import (
     ACTION_FORGE_OPERATIONS,
     ACTION_LABELS,
     ACTION_TAXONOMY,
     EvidencePacket,
+    action_disposition,
 )
 
 _TAXONOMY_GUIDE: dict[str, str] = {
@@ -49,9 +52,9 @@ _TAXONOMY_GUIDE: dict[str, str] = {
 }
 
 
-def _render_taxonomy() -> str:
+def _render_taxonomy(actions: Sequence[str]) -> str:
     lines: list[str] = []
-    for action in ACTION_TAXONOMY:
+    for action in actions:
         label = ACTION_LABELS.get(action, action)
         guide = _TAXONOMY_GUIDE.get(action, "")
         op = ACTION_FORGE_OPERATIONS.get(action, "")
@@ -140,11 +143,18 @@ def _render_packet(packet: EvidencePacket) -> str:
     return "\n".join(lines)
 
 
-def build_advisor_prompt(packet: EvidencePacket) -> str:
+def build_advisor_prompt(
+    packet: EvidencePacket, available_actions: Sequence[str] | None = None
+) -> str:
     """Build the fresh-context escalation-advisor prompt from an evidence packet."""
-    taxonomy = _render_taxonomy()
+    if available_actions is None:
+        available_actions = [
+            action for action in ACTION_TAXONOMY if action_disposition(action) != "named"
+        ]
+    available_actions = [action for action in available_actions if action in ACTION_TAXONOMY]
+    taxonomy = _render_taxonomy(available_actions)
     packet_text = _render_packet(packet)
-    example_action = ACTION_TAXONOMY[2]  # "redirect"
+    example_action = available_actions[0] if available_actions else ACTION_TAXONOMY[0]
     # An escalation no longer implies the cycle budget ran out: a detected
     # topology walk routes here with cycles still available, precisely so the
     # decision is made while it is still worth something. Saying "exhausted"
@@ -177,9 +187,9 @@ constrained menu of evidence-backed action choices for a human operator.
 An escalation is not just a failed implementation attempt — it is evidence that \
 the current task framing may be invalid. The churn pattern (what reviewers kept \
 flagging, what the dev kept re-breaking) is the most valuable signal. Look for \
-the case where the dev kept attacking an unbounded space (whack-a-mole) when the \
-issue itself already named a winnable primitive — that is usually a Redirect or \
-an Elevate, not another dev cycle.
+the case where the dev kept attacking an unbounded space (whack-a-mole) instead \
+of converging on a concrete, reviewable outcome. Recommend only from the \
+currently executable actions listed below.
 
 ## Action taxonomy (your recommendation and every option's `action` MUST be one \
 of these exact values)
@@ -197,11 +207,11 @@ the block inside a code fence. Free-form prose recommendations are NOT allowed �
 the recommendation must be one of the taxonomy values above.
 
 The YAML mapping must have:
-- `recommendation`: one of {list(ACTION_TAXONOMY)} — your single best action.
+- `recommendation`: one of {list(available_actions)} — your single best action.
 - `rationale`: one or two sentences citing the packet for why.
 - `options`: a non-empty list. Include the recommended action AND any other \
 credible actions. Each option is a mapping with:
-    - `action`: one of {list(ACTION_TAXONOMY)}
+    - `action`: one of {list(available_actions)}
     - `evidence`: what in the packet supports this action (cite cycles/findings/ACs)
     - `forge_operation`: the concrete forge operation this action triggers
     - `risk`: the risk of taking this action

--- a/tests/test_coord_escalate_offerable_actions.py
+++ b/tests/test_coord_escalate_offerable_actions.py
@@ -29,6 +29,7 @@ from theforge.config import BackendConfig, NotificationConfig
 from theforge.coordinator import review_phase as rp
 from theforge.coordinator.escalate_actions import (
     ACCEPT_UNAVAILABLE_REASON,
+    NAMED_ACTION_UNAVAILABLE_REASON,
     approvable_review_result,
     available_escalate_actions,
 )
@@ -125,14 +126,25 @@ class TestApprovableResolution:
     def test_accept_is_the_only_state_gated_action(self):
         available, omitted = available_escalate_actions(_quorum_collapsed_state(), ACTION_TAXONOMY)
         assert "accept" not in available
-        assert available == [a for a in ACTION_TAXONOMY if a != "accept"]
-        assert omitted == {"accept": ACCEPT_UNAVAILABLE_REASON}
+        assert available == ["defer_or_abandon"]
+        assert omitted == {
+            "accept": ACCEPT_UNAVAILABLE_REASON,
+            "land_core_defer_edges": NAMED_ACTION_UNAVAILABLE_REASON,
+            "redirect": NAMED_ACTION_UNAVAILABLE_REASON,
+            "decompose": NAMED_ACTION_UNAVAILABLE_REASON,
+            "elevate": NAMED_ACTION_UNAVAILABLE_REASON,
+        }
 
     def test_nothing_is_withheld_when_a_result_exists(self):
         state = _quorum_collapsed_state("APPROVE")
         available, omitted = available_escalate_actions(state, ACTION_TAXONOMY)
-        assert available == list(ACTION_TAXONOMY)
-        assert omitted == {}
+        assert available == ["accept", "defer_or_abandon"]
+        assert omitted == {
+            "land_core_defer_edges": NAMED_ACTION_UNAVAILABLE_REASON,
+            "redirect": NAMED_ACTION_UNAVAILABLE_REASON,
+            "decompose": NAMED_ACTION_UNAVAILABLE_REASON,
+            "elevate": NAMED_ACTION_UNAVAILABLE_REASON,
+        }
 
 
 # ── Pending-file gate: what is written to the checkpoint ──────────────────────
@@ -165,12 +177,14 @@ class TestPendingGateOptions:
         )
 
         assert "accept" not in data["options"]
-        assert data["options"] == [a for a in ACTION_TAXONOMY if a != "accept"]
+        assert data["options"] == ["defer_or_abandon"]
         # Withheld, not silently dropped: the reason is legible at the checkpoint.
         assert data["omitted_actions"]["accept"] == ACCEPT_UNAVAILABLE_REASON
+        assert data["omitted_actions"]["redirect"] == NAMED_ACTION_UNAVAILABLE_REASON
         assert "NOT OFFERED" in data["reason"]
         # And the advisory payload does not advertise it as a selectable option.
-        assert [o["action"] for o in data["advisory"]["options"]] == ["redirect"]
+        assert data["advisory"]["options"] == []
+        assert data["advisory"]["recommendation"] == ""
 
     def test_recommendation_the_gate_cannot_honour_is_dropped_and_explained(self, tmp_path):
         state = _quorum_collapsed_state()
@@ -191,16 +205,17 @@ class TestPendingGateOptions:
             tmp_path, state, "run-survivor", _advisory("accept", ["accept", "redirect"])
         )
 
-        assert data["options"] == list(ACTION_TAXONOMY)
-        assert "omitted_actions" not in data
+        assert data["options"] == ["accept", "defer_or_abandon"]
+        assert data["omitted_actions"]["redirect"] == NAMED_ACTION_UNAVAILABLE_REASON
         assert data["advisory"]["recommendation"] == "accept"
 
     def test_unavailable_advisory_checkpoint_also_filters(self, tmp_path):
         state = _quorum_collapsed_state()
         data = self._write(tmp_path, state, "run-noadvisory", None)
 
-        assert "accept" not in data["options"]
+        assert data["options"] == ["defer_or_abandon"]
         assert data["omitted_actions"]["accept"] == ACCEPT_UNAVAILABLE_REASON
+        assert data["omitted_actions"]["redirect"] == NAMED_ACTION_UNAVAILABLE_REASON
         assert ACCEPT_UNAVAILABLE_REASON in data["reason"]
 
 
@@ -317,6 +332,18 @@ class TestApproveDispositionDeclines:
         assert finalized == {}
         assert state.phase == Phase.ESCALATE
         assert "declined" in result.message
+
+    def test_named_action_is_declined_without_recording_resolution(self, tmp_path, monkeypatch):
+        state = _quorum_collapsed_state("APPROVE")
+        result, finalized = self._call(tmp_path, monkeypatch, state, "redirect")
+
+        assert result is not None and result.success is False
+        assert state.escalate_selected_action == "redirect"
+        assert state.escalate_declined_action == "redirect"
+        assert state.escalate_declined_reason == NAMED_ACTION_UNAVAILABLE_REASON
+        assert state.escalate_decision is None
+        assert finalized == {}
+        assert "was not carried out" in result.message
 
     def test_legacy_approve_selection_is_declined_the_same_way(self, tmp_path, monkeypatch):
         state = _quorum_collapsed_state()

--- a/tests/test_coord_escalate_timeout_advice.py
+++ b/tests/test_coord_escalate_timeout_advice.py
@@ -4,8 +4,8 @@ Covers the coordinator boundary issue #2279 touches:
 
 * ``retry.escalate_timeout_policy`` is opt-in, validated at config load, and
   defaults to today's preserve-on-expiry behaviour.
-* an opted-in expiry applies a usable, performable recommendation and reaches the
-  same outcome an operator selecting that action deliberately would.
+* an opted-in expiry applies a usable, performable recommendation, and declines
+  a named recommendation the run cannot execute without claiming it happened.
 * ``elevate`` and every flavour of absent advice still preserve the story, and
   the run states WHICH of those situations occurred.
 * a selection that arrives before expiry governs, whatever the advisor said.
@@ -38,7 +38,6 @@ from theforge.coordinator.resume_persistence import (
 )
 from theforge.coordinator.review_phase import _run_escalate_gate
 from theforge.coordinator.state import (
-    ADVICE_APPLIED,
     ADVICE_ELEVATE,
     ADVICE_LAUNCH_FAILURE,
     ADVICE_NO_RECOMMENDATION,
@@ -48,6 +47,7 @@ from theforge.coordinator.state import (
     ADVICE_UNPARSEABLE,
     ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT,
     ESCALATE_SOURCE_OPERATOR,
+    ESCALATE_SOURCE_OPERATOR_DECLINED,
     ESCALATE_SOURCE_POLICY_AUTO_APPROVE,
     ESCALATE_SOURCE_POLICY_REJECT,
     ESCALATE_SOURCE_TIMEOUT_PENDING,
@@ -319,7 +319,7 @@ class TestDefaultPolicyUnchanged:
 
 
 class TestAppliesAdviceOnExpiry:
-    def test_named_recommendation_is_applied_like_a_deliberate_selection(
+    def test_named_recommendation_is_declined_like_a_deliberate_selection(
         self, tmp_path, monkeypatch
     ):
         state, result = _drive_gate(
@@ -329,13 +329,12 @@ class TestAppliesAdviceOnExpiry:
             report=_report("land_core_defer_edges"),
             timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
         )
-        # Identical to what an operator selecting land_core_defer_edges gets: the
-        # named disposition, the named forge operation, the worktree preserved.
-        assert state.escalate_decision == "land_core_defer_edges"
-        assert state.escalate_selected_action == "land_core_defer_edges"
-        assert "land-core" in result.message
-        assert state.escalate_decision_source == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
-        assert state.escalate_timeout_advice == ADVICE_APPLIED
+        assert state.escalate_decision == "advisory_pending"
+        assert state.escalate_selected_action is None
+        assert state.escalate_declined_action is None
+        assert "cannot perform it" in result.message
+        assert state.escalate_decision_source == ESCALATE_SOURCE_TIMEOUT_PENDING
+        assert state.escalate_timeout_advice == ADVICE_NOT_PERFORMABLE
 
     def test_accept_recommendation_finalizes_the_approval(self, tmp_path, monkeypatch):
         state, result = _drive_gate(
@@ -382,7 +381,7 @@ class TestAppliesAdviceOnExpiry:
         )
         assert "Human approved via escalate gate" in finalize_calls["message"]
 
-    def test_applied_named_action_message_names_the_expiry(self, tmp_path, monkeypatch):
+    def test_applied_named_action_message_names_the_decline(self, tmp_path, monkeypatch):
         _state, result = _drive_gate(
             tmp_path,
             monkeypatch,
@@ -390,10 +389,10 @@ class TestAppliesAdviceOnExpiry:
             report=_report("land_core_defer_edges"),
             timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
         )
-        assert "advisory recommendation was applied" in result.message
-        assert "Worktree preserved" in result.message
+        assert "recommendation could not be applied" in result.message
+        assert "operator action selection is still required" in result.message
 
-    def test_operator_named_action_message_is_unchanged(self, tmp_path, monkeypatch):
+    def test_operator_named_action_message_reports_decline(self, tmp_path, monkeypatch):
         _state, result = _drive_gate(
             tmp_path,
             monkeypatch,
@@ -402,7 +401,7 @@ class TestAppliesAdviceOnExpiry:
             timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
         )
         assert "advisory recommendation was applied" not in result.message
-        assert "Worktree preserved" in result.message
+        assert "was not carried out" in result.message
 
     def test_defer_or_abandon_recommendation_rejects(self, tmp_path, monkeypatch):
         state, result = _drive_gate(
@@ -563,8 +562,9 @@ class TestOperatorSelectionBeatsAdvice:
                 )
 
         assert state.escalate_selected_action == "redirect"
-        assert state.escalate_decision == "redirect"
-        assert state.escalate_decision_source == ESCALATE_SOURCE_OPERATOR
+        assert state.escalate_decision is None
+        assert state.escalate_declined_action == "redirect"
+        assert state.escalate_decision_source == ESCALATE_SOURCE_OPERATOR_DECLINED
         assert result.success is False
 
 
@@ -611,8 +611,8 @@ class TestPendingCheckpointLifecycle:
             timeout_policy=ESCALATE_TIMEOUT_APPLY_ADVICE,
             run_id="run-applied",
         )
-        assert state.escalate_decision == "land_core_defer_edges"
-        assert not pending_file.exists(), "a decided story must not look still-pending"
+        assert state.escalate_decision == "advisory_pending"
+        assert pending_file.exists(), "an unapplied recommendation must remain operator-actionable"
 
     def test_elevate_leaves_the_checkpoint_for_the_operator(self, tmp_path, monkeypatch):
         state, pending_file = self._run_real_gate(
@@ -647,11 +647,12 @@ class TestDecisionProvenanceIsRecorded:
             CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message="m"),
         )
         block = record["escalation"]
-        assert block["decision_source"] == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
-        assert block["timeout_advice"] == ADVICE_APPLIED
-        assert block["selected_action"] == "land_core_defer_edges"
+        assert block["decision_source"] == ESCALATE_SOURCE_TIMEOUT_PENDING
+        assert block["timeout_advice"] == ADVICE_NOT_PERFORMABLE
+        assert block["selected_action"] is None
+        assert block["declined_action"] is None
         assert block["advisory_recommendation"] == "land_core_defer_edges"
-        assert block["awaiting_operator"] is False
+        assert block["awaiting_operator"] is True
 
     def test_audit_record_marks_a_still_waiting_gate(self, tmp_path, monkeypatch):
         state, _result = _drive_gate(
@@ -681,12 +682,13 @@ class TestDecisionProvenanceIsRecorded:
         )
         block = _escalation_block(state)
         assert block is not None
-        assert block["decision_source"] == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
-        assert block["timeout_advice"] == ADVICE_APPLIED
-        assert block["awaiting_operator"] is False
+        assert block["decision_source"] == ESCALATE_SOURCE_TIMEOUT_PENDING
+        assert block["timeout_advice"] == ADVICE_NOT_PERFORMABLE
+        assert block["awaiting_operator"] is True
 
         restored = CoordinatorState()
         assert _apply_escalation(restored, block)
-        assert restored.escalate_decision == "land_core_defer_edges"
-        assert restored.escalate_decision_source == ESCALATE_SOURCE_ADVISOR_ON_TIMEOUT
-        assert restored.escalate_timeout_advice == ADVICE_APPLIED
+        assert restored.escalate_decision == "advisory_pending"
+        assert restored.escalate_declined_action is None
+        assert restored.escalate_decision_source == ESCALATE_SOURCE_TIMEOUT_PENDING
+        assert restored.escalate_timeout_advice == ADVICE_NOT_PERFORMABLE

--- a/tests/test_coord_escalation_advisor.py
+++ b/tests/test_coord_escalation_advisor.py
@@ -305,8 +305,8 @@ class TestPendingEscalateGate:
                 )
 
         assert decision == "redirect"
-        assert seen["options"] == list(rp.ACTION_TAXONOMY)
-        assert seen["advisory"]["recommendation"] == "redirect"
+        assert seen["options"] == ["accept", "defer_or_abandon"]
+        assert seen["advisory"]["recommendation"] == ""
         assert seen["decision_required"] is True
 
     def test_timeout_returns_timeout_not_reject(self, tmp_path):
@@ -356,8 +356,8 @@ class TestPendingEscalateGate:
         pending_file = tmp_path / ".forge" / "pending" / "run-preserve.yaml"
         assert pending_file.exists(), "pending checkpoint must survive a timeout"
         data = yaml.safe_load(pending_file.read_text())
-        assert data["options"] == list(rp.ACTION_TAXONOMY)
-        assert data["advisory"]["recommendation"] == "redirect"
+        assert data["options"] == ["accept", "defer_or_abandon"]
+        assert data["advisory"]["recommendation"] == ""
         assert data["timed_out_awaiting_decision"] is True
         assert data.get("decision") is None  # still resolvable — no auto-decision written
 
@@ -401,8 +401,8 @@ class TestPendingEscalateGate:
         assert data["advisory_cost_usd"] == 0.0
         assert "FAILED TO LAUNCH" in data["reason"]
         assert "$0.00" in data["reason"]
-        # Options are still the full taxonomy — the operator must still choose.
-        assert data["options"] == list(rp.ACTION_TAXONOMY)
+        # Only executable actions are offered, even when the advisor is unavailable.
+        assert data["options"] == ["accept", "defer_or_abandon"]
 
     def test_advisory_unavailable_checkpoint_unchanged_without_launch_failure(self, tmp_path):
         """An advisor that ran and produced nothing keeps the plain unavailable wording."""
@@ -563,22 +563,22 @@ class TestRunEscalateGateDispositions:
         assert state.escalate_decision == "reject"
         assert state.escalate_selected_action == "defer_or_abandon"
 
-    def test_redirect_maps_to_named_preserve(self, tmp_path, monkeypatch):
+    def test_redirect_is_declined_not_recorded_as_resolved(self, tmp_path, monkeypatch):
         state, result = self._call(tmp_path, monkeypatch, "redirect")
         assert result is not None and result.success is False
-        # Named action preserves the worktree and records the taxonomy action —
-        # it is NOT a plain reject that discards the work.
-        assert state.escalate_decision == "redirect"
         assert state.escalate_selected_action == "redirect"
-        assert "re-run with constraint" in result.message
+        assert state.escalate_declined_action == "redirect"
+        assert state.escalate_decision is None
+        assert "was not carried out" in result.message
 
-    def test_elevate_maps_to_named_preserve(self, tmp_path, monkeypatch):
+    def test_elevate_is_declined_not_recorded_as_resolved(self, tmp_path, monkeypatch):
         state, result = self._call(
             tmp_path, monkeypatch, "elevate", report=_canned_report("elevate")
         )
         assert result.success is False
-        assert state.escalate_decision == "elevate"
-        assert "bump" in result.message
+        assert state.escalate_declined_action == "elevate"
+        assert state.escalate_decision is None
+        assert "was not carried out" in result.message
 
     def test_timeout_does_not_auto_reject(self, tmp_path, monkeypatch):
         state, result = self._call(tmp_path, monkeypatch, "timeout")

--- a/tests/test_escalation_advisor.py
+++ b/tests/test_escalation_advisor.py
@@ -444,17 +444,19 @@ options:
 
     def test_prompt_construction_exercises_1365_packet(self):
         # Exercise the #1365 evidence packet through prompt construction (not just
-        # a prewritten report): the fresh-advisor prompt must carry the full
-        # taxonomy AND the per-cycle churn signal so a fresh model can surface the
-        # blocklist-vs-invariant framing.
+        # a prewritten report): the fresh-advisor prompt must carry only the
+        # currently executable actions plus the per-cycle churn signal so a fresh
+        # model cannot recommend a gate action this run will refuse.
         from theforge.task.advisor_prompts import build_advisor_prompt
 
         packet = self._packet_1365()
         prompt = build_advisor_prompt(packet)
 
         # The constrained taxonomy is presented to the advisor.
-        for action in ACTION_TAXONOMY:
+        for action in ("accept", "defer_or_abandon"):
             assert f"`{action}`" in prompt
+        for action in ("land_core_defer_edges", "redirect", "decompose", "elevate"):
+            assert f"`{action}`" not in prompt
         # The churn pattern (each cycle's bypass finding) is in the packet section.
         assert "force-push" in prompt
         assert "case-varied alias" in prompt
@@ -571,6 +573,17 @@ class TestTopologySignalReachesTheAdvisor:
         # The cycle history section is intact — this evidence is additive.
         assert "Review cycle history" in prompt
         assert "Cycle 3" in prompt
+
+    def test_prompt_can_be_shaped_to_the_current_gate_actions(self):
+        from theforge.task.advisor_prompts import build_advisor_prompt
+
+        prompt = build_advisor_prompt(
+            self._packet(dict(_TOPOLOGY_SIGNAL)),
+            ["defer_or_abandon"],
+        )
+
+        assert "`defer_or_abandon`" in prompt
+        assert "`accept`" not in prompt
 
     def test_prompt_does_not_claim_cycles_were_exhausted_on_an_early_escalation(self):
         from theforge.task.advisor_prompts import build_advisor_prompt


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] No P1 regressions found; non-executable named escalation actions are no longer offered, and stale/manual selections are recorded as declined rather than resolved. | [anthropic-opus-cli] Iteration 1 addressed every prior P2: the withheld set is now derived from the taxonomy's named disposition, the advisor prompt is shaped to the executable actions, the dead by-advice branch is gone, and the CLI reference no longer documents a land_core_defer_edges resume. Gate verdict PASS matches HEAD 00797d27 so I did not rerun it; the 100 tests across the four touched test files pass, and imports of the new module-level dependency are clean. Two non-blocking P2s remain, both in code this iteration touched.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $5.22
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/task/advisor_prompts.py:234`** The advisor prompt now instructs the model to recommend only from the currently executable actions and renders a taxonomy section that excludes the four withheld ones, but the illustrative report block immediately below still hardcodes an option with action 'elevate' and pairs the recommendation placeholder — which now resolves to accept or defer_or_abandon — with the redirect rationale and the 're-run with constraint' forge operation.
- **[P2] `src/theforge/coordinator/escalate_actions.py:11`** The module docstring still states 'Stdlib-only by design' while the module now imports theforge.escalation_advisor at module scope, which pulls in the third-party yaml dependency for every gate front-end that imports it.

## Story

An escalate-gate action an operator selects is recorded as resolving the escalation while none of the operation it names is performed (GitHub Issue #2504)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2504