### PR TITLE
Diagnose discards every response field after a nested code fence, then reports the loss as a timeout

### DIFF
--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -1434,14 +1434,17 @@ def _run_diagnose_flow_body(
         return DiagnoseResult(success=False, state=state, message=message)
 
     # If essential fields are missing OR the run breached its budget/timeout
-    # envelope, treat as TIMEOUT_PARTIAL — return the partial work for operator
-    # review rather than landing a misleading "fix-ready" artifact.
+    # envelope, return the partial work for operator review rather than landing
+    # a misleading "fix-ready" artifact. Name the specific reason when known.
     if not artifact.is_complete() or partial:
         artifact = dataclasses.replace(artifact, partial=True)
         state.artifact = artifact
-        partial_phase = (
-            DiagnosePhase.BUDGET_EXCEEDED if budget_exceeded else DiagnosePhase.TIMEOUT_PARTIAL
-        )
+        if budget_exceeded:
+            partial_phase = DiagnosePhase.BUDGET_EXCEEDED
+        elif state.agent_failure_code == "timeout":
+            partial_phase = DiagnosePhase.TIMEOUT_PARTIAL
+        else:
+            partial_phase = DiagnosePhase.UNCLASSIFIED_PARTIAL
         emit_phase(partial_phase)
         if interactive and confirm_landing is None:
             confirm_landing = _stdin_confirm

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -665,6 +665,7 @@ def _artifact_to_dict(artifact: DiagnosisArtifact) -> dict:
         "affected_code_path": artifact.affected_code_path,
         "fix_success_criterion": artifact.fix_success_criterion,
         "partial": artifact.partial,
+        "partial_reason": artifact.partial_reason.value,
         "notes": artifact.notes,
         "baseline_sha": artifact.baseline_sha,
         "baseline_captured_at": artifact.baseline_captured_at,

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -38,6 +38,7 @@ from theforge.coordinator.util import _log as _progress_log
 from theforge.diagnose_types import (
     DIAGNOSE_OUTPUT_DESTINATIONS,
     AbsentPremise,
+    DiagnosePartialReason,
     DiagnosePhase,
     DiagnoseResult,
     DiagnoseState,
@@ -1437,14 +1438,21 @@ def _run_diagnose_flow_body(
     # envelope, return the partial work for operator review rather than landing
     # a misleading "fix-ready" artifact. Name the specific reason when known.
     if not artifact.is_complete() or partial:
-        artifact = dataclasses.replace(artifact, partial=True)
-        state.artifact = artifact
         if budget_exceeded:
             partial_phase = DiagnosePhase.BUDGET_EXCEEDED
+            partial_reason = DiagnosePartialReason.BUDGET_EXCEEDED
         elif state.agent_failure_code == "timeout":
             partial_phase = DiagnosePhase.TIMEOUT_PARTIAL
+            partial_reason = DiagnosePartialReason.TIMEOUT
         else:
             partial_phase = DiagnosePhase.UNCLASSIFIED_PARTIAL
+            partial_reason = DiagnosePartialReason.UNCLASSIFIED
+        artifact = dataclasses.replace(
+            artifact,
+            partial=True,
+            partial_reason=partial_reason,
+        )
+        state.artifact = artifact
         emit_phase(partial_phase)
         if interactive and confirm_landing is None:
             confirm_landing = _stdin_confirm

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -27,6 +27,7 @@ class DiagnosePhase(Enum):
     FAILED = auto()
     TIMEOUT_PARTIAL = auto()  # ran out of time/budget; partial artifact returned
     BUDGET_EXCEEDED = auto()
+    UNCLASSIFIED_PARTIAL = auto()  # partial artifact for a non-budget, non-timeout reason
     ALREADY_RESOLVED = auto()  # premise absent from baseline; no diagnosis written
 
 

--- a/src/theforge/diagnose_types.py
+++ b/src/theforge/diagnose_types.py
@@ -31,6 +31,14 @@ class DiagnosePhase(Enum):
     ALREADY_RESOLVED = auto()  # premise absent from baseline; no diagnosis written
 
 
+class DiagnosePartialReason(Enum):
+    """Operator-visible reason a landed partial diagnosis is incomplete."""
+
+    BUDGET_EXCEEDED = "budget_exceeded"
+    TIMEOUT = "timeout"
+    UNCLASSIFIED = "unclassified"
+
+
 # Output destinations for a completed diagnosis artifact.
 DIAGNOSE_OUTPUT_DESTINATIONS: frozenset[str] = frozenset({"comment", "body_section", "pr_to_body"})
 
@@ -141,6 +149,7 @@ class DiagnosisArtifact:
     affected_code_path: str
     fix_success_criterion: str
     partial: bool = False  # True when the agent ran out of time/budget
+    partial_reason: DiagnosePartialReason = DiagnosePartialReason.UNCLASSIFIED
     notes: str = ""
     baseline_sha: str = ""
     baseline_captured_at: str = ""
@@ -305,11 +314,23 @@ def render_artifact_markdown(artifact: DiagnosisArtifact) -> str:
         )
     lines: list[str] = ["## Diagnosis"]
     if artifact.partial:
+        if artifact.partial_reason is DiagnosePartialReason.BUDGET_EXCEEDED:
+            warning = (
+                "> ⚠ Partial diagnosis — the investigation exceeded its budget "
+                "before reaching a confirmed cause. Operator review required."
+            )
+        elif artifact.partial_reason is DiagnosePartialReason.TIMEOUT:
+            warning = (
+                "> ⚠ Partial diagnosis — the investigation timed out before "
+                "reaching a confirmed cause. Operator review required."
+            )
+        else:
+            warning = (
+                "> ⚠ Partial diagnosis — the investigation did not reach a "
+                "confirmed cause. Operator review required."
+            )
         lines.append("")
-        lines.append(
-            "> ⚠ Partial diagnosis — the investigation hit its budget or "
-            "timeout before reaching a confirmed cause. Operator review required."
-        )
+        lines.append(warning)
     if artifact.baseline_sha:
         lines.append("")
         ts = artifact.baseline_captured_at or "unknown"

--- a/src/theforge/task/diagnose_prompts.py
+++ b/src/theforge/task/diagnose_prompts.py
@@ -7,6 +7,7 @@ plan describes how to *act on* a known cause; diagnose describes how to
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 import yaml
@@ -305,23 +306,81 @@ def build_diagnose_reformat_prompt(*, original_output: str, parse_error: str) ->
     )
 
 
+_FENCE_LINE_RE = re.compile(r"^(?P<indent>[ \t]*)```(?P<info>[^\n`]*)[ \t]*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class _FenceLine:
+    indent: int
+    info: str
+    start: int
+    end: int
+
+    @property
+    def is_close(self) -> bool:
+        return self.info == ""
+
+    @property
+    def opens_yaml(self) -> bool:
+        return self.info.lower().startswith("yaml")
+
+
+def _iter_fence_lines(output: str) -> list[_FenceLine]:
+    return [
+        _FenceLine(
+            indent=len(match.group("indent")),
+            info=match.group("info").strip(),
+            start=match.start(),
+            end=match.end(),
+        )
+        for match in _FENCE_LINE_RE.finditer(output)
+    ]
+
+
 def _extract_yaml_block(output: str) -> str:
     """Pull the first fenced YAML block out of agent output, falling back to raw."""
-    if "```yaml" in output:
-        start = output.index("```yaml") + len("```yaml")
-        try:
-            end = output.index("```", start)
-            return output[start:end]
-        except ValueError:
-            return output[start:]
-    if "```" in output:
-        start = output.index("```") + len("```")
-        try:
-            end = output.index("```", start)
-            return output[start:end]
-        except ValueError:
-            return output[start:]
-    return output
+    fences = _iter_fence_lines(output)
+    if not fences:
+        return output
+
+    opener = next((fence for fence in fences if fence.opens_yaml), fences[0])
+    closing_candidates = [
+        fence
+        for fence in fences
+        if fence.start > opener.start and fence.is_close and fence.indent <= opener.indent
+    ]
+    if not closing_candidates:
+        raise ValueError("Malformed fenced response: opening fence is missing a matching close.")
+    if len(closing_candidates) > 1:
+        raise ValueError("Malformed fenced response: multiple closing fences match the envelope.")
+    closer = closing_candidates[0]
+    start = opener.end
+    if start < len(output) and output[start] == "\n":
+        start += 1
+    end = closer.start
+    if end > start and output[end - 1] == "\n":
+        end -= 1
+    return output[start:end]
+
+
+def _parse_yaml_mapping(yaml_text: str) -> dict[object, object]:
+    parsed = yaml.safe_load(yaml_text)
+    if not isinstance(parsed, dict):
+        raise TypeError(type(parsed).__name__)
+    return parsed
+
+
+def _normalize_parse_error(exc: yaml.YAMLError) -> str:
+    detail = " ".join(str(exc).split())
+    return f"YAML syntax error: {detail}"
+
+
+def _normalize_extract_error(exc: ValueError) -> str:
+    return str(exc)
+
+
+def _normalize_root_error(root_type: str) -> str:
+    return f"YAML block did not parse to a mapping of diagnosis keys (root was {root_type})."
 
 
 @dataclass(frozen=True)
@@ -373,18 +432,15 @@ def parse_diagnose_output_result(
     of discarded, so the diagnose flow can put it in the audit trail and in a
     bounded reformat-retry prompt.
     """
-    yaml_text = _extract_yaml_block(output)
     try:
-        parsed = yaml.safe_load(yaml_text)
+        yaml_text = _extract_yaml_block(output)
+        parsed = _parse_yaml_mapping(yaml_text)
+    except ValueError as exc:
+        return DiagnoseParseOutcome(None, _normalize_extract_error(exc))
     except yaml.YAMLError as exc:
-        detail = " ".join(str(exc).split())
-        return DiagnoseParseOutcome(None, f"YAML syntax error: {detail}")
-    if not isinstance(parsed, dict):
-        return DiagnoseParseOutcome(
-            None,
-            "YAML block did not parse to a mapping of diagnosis keys "
-            f"(root was {type(parsed).__name__}).",
-        )
+        return DiagnoseParseOutcome(None, _normalize_parse_error(exc))
+    except TypeError as exc:
+        return DiagnoseParseOutcome(None, _normalize_root_error(str(exc)))
 
     raw_hypotheses = parsed.get("hypotheses") or []
     hypotheses: list[Hypothesis] = []

--- a/src/theforge/task/diagnose_prompts.py
+++ b/src/theforge/task/diagnose_prompts.py
@@ -344,16 +344,16 @@ def _extract_yaml_block(output: str) -> str:
         return output
 
     opener = next((fence for fence in fences if fence.opens_yaml), fences[0])
-    closing_candidates = [
-        fence
-        for fence in fences
-        if fence.start > opener.start and fence.is_close and fence.indent <= opener.indent
-    ]
-    if not closing_candidates:
+    closer = next(
+        (
+            fence
+            for fence in fences
+            if fence.start > opener.start and fence.is_close and fence.indent <= opener.indent
+        ),
+        None,
+    )
+    if closer is None:
         raise ValueError("Malformed fenced response: opening fence is missing a matching close.")
-    if len(closing_candidates) > 1:
-        raise ValueError("Malformed fenced response: multiple closing fences match the envelope.")
-    closer = closing_candidates[0]
     start = opener.end
     if start < len(output) and output[start] == "\n":
         start += 1

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -303,7 +303,13 @@ class TestEnvironmentBriefing:
 # ── State machine / flow tests ────────────────────────────────────────
 
 
-def _fake_agent_result(output: str, *, success: bool = True, cost: float | None = 0.05):
+def _fake_agent_result(
+    output: str,
+    *,
+    success: bool = True,
+    cost: float | None = 0.05,
+    failure_code: str | None = None,
+):
     """Build a minimal AgentResult-shaped object usable as a runner stub."""
     from theforge.agent_types import AgentResult
 
@@ -314,6 +320,7 @@ def _fake_agent_result(output: str, *, success: bool = True, cost: float | None 
         cost_usd=cost,
         exit_code=0 if success else 1,
         raw={},
+        failure_code=failure_code,
     )
 
 
@@ -420,7 +427,7 @@ class TestDiagnoseFlow:
             output_destination="comment",
         )
         assert not result.success  # partial
-        assert result.state.phase == DiagnosePhase.TIMEOUT_PARTIAL
+        assert result.state.phase == DiagnosePhase.UNCLASSIFIED_PARTIAL
         # Artifact still landed so operator can review
         assert mock_post.called
         posted_body = mock_post.call_args[0][1]
@@ -621,6 +628,39 @@ class TestDiagnoseFlow:
         loaded = yaml.safe_load(audit_files[0].read_text())
         assert loaded["agent"]["cost_usd"] >= config.diagnose.budget_usd
         assert loaded["artifact"]["partial"] is True
+
+    @patch("theforge.coordinator.diagnose_flow._gh_post_comment")
+    @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")
+    @patch("theforge.coordinator.diagnose_flow.run_agent")
+    def test_timeout_partial_still_reports_timeout_when_agent_timed_out(
+        self, mock_agent, mock_fetch, mock_post, tmp_path
+    ):
+        config = self._setup_config(tmp_path)
+        mock_fetch.return_value = {
+            "number": 81,
+            "title": "x",
+            "body": "y",
+            "state": "OPEN",
+        }
+        mock_agent.return_value = _fake_agent_result(
+            _agent_yaml_output(hypothesis_statuses=("ruled_out", "inconclusive")),
+            success=False,
+            failure_code="timeout",
+        )
+        mock_post.return_value = "https://example/comment"
+
+        from theforge.coordinator.diagnose_flow import run_diagnose_flow
+
+        result = run_diagnose_flow(
+            issue_number=81,
+            config=config,
+            project_root=tmp_path,
+            output_destination="comment",
+        )
+
+        assert not result.success
+        assert result.state.agent_failure_code == "timeout"
+        assert result.state.phase == DiagnosePhase.TIMEOUT_PARTIAL
 
     @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
     @patch("theforge.coordinator.diagnose_flow._gh_post_comment")

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -83,6 +83,16 @@ def _agent_yaml_output(
     return f"```yaml\n{yaml.safe_dump(payload, sort_keys=False)}```"
 
 
+def _load_audit_artifact(tmp_path: Path) -> dict:
+    audit_files = sorted((tmp_path / ".forge" / "audits").glob("diagnose-*.yaml"))
+    assert audit_files, "expected at least one audit file"
+    audit = yaml.safe_load(audit_files[-1].read_text())
+    assert isinstance(audit, dict)
+    artifact = audit.get("artifact")
+    assert isinstance(artifact, dict), "expected artifact in audit payload"
+    return artifact
+
+
 # ── Artifact / rendering tests ────────────────────────────────────────
 
 
@@ -437,6 +447,7 @@ class TestDiagnoseFlow:
         assert "budget or timeout" not in posted_body
         assert result.state.artifact is not None
         assert result.state.artifact.partial_reason is DiagnosePartialReason.UNCLASSIFIED
+        assert _load_audit_artifact(tmp_path)["partial_reason"] == "unclassified"
 
     @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
     @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")

--- a/tests/test_diagnose_flow.py
+++ b/tests/test_diagnose_flow.py
@@ -21,6 +21,7 @@ import yaml
 from coord_test_helpers import _make_config
 
 from theforge.diagnose_types import (
+    DiagnosePartialReason,
     DiagnosePhase,
     DiagnoseState,
     DiagnosisArtifact,
@@ -432,6 +433,10 @@ class TestDiagnoseFlow:
         assert mock_post.called
         posted_body = mock_post.call_args[0][1]
         assert "Partial diagnosis" in posted_body
+        assert "did not reach a confirmed cause" in posted_body
+        assert "budget or timeout" not in posted_body
+        assert result.state.artifact is not None
+        assert result.state.artifact.partial_reason is DiagnosePartialReason.UNCLASSIFIED
 
     @patch("theforge.coordinator.diagnose_flow._gh_edit_body")
     @patch("theforge.coordinator.diagnose_flow._gh_fetch_issue")

--- a/tests/test_diagnose_parse_retry.py
+++ b/tests/test_diagnose_parse_retry.py
@@ -136,6 +136,51 @@ def _audit_for(tmp_path: Path, issue_number: int, run_id: str) -> dict:
 
 
 class TestStrictParseReportsReason:
+    def test_nested_fence_inside_yaml_scalar_preserves_following_fields(self):
+        output = """```yaml
+observed_symptom: |
+  diagnose truncates after evidence
+reproduction_or_evidence: |
+  This evidence quotes source:
+    ```
+    def buggy():
+        return True
+    ```
+hypotheses:
+  - statement: Nested fence breaks extraction
+    status: confirmed
+    evidence: Extraction must continue past inner fences
+confirmed_cause: |
+  The outer envelope closes later than the nested fence.
+affected_code_path: |
+  src/theforge/task/diagnose_prompts.py
+fix_success_criterion: |
+  All supplied fields survive parsing.
+```"""
+        outcome = parse_diagnose_output_result(output, issue_number=2191)
+        assert outcome.error == ""
+        assert outcome.artifact is not None
+        assert "def buggy()" in outcome.artifact.reproduction_or_evidence
+        assert outcome.artifact.confirmed_cause.startswith("The outer envelope closes")
+        assert outcome.artifact.is_complete()
+
+    def test_ambiguous_matching_close_is_rejected(self):
+        output = """```yaml
+observed_symptom: x
+reproduction_or_evidence: y
+hypotheses:
+  - statement: z
+    status: confirmed
+    evidence: e
+confirmed_cause: c
+affected_code_path: p
+fix_success_criterion: f
+```
+```"""
+        outcome = parse_diagnose_output_result(output, issue_number=2191)
+        assert outcome.artifact is None
+        assert "multiple closing fences" in outcome.error
+
     def test_yaml_syntax_error_is_named(self):
         outcome = parse_diagnose_output_result(
             _output_with_unterminated_quote(), issue_number=2029

--- a/tests/test_diagnose_parse_retry.py
+++ b/tests/test_diagnose_parse_retry.py
@@ -164,7 +164,7 @@ fix_success_criterion: |
         assert outcome.artifact.confirmed_cause.startswith("The outer envelope closes")
         assert outcome.artifact.is_complete()
 
-    def test_ambiguous_matching_close_is_rejected(self):
+    def test_top_level_fence_after_closed_envelope_is_ignored(self):
         output = """```yaml
 observed_symptom: x
 reproduction_or_evidence: y
@@ -176,10 +176,29 @@ confirmed_cause: c
 affected_code_path: p
 fix_success_criterion: f
 ```
+```python
+print("trailing snippet")
 ```"""
         outcome = parse_diagnose_output_result(output, issue_number=2191)
+        assert outcome.error == ""
+        assert outcome.artifact is not None
+        assert outcome.artifact.confirmed_cause == "c"
+
+    def test_unclosed_yaml_envelope_is_rejected(self):
+        output = """```yaml
+observed_symptom: x
+reproduction_or_evidence: y
+hypotheses:
+  - statement: z
+    status: confirmed
+    evidence: e
+confirmed_cause: c
+affected_code_path: p
+fix_success_criterion: f
+"""
+        outcome = parse_diagnose_output_result(output, issue_number=2191)
         assert outcome.artifact is None
-        assert "multiple closing fences" in outcome.error
+        assert "missing a matching close" in outcome.error
 
     def test_yaml_syntax_error_is_named(self):
         outcome = parse_diagnose_output_result(

--- a/tests/test_diagnose_types.py
+++ b/tests/test_diagnose_types.py
@@ -49,6 +49,7 @@ class TestDiagnosePhase:
             "DONE",
             "FAILED",
             "TIMEOUT_PARTIAL",
+            "UNCLASSIFIED_PARTIAL",
             "VERIFY_PREMISE",
             "ALREADY_RESOLVED",
         ):

--- a/tests/test_diagnose_types.py
+++ b/tests/test_diagnose_types.py
@@ -12,6 +12,7 @@ import pytest
 from theforge.diagnose_types import (
     DIAGNOSE_OUTPUT_DESTINATIONS,
     AbsentPremise,
+    DiagnosePartialReason,
     DiagnosePhase,
     DiagnoseResult,
     DiagnoseState,
@@ -368,6 +369,52 @@ class TestRenderArtifactMarkdown:
         md = render_artifact_markdown(artifact)
         assert "Partial diagnosis" in md
         assert "Operator review required" in md
+
+    def test_unclassified_partial_artifact_does_not_claim_budget_or_timeout(self):
+        artifact = DiagnosisArtifact(
+            issue_number=1,
+            observed_symptom="x",
+            reproduction_or_evidence="y",
+            hypotheses=(Hypothesis("z", "inconclusive", ""),),
+            confirmed_cause="",
+            affected_code_path="?",
+            fix_success_criterion="?",
+            partial=True,
+            partial_reason=DiagnosePartialReason.UNCLASSIFIED,
+        )
+        md = render_artifact_markdown(artifact)
+        assert "did not reach a confirmed cause" in md
+        assert "budget or timeout" not in md
+
+    def test_budget_partial_artifact_names_budget(self):
+        artifact = DiagnosisArtifact(
+            issue_number=1,
+            observed_symptom="x",
+            reproduction_or_evidence="y",
+            hypotheses=(Hypothesis("z", "inconclusive", ""),),
+            confirmed_cause="",
+            affected_code_path="?",
+            fix_success_criterion="?",
+            partial=True,
+            partial_reason=DiagnosePartialReason.BUDGET_EXCEEDED,
+        )
+        md = render_artifact_markdown(artifact)
+        assert "exceeded its budget" in md
+
+    def test_timeout_partial_artifact_names_timeout(self):
+        artifact = DiagnosisArtifact(
+            issue_number=1,
+            observed_symptom="x",
+            reproduction_or_evidence="y",
+            hypotheses=(Hypothesis("z", "inconclusive", ""),),
+            confirmed_cause="",
+            affected_code_path="?",
+            fix_success_criterion="?",
+            partial=True,
+            partial_reason=DiagnosePartialReason.TIMEOUT,
+        )
+        md = render_artifact_markdown(artifact)
+        assert "timed out" in md
 
     def test_empty_required_field_renders_placeholder(self):
         # A partial artifact with *some* content renders explicit placeholders


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior P1s are resolved; nested fenced diagnose output is preserved and partial artifacts no longer default to budget-or-timeout wording. | [anthropic-opus-cli] Both cycle-1 P1s are fixed — the extractor now takes the first envelope-level close (trailing fenced blocks parse again, verified against the real #2191 raw output which now extracts all 130 body lines including confirmed_cause) and the landed banner names budget, timeout, or unclassified; two P2s remain (partial_reason absent from the audit record, and a single malformed escape late in a response still discards every field).

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $5.51
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/diagnose_flow.py:667`** A landed partial diagnosis records only 'partial: true' in its audit artifact block, so the reason the coordinator selected — budget exceeded, timeout, or unclassified — is written into the operator-visible issue banner but never into the audit record alongside the artifact it describes.
- **[P2] `src/theforge/task/diagnose_prompts.py:437`** Running the persisted #2191 response through the parser now extracts the complete 130-line envelope but returns no artifact at all, because a single invalid escape sequence in a double-quoted scalar at line 125 of that response makes the whole document unparseable, so a diagnosis carrying a confirmed cause and three hypotheses still yields nothing to land.

## Story

Diagnose discards every response field after a nested code fence, then reports the loss as a timeout (GitHub Issue #2216)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2216