### PR TITLE
Preflight cache invalidation reports one cause when several fingerprint components changed at once

### DIFF
--- a/src/theforge/coordinator/preflight_cache.py
+++ b/src/theforge/coordinator/preflight_cache.py
@@ -97,24 +97,21 @@ def validate_preflight_cache(
         validation["reason"] = "git_state_unavailable"
         return False, validation
 
+    mismatch_reasons: list[str] = []
     if snapshot["evaluation_base_branch"] != current_base_branch:
-        validation["status"] = "invalidated"
-        validation["reason"] = "evaluation_base_branch_changed"
-        return False, validation
-
+        mismatch_reasons.append("evaluation_base_branch_changed")
     if snapshot["worktree_head"] != current_worktree_head:
-        validation["status"] = "invalidated"
-        validation["reason"] = "worktree_head_changed"
-        return False, validation
-
+        mismatch_reasons.append("worktree_head_changed")
     if snapshot["evaluation_base_branch_head"] != current_base_branch_head:
-        validation["status"] = "invalidated"
-        validation["reason"] = "evaluation_base_branch_head_changed"
-        return False, validation
-
+        mismatch_reasons.append("evaluation_base_branch_head_changed")
     if snapshot["story_content_hash"] != current_story_content_hash:
+        mismatch_reasons.append("story_content_changed")
+
+    if mismatch_reasons:
         validation["status"] = "invalidated"
-        validation["reason"] = "story_content_changed"
+        validation["reason"] = mismatch_reasons[0]
+        if len(mismatch_reasons) > 1:
+            validation["reasons"] = mismatch_reasons
         return False, validation
 
     validation["status"] = "accepted"

--- a/src/theforge/coordinator/preflight_cache.py
+++ b/src/theforge/coordinator/preflight_cache.py
@@ -24,6 +24,12 @@ def _story_content_hash(story_content: str) -> str:
     return hashlib.sha256(story_content.encode("utf-8")).hexdigest()
 
 
+def _cache_mismatch_reason(mismatch_reasons: list[str]) -> str:
+    if len(mismatch_reasons) == 1:
+        return mismatch_reasons[0]
+    return "multiple_components_changed:" + ",".join(mismatch_reasons)
+
+
 def capture_preflight_cache_snapshot(
     *,
     config: "ForgeConfig",
@@ -109,9 +115,8 @@ def validate_preflight_cache(
 
     if mismatch_reasons:
         validation["status"] = "invalidated"
-        validation["reason"] = mismatch_reasons[0]
-        if len(mismatch_reasons) > 1:
-            validation["reasons"] = mismatch_reasons
+        validation["reason"] = _cache_mismatch_reason(mismatch_reasons)
+        validation["reasons"] = mismatch_reasons
         return False, validation
 
     validation["status"] = "accepted"

--- a/tests/test_coord_preflight_cached.py
+++ b/tests/test_coord_preflight_cached.py
@@ -260,6 +260,7 @@ criteria_checked: []
         assert result.state.preflight_verdict == "PROCEED"
         assert result.state.preflight_cache_validation["status"] == "invalidated"
         assert result.state.preflight_cache_validation["reason"] == "worktree_head_changed"
+        assert result.state.preflight_cache_validation["reasons"] == ["worktree_head_changed"]
 
     def test_stale_cached_preflight_reports_all_diverged_fingerprint_components(self, tmp_path):
         """Simultaneous fingerprint divergence must be reported in stable order."""
@@ -327,7 +328,9 @@ criteria_checked: []
         assert result.state.preflight_cached is False
         assert result.state.preflight_verdict == "PROCEED"
         assert result.state.preflight_cache_validation["status"] == "invalidated"
-        assert result.state.preflight_cache_validation["reason"] == "worktree_head_changed"
+        assert result.state.preflight_cache_validation["reason"] == (
+            "multiple_components_changed:worktree_head_changed,evaluation_base_branch_head_changed"
+        )
         assert result.state.preflight_cache_validation["reasons"] == [
             "worktree_head_changed",
             "evaluation_base_branch_head_changed",
@@ -399,6 +402,7 @@ criteria_checked: []
         assert result.state.preflight_verdict == "PROCEED"
         assert result.state.preflight_cache_validation["status"] == "invalidated"
         assert result.state.preflight_cache_validation["reason"] == "story_content_changed"
+        assert result.state.preflight_cache_validation["reasons"] == ["story_content_changed"]
 
 
 class TestResumeStaleCacheRerunsPreflight:

--- a/tests/test_coord_preflight_cached.py
+++ b/tests/test_coord_preflight_cached.py
@@ -261,6 +261,78 @@ criteria_checked: []
         assert result.state.preflight_cache_validation["status"] == "invalidated"
         assert result.state.preflight_cache_validation["reason"] == "worktree_head_changed"
 
+    def test_stale_cached_preflight_reports_all_diverged_fingerprint_components(self, tmp_path):
+        """Simultaneous fingerprint divergence must be reported in stable order."""
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        cached_state = replace(
+            CoordinatorState(),
+            preflight_verdict="ALREADY_DONE",
+            preflight_reason="Stale cached verdict.",
+            preflight_complexity="medium",
+            preflight_sufficiency="implementation_ready",
+            preflight_work_type="feature",
+            preflight_cache_snapshot={
+                "worktree_head": "old-head",
+                "evaluation_base_branch": "main",
+                "evaluation_base_branch_head": "old-head",
+                "story_content_hash": _TEST_STORY_CONTENT_HASH,
+            },
+        )
+
+        fresh_preflight = _make_agent_result(
+            output="""\
+```yaml
+verdict: PROCEED
+complexity: small
+sufficiency: implementation_ready
+work_type: bug
+reason: "Heads changed; reevaluated."
+criteria_checked: []
+```
+""",
+            profile_name="preflight",
+        )
+
+        def shell_side_effect(cmd, cwd, **kwargs):
+            rendered = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            if rendered.startswith("git rev-parse "):
+                return (True, "new-head")
+            if rendered.startswith("mkdir -p "):
+                Path(cwd, rendered.removeprefix("mkdir -p ").strip()).mkdir(
+                    parents=True, exist_ok=True
+                )
+                return (True, "")
+            return (True, "")
+
+        with (
+            patch("theforge.coordinator.util._run_shell", side_effect=shell_side_effect),
+            patch(
+                "theforge.coordinator.preflight_flow.run_agent",
+                return_value=fresh_preflight,
+            ) as mock_preflight,
+        ):
+            result = run_task(
+                config,
+                task,
+                cached_preflight_state=cached_state,
+                stop_phase=Phase.PREFLIGHT,
+            )
+
+        assert result.success is True
+        assert mock_preflight.call_count == 1
+        assert result.state.preflight_cached is False
+        assert result.state.preflight_verdict == "PROCEED"
+        assert result.state.preflight_cache_validation["status"] == "invalidated"
+        assert result.state.preflight_cache_validation["reason"] == "worktree_head_changed"
+        assert result.state.preflight_cache_validation["reasons"] == [
+            "worktree_head_changed",
+            "evaluation_base_branch_head_changed",
+        ]
+
     def test_rewritten_story_body_invalidates_cache_despite_unchanged_git_state(self, tmp_path):
         """A re-scoped story must not reuse a preflight verdict from its old text.
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The prior P1 is resolved: simultaneous fingerprint mismatches are now reported with all diverged components, and the regression test covers the original worktree/base-head movement case. | [anthropic-opus-cli] Cycle 1 P1 is resolved — the scalar reason is now the self-describing multiple_components_changed token for simultaneous divergence and the reasons list is emitted on every component-mismatch record; no regressions found and the authoritative gate is PASS at the reviewed HEAD.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $2.61
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Preflight cache invalidation reports one cause when several fingerprint components changed at once (GitHub Issue #2138)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2138