### PR TITLE
A config-contract change is validated by the runtime it replaces, so correct work is rejected

### DIFF
--- a/src/theforge/cli/batch_report.py
+++ b/src/theforge/cli/batch_report.py
@@ -13,7 +13,7 @@ import json
 import sys
 from pathlib import Path
 
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.config import load_config
 
 
@@ -38,7 +38,11 @@ def cmd_batch_report(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
 
     run_id = args.run_id
     summary_path = find_sprint_summary(run_id, config.project_root)

--- a/src/theforge/cli/check_config.py
+++ b/src/theforge/cli/check_config.py
@@ -8,7 +8,7 @@ from datetime import date
 from pathlib import Path
 
 from theforge.cli.hooks import post_run_hook_upgrade_warnings
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, print_config_load_error
 from theforge.config import (
     ForgeConfig,
     ModelProfile,
@@ -763,6 +763,9 @@ def cmd_check_config(args: object) -> int:
     config_logger.addHandler(log_handler)
     try:
         config = load_config(config_path)
+    except ValueError as exc:
+        print_config_load_error(config_path, exc, prefix="[check-config] Invalid config")
+        return 2
     except Exception as exc:
         print(f"[check-config] Invalid config: {exc}", file=sys.stderr)
         return 2

--- a/src/theforge/cli/daemon.py
+++ b/src/theforge/cli/daemon.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.config import load_config
 
 
@@ -69,7 +69,11 @@ def cmd_daemon(args: object) -> int:
                 file=sys.stderr,
             )
             return 1
-        config = load_config(config_path)
+        config = load_config_checked(
+            config_path,
+            loader=load_config,
+            emit_startup_auth_warnings=False,
+        )
         if _daemon.is_daemon_running(config.project_root):
             state = _daemon.get_daemon_status(config.project_root)
             pid = state.get("pid", "?")
@@ -93,7 +97,11 @@ def cmd_daemon(args: object) -> int:
         if config_path is None or not config_path.exists():
             print("forge.yaml not found.", file=sys.stderr)
             return 1
-        config = load_config(config_path)
+        config = load_config_checked(
+            config_path,
+            loader=load_config,
+            emit_startup_auth_warnings=False,
+        )
         if not _daemon.is_daemon_running(config.project_root):
             print("No daemon running.")
             return 0
@@ -110,7 +118,11 @@ def cmd_daemon(args: object) -> int:
         if config_path is None or not config_path.exists():
             print("forge.yaml not found.", file=sys.stderr)
             return 1
-        config = load_config(config_path)
+        config = load_config_checked(
+            config_path,
+            loader=load_config,
+            emit_startup_auth_warnings=False,
+        )
         state = _daemon.get_daemon_status(config.project_root)
         _print_daemon_status(state)
         return 0
@@ -122,7 +134,11 @@ def cmd_daemon(args: object) -> int:
         if config_path is None or not config_path.exists():
             print("forge.yaml not found.", file=sys.stderr)
             return 1
-        config = load_config(config_path)
+        config = load_config_checked(
+            config_path,
+            loader=load_config,
+            emit_startup_auth_warnings=False,
+        )
         forge_bin = shutil.which("forge")
         if forge_bin is None:
             print("'forge' binary not found in PATH.", file=sys.stderr)

--- a/src/theforge/cli/diagnose.py
+++ b/src/theforge/cli/diagnose.py
@@ -11,7 +11,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.config import load_config
 from theforge.coordinator.diagnose_flow import run_diagnose_flow
 from theforge.coordinator.log_tee import set_worker_slug
@@ -52,7 +52,11 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
 
     destination = args.output_destination or config.diagnose.output_destination
     if destination not in DIAGNOSE_OUTPUT_DESTINATIONS:

--- a/src/theforge/cli/eval_cmd.py
+++ b/src/theforge/cli/eval_cmd.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 
 
 def _infer_profile(
@@ -106,7 +106,11 @@ def cmd_eval_preflight(args: object) -> int:
         print("[eval-preflight] No forge.yaml found", file=sys.stderr)
         return 1
 
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
 
     # ── Golden set ───────────────────────────────────────────────────────────
     golden_set_path_str = getattr(args, "golden_set", None)

--- a/src/theforge/cli/forge_yaml_guard.py
+++ b/src/theforge/cli/forge_yaml_guard.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import yaml
 
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, print_config_load_error
 from theforge.config import load_config
 from theforge.task import (
     ALLOW_MUTATE_FORGE_YAML_KEY,
@@ -301,11 +301,19 @@ def cmd_check_story_config(args: argparse.Namespace) -> int:
 
     try:
         config = load_config(config_path)
+    except ValueError as exc:
+        print_config_load_error(
+            config_path,
+            exc,
+            prefix="forge.yaml story-mutation guard failed",
+        )
+        return 2
+    try:
         result = evaluate_forge_yaml_guard(
             config.project_root,
             base_branch=config.workspace.base_branch,
         )
-    except (RuntimeError, ValueError) as exc:
+    except RuntimeError as exc:
         print(f"forge.yaml story-mutation guard failed: {exc}", file=sys.stderr)
         return 1
 

--- a/src/theforge/cli/forge_yaml_guard.py
+++ b/src/theforge/cli/forge_yaml_guard.py
@@ -313,7 +313,7 @@ def cmd_check_story_config(args: argparse.Namespace) -> int:
             config.project_root,
             base_branch=config.workspace.base_branch,
         )
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         print(f"forge.yaml story-mutation guard failed: {exc}", file=sys.stderr)
         return 1
 

--- a/src/theforge/cli/ideate.py
+++ b/src/theforge/cli/ideate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import yaml
 
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.config import load_config
 from theforge.ideate import generate_ideation_audit, run_ideation
 from theforge.runners import LogLevel
@@ -45,11 +45,11 @@ def cmd_ideate(args: object) -> int:
         )
         return 1
 
-    try:
-        config = load_config(config_path)
-    except ValueError as exc:
-        print(f"Configuration error: {exc}", file=sys.stderr)
-        return 1
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
 
     if getattr(args, "verbose", False):
         runner_set_log_level(LogLevel.VERBOSE)

--- a/src/theforge/cli/index.py
+++ b/src/theforge/cli/index.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.indexer import INDEX_PATH, generate_index
 from theforge.invariant_index import rebuild_invariant_index
 from theforge.knowledge_index import rebuild_knowledge_index
@@ -26,7 +26,11 @@ def cmd_index(args: argparse.Namespace) -> int:
     if getattr(args, "invariants", False):
         from theforge.config.load import load_config  # noqa: PLC0415
 
-        config = load_config(config_path)
+        config = load_config_checked(
+            config_path,
+            loader=load_config,
+            emit_startup_auth_warnings=False,
+        )
         result = rebuild_invariant_index(project_root, config.knowledge.invariant_sources)
         for diagnostic in result.diagnostics:
             print(

--- a/src/theforge/cli/providers.py
+++ b/src/theforge/cli/providers.py
@@ -13,7 +13,7 @@ from theforge.cli.provider_readiness import (
     capability_observations,
     run_readiness_probe,
 )
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.config import load_config
 from theforge.model_capabilities import (
     capabilities_path,
@@ -36,7 +36,11 @@ def cmd_check_providers(args: object) -> int:
         print("[check-providers] No forge.yaml found", file=sys.stderr)
         return 1
 
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
     probes = build_readiness_probes(config)
 
     # Optional single-profile filter.

--- a/src/theforge/cli/rca.py
+++ b/src/theforge/cli/rca.py
@@ -12,7 +12,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.config import load_config
 
 
@@ -61,7 +61,11 @@ def cmd_rca(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
     project_root = config.project_root
 
     run_id = args.run_id

--- a/src/theforge/cli/review.py
+++ b/src/theforge/cli/review.py
@@ -6,7 +6,7 @@ import sys
 from dataclasses import replace
 from pathlib import Path
 
-from theforge.cli.shared import _build_task, _find_config, _write_audit
+from theforge.cli.shared import _build_task, _find_config, _write_audit, load_config_checked
 from theforge.config import load_config
 from theforge.coordinator.engine import run_from_review
 from theforge.coordinator.run_setup import REENTRY_MODE_REVIEW
@@ -66,7 +66,11 @@ def cmd_review(args: object) -> int:
         coordinator_set_log_level(LogLevel.VERBOSE)
         runner_set_log_level(LogLevel.VERBOSE)
 
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
     if story_path is not None:
         task = _build_task(story_path, slug=args.slug)
     else:

--- a/src/theforge/cli/shared.py
+++ b/src/theforge/cli/shared.py
@@ -187,10 +187,28 @@ def _print_startup_auth_warnings(config: ForgeConfig) -> None:
         )
 
 
+def print_config_load_error(
+    config_path: Path,
+    exc: ValueError,
+    *,
+    prefix: str = "✗ forge.yaml is invalid",
+) -> None:
+    """Print a structural config error plus runtime/checkout provenance, if any."""
+    print(f"{prefix}: {exc}", file=sys.stderr)
+    try:
+        from theforge.cli.substrate import format_config_validation_provenance_lines
+
+        for line in format_config_validation_provenance_lines(config_path=config_path):
+            print(line, file=sys.stderr)
+    except Exception:
+        pass
+
+
 def load_config_checked(
     config_path: Path,
     *,
     loader: Callable[[Path], ForgeConfig] | None = None,
+    emit_startup_auth_warnings: bool = True,
 ) -> ForgeConfig:
     """Load config for a run/sprint entrypoint, enforcing startup contracts.
 
@@ -209,9 +227,10 @@ def load_config_checked(
     try:
         config = load(config_path)
     except ValueError as exc:
-        print(f"✗ forge.yaml is invalid: {exc}", file=sys.stderr)
+        print_config_load_error(config_path, exc)
         raise SystemExit(2) from exc
-    _print_startup_auth_warnings(config)
+    if emit_startup_auth_warnings:
+        _print_startup_auth_warnings(config)
     return config
 
 

--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -9,6 +9,7 @@ import textwrap
 from pathlib import Path
 
 from theforge.cli.reentry_display import issue_cost_line
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.coordinator.issue_cost import issue_number_from_slug
 from theforge.coordinator.util import _fmt_cost_total
 
@@ -362,7 +363,6 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
 
 def cmd_sprint_status(args: object) -> int:
     """Show per-story status for a sprint run."""
-    from theforge.cli.shared import _find_config
     from theforge.config import load_config
 
     run_id: str = getattr(args, "run_id", "")
@@ -374,7 +374,11 @@ def cmd_sprint_status(args: object) -> int:
     if config_path is None or not config_path.exists():
         print("forge.yaml not found.", file=sys.stderr)
         return 1
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
     project_root = config.project_root
 
     return display_sprint_status(run_id, project_root)

--- a/src/theforge/cli/status.py
+++ b/src/theforge/cli/status.py
@@ -9,7 +9,7 @@ import sys
 import time
 from pathlib import Path
 
-from theforge.cli.shared import _find_config
+from theforge.cli.shared import _find_config, load_config_checked
 from theforge.cli.status_run_helpers import is_diagnose_run as _is_diagnose_run
 from theforge.cli.status_run_helpers import is_sprint_run as _is_sprint_run
 from theforge.config import load_config
@@ -467,7 +467,11 @@ def cmd_status(args: object) -> int:
     if config_path is None or not config_path.exists():
         print("forge.yaml not found.", file=sys.stderr)
         return 1
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
     project_root = config.project_root
 
     # Report — never signal — agent process groups orphaned by an abruptly-killed
@@ -763,7 +767,11 @@ def cmd_logs(args: object) -> int:
     if config_path is None or not config_path.exists():
         print("forge.yaml not found.", file=sys.stderr)
         return 1
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
     project_root = config.project_root
     run_id = args.run_id
 
@@ -923,7 +931,11 @@ def cmd_stop(args: object) -> int:
     if config_path is None or not config_path.exists():
         print("forge.yaml not found.", file=sys.stderr)
         return 1
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
     project_root = config.project_root
     run_id = args.run_id
 
@@ -1005,7 +1017,11 @@ def cmd_runs_clean(args: object) -> int:
     if config_path is None or not config_path.exists():
         print("forge.yaml not found.", file=sys.stderr)
         return 1
-    config = load_config(config_path)
+    config = load_config_checked(
+        config_path,
+        loader=load_config,
+        emit_startup_auth_warnings=False,
+    )
     project_root = config.project_root
 
     logs_dir = project_root / ".forge" / "logs"

--- a/src/theforge/cli/substrate.py
+++ b/src/theforge/cli/substrate.py
@@ -222,6 +222,26 @@ def _runtime_schema_catalog_paths(sub: Substrate) -> tuple[str, str] | None:
     )
 
 
+def _format_config_validation_relation_line(checkout_version: str, runtime_version: str) -> str:
+    """Describe the version relationship without over-claiming causality."""
+    version_cmp = _checkout_version_ahead_of_runtime(checkout_version, runtime_version)
+    if version_cmp is True:
+        relation = "appears ahead of it"
+        explanation = "That runtime/checkout drift may explain this validation failure."
+    elif version_cmp is False:
+        relation = "does not appear ahead of it"
+        explanation = "The version mismatch may or may not explain this validation failure."
+    else:
+        relation = "differs from it, but their version order could not be determined"
+        explanation = "That version mismatch may explain this validation failure."
+
+    return (
+        f"[forge] This installed runtime is judging a checkout that {relation}. "
+        f"{explanation} Use the checkout-local launcher (for example "
+        "`.venv/bin/forge`) or repoint the managed launcher, then retry."
+    )
+
+
 def format_provenance_lines(sub: Substrate | None = None) -> list[str]:
     """Return operator-facing substrate lines for launch banners.
 
@@ -299,7 +319,7 @@ def format_config_validation_provenance_lines(
     cwd: Path | None = None,
     sub: Substrate | None = None,
 ) -> list[str]:
-    """Return extra context for a config ValueError caused by runtime drift.
+    """Return extra context for a config ValueError when runtime drift is visible.
 
     Silent on the documented dogfood happy path unless a structural config
     failure occurs under a non-editable runtime whose version differs from the
@@ -316,11 +336,6 @@ def format_config_validation_provenance_lines(
         return []
 
     schema_catalog = _runtime_schema_catalog_paths(sub)
-    version_cmp = _checkout_version_ahead_of_runtime(checkout.version, sub.version)
-    if version_cmp is False:
-        relation = "does not match it"
-    else:
-        relation = "appears ahead of it"
 
     lines = [
         "[forge] Runtime/checkout mismatch: this installed runtime is validating a "
@@ -341,9 +356,7 @@ def format_config_validation_provenance_lines(
         [
             f"[forge] Checkout root:   {checkout.root}",
             f"[forge] Checkout version: {checkout.version}",
-            f"[forge] This installed runtime is judging a checkout that {relation}. "
-            "Use the checkout-local launcher (for example `.venv/bin/forge`) or "
-            "repoint the managed launcher, then retry.",
+            _format_config_validation_relation_line(checkout.version, sub.version),
         ]
     )
     return lines

--- a/src/theforge/cli/substrate.py
+++ b/src/theforge/cli/substrate.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -34,6 +35,13 @@ class Substrate:
     editable: bool
     source_root: str | None
     git_ref: str | None
+
+
+@dataclass(frozen=True)
+class CheckoutProvenance:
+    root: str
+    pyproject_file: str
+    version: str | None
 
 
 def _read_direct_url_editable(dist_files_root: Path) -> tuple[bool, str | None]:
@@ -159,6 +167,61 @@ def detect_substrate() -> Substrate:
     )
 
 
+def _read_checkout_provenance(pyproject: Path) -> CheckoutProvenance | None:
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    project = data.get("project")
+    if not isinstance(project, dict) or project.get("name") != "theforge":
+        return None
+
+    version = project.get("version")
+    if version is not None:
+        version = str(version)
+
+    return CheckoutProvenance(
+        root=str(pyproject.parent),
+        pyproject_file=str(pyproject),
+        version=version,
+    )
+
+
+def _find_checkout_provenance(cwd: Path) -> CheckoutProvenance | None:
+    for parent in [cwd, *cwd.parents]:
+        pyproject = parent / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        checkout = _read_checkout_provenance(pyproject)
+        if checkout is not None:
+            return checkout
+    return None
+
+
+def _checkout_version_ahead_of_runtime(checkout_version: str, runtime_version: str) -> bool | None:
+    try:
+        from packaging.version import InvalidVersion, Version
+    except Exception:
+        return None
+
+    try:
+        return Version(checkout_version) > Version(runtime_version)
+    except InvalidVersion:
+        return None
+
+
+def _runtime_schema_catalog_paths(sub: Substrate) -> tuple[str, str] | None:
+    package_file = sub.package_file
+    if not package_file:
+        return None
+    package_root = Path(package_file).resolve().parent
+    return (
+        str(package_root / "config" / "model_catalog.py"),
+        str(package_root / "config" / "data" / "models.yaml"),
+    )
+
+
 def format_provenance_lines(sub: Substrate | None = None) -> list[str]:
     """Return operator-facing substrate lines for launch banners.
 
@@ -201,16 +264,8 @@ def detect_mismatch(cwd: Path | None = None, sub: Substrate | None = None) -> st
         sub = detect_substrate()
 
     cwd = cwd or Path.cwd()
-    pyproject = cwd / "pyproject.toml"
-    if not pyproject.is_file():
-        return None
-
-    try:
-        text = pyproject.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return None
-
-    if 'name = "theforge"' not in text:
+    checkout = _find_checkout_provenance(cwd)
+    if checkout is None:
         return None
 
     # Released (non-editable) substrate orchestrating a newer-version theforge
@@ -220,14 +275,7 @@ def detect_mismatch(cwd: Path | None = None, sub: Substrate | None = None) -> st
     if not sub.editable:
         return None
 
-    src_version: str | None = None
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("version") and "=" in stripped:
-            _, _, rhs = stripped.partition("=")
-            src_version = rhs.strip().strip('"').strip("'")
-            break
-
+    src_version = checkout.version
     if not src_version:
         return None
 
@@ -238,11 +286,67 @@ def detect_mismatch(cwd: Path | None = None, sub: Substrate | None = None) -> st
     return (
         f"[forge] WARNING: substrate version {sub.version} (binary: {sub.binary});"
         f"{source_note} does not match this checkout's pyproject version "
-        f"{src_version} (cwd: {cwd}). The editable install resolving as `forge` "
+        f"{src_version} (cwd: {checkout.root}). The editable install resolving as `forge` "
         f"is out of sync with this checkout — either a stale build of this tree "
         f"or an editable install of a different theforge repo is shadowing it. "
         f"Pass --force to bypass."
     )
+
+
+def format_config_validation_provenance_lines(
+    *,
+    config_path: Path | None = None,
+    cwd: Path | None = None,
+    sub: Substrate | None = None,
+) -> list[str]:
+    """Return extra context for a config ValueError caused by runtime drift.
+
+    Silent on the documented dogfood happy path unless a structural config
+    failure occurs under a non-editable runtime whose version differs from the
+    checkout version that owns ``forge.yaml``.
+    """
+    if sub is None:
+        sub = detect_substrate()
+
+    start = cwd or (config_path.parent if config_path is not None else Path.cwd())
+    checkout = _find_checkout_provenance(start)
+    if checkout is None or checkout.version is None:
+        return []
+    if sub.editable or checkout.version == sub.version:
+        return []
+
+    schema_catalog = _runtime_schema_catalog_paths(sub)
+    version_cmp = _checkout_version_ahead_of_runtime(checkout.version, sub.version)
+    if version_cmp is False:
+        relation = "does not match it"
+    else:
+        relation = "appears ahead of it"
+
+    lines = [
+        "[forge] Runtime/checkout mismatch: this installed runtime is validating a "
+        "different checkout's forge.yaml.",
+        f"[forge] Runtime binary:  {sub.binary}",
+        f"[forge] Runtime package: {sub.package_file}",
+        f"[forge] Runtime version: {sub.version}",
+    ]
+    if schema_catalog is not None:
+        schema_path, catalog_path = schema_catalog
+        lines.extend(
+            [
+                f"[forge] Runtime schema:  {schema_path}",
+                f"[forge] Runtime catalog: {catalog_path}",
+            ]
+        )
+    lines.extend(
+        [
+            f"[forge] Checkout root:   {checkout.root}",
+            f"[forge] Checkout version: {checkout.version}",
+            f"[forge] This installed runtime is judging a checkout that {relation}. "
+            "Use the checkout-local launcher (for example `.venv/bin/forge`) or "
+            "repoint the managed launcher, then retry.",
+        ]
+    )
+    return lines
 
 
 def emit_provenance(

--- a/tests/test_cli_diagnose_parallel.py
+++ b/tests/test_cli_diagnose_parallel.py
@@ -16,7 +16,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from theforge.cli.diagnose import _run_diagnoses, cmd_diagnose, register_parser
+from theforge.cli.substrate import Substrate
 from theforge.coordinator import diagnose_flow
 from theforge.coordinator.diagnose_flow import _emit_dry_run, _run_agent_with_heartbeat
 from theforge.coordinator.log_tee import get_worker_slug, set_worker_slug
@@ -366,3 +369,40 @@ class TestCmdDiagnose:
 
         assert rc == 0
         assert "ignored in interactive mode" in capsys.readouterr().err
+
+    def test_stale_runtime_config_error_names_runtime_and_checkout(self, tmp_path, capsys):
+        cfg_path = tmp_path / "forge.yaml"
+        cfg_path.write_text("project: test\n", encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "theforge"\nversion = "0.15.0rc3"\n',
+            encoding="utf-8",
+        )
+        runtime = Substrate(
+            binary="/Users/me/.local/bin/forge",
+            package_file="/tmp/rc16/site-packages/theforge/__init__.py",
+            version="0.13.0rc16",
+            editable=False,
+            source_root=None,
+            git_ref=None,
+        )
+        err_msg = (
+            "Unknown model 'anthropic/sonnet/cli': not in AGENT_REGISTRY. "
+            "Known models: ['claude/opus']"
+        )
+
+        with (
+            patch("theforge.cli.diagnose._find_config", return_value=cfg_path),
+            patch("theforge.cli.diagnose.load_config", side_effect=ValueError(err_msg)),
+            patch("theforge.cli.substrate.detect_substrate", return_value=runtime),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_diagnose(self._args(issue=["1"]))
+
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert err_msg in err
+        assert "Runtime binary:  /Users/me/.local/bin/forge" in err
+        assert "Runtime version: 0.13.0rc16" in err
+        assert "Checkout version: 0.15.0rc3" in err
+        assert f"Checkout root:   {tmp_path}" in err
+        assert "appears ahead of it" in err

--- a/tests/test_cli_startup_config_warnings.py
+++ b/tests/test_cli_startup_config_warnings.py
@@ -8,12 +8,14 @@ config errors into exit code 2 rather than a generic exit-1 crash.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from theforge.cli import shared
+from theforge.cli.substrate import Substrate
 from theforge.config import ModelProfile
 
 
@@ -54,6 +56,19 @@ def _fake_config(**overrides) -> SimpleNamespace:
     )
     base.update(overrides)
     return SimpleNamespace(**base)
+
+
+def _installed_substrate(**overrides) -> Substrate:
+    base = dict(
+        binary="/Users/me/.local/bin/forge",
+        package_file="/tmp/rc16/site-packages/theforge/__init__.py",
+        version="0.13.0rc16",
+        editable=False,
+        source_root=None,
+        git_ref=None,
+    )
+    base.update(overrides)
+    return Substrate(**base)
 
 
 # ── Startup auth warnings ───────────────────────────────────────────────
@@ -155,6 +170,46 @@ def test_structural_error_exits_code_2(capsys):
     err = capsys.readouterr().err
     assert "forge.yaml is invalid" in err
     assert "bad key" in err
+
+
+def test_structural_error_includes_stale_runtime_provenance(tmp_path, capsys):
+    config_path = tmp_path / "forge.yaml"
+    config_path.write_text("project: test\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "theforge"\nversion = "0.15.0rc3"\n',
+        encoding="utf-8",
+    )
+    err_msg = (
+        "Unknown model 'anthropic/sonnet/cli': not in AGENT_REGISTRY. "
+        "Known models: ['claude/opus']"
+    )
+
+    with (
+        patch("theforge.cli.shared.load_config", side_effect=ValueError(err_msg)),
+        patch(
+            "theforge.cli.substrate.detect_substrate",
+            return_value=_installed_substrate(),
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            shared.load_config_checked(config_path)
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    expected_schema = str(
+        Path("/tmp/rc16/site-packages/theforge/config/model_catalog.py").resolve()
+    )
+    expected_catalog = str(
+        Path("/tmp/rc16/site-packages/theforge/config/data/models.yaml").resolve()
+    )
+    assert err_msg in err
+    assert "Runtime binary:  /Users/me/.local/bin/forge" in err
+    assert "Runtime package: /tmp/rc16/site-packages/theforge/__init__.py" in err
+    assert f"Runtime schema:  {expected_schema}" in err
+    assert f"Runtime catalog: {expected_catalog}" in err
+    assert f"Checkout root:   {tmp_path}" in err
+    assert "Checkout version: 0.15.0rc3" in err
+    assert "appears ahead of it" in err
 
 
 def test_unclassifiable_profile_is_skipped_not_fatal(monkeypatch, capsys):

--- a/tests/test_cli_substrate.py
+++ b/tests/test_cli_substrate.py
@@ -8,6 +8,7 @@ from theforge.cli.substrate import (
     Substrate,
     detect_mismatch,
     detect_substrate,
+    format_config_validation_provenance_lines,
     format_provenance_lines,
 )
 
@@ -102,6 +103,36 @@ def test_detect_mismatch_silent_for_released_substrate_on_newer_checkout(
 
 def test_detect_mismatch_returns_none_when_no_pyproject(tmp_path: Path) -> None:
     assert detect_mismatch(cwd=tmp_path, sub=_sub()) is None
+
+
+def test_config_validation_provenance_names_runtime_schema_catalog_and_checkout(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "forge.yaml"
+    config_path.write_text("project: test\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "theforge"\nversion = "0.11.0.dev0"\n',
+        encoding="utf-8",
+    )
+
+    lines = format_config_validation_provenance_lines(
+        config_path=config_path,
+        sub=_sub(
+            binary="/Users/me/.local/bin/forge",
+            package_file="/tmp/rc16/site-packages/theforge/__init__.py",
+            version="0.10.0rc12",
+            editable=False,
+        ),
+    )
+
+    joined = "\n".join(lines)
+    assert "/Users/me/.local/bin/forge" in joined
+    assert "/tmp/rc16/site-packages/theforge/__init__.py" in joined
+    assert "/tmp/rc16/site-packages/theforge/config/model_catalog.py" in joined
+    assert "/tmp/rc16/site-packages/theforge/config/data/models.yaml" in joined
+    assert f"Checkout root:   {tmp_path}" in joined
+    assert "Checkout version: 0.11.0.dev0" in joined
+    assert "appears ahead of it" in joined
 
 
 def test_detect_substrate_returns_real_runtime_metadata() -> None:

--- a/tests/test_cli_substrate.py
+++ b/tests/test_cli_substrate.py
@@ -133,6 +133,48 @@ def test_config_validation_provenance_names_runtime_schema_catalog_and_checkout(
     assert f"Checkout root:   {tmp_path}" in joined
     assert "Checkout version: 0.11.0.dev0" in joined
     assert "appears ahead of it" in joined
+    assert "may explain this validation failure" in joined
+
+
+def test_config_validation_provenance_softens_claim_when_runtime_is_newer(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "forge.yaml"
+    config_path.write_text("project: test\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "theforge"\nversion = "0.10.0rc12"\n',
+        encoding="utf-8",
+    )
+
+    lines = format_config_validation_provenance_lines(
+        config_path=config_path,
+        sub=_sub(version="0.11.0rc1", editable=False),
+    )
+
+    joined = "\n".join(lines)
+    assert "does not appear ahead of it" in joined
+    assert "may or may not explain this validation failure" in joined
+    assert "appears ahead of it" not in joined
+
+
+def test_config_validation_provenance_handles_unorderable_versions(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "forge.yaml"
+    config_path.write_text("project: test\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "theforge"\nversion = "main-branch"\n',
+        encoding="utf-8",
+    )
+
+    lines = format_config_validation_provenance_lines(
+        config_path=config_path,
+        sub=_sub(version="rc-build", editable=False),
+    )
+
+    joined = "\n".join(lines)
+    assert "version order could not be determined" in joined
+    assert "may explain this validation failure" in joined
 
 
 def test_detect_substrate_returns_real_runtime_metadata() -> None:

--- a/tests/test_forge_yaml_guard.py
+++ b/tests/test_forge_yaml_guard.py
@@ -13,6 +13,7 @@ from theforge.cli.forge_yaml_guard import (
     evaluate_forge_yaml_guard,
 )
 from theforge.cli.shared import _build_task
+from theforge.cli.substrate import Substrate
 from theforge.sprint.manifest import _build_task_from_story
 from theforge.sprint.sources import GitHubIssueSource
 
@@ -357,3 +358,42 @@ def test_cmd_check_story_config_prints_violating_keys(capsys, tmp_path: Path) ->
     assert "validation, workspace" in err
     assert "allow_mutate_forge_yaml: true" in err
     assert "local story file frontmatter" in err
+
+
+def test_cmd_check_story_config_reports_stale_runtime_provenance(capsys, tmp_path: Path) -> None:
+    config_path = tmp_path / "forge.yaml"
+    config_path.write_text("project: test\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "theforge"\nversion = "0.15.0rc3"\n',
+        encoding="utf-8",
+    )
+    runtime = Substrate(
+        binary="/Users/me/.local/bin/forge",
+        package_file="/tmp/rc16/site-packages/theforge/__init__.py",
+        version="0.13.0rc16",
+        editable=False,
+        source_root=None,
+        git_ref=None,
+    )
+    err_msg = (
+        "Unknown model 'anthropic/sonnet/cli': not in AGENT_REGISTRY. "
+        "Known models: ['claude/opus']"
+    )
+
+    with (
+        patch("theforge.cli.forge_yaml_guard._find_config", return_value=config_path),
+        patch("theforge.cli.forge_yaml_guard.load_config", side_effect=ValueError(err_msg)),
+        patch("theforge.cli.substrate.detect_substrate", return_value=runtime),
+    ):
+        rc = cmd_check_story_config(SimpleNamespace(config=None))
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    expected_catalog = str(
+        Path("/tmp/rc16/site-packages/theforge/config/data/models.yaml").resolve()
+    )
+    assert "forge.yaml story-mutation guard failed" in err
+    assert err_msg in err
+    assert f"Runtime catalog: {expected_catalog}" in err
+    assert f"Checkout root:   {tmp_path}" in err
+    assert "Checkout version: 0.15.0rc3" in err

--- a/tests/test_forge_yaml_guard.py
+++ b/tests/test_forge_yaml_guard.py
@@ -397,3 +397,24 @@ def test_cmd_check_story_config_reports_stale_runtime_provenance(capsys, tmp_pat
     assert f"Runtime catalog: {expected_catalog}" in err
     assert f"Checkout root:   {tmp_path}" in err
     assert "Checkout version: 0.15.0rc3" in err
+
+
+def test_cmd_check_story_config_reports_guard_value_error(capsys, tmp_path: Path) -> None:
+    config_path = tmp_path / "forge.yaml"
+    config_path.write_text("project: test\n", encoding="utf-8")
+    config = SimpleNamespace(project_root=tmp_path, workspace=SimpleNamespace(base_branch="main"))
+    guard_error = "main:forge.yaml is not valid YAML: while parsing a flow mapping"
+
+    with (
+        patch("theforge.cli.forge_yaml_guard._find_config", return_value=config_path),
+        patch("theforge.cli.forge_yaml_guard.load_config", return_value=config),
+        patch(
+            "theforge.cli.forge_yaml_guard.evaluate_forge_yaml_guard",
+            side_effect=ValueError(guard_error),
+        ),
+    ):
+        rc = cmd_check_story_config(SimpleNamespace(config=None))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert f"forge.yaml story-mutation guard failed: {guard_error}" in err


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The prior P1 is fixed, the stale-runtime provenance path is covered, and I found no blocking regressions in the latest iteration. | [anthropic-opus-cli] Cycle-1 P1 (guard-evaluation ValueError escaping check-story-config) is resolved — the guard block again catches RuntimeError and ValueError with a regression test asserting exit 1 and the operator-facing text; the provenance wording P2 is also addressed with newer-runtime and unorderable-version cases covered. HEAD 5b707794 matches the authoritative gate commit (PASS); 67 tests across the four touched files pass locally, and the iteration-2 diff introduces no regressions.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $5.52
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

A config-contract change is validated by the runtime it replaces, so correct work is rejected (GitHub Issue #2191)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2191