### PR TITLE
Run summary generation produces output the artifact validator refuses, so an enabled knowledge corpus accumulates nothing

### DIFF
--- a/src/theforge/runners/adapters/deepseek.py
+++ b/src/theforge/runners/adapters/deepseek.py
@@ -82,7 +82,11 @@ def deepseek_request_kwargs(profile: "ModelProfile") -> dict[str, Any]:
 
 
 def _run_deepseek(
-    prompt: str, profile: "ModelProfile", secrets: dict[str, str] | None = None
+    prompt: str,
+    profile: "ModelProfile",
+    secrets: dict[str, str] | None = None,
+    *,
+    plain_text: bool = False,
 ) -> AgentResult:
     """Run via DeepSeek API (OpenAI-compatible Chat Completions).
 
@@ -95,8 +99,9 @@ def _run_deepseek(
         secrets,
         client=client,
         provider="deepseek",
-        response_format={"type": "json_object"},
+        response_format=None if plain_text else {"type": "json_object"},
         extra_kwargs=deepseek_request_kwargs(profile),
+        plain_text=plain_text,
     )
 
 

--- a/src/theforge/runners/adapters/openai.py
+++ b/src/theforge/runners/adapters/openai.py
@@ -119,6 +119,7 @@ def _openai_result(
     *,
     cache_read_tokens: int = 0,
     thinking_tokens: int = 0,
+    structured_data: Any = ...,
 ) -> AgentResult:
     """Build AgentResult from parsed OpenAI-compatible response fields."""
     cost = _estimate_cost(
@@ -150,7 +151,7 @@ def _openai_result(
         raw=raw,
         profile_name=profile.name,
         model_usage=(model_usage,),
-        structured_data=json.loads(output_text),
+        structured_data=json.loads(output_text) if structured_data is ... else structured_data,
     )
 
 
@@ -162,6 +163,8 @@ def _run_openai_chat(
     provider: str = "openai",
     response_format: dict[str, Any] | None = None,
     extra_kwargs: dict[str, Any] | None = None,
+    *,
+    plain_text: bool = False,
 ) -> AgentResult:
     """Run via OpenAI Chat Completions (/v1/chat/completions).
 
@@ -170,24 +173,26 @@ def _run_openai_chat(
     so a provider wrapper can state a control this generic path knows nothing of,
     without that knowledge leaking back into the shared adapter.
     """
-    from theforge.schemas import review_json_schema
-
     if client is None:
         client = _openai_client(profile, secrets)
-    schema = review_json_schema()
-    if response_format is None:
-        response_format = {
-            "type": "json_schema",
-            "json_schema": {"name": "review_output", "schema": schema, "strict": True},
-        }
+    if not plain_text:
+        from theforge.schemas import review_json_schema
+
+        schema = review_json_schema()
+        if response_format is None:
+            response_format = {
+                "type": "json_schema",
+                "json_schema": {"name": "review_output", "schema": schema, "strict": True},
+            }
     try:
         create_kwargs: dict[str, Any] = {
             "model": profile.model,
             "messages": [{"role": "user", "content": prompt}],
-            "response_format": response_format,
             **sampling_control_kwargs(),
             **(extra_kwargs or {}),
         }
+        if response_format is not None:
+            create_kwargs["response_format"] = response_format
         response = client.chat.completions.create(**create_kwargs)
         output_text = response.choices[0].message.content or ""
         chat_usage = _read_chat_usage(response.usage)
@@ -200,6 +205,7 @@ def _run_openai_chat(
             provider=provider,
             cache_read_tokens=chat_usage.cache_read_tokens,
             thinking_tokens=chat_usage.thinking_tokens,
+            structured_data=None if plain_text else ...,
         )
     except Exception as e:
         return AgentResult(
@@ -214,26 +220,32 @@ def _run_openai_chat(
 
 
 def _run_openai_responses(
-    prompt: str, profile: "ModelProfile", secrets: dict[str, str] | None = None
+    prompt: str,
+    profile: "ModelProfile",
+    secrets: dict[str, str] | None = None,
+    *,
+    plain_text: bool = False,
 ) -> AgentResult:
     """Run via OpenAI Responses API (/v1/responses) — required for Codex models."""
-    from theforge.schemas import review_json_schema
-
     client = _openai_client(profile, secrets)
-    schema = review_json_schema()
     try:
-        response = client.responses.create(
-            model=profile.model,
-            input=prompt,
-            text={
+        create_kwargs: dict[str, Any] = {
+            "model": profile.model,
+            "input": prompt,
+        }
+        if not plain_text:
+            from theforge.schemas import review_json_schema
+
+            schema = review_json_schema()
+            create_kwargs["text"] = {
                 "format": {
                     "type": "json_schema",
                     "name": "review_output",
                     "schema": schema,
                     "strict": True,
                 }
-            },
-        )
+            }
+        response = client.responses.create(**create_kwargs)
         output_text = response.output_text
         usage = response.usage
         return _openai_result(
@@ -242,6 +254,7 @@ def _run_openai_responses(
             usage.input_tokens if usage else 0,
             usage.output_tokens if usage else 0,
             {},
+            structured_data=None if plain_text else ...,
         )
     except Exception as e:
         return AgentResult(
@@ -256,12 +269,16 @@ def _run_openai_responses(
 
 
 def _run_openai(
-    prompt: str, profile: "ModelProfile", secrets: dict[str, str] | None = None
+    prompt: str,
+    profile: "ModelProfile",
+    secrets: dict[str, str] | None = None,
+    *,
+    plain_text: bool = False,
 ) -> AgentResult:
     """Dispatch to Chat Completions or Responses API based on model."""
     if uses_openai_responses_api(profile.model):
-        return _run_openai_responses(prompt, profile, secrets)
-    return _run_openai_chat(prompt, profile, secrets)
+        return _run_openai_responses(prompt, profile, secrets, plain_text=plain_text)
+    return _run_openai_chat(prompt, profile, secrets, plain_text=plain_text)
 
 
 def _make_openai_usage(usage: Any, model: str) -> ModelUsage | None:

--- a/src/theforge/runners/api.py
+++ b/src/theforge/runners/api.py
@@ -1008,8 +1008,8 @@ def _run_single_api_model(
 
     Does not handle model-preference iteration — that lives in run_api_agent.
     """
-    if profile.provider == "google" and plain_text:
-        runner_fn = PROVIDER_RUNNERS.get(profile.provider)
+    runner_fn = PROVIDER_RUNNERS.get(profile.provider)
+    if plain_text and (profile.provider == "google" or not profile.allowed_tools):
         if not runner_fn:
             return AgentResult(
                 success=False,
@@ -1021,20 +1021,7 @@ def _run_single_api_model(
                 profile_name=profile.name,
             )
         return runner_fn(prompt, profile, secrets, plain_text=True)
-    elif profile.provider == "anthropic" and plain_text and not profile.allowed_tools:
-        runner_fn = PROVIDER_RUNNERS.get(profile.provider)
-        if not runner_fn:
-            return AgentResult(
-                success=False,
-                output=f"Unknown API provider: {profile.provider}",
-                session_id=None,
-                cost_usd=None,
-                exit_code=1,
-                raw={},
-                profile_name=profile.name,
-            )
-        return runner_fn(prompt, profile, secrets, plain_text=True)
-    elif profile.allowed_tools:
+    if profile.allowed_tools:
         loop_runner = _LOOP_RUNNERS.get(profile.provider)
         if not loop_runner:
             return AgentResult(
@@ -1047,19 +1034,17 @@ def _run_single_api_model(
                 profile_name=profile.name,
             )
         return loop_runner(prompt, profile, working_dir, secrets, progress_cb=progress_cb)
-    else:
-        runner_fn = PROVIDER_RUNNERS.get(profile.provider)
-        if not runner_fn:
-            return AgentResult(
-                success=False,
-                output=f"Unknown API provider: {profile.provider}",
-                session_id=None,
-                cost_usd=None,
-                exit_code=1,
-                raw={},
-                profile_name=profile.name,
-            )
-        return runner_fn(prompt, profile, secrets)
+    if not runner_fn:
+        return AgentResult(
+            success=False,
+            output=f"Unknown API provider: {profile.provider}",
+            session_id=None,
+            cost_usd=None,
+            exit_code=1,
+            raw={},
+            profile_name=profile.name,
+        )
+    return runner_fn(prompt, profile, secrets)
 
 
 def _estimated_provenance(provider: str | None, model: str | None) -> str:

--- a/tests/test_coord_knowledge_summary.py
+++ b/tests/test_coord_knowledge_summary.py
@@ -83,7 +83,13 @@ class _FakeAgentResult:
         self.transport_used = "api"
 
 
-def _make_config(project_root: Path, *, run_summaries: bool = True) -> ForgeConfig:
+def _make_config(
+    project_root: Path,
+    *,
+    run_summaries: bool = True,
+    provider: str = "anthropic",
+    model: str | None = None,
+) -> ForgeConfig:
     """A config whose plan model dispatches over an API transport.
 
     The API transport is the containment property under test, not incidental
@@ -111,10 +117,10 @@ def _make_config(project_root: Path, *, run_summaries: bool = True) -> ForgeConf
         plan=PlanConfig(
             enabled=True,
             ref=ModelRef(
-                model="claude-sonnet-4-5",
+                model=model or ("claude-sonnet-4-5" if provider == "anthropic" else "gpt-5.4"),
                 budget_usd=0.5,
                 timeout_seconds=300,
-                provider="anthropic",
+                provider=provider,
             ),
         ),
         knowledge=KnowledgeConfig(run_summaries=run_summaries),
@@ -215,15 +221,15 @@ class TestGeneration:
         from theforge import runners as runner_exports
         from theforge.runners.cli import run_agent as real_run_agent
 
-        config = _make_config(tmp_path)
+        config = _make_config(tmp_path, provider="openai", model="gpt-5.4")
         loop_runner = MagicMock()
         single_shot_runner = MagicMock(return_value=_FakeAgentResult())
 
         monkeypatch.setattr(runner_exports, "run_agent", real_run_agent)
         monkeypatch.setattr(knowledge_summary_flow, "run_agent", None)
         with (
-            patch.dict("theforge.runners.api._LOOP_RUNNERS", {"anthropic": loop_runner}),
-            patch.dict("theforge.runners.api.PROVIDER_RUNNERS", {"anthropic": single_shot_runner}),
+            patch.dict("theforge.runners.api._LOOP_RUNNERS", {"openai": loop_runner}),
+            patch.dict("theforge.runners.api.PROVIDER_RUNNERS", {"openai": single_shot_runner}),
         ):
             path = knowledge_summary_flow.maybe_generate_run_summary(
                 config, _done_result(), _audit()

--- a/tests/test_runner_api_providers.py
+++ b/tests/test_runner_api_providers.py
@@ -335,6 +335,28 @@ class TestRunApiAgentLoopIntegration:
         loop_runner.assert_called_once_with("summarize", profile, tmp_path, None, progress_cb=None)
         single_shot_runner.assert_not_called()
 
+    def test_openai_plain_text_tool_free_uses_single_shot_runner(self, tmp_path):
+        profile = _make_profile(
+            provider="openai",
+            model="gpt-5.4",
+            allowed_tools=(),
+        )
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.cost_usd = None
+
+        single_shot_runner = MagicMock(return_value=mock_result)
+        with patch.dict("theforge.runners.api.PROVIDER_RUNNERS", {"openai": single_shot_runner}):
+            run_api_agent(
+                prompt="summarize",
+                profile=profile,
+                working_dir=tmp_path,
+                quiet=True,
+                plain_text=True,
+            )
+
+        single_shot_runner.assert_called_once_with("summarize", profile, None, plain_text=True)
+
     def test_run_api_agent_no_provider_returns_failure(self, tmp_path):
         profile = ModelProfile(
             name="no-provider",

--- a/tests/test_runner_api_providers.py
+++ b/tests/test_runner_api_providers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import time
 from unittest.mock import MagicMock, patch
@@ -12,6 +13,7 @@ from theforge.agent_types import ModelUsage
 from theforge.config import ModelProfile
 from theforge.runners.adapters.deepseek import _deepseek_client, _run_deepseek
 from theforge.runners.api import (
+    PROVIDER_RUNNERS,
     AgentLoopManager,
     run_api_agent,
 )
@@ -608,6 +610,39 @@ class TestDeepSeekProvider:
         assert result.success
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert "temperature" not in call_kwargs
+
+    def test_run_deepseek_plain_text_omits_structured_response_format(self, tmp_path):
+        profile = self._make_deepseek_profile(model="deepseek-v3")
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "plain text summary"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.model_dump.return_value = {}
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch(
+            "theforge.runners.adapters.deepseek._deepseek_client", return_value=mock_client
+        ):
+            result = _run_deepseek("summarize this", profile, plain_text=True)
+
+        assert result.success
+        assert result.output == "plain text summary"
+        assert result.structured_data is None
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert "response_format" not in call_kwargs
+
+    def test_all_single_shot_provider_runners_accept_plain_text(self):
+        for provider, runner in PROVIDER_RUNNERS.items():
+            signature = inspect.signature(runner)
+            plain_text = signature.parameters.get("plain_text")
+            assert plain_text is not None, f"{provider} runner must accept plain_text"
+            assert plain_text.kind is inspect.Parameter.KEYWORD_ONLY, (
+                f"{provider} runner must accept plain_text as keyword-only"
+            )
+            assert plain_text.default is False, (
+                f"{provider} runner must default plain_text to False"
+            )
 
     # ── _run_loop_deepseek dispatch ───────────────────────────────────
 

--- a/tests/test_runner_sampling_controls.py
+++ b/tests/test_runner_sampling_controls.py
@@ -69,6 +69,16 @@ def _openai_chat_client() -> MagicMock:
     return client
 
 
+def _openai_responses_client(output_text: str = REVIEW_JSON) -> MagicMock:
+    client = MagicMock()
+    response = MagicMock()
+    response.output_text = output_text
+    response.usage.input_tokens = 10
+    response.usage.output_tokens = 5
+    client.responses.create.return_value = response
+    return client
+
+
 class TestSamplingControlPolicy:
     """The shared decision point sends no optional sampling controls."""
 
@@ -123,6 +133,47 @@ class TestOpenAICompatibleRequests:
         kwargs = client.chat.completions.create.call_args.kwargs
         assert "temperature" not in kwargs
         assert kwargs["response_format"]["type"] == "json_schema"
+
+    @pytest.mark.parametrize("model", FUTURE_AND_CURRENT_MODELS)
+    def test_single_shot_plain_text_omits_forced_schema(self, model):
+        from theforge.runners.adapters.openai import _run_openai_chat
+
+        client = _openai_chat_client()
+        client.chat.completions.create.return_value.choices[
+            0
+        ].message.content = "run_summary:\n  summary: kept as text"
+
+        result = _run_openai_chat(
+            "summarize this",
+            _profile(model=model),
+            client=client,
+            plain_text=True,
+        )
+
+        assert result.success
+        assert result.output == "run_summary:\n  summary: kept as text"
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert "response_format" not in kwargs
+
+    def test_responses_single_shot_plain_text_omits_forced_schema(self):
+        from theforge.runners.adapters.openai import _run_openai_responses
+
+        client = _openai_responses_client("run_summary:\n  summary: kept as text")
+        with patch(
+            "theforge.runners.adapters.openai._openai_client",
+            return_value=client,
+        ):
+            result = _run_openai_responses(
+                "summarize this",
+                _profile(model="gpt-5.1-codex"),
+                plain_text=True,
+            )
+
+        assert result.success
+        assert result.output == "run_summary:\n  summary: kept as text"
+        kwargs = client.responses.create.call_args.kwargs
+        assert kwargs == {"model": "gpt-5.1-codex", "input": "summarize this"}
 
     @pytest.mark.parametrize("model", FUTURE_AND_CURRENT_MODELS)
     def test_loop_adapter_omits_temperature_and_keeps_tools(self, model):


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The prior DeepSeek plain-text TypeError is resolved, and the touched provider dispatch paths now preserve plain-text summary output without introducing a blocking regression. | [anthropic-opus-cli] Cycle 1's DeepSeek TypeError is fixed and verified live — a tool-free DeepSeek plain-text dispatch now returns plain text instead of raising; all four registered single-shot runners share the keyword-only plain_text contract, and 120 related tests pass. Note: the dev handoff omitted commit 3efac08c from its commit list even though it is on the branch.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $3.82
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Run summary generation produces output the artifact validator refuses, so an enabled knowledge corpus accumulates nothing (GitHub Issue #2501)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2501