### PR TITLE
Each dispatchable phase added to forge needs a separate source edit before an operator can constrain it, so the newest phase is always the one that cannot be restricted

### DIFF
--- a/src/theforge/assignment.py
+++ b/src/theforge/assignment.py
@@ -27,6 +27,7 @@ from .config import (
     TransportFallbackConfig,
 )
 from .config.auth import check_agent_auth
+from .config.model_identity import PHASE_PLAN_REVIEW, PHASE_REVIEW
 from .config.pricing import price_tiebreak_signal_for
 from .config.profiles import _apply_transport_fallback
 from .model_capabilities import (
@@ -4020,7 +4021,7 @@ def assign_models(
             value_audit=evidence.plan_review.value.audit,
         )
         plan_reviewers = [
-            _agent_to_profile(a, role="review", transport_fallbacks=transport_fallbacks)
+            _agent_to_profile(a, role=PHASE_PLAN_REVIEW, transport_fallbacks=transport_fallbacks)
             for a in selected
         ]
         providers = [a.effective_provider for a in selected]
@@ -4096,7 +4097,7 @@ def assign_models(
             value_phase="code_review",
         )
         code_reviewers = [
-            _agent_to_profile(a, role="review", transport_fallbacks=transport_fallbacks)
+            _agent_to_profile(a, role=PHASE_REVIEW, transport_fallbacks=transport_fallbacks)
             for a in selected
         ]
         providers = [a.effective_provider for a in selected]

--- a/src/theforge/cli/eval_cmd.py
+++ b/src/theforge/cli/eval_cmd.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from theforge.cli.shared import _find_config, load_config_checked
+from theforge.config.model_identity import PHASE_PREFLIGHT
 
 
 def _infer_profile(
@@ -44,7 +45,7 @@ def _infer_profile(
             timeout_seconds=timeout_seconds,
             allowed_tools=DEFAULT_TOOLS,
             cli="claude",
-            phase="preflight",
+            phase=PHASE_PREFLIGHT,
         )
     elif model.startswith("gpt-"):
         return ModelProfile(
@@ -54,7 +55,7 @@ def _infer_profile(
             timeout_seconds=timeout_seconds,
             allowed_tools=DEFAULT_TOOLS,
             provider="openai",
-            phase="preflight",
+            phase=PHASE_PREFLIGHT,
         )
     elif model.startswith("deepseek-"):
         return ModelProfile(
@@ -64,7 +65,7 @@ def _infer_profile(
             timeout_seconds=timeout_seconds,
             allowed_tools=DEFAULT_TOOLS,
             provider="deepseek",
-            phase="preflight",
+            phase=PHASE_PREFLIGHT,
         )
     elif model.startswith("gemini-"):
         return ModelProfile(
@@ -74,7 +75,7 @@ def _infer_profile(
             timeout_seconds=timeout_seconds,
             allowed_tools=DEFAULT_TOOLS,
             provider="google",
-            phase="preflight",
+            phase=PHASE_PREFLIGHT,
         )
     else:
         # Best-effort: treat as CLI with model name as cli identifier
@@ -85,7 +86,7 @@ def _infer_profile(
             timeout_seconds=timeout_seconds,
             allowed_tools=DEFAULT_TOOLS,
             cli=model,
-            phase="preflight",
+            phase=PHASE_PREFLIGHT,
         )
 
 

--- a/src/theforge/cli/provider_readiness.py
+++ b/src/theforge/cli/provider_readiness.py
@@ -22,6 +22,13 @@ from theforge.config import (
     transport_for,
 )
 from theforge.config.auth import check_agent_auth
+from theforge.config.model_identity import (
+    PHASE_DEV,
+    PHASE_PLAN,
+    PHASE_PLAN_REVIEW,
+    PHASE_PREFLIGHT,
+    PHASE_REVIEW,
+)
 from theforge.config.models import mirror_fields_for_transport
 from theforge.config.profiles import iter_config_profiles, iter_plan_phase_profiles
 from theforge.config.types import ModelProfile
@@ -639,19 +646,19 @@ def _probe_for_profile(role: str, profile: ModelProfile) -> ReadinessProbe:
 
 def _stamp_phase(profile: ModelProfile, role: str) -> ModelProfile:
     phase_by_role = {
-        "dev": "dev",
-        "preflight": "preflight",
-        "preflight-fallback": "preflight",
-        "review": "review",
+        "dev": PHASE_DEV,
+        "preflight": PHASE_PREFLIGHT,
+        "preflight-fallback": PHASE_PREFLIGHT,
+        "review": PHASE_REVIEW,
         "synthesis": "synthesis",
-        "plan": "plan",
-        "plan-review": "plan_review",
-        "advisor": "preflight",
-        "agent-dev": "dev",
-        "agent-preflight": "preflight",
-        "agent-planner": "plan",
-        "agent-plan-review": "plan_review",
-        "agent-code-review": "review",
+        "plan": PHASE_PLAN,
+        "plan-review": PHASE_PLAN_REVIEW,
+        "advisor": PHASE_PREFLIGHT,
+        "agent-dev": PHASE_DEV,
+        "agent-preflight": PHASE_PREFLIGHT,
+        "agent-planner": PHASE_PLAN,
+        "agent-plan-review": PHASE_PLAN_REVIEW,
+        "agent-code-review": PHASE_REVIEW,
     }
     phase = phase_by_role.get(role, profile.phase)
     return dataclasses.replace(profile, phase=phase)
@@ -660,21 +667,21 @@ def _stamp_phase(profile: ModelProfile, role: str) -> ModelProfile:
 def _agent_role_probes(agent: object) -> list[ReadinessProbe]:
     planner_profile = _agent_to_profile(
         agent,
-        role="plan",
+        role=PHASE_PLAN,
         allowed_tools=DEFAULT_INVESTIGATION_TOOLS,
     )
     review_tools = DEFAULT_REVIEW_PROFILE.allowed_tools
     plan_review_profile = dataclasses.replace(
-        _agent_to_profile(agent, role="review", allowed_tools=review_tools),
-        phase="plan_review",
+        _agent_to_profile(agent, role=PHASE_REVIEW, allowed_tools=review_tools),
+        phase=PHASE_PLAN_REVIEW,
     )
     return [
-        _probe_for_profile("agent-dev", _agent_to_profile(agent, role="dev")),
+        _probe_for_profile("agent-dev", _agent_to_profile(agent, role=PHASE_DEV)),
         _probe_for_profile(
             "agent-preflight",
             _agent_to_profile(
                 agent,
-                role="preflight",
+                role=PHASE_PREFLIGHT,
                 allowed_tools=DEFAULT_PREFLIGHT_PROFILE.allowed_tools,
             ),
         ),
@@ -682,7 +689,7 @@ def _agent_role_probes(agent: object) -> list[ReadinessProbe]:
         _probe_for_profile("agent-plan-review", plan_review_profile),
         _probe_for_profile(
             "agent-code-review",
-            _agent_to_profile(agent, role="review", allowed_tools=review_tools),
+            _agent_to_profile(agent, role=PHASE_REVIEW, allowed_tools=review_tools),
         ),
     ]
 

--- a/src/theforge/config/bridge.py
+++ b/src/theforge/config/bridge.py
@@ -11,6 +11,13 @@ to replace the direct ForgeConfig construction in load.py.
 
 from __future__ import annotations
 
+from .model_identity import (
+    PHASE_DEV,
+    PHASE_PLAN,
+    PHASE_PLAN_REVIEW,
+    PHASE_PREFLIGHT,
+    PHASE_REVIEW,
+)
 from .schema import (
     DevRoleConfig,
     PlanRoleConfig,
@@ -108,27 +115,27 @@ def role_assignment_to_profiles(ra: RoleAssignment) -> dict[str, object]:
           "synthesis_profile":        ModelProfile | None
           "plan_agent_review_profile": ModelProfile | None
     """
-    dev_profile = _role_config_to_profile("dev", ra.dev, phase="dev")
-    preflight_profile = _role_config_to_profile("preflight", ra.preflight, phase="preflight")
-    plan_profile = _role_config_to_profile("plan", ra.plan, phase="plan")
+    dev_profile = _role_config_to_profile("dev", ra.dev, phase=PHASE_DEV)
+    preflight_profile = _role_config_to_profile("preflight", ra.preflight, phase=PHASE_PREFLIGHT)
+    plan_profile = _role_config_to_profile("plan", ra.plan, phase=PHASE_PLAN)
 
     review_pool: list[ModelProfile] = [
         _role_config_to_profile(
             rc.name if rc.name else rc.ref.model.replace("/", "-"),
             rc,
-            phase="review",
+            phase=PHASE_REVIEW,
         )
         for rc in ra.review_pool
     ]
 
     synthesis_profile: ModelProfile | None = None
     if ra.synthesis is not None:
-        synthesis_profile = _role_config_to_profile("synthesis", ra.synthesis, phase="review")
+        synthesis_profile = _role_config_to_profile("synthesis", ra.synthesis, phase=PHASE_REVIEW)
 
     plan_agent_review_profile: ModelProfile | None = None
     if ra.plan_agent_review is not None:
         plan_agent_review_profile = _role_config_to_profile(
-            "plan-agent-review", ra.plan_agent_review, phase="plan_review"
+            "plan-agent-review", ra.plan_agent_review, phase=PHASE_PLAN_REVIEW
         )
 
     return {

--- a/src/theforge/config/defaults.py
+++ b/src/theforge/config/defaults.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .model_identity import PHASE_DEV, PHASE_PREFLIGHT, PHASE_REVIEW
 from .types import ModelProfile, ValidationConfig, WorkspaceConfig
 
 DEFAULT_DEV_PROFILE = ModelProfile(
@@ -12,7 +13,7 @@ DEFAULT_DEV_PROFILE = ModelProfile(
     budget_usd=2.00,
     timeout_seconds=900,
     allowed_tools=("Read", "Edit", "Write", "Bash", "Glob", "Grep", "WebFetch"),
-    phase="dev",
+    phase=PHASE_DEV,
 )
 
 DEFAULT_REVIEW_PROFILE = ModelProfile(
@@ -23,6 +24,7 @@ DEFAULT_REVIEW_PROFILE = ModelProfile(
     budget_usd=1.00,
     timeout_seconds=300,
     allowed_tools=("Read", "Bash", "Glob", "Grep"),
+    phase=PHASE_REVIEW,
 )
 
 # Preflight is a read-only classifier and is deliberately denied Bash (#2346).
@@ -120,7 +122,7 @@ DEFAULT_PREFLIGHT_PROFILE = ModelProfile(
     budget_usd=1.00,
     timeout_seconds=300,
     allowed_tools=PREFLIGHT_READ_ONLY_TOOLS,
-    phase="preflight",
+    phase=PHASE_PREFLIGHT,
 )
 
 DEFAULT_WORKSPACE = WorkspaceConfig(

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -35,7 +35,7 @@ from .model_catalog import (
     resolve_project,
 )
 from .model_duplicates import DuplicateDeclaration, compare_duplicate_declaration
-from .model_identity import MODEL_TIERS
+from .model_identity import MODEL_TIERS, PHASE_PLAN_REVIEW, PHASE_PREFLIGHT
 from .models import (
     AGENT_REGISTRY,
     AgentSpec,
@@ -1222,7 +1222,7 @@ def load_config(config_path: Path) -> ForgeConfig:
             preflight_fallback_profile = dataclasses.replace(
                 preflight_fallback_profile,
                 name="preflight_fallback",
-                phase="preflight",
+                phase=PHASE_PREFLIGHT,
             )
         if synthesis_profile is not None and "synthesis" in overrides:
             synthesis_profile = _apply_profile_overrides(synthesis_profile, overrides["synthesis"])
@@ -1472,6 +1472,7 @@ def load_config(config_path: Path) -> ForgeConfig:
             budget_usd=plan_agent_review_cfg.budget_usd,
             timeout_seconds=plan_agent_review_cfg.timeout,
             allowed_tools=(),
+            phase=PHASE_PLAN_REVIEW,
         )
         legacy_plan_review_profile = _apply_transport_fallback(
             legacy_plan_review_profile, transport_fallbacks

--- a/src/theforge/config/model_catalog.py
+++ b/src/theforge/config/model_catalog.py
@@ -63,6 +63,7 @@ import yaml
 from .model_identity import (
     _DEFAULT_PHASE_ELIGIBILITY,
     CAPABILITY_RANGE,
+    CLOSED_OPERATOR_PHASES,
     COST_RANK_RANGE,
     IDENTITY_STATUS_RETIRED,
     IDENTITY_STATUSES,
@@ -420,6 +421,12 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
         parsed_phases = frozenset(
             _require_str(p, where=f"{where}.routing.phase_eligibility") for p in phases
         )
+        closed_phases = parsed_phases & CLOSED_OPERATOR_PHASES
+        if closed_phases:
+            raise ValueError(
+                f"forge.yaml '{where}.routing.phase_eligibility' names known dispatch "
+                f"phase(s) deliberately closed to operator constraint: {sorted(closed_phases)}"
+            )
         unknown_phases = parsed_phases - KNOWN_PHASES
         if unknown_phases:
             raise ValueError(

--- a/src/theforge/config/model_catalog.py
+++ b/src/theforge/config/model_catalog.py
@@ -63,7 +63,6 @@ import yaml
 from .model_identity import (
     _DEFAULT_PHASE_ELIGIBILITY,
     CAPABILITY_RANGE,
-    CLOSED_OPERATOR_PHASES,
     COST_RANK_RANGE,
     IDENTITY_STATUS_RETIRED,
     IDENTITY_STATUSES,
@@ -79,6 +78,8 @@ from .model_identity import (
     canonical_model_id,
     custom_model_capability,
     custom_model_dev_capable,
+    is_known_dispatch_phase,
+    is_operator_constrainable_phase,
     transport_for,
 )
 from .pricing import (
@@ -421,13 +422,19 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
         parsed_phases = frozenset(
             _require_str(p, where=f"{where}.routing.phase_eligibility") for p in phases
         )
-        closed_phases = parsed_phases & CLOSED_OPERATOR_PHASES
+        closed_phases = frozenset(
+            phase
+            for phase in parsed_phases
+            if is_known_dispatch_phase(phase) and not is_operator_constrainable_phase(phase)
+        )
         if closed_phases:
             raise ValueError(
                 f"forge.yaml '{where}.routing.phase_eligibility' names known dispatch "
                 f"phase(s) deliberately closed to operator constraint: {sorted(closed_phases)}"
             )
-        unknown_phases = parsed_phases - KNOWN_PHASES
+        unknown_phases = frozenset(
+            phase for phase in parsed_phases if not is_known_dispatch_phase(phase)
+        )
         if unknown_phases:
             raise ValueError(
                 f"forge.yaml '{where}.routing.phase_eligibility' only supports "

--- a/src/theforge/config/model_catalog.py
+++ b/src/theforge/config/model_catalog.py
@@ -66,8 +66,8 @@ from .model_identity import (
     COST_RANK_RANGE,
     IDENTITY_STATUS_RETIRED,
     IDENTITY_STATUSES,
-    KNOWN_PHASES,
     MODEL_TIERS,
+    OPERATOR_CONSTRAINABLE_PHASES,
     REASONING_MODES,
     TRANSPORT_KINDS,
     UNCONFIRMED_IDENTITY,
@@ -438,7 +438,7 @@ def parse_definition(entry: Any, *, where: str) -> ParsedDefinition:
         if unknown_phases:
             raise ValueError(
                 f"forge.yaml '{where}.routing.phase_eligibility' only supports "
-                f"{sorted(KNOWN_PHASES)}; got {sorted(unknown_phases)}"
+                f"{sorted(OPERATOR_CONSTRAINABLE_PHASES)}; got {sorted(unknown_phases)}"
             )
         routing["phase_eligibility"] = parsed_phases
     if "cost_rank_basis" in routing_raw:

--- a/src/theforge/config/model_identity.py
+++ b/src/theforge/config/model_identity.py
@@ -175,6 +175,7 @@ class DispatchPhaseRegistry:
     phases: tuple[DispatchPhase, ...]
     by_name: dict[str, DispatchPhase]
     known_phases: frozenset[str]
+    operator_constrainable_phases: frozenset[str]
     default_phase_eligibility: frozenset[str]
     closed_operator_phases: frozenset[str]
 
@@ -187,6 +188,9 @@ def build_dispatch_phase_registry(phases: tuple[DispatchPhase, ...]) -> Dispatch
             raise ValueError(f"duplicate dispatch phase metadata for {phase.name!r}")
         by_name[phase.name] = phase
     known = frozenset(by_name)
+    operator_constrainable = frozenset(
+        phase.name for phase in phases if phase.operator_constrainable
+    )
     default_eligible = frozenset(
         phase.name for phase in phases if phase.operator_constrainable and phase.default_eligible
     )
@@ -195,6 +199,7 @@ def build_dispatch_phase_registry(phases: tuple[DispatchPhase, ...]) -> Dispatch
         phases=phases,
         by_name=by_name,
         known_phases=known,
+        operator_constrainable_phases=operator_constrainable,
         default_phase_eligibility=default_eligible,
         closed_operator_phases=closed,
     )
@@ -226,6 +231,9 @@ def is_known_dispatch_phase(phase: str) -> bool:
 
 _DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = DISPATCH_PHASE_REGISTRY.default_phase_eligibility
 DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = _DEFAULT_PHASE_ELIGIBILITY
+OPERATOR_CONSTRAINABLE_PHASES: frozenset[str] = (
+    DISPATCH_PHASE_REGISTRY.operator_constrainable_phases
+)
 CLOSED_OPERATOR_PHASES: frozenset[str] = DISPATCH_PHASE_REGISTRY.closed_operator_phases
 
 # Domains of the routing fields, kept next to the policy they constrain so both

--- a/src/theforge/config/model_identity.py
+++ b/src/theforge/config/model_identity.py
@@ -142,9 +142,91 @@ class TransportSpec:
             raise ValueError("TransportSpec(kind='api') must not set an executable")
 
 
-_DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = frozenset(
-    {"preflight", "dev", "plan", "review", "advisor"}
+PHASE_PREFLIGHT = "preflight"
+PHASE_DEV = "dev"
+PHASE_PLAN = "plan"
+PHASE_REVIEW = "review"
+PHASE_PLAN_REVIEW = "plan_review"
+PHASE_ADVISOR = "advisor"
+PHASE_KNOWLEDGE_SUMMARY = "knowledge_summary"
+PHASE_DIAGNOSE = "diagnose"
+
+
+@dataclass(frozen=True)
+class DispatchPhase:
+    """Metadata for one runtime ModelProfile phase token."""
+
+    name: str
+    operator_constrainable: bool = True
+    default_eligible: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.operator_constrainable and self.default_eligible:
+            raise ValueError(
+                f"dispatch phase {self.name!r} cannot be default-eligible when it is closed "
+                "to operator routing.phase_eligibility constraints"
+            )
+
+
+@dataclass(frozen=True)
+class DispatchPhaseRegistry:
+    """Derived views over the dispatch-phase metadata source."""
+
+    phases: tuple[DispatchPhase, ...]
+    by_name: dict[str, DispatchPhase]
+    known_phases: frozenset[str]
+    default_phase_eligibility: frozenset[str]
+    closed_operator_phases: frozenset[str]
+
+
+def build_dispatch_phase_registry(phases: tuple[DispatchPhase, ...]) -> DispatchPhaseRegistry:
+    """Derive the routing-phase vocabulary from phase metadata."""
+    by_name: dict[str, DispatchPhase] = {}
+    for phase in phases:
+        if phase.name in by_name:
+            raise ValueError(f"duplicate dispatch phase metadata for {phase.name!r}")
+        by_name[phase.name] = phase
+    known = frozenset(by_name)
+    default_eligible = frozenset(
+        phase.name for phase in phases if phase.operator_constrainable and phase.default_eligible
+    )
+    closed = frozenset(phase.name for phase in phases if not phase.operator_constrainable)
+    return DispatchPhaseRegistry(
+        phases=phases,
+        by_name=by_name,
+        known_phases=known,
+        default_phase_eligibility=default_eligible,
+        closed_operator_phases=closed,
+    )
+
+
+DISPATCH_PHASES: tuple[DispatchPhase, ...] = (
+    DispatchPhase(PHASE_PREFLIGHT),
+    DispatchPhase(PHASE_DEV),
+    DispatchPhase(PHASE_PLAN),
+    DispatchPhase(PHASE_REVIEW),
+    DispatchPhase(PHASE_PLAN_REVIEW),
+    DispatchPhase(PHASE_ADVISOR),
+    DispatchPhase(PHASE_KNOWLEDGE_SUMMARY),
+    DispatchPhase(PHASE_DIAGNOSE, operator_constrainable=False, default_eligible=False),
 )
+DISPATCH_PHASE_REGISTRY = build_dispatch_phase_registry(DISPATCH_PHASES)
+
+
+def is_operator_constrainable_phase(phase: str) -> bool:
+    """Return True when operators may name the phase in routing.phase_eligibility."""
+    meta = DISPATCH_PHASE_REGISTRY.by_name.get(phase)
+    return bool(meta and meta.operator_constrainable)
+
+
+def is_known_dispatch_phase(phase: str) -> bool:
+    """Return True when the phase is a known runtime dispatch token."""
+    return phase in KNOWN_PHASES
+
+
+_DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = DISPATCH_PHASE_REGISTRY.default_phase_eligibility
+DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = _DEFAULT_PHASE_ELIGIBILITY
+CLOSED_OPERATOR_PHASES: frozenset[str] = DISPATCH_PHASE_REGISTRY.closed_operator_phases
 
 # Domains of the routing fields, kept next to the policy they constrain so both
 # declaration surfaces check the same thing. Each is bounded by what actually
@@ -154,11 +236,10 @@ _DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = frozenset(
 # - ``CAPABILITY_RANGE``: the 1-10 scale ``RoutingPolicy.capability`` documents.
 # - ``COST_RANK_RANGE``: the bands role selection reads (1=cheap, 2=mid,
 #   3=strong) — see ``config/pricing.py``.
-# - ``KNOWN_PHASES``: the only phases ever queried, by ``derive_roles()`` in
-#   ``role_derivation.py`` and the single-role advisor selector. It equals the
-#   default set today because every known phase is eligible by default; they are
-#   separate names because a future phase that is *not* default-eligible would
-#   make them diverge.
+# - ``KNOWN_PHASES``: every known runtime dispatch phase token. It is derived
+#   from the dispatch-phase metadata above rather than hand-maintained beside it.
+# - ``DEFAULT_PHASE_ELIGIBILITY``: the constrainable phases a model is eligible
+#   for when it does not declare a narrower list.
 #
 # An unrecognized phase is the sharpest of these: ``_phase_candidates`` falls
 # back to the whole list when filtering empties it, so ``[reviewer]`` for
@@ -167,7 +248,7 @@ _DEFAULT_PHASE_ELIGIBILITY: frozenset[str] = frozenset(
 MODEL_TIERS: frozenset[str] = frozenset({"cheap", "fast", "strong"})
 CAPABILITY_RANGE: tuple[int, int] = (1, 10)
 COST_RANK_RANGE: tuple[int, int] = (1, 3)
-KNOWN_PHASES: frozenset[str] = frozenset({"preflight", "dev", "plan", "review", "advisor"})
+KNOWN_PHASES: frozenset[str] = DISPATCH_PHASE_REGISTRY.known_phases
 
 
 @dataclass(frozen=True)

--- a/src/theforge/config/profiles.py
+++ b/src/theforge/config/profiles.py
@@ -18,6 +18,7 @@ from .defaults import (
     PROVIDER_SDK_MAP,
     SUPPORTED_CLIS,
 )
+from .model_identity import PHASE_DEV, PHASE_PLAN, PHASE_PREFLIGHT, PHASE_REVIEW
 from .models import AgentDef, AgentSpec, _resolve_model_info
 from .pricing import price_tiebreak_signal_for
 from .types import SUPPORTED_PROVIDERS, ModelProfile, TransportFallbackConfig
@@ -79,6 +80,7 @@ def iter_plan_phase_profiles(config: "ForgeConfig") -> Iterator[tuple[str, Model
                 # the investigation set rather than borrowing preflight's
                 # narrowed surface (#2346).
                 allowed_tools=DEFAULT_INVESTIGATION_TOOLS,
+                phase=PHASE_PLAN,
             ),
         )
     plan_agent_review = getattr(config, "plan_agent_review", None)
@@ -406,7 +408,7 @@ def _auto_assign_models(
         budget_usd=dev_budget,
         timeout_seconds=DEFAULT_DEV_PROFILE.timeout_seconds,
         allowed_tools=DEFAULT_DEV_PROFILE.allowed_tools,
-        phase="dev",
+        phase=PHASE_DEV,
         registry_id=dev_info.registry_id,
         registry_source=dev_info.registry_source,
     )
@@ -420,7 +422,7 @@ def _auto_assign_models(
         budget_usd=preflight_budget,
         timeout_seconds=DEFAULT_PREFLIGHT_PROFILE.timeout_seconds,
         allowed_tools=DEFAULT_PREFLIGHT_PROFILE.allowed_tools,
-        phase="preflight",
+        phase=PHASE_PREFLIGHT,
         registry_id=preflight_info.registry_id,
         registry_source=preflight_info.registry_source,
     )
@@ -435,6 +437,7 @@ def _auto_assign_models(
             budget_usd=reviewer_budget,
             timeout_seconds=DEFAULT_REVIEW_PROFILE.timeout_seconds,
             allowed_tools=DEFAULT_REVIEW_PROFILE.allowed_tools,
+            phase=PHASE_REVIEW,
             registry_id=i.registry_id,
             registry_source=i.registry_source,
         )
@@ -454,6 +457,7 @@ def _auto_assign_models(
             budget_usd=synthesis_budget,
             timeout_seconds=DEFAULT_REVIEW_PROFILE.timeout_seconds,
             allowed_tools=DEFAULT_REVIEW_PROFILE.allowed_tools,
+            phase=PHASE_REVIEW,
             registry_id=synth_info.registry_id,
             registry_source=synth_info.registry_source,
         )

--- a/src/theforge/config/role_derivation.py
+++ b/src/theforge/config/role_derivation.py
@@ -18,6 +18,7 @@ from .defaults import (
     DEFAULT_PREFLIGHT_PROFILE,
     DEFAULT_REVIEW_PROFILE,
 )
+from .model_identity import PHASE_DEV, PHASE_PLAN, PHASE_PREFLIGHT, PHASE_REVIEW
 from .models import AgentSpec, ModelInfo, _resolve_model_info
 from .pricing import price_tiebreak_signal_for
 from .schema import (
@@ -269,10 +270,10 @@ def derive_roles(
 
     # Phase-eligibility-aware candidate pools — a model's AgentSpec may exclude it
     # from specific phases (e.g. a pro model excluded from preflight to avoid overspend).
-    dev_pool = _phase_candidates(sorted_models, "dev")
-    preflight_pool = _phase_candidates(sorted_models, "preflight")
-    plan_pool = _phase_candidates(sorted_models, "plan")
-    review_pool_sorted = _phase_candidates(sorted_models, "review")
+    dev_pool = _phase_candidates(sorted_models, PHASE_DEV)
+    preflight_pool = _phase_candidates(sorted_models, PHASE_PREFLIGHT)
+    plan_pool = _phase_candidates(sorted_models, PHASE_PLAN)
+    review_pool_sorted = _phase_candidates(sorted_models, PHASE_REVIEW)
 
     # dev: cheapest dev-capable model; fall back to first if none are dev-capable
     dev_candidates = [(k, i) for k, i in dev_pool if i.dev_capable]

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -1092,6 +1092,7 @@ class PlanAgentReviewConfig:
         if ref is None or (not ref.cli and not ref.provider):
             return []
         from .defaults import API_PROVIDER_DEFAULT_TOOLS, DEFAULT_INVESTIGATION_TOOLS
+        from .model_identity import PHASE_PLAN_REVIEW
 
         allowed_tools = (
             API_PROVIDER_DEFAULT_TOOLS
@@ -1108,6 +1109,7 @@ class PlanAgentReviewConfig:
                 timeout_seconds=ref.timeout_seconds,
                 allowed_tools=allowed_tools,
                 api_fallback=ref.api_fallback,
+                phase=PHASE_PLAN_REVIEW,
             )
         ]
 

--- a/src/theforge/coordinator/diagnose_flow.py
+++ b/src/theforge/coordinator/diagnose_flow.py
@@ -32,6 +32,7 @@ import yaml
 
 from theforge import detach
 from theforge.config import DEFAULT_INVESTIGATION_TOOLS, ForgeConfig, ModelProfile
+from theforge.config.model_identity import PHASE_DIAGNOSE
 from theforge.coordinator.diagnose_evidence import build_starting_evidence
 from theforge.coordinator.log_tee import get_worker_slug, set_worker_slug
 from theforge.coordinator.util import _log as _progress_log
@@ -713,7 +714,7 @@ def _build_diagnose_profile(
         timeout_seconds=(
             timeout_seconds if timeout_seconds is not None else config.diagnose.timeout_seconds
         ),
-        phase="diagnose",
+        phase=PHASE_DIAGNOSE,
     )
 
 

--- a/src/theforge/coordinator/escalation_advisor_flow.py
+++ b/src/theforge/coordinator/escalation_advisor_flow.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 
 from theforge.assignment import NoCapableCandidateError, _capability_exclusions, _capability_pool
 from theforge.config import DEFAULT_INVESTIGATION_TOOLS
-from theforge.config.model_identity import KNOWN_PHASES
+from theforge.config.model_identity import DEFAULT_PHASE_ELIGIBILITY, PHASE_ADVISOR
 from theforge.config.pricing import price_tiebreak_signal_for
 from theforge.escalation_advisor import (
     ACTION_TAXONOMY,
@@ -97,7 +97,7 @@ def _agent_phase_eligibility(config: "ForgeConfig", agent: object) -> frozenset[
     spec = _agent_registry_spec(config, agent)
     if spec is not None:
         return spec.phase_eligibility
-    return KNOWN_PHASES
+    return DEFAULT_PHASE_ELIGIBILITY
 
 
 def _select_advisor_profile(config: "ForgeConfig") -> object:
@@ -107,7 +107,7 @@ def _select_advisor_profile(config: "ForgeConfig") -> object:
         raise ValueError("no configured model candidates are available for the advisor role")
 
     phase_eligible = [
-        agent for agent in agents if "advisor" in _agent_phase_eligibility(config, agent)
+        agent for agent in agents if PHASE_ADVISOR in _agent_phase_eligibility(config, agent)
     ]
     if not phase_eligible:
         raise ValueError(
@@ -142,7 +142,7 @@ def _select_advisor_profile(config: "ForgeConfig") -> object:
     return replace(
         config.preflight_profile,
         name="advisor",
-        phase="advisor",
+        phase=PHASE_ADVISOR,
         cli=selected.cli,
         provider=selected.provider,
         transport=selected.transport,

--- a/src/theforge/coordinator/knowledge_summary_flow.py
+++ b/src/theforge/coordinator/knowledge_summary_flow.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from theforge.config.model_identity import DEFAULT_PHASE_ELIGIBILITY, PHASE_KNOWLEDGE_SUMMARY
 from theforge.knowledge_summary import (
     SummaryValidationError,
     build_summary_artifact,
@@ -41,6 +42,7 @@ from theforge.knowledge_summary import (
     validate_proposed_summary,
     write_summary,
 )
+from theforge.model_capabilities import identity_for_agent, identity_for_profile
 from theforge.task.summary_prompts import build_run_summary_prompt
 
 from . import util as _cu
@@ -172,27 +174,25 @@ def _ensure_runner() -> None:
     run_agent = _r.run_agent
 
 
-def _summary_profile(config: "ForgeConfig") -> "ModelProfile | None":
-    """Derive a tool-free API profile for the summary agent, or None.
+def _agent_registry_spec(config: "ForgeConfig", agent: object) -> object | None:
+    registry = getattr(config, "model_registry", None) or {}
+    registry_id = getattr(agent, "registry_id", None)
+    spec = registry.get(registry_id) if registry_id else None
+    if spec is None:
+        identity = identity_for_agent(agent)
+        if identity is not None:
+            spec = registry.get(identity.key)
+    return spec
 
-    Built from ``config.plan.ref`` — the plan model is the cheap bounded-writing
-    role and the summary is the same kind of work. A CLI-transport ref is
-    projected onto its configured same-provider API fallback; without one there
-    is no dispatch path that is mechanically tool-free, and the caller skips.
-    """
-    from theforge.config.bridge import model_ref_to_profile  # noqa: PLC0415
 
-    ref = getattr(getattr(config, "plan", None), "ref", None)
-    if ref is None:
-        return None
+def _agent_phase_eligibility(config: "ForgeConfig", agent: object) -> frozenset[str]:
+    spec = _agent_registry_spec(config, agent)
+    if spec is not None:
+        return spec.phase_eligibility
+    return DEFAULT_PHASE_ELIGIBILITY
 
-    profile = model_ref_to_profile(
-        "knowledge_summary",
-        ref,
-        allowed_tools=(),
-        phase="knowledge_summary",
-        sandbox_mode="read-only",
-    )
+
+def _project_summary_api_profile(profile: "ModelProfile") -> "ModelProfile | None":
     if profile.mode == "api":
         return profile
 
@@ -210,6 +210,76 @@ def _summary_profile(config: "ForgeConfig") -> "ModelProfile | None":
         base_url=fallback.base_url if fallback.base_url is not None else profile.base_url,
         api_fallback=None,
     )
+
+
+def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str | None]:
+    """Derive a tool-free API profile for the summary agent, or None.
+
+    Built from ``config.plan.ref`` — the plan model is the cheap bounded-writing
+    role and the summary is the same kind of work. A CLI-transport ref is
+    projected onto its configured same-provider API fallback; without one there
+    is no dispatch path that is mechanically tool-free, and the caller skips.
+    """
+    from theforge.config.bridge import model_ref_to_profile  # noqa: PLC0415
+
+    ref = getattr(getattr(config, "plan", None), "ref", None)
+    if ref is None:
+        return (None, None)
+
+    base_profile = model_ref_to_profile(
+        "knowledge_summary",
+        ref,
+        allowed_tools=(),
+        phase=PHASE_KNOWLEDGE_SUMMARY,
+        sandbox_mode="read-only",
+    )
+    base_profile = _project_summary_api_profile(base_profile)
+
+    agents = getattr(config, "agents", None) or []
+    if not agents:
+        return (base_profile, None)
+
+    phase_eligible = [
+        agent
+        for agent in agents
+        if PHASE_KNOWLEDGE_SUMMARY in _agent_phase_eligibility(config, agent)
+    ]
+    if not phase_eligible:
+        return (
+            None,
+            "routing.phase_eligibility excludes knowledge_summary for every configured candidate",
+        )
+
+    projected: list[ModelProfile] = []
+    for agent in phase_eligible:
+        candidate = replace(
+            agent.to_model_profile(allowed_tools=()),
+            phase=PHASE_KNOWLEDGE_SUMMARY,
+            sandbox_mode="read-only",
+        )
+        candidate = _project_summary_api_profile(candidate)
+        if candidate is not None:
+            projected.append(candidate)
+    if not projected:
+        return (
+            None,
+            "no phase-eligible configured model can dispatch knowledge_summary over a tool-free "
+            "API transport",
+        )
+
+    base_identity = identity_for_profile(base_profile) if base_profile is not None else None
+    if base_identity is not None:
+        matching = next(
+            (
+                candidate
+                for candidate in projected
+                if identity_for_profile(candidate) == base_identity
+            ),
+            None,
+        )
+        if matching is not None:
+            return (matching, None)
+    return (projected[0], None)
 
 
 def _should_generate(config: "ForgeConfig", result: "CoordinatorResult", run_id: str) -> bool:
@@ -266,9 +336,9 @@ def maybe_generate_run_summary(
                 ),
             )
 
-        profile = _summary_profile(config)
+        profile, profile_reason = _summary_profile(config)
         if profile is None:
-            reason = (
+            reason = profile_reason or (
                 "no tool-free API transport available for the plan model "
                 "(configure transport_fallback to enable summaries)"
             )

--- a/src/theforge/coordinator/knowledge_summary_flow.py
+++ b/src/theforge/coordinator/knowledge_summary_flow.py
@@ -192,6 +192,19 @@ def _agent_phase_eligibility(config: "ForgeConfig", agent: object) -> frozenset[
     return DEFAULT_PHASE_ELIGIBILITY
 
 
+def _apply_summary_transport_fallback(
+    config: "ForgeConfig",
+    profile: "ModelProfile",
+) -> "ModelProfile":
+    fallbacks = getattr(config, "transport_fallbacks", None) or {}
+    if not fallbacks or profile.api_fallback is not None:
+        return profile
+
+    from theforge.config.profiles import _apply_transport_fallback  # noqa: PLC0415
+
+    return _apply_transport_fallback(profile, fallbacks)
+
+
 def _project_summary_api_profile(profile: "ModelProfile") -> "ModelProfile | None":
     if profile.mode == "api":
         return profile
@@ -212,6 +225,26 @@ def _project_summary_api_profile(profile: "ModelProfile") -> "ModelProfile | Non
     )
 
 
+def _summary_dispatch_profile(
+    summary_envelope: "ModelProfile",
+    selected: "ModelProfile",
+) -> "ModelProfile":
+    """Keep the plan role envelope while swapping in the selected model identity."""
+    return replace(
+        summary_envelope,
+        cli=selected.cli,
+        provider=selected.provider,
+        transport=selected.transport,
+        base_url=selected.base_url,
+        model=selected.model,
+        fallback_models=selected.fallback_models,
+        api_fallback=selected.api_fallback,
+        registry_id=selected.registry_id,
+        registry_source=selected.registry_source,
+        reasoning_mode=selected.reasoning_mode,
+    )
+
+
 def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str | None]:
     """Derive a tool-free API profile for the summary agent, or None.
 
@@ -226,14 +259,15 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
     if ref is None:
         return (None, None)
 
-    base_profile = model_ref_to_profile(
+    summary_envelope = model_ref_to_profile(
         "knowledge_summary",
         ref,
         allowed_tools=(),
         phase=PHASE_KNOWLEDGE_SUMMARY,
         sandbox_mode="read-only",
     )
-    base_profile = _project_summary_api_profile(base_profile)
+    summary_envelope = _apply_summary_transport_fallback(config, summary_envelope)
+    base_profile = _project_summary_api_profile(summary_envelope)
 
     agents = getattr(config, "agents", None) or []
     if not agents:
@@ -250,6 +284,8 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
             "routing.phase_eligibility excludes knowledge_summary for every configured candidate",
         )
 
+    summary_identity = identity_for_profile(summary_envelope)
+    base_identity = identity_for_profile(base_profile) if base_profile is not None else None
     projected: list[ModelProfile] = []
     for agent in phase_eligible:
         candidate = replace(
@@ -257,17 +293,20 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
             phase=PHASE_KNOWLEDGE_SUMMARY,
             sandbox_mode="read-only",
         )
+        candidate = _apply_summary_transport_fallback(config, candidate)
         candidate = _project_summary_api_profile(candidate)
         if candidate is not None:
             projected.append(candidate)
     if not projected:
+        if base_profile is not None and summary_identity is not None:
+            if any(identity_for_agent(agent) == summary_identity for agent in phase_eligible):
+                return (base_profile, None)
         return (
             None,
             "no phase-eligible configured model can dispatch knowledge_summary over a tool-free "
             "API transport",
         )
 
-    base_identity = identity_for_profile(base_profile) if base_profile is not None else None
     if base_identity is not None:
         matching = next(
             (
@@ -278,8 +317,8 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
             None,
         )
         if matching is not None:
-            return (matching, None)
-    return (projected[0], None)
+            return (base_profile, None)
+    return (_summary_dispatch_profile(summary_envelope, projected[0]), None)
 
 
 def _should_generate(config: "ForgeConfig", result: "CoordinatorResult", run_id: str) -> bool:

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -34,6 +34,7 @@ from theforge.config import (
     apply_model_info,
 )
 from theforge.config.bridge import model_ref_to_profile
+from theforge.config.model_identity import PHASE_PLAN
 from theforge.config.profiles import _apply_transport_fallback
 from theforge.log_level import _LOG_LEVEL, LogLevel
 from theforge.plan_finding_classifier import (
@@ -894,6 +895,7 @@ def _run_plan_phase(
             # deliberately narrower (no Bash, #2346) and the plan agent has no
             # reason to inherit that narrowing.
             allowed_tools=DEFAULT_INVESTIGATION_TOOLS,
+            phase=PHASE_PLAN,
             timeout_seconds=_plan_timeout,
         )
         plan_profile = _apply_transport_fallback(plan_profile, config.transport_fallbacks)

--- a/src/theforge/coordinator/preflight.py
+++ b/src/theforge/coordinator/preflight.py
@@ -20,6 +20,7 @@ from theforge.config import (
     model_info_view,
 )
 from theforge.config.bridge import model_ref_to_profile
+from theforge.config.model_identity import PHASE_PLAN
 from theforge.config.profiles import _apply_transport_fallback
 from theforge.review import ReviewFinding
 from theforge.routing import DEV_COMPLEXITY_TIER, score_to_dev_tier
@@ -1405,7 +1406,7 @@ def _apply_preflight_config(
             # See plan_flow: the plan role names the investigation set rather
             # than borrowing preflight's narrowed one (#2346).
             allowed_tools=DEFAULT_INVESTIGATION_TOOLS,
-            phase="plan",
+            phase=PHASE_PLAN,
         )
         _explicit["planner"] = _explicit_planner
     if config.plan_agent_review.enabled and config.plan_agent_review.profiles:

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -23,6 +23,7 @@ from .. import worker_budget
 from ..advisory_conventions import AdvisoryArtifactError
 from ..config import ForgeConfig, ModelProfile
 from ..config.auth import check_agent_auth
+from ..config.model_identity import PHASE_PREFLIGHT
 from ..coordinator import config_snapshot as config_snapshot_mod
 from ..coordinator import workspace as coordinator_workspace
 from ..coordinator.agent_failure import (
@@ -224,7 +225,7 @@ def _build_intake_agent_caller(
         profile = replace(
             config.dev_profile,
             name="intake-remediation",
-            phase="preflight",
+            phase=PHASE_PREFLIGHT,
             allowed_tools=(),
         )
     except TypeError:

--- a/tests/test_coord_knowledge_summary.py
+++ b/tests/test_coord_knowledge_summary.py
@@ -18,6 +18,7 @@ What is pinned here:
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -30,6 +31,7 @@ from theforge.config import (
     DEFAULT_PREFLIGHT_PROFILE,
     DEFAULT_REVIEW_PROFILE,
     DEFAULT_VALIDATION,
+    AgentDef,
     ForgeConfig,
     KnowledgeConfig,
     LogConfig,
@@ -37,7 +39,10 @@ from theforge.config import (
     PlanConfig,
     RetryPolicy,
     WorkspaceConfig,
+    transport_for,
 )
+from theforge.config.model_identity import DEFAULT_PHASE_ELIGIBILITY, PHASE_KNOWLEDGE_SUMMARY
+from theforge.config.models import AGENT_REGISTRY
 from theforge.coordinator import knowledge_summary_flow
 from theforge.coordinator.audit_substrate import CURRENT_RECORD_SCHEMA_VERSION
 from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
@@ -221,6 +226,53 @@ class TestGeneration:
         assert profile.allowed_tools == ()
         assert calls[0]["plain_text"] is True
         assert outcome.status == "written"
+
+    def test_phase_eligibility_can_move_summary_to_another_api_candidate(
+        self, tmp_path: Path, calls: list[dict]
+    ) -> None:
+        excluded = replace(
+            AGENT_REGISTRY["openai/gpt-5.4/api"],
+            routing=replace(
+                AGENT_REGISTRY["openai/gpt-5.4/api"].routing,
+                phase_eligibility=frozenset(DEFAULT_PHASE_ELIGIBILITY - {PHASE_KNOWLEDGE_SUMMARY}),
+            ),
+        )
+        eligible = AGENT_REGISTRY["google/gemini-2.5-pro/api"]
+        config = replace(
+            _make_config(tmp_path, provider="openai", model="gpt-5.4"),
+            agents=[
+                AgentDef(
+                    name="openai-gpt-5-4",
+                    provider="openai",
+                    model="gpt-5.4",
+                    budget_usd=1.0,
+                    timeout_seconds=120,
+                    tier="mid",
+                    transport=transport_for("openai", "api"),
+                ),
+                AgentDef(
+                    name="google-gemini-2-5-pro",
+                    provider="google",
+                    model="gemini-2.5-pro",
+                    budget_usd=1.0,
+                    timeout_seconds=120,
+                    tier="mid",
+                    transport=transport_for("google", "api"),
+                ),
+            ],
+            model_registry={
+                "openai/gpt-5.4/api": excluded,
+                "google/gemini-2.5-pro/api": eligible,
+            },
+        )
+
+        outcome = knowledge_summary_flow.maybe_generate_run_summary(
+            config, _done_result(), _audit()
+        )
+
+        assert outcome.status == "written"
+        assert calls[0]["profile"].model == "gemini-2.5-pro"
+        assert calls[0]["profile"].phase == PHASE_KNOWLEDGE_SUMMARY
 
     def test_summary_dispatch_uses_plain_text_through_the_real_runner_api_seam(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_coord_knowledge_summary.py
+++ b/tests/test_coord_knowledge_summary.py
@@ -38,6 +38,7 @@ from theforge.config import (
     ModelRef,
     PlanConfig,
     RetryPolicy,
+    TransportFallbackConfig,
     WorkspaceConfig,
     transport_for,
 )
@@ -97,6 +98,7 @@ def _make_config(
     run_summaries: bool = True,
     provider: str = "anthropic",
     model: str | None = None,
+    transport_fallbacks: dict[str, TransportFallbackConfig] | None = None,
 ) -> ForgeConfig:
     """A config whose plan model dispatches over an API transport.
 
@@ -132,6 +134,7 @@ def _make_config(
             ),
         ),
         knowledge=KnowledgeConfig(run_summaries=run_summaries),
+        transport_fallbacks=transport_fallbacks or {},
     )
 
 
@@ -272,7 +275,76 @@ class TestGeneration:
 
         assert outcome.status == "written"
         assert calls[0]["profile"].model == "gemini-2.5-pro"
+        assert calls[0]["profile"].name == "knowledge_summary"
+        assert calls[0]["profile"].budget_usd == 0.5
+        assert calls[0]["profile"].timeout_seconds == 300
         assert calls[0]["profile"].phase == PHASE_KNOWLEDGE_SUMMARY
+
+    def test_provider_level_transport_fallback_keeps_cli_pool_summary_dispatchable(
+        self, tmp_path: Path, calls: list[dict]
+    ) -> None:
+        fallback = TransportFallbackConfig(provider="openai", model="gpt-5.4-mini")
+        config = replace(
+            _make_config(
+                tmp_path,
+                provider="openai",
+                model="gpt-5.4",
+                transport_fallbacks={"openai": fallback},
+            ),
+            agents=[
+                AgentDef(
+                    name="openai-gpt-5-4",
+                    provider=None,
+                    cli="codex",
+                    model="gpt-5.4",
+                    budget_usd=3.0,
+                    timeout_seconds=900,
+                    tier="mid",
+                    transport=transport_for("openai", "cli"),
+                ),
+            ],
+        )
+
+        outcome = knowledge_summary_flow.maybe_generate_run_summary(
+            config, _done_result(), _audit()
+        )
+
+        assert outcome.status == "written"
+        profile = calls[0]["profile"]
+        assert profile.mode == "api"
+        assert profile.model == "gpt-5.4-mini"
+        assert profile.name == "knowledge_summary"
+        assert profile.budget_usd == 0.5
+        assert profile.timeout_seconds == 300
+
+    def test_matching_pool_model_keeps_plan_derived_summary_limits(
+        self, tmp_path: Path, calls: list[dict]
+    ) -> None:
+        config = replace(
+            _make_config(tmp_path, provider="openai", model="gpt-5.4"),
+            agents=[
+                AgentDef(
+                    name="openai-gpt-5-4",
+                    provider="openai",
+                    model="gpt-5.4",
+                    budget_usd=3.0,
+                    timeout_seconds=900,
+                    tier="mid",
+                    transport=transport_for("openai", "api"),
+                ),
+            ],
+        )
+
+        outcome = knowledge_summary_flow.maybe_generate_run_summary(
+            config, _done_result(), _audit()
+        )
+
+        assert outcome.status == "written"
+        profile = calls[0]["profile"]
+        assert profile.model == "gpt-5.4"
+        assert profile.name == "knowledge_summary"
+        assert profile.budget_usd == 0.5
+        assert profile.timeout_seconds == 300
 
     def test_summary_dispatch_uses_plain_text_through_the_real_runner_api_seam(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -322,6 +394,49 @@ class TestGeneration:
         assert outcome.attempted is True
         assert calls == []
         assert not summary_path(tmp_path, RUN_ID).exists()
+
+    def test_phase_eligible_matching_cli_pool_model_can_use_plan_ref_api_fallback(
+        self, tmp_path: Path, calls: list[dict]
+    ) -> None:
+        fallback = TransportFallbackConfig(provider="openai", model="gpt-5.4-mini")
+        config = _make_config(tmp_path, provider="openai", model="gpt-5.4")
+        config = replace(
+            config,
+            plan=replace(
+                config.plan,
+                ref=replace(
+                    config.plan.ref,
+                    cli="codex",
+                    provider=None,
+                    transport=transport_for("openai", "cli"),
+                    api_fallback=fallback,
+                ),
+            ),
+            agents=[
+                AgentDef(
+                    name="openai-gpt-5-4",
+                    provider=None,
+                    cli="codex",
+                    model="gpt-5.4",
+                    budget_usd=3.0,
+                    timeout_seconds=900,
+                    tier="mid",
+                    transport=transport_for("openai", "cli"),
+                ),
+            ],
+        )
+
+        outcome = knowledge_summary_flow.maybe_generate_run_summary(
+            config, _done_result(), _audit()
+        )
+
+        assert outcome.status == "written"
+        profile = calls[0]["profile"]
+        assert profile.mode == "api"
+        assert profile.model == "gpt-5.4-mini"
+        assert profile.name == "knowledge_summary"
+        assert profile.budget_usd == 0.5
+        assert profile.timeout_seconds == 300
 
 
 class TestGate:

--- a/tests/test_dispatch_phase_registry.py
+++ b/tests/test_dispatch_phase_registry.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from theforge.config import model_catalog
+from theforge.config.model_catalog import parse_definition
+from theforge.config.model_identity import DispatchPhase, build_dispatch_phase_registry
+
+
+def test_registry_derives_known_default_and_closed_sets_from_phase_metadata() -> None:
+    registry = build_dispatch_phase_registry(
+        (
+            DispatchPhase("synthetic_open"),
+            DispatchPhase(
+                "synthetic_closed",
+                operator_constrainable=False,
+                default_eligible=False,
+            ),
+        )
+    )
+
+    assert registry.known_phases == frozenset({"synthetic_open", "synthetic_closed"})
+    assert registry.default_phase_eligibility == frozenset({"synthetic_open"})
+    assert registry.closed_operator_phases == frozenset({"synthetic_closed"})
+
+
+def test_parser_uses_registry_derived_vocabulary_without_a_second_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = build_dispatch_phase_registry(
+        (
+            DispatchPhase("synthetic_open"),
+            DispatchPhase(
+                "synthetic_closed",
+                operator_constrainable=False,
+                default_eligible=False,
+            ),
+        )
+    )
+    monkeypatch.setattr(model_catalog, "KNOWN_PHASES", registry.known_phases)
+    monkeypatch.setattr(model_catalog, "CLOSED_OPERATOR_PHASES", registry.closed_operator_phases)
+
+    opened = parse_definition(
+        {
+            "provider": "openai",
+            "model": "m",
+            "transport": {"kind": "api"},
+            "routing": {
+                "tier": "cheap",
+                "capability": 7,
+                "cost_rank": 1,
+                "phase_eligibility": ["synthetic_open"],
+            },
+        },
+        where="x",
+    )
+    assert opened.routing["phase_eligibility"] == frozenset({"synthetic_open"})
+
+    with pytest.raises(ValueError, match="deliberately closed"):
+        parse_definition(
+            {
+                "provider": "openai",
+                "model": "m",
+                "transport": {"kind": "api"},
+                "routing": {
+                    "tier": "cheap",
+                    "capability": 7,
+                    "cost_rank": 1,
+                    "phase_eligibility": ["synthetic_closed"],
+                },
+            },
+            where="x",
+        )
+
+
+def test_model_profile_phase_sites_do_not_introduce_new_string_literals() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    guarded = (
+        "src/theforge/config/defaults.py",
+        "src/theforge/config/bridge.py",
+        "src/theforge/config/profiles.py",
+        "src/theforge/config/load.py",
+        "src/theforge/config/types.py",
+        "src/theforge/coordinator/preflight.py",
+        "src/theforge/coordinator/plan_flow.py",
+        "src/theforge/coordinator/escalation_advisor_flow.py",
+        "src/theforge/coordinator/diagnose_flow.py",
+        "src/theforge/coordinator/knowledge_summary_flow.py",
+        "src/theforge/cli/provider_readiness.py",
+        "src/theforge/assignment.py",
+    )
+    violations: list[str] = []
+
+    for relative_path in guarded:
+        path = repo_root / relative_path
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            phase_kw = next((kw for kw in node.keywords if kw.arg == "phase"), None)
+            if phase_kw is None or not isinstance(phase_kw.value, ast.Constant):
+                continue
+            if not isinstance(phase_kw.value.value, str):
+                continue
+            func = node.func
+            func_name = None
+            if isinstance(func, ast.Name):
+                func_name = func.id
+            elif isinstance(func, ast.Attribute):
+                func_name = func.attr
+            if func_name not in {"ModelProfile", "model_ref_to_profile", "replace"}:
+                continue
+            violations.append(f"{relative_path}:{node.lineno}:{phase_kw.value.value}")
+
+    assert not violations, f"phase literals must flow through shared constants: {violations}"

--- a/tests/test_dispatch_phase_registry.py
+++ b/tests/test_dispatch_phase_registry.py
@@ -23,6 +23,7 @@ def test_registry_derives_known_default_and_closed_sets_from_phase_metadata() ->
     )
 
     assert registry.known_phases == frozenset({"synthetic_open", "synthetic_closed"})
+    assert registry.operator_constrainable_phases == frozenset({"synthetic_open"})
     assert registry.default_phase_eligibility == frozenset({"synthetic_open"})
     assert registry.closed_operator_phases == frozenset({"synthetic_closed"})
 
@@ -40,7 +41,11 @@ def test_parser_uses_registry_derived_vocabulary_without_a_second_list(
             ),
         )
     )
-    monkeypatch.setattr(model_catalog, "KNOWN_PHASES", registry.known_phases)
+    monkeypatch.setattr(
+        model_catalog,
+        "OPERATOR_CONSTRAINABLE_PHASES",
+        registry.operator_constrainable_phases,
+    )
     monkeypatch.setattr(
         model_catalog,
         "is_known_dispatch_phase",
@@ -107,8 +112,6 @@ def test_model_profile_phase_sites_do_not_introduce_new_string_literals() -> Non
             elif isinstance(func, ast.Attribute):
                 func_name = func.attr
             if func_name not in {"ModelProfile", "model_ref_to_profile", "replace"}:
-                continue
-            if phase_kw.value.value.upper() == phase_kw.value.value:
                 continue
             violations.append(f"{relative_path}:{node.lineno}:{phase_kw.value.value}")
 

--- a/tests/test_dispatch_phase_registry.py
+++ b/tests/test_dispatch_phase_registry.py
@@ -41,7 +41,16 @@ def test_parser_uses_registry_derived_vocabulary_without_a_second_list(
         )
     )
     monkeypatch.setattr(model_catalog, "KNOWN_PHASES", registry.known_phases)
-    monkeypatch.setattr(model_catalog, "CLOSED_OPERATOR_PHASES", registry.closed_operator_phases)
+    monkeypatch.setattr(
+        model_catalog,
+        "is_known_dispatch_phase",
+        lambda phase: phase in registry.known_phases,
+    )
+    monkeypatch.setattr(
+        model_catalog,
+        "is_operator_constrainable_phase",
+        lambda phase: phase not in registry.closed_operator_phases,
+    )
 
     opened = parse_definition(
         {
@@ -78,24 +87,10 @@ def test_parser_uses_registry_derived_vocabulary_without_a_second_list(
 
 def test_model_profile_phase_sites_do_not_introduce_new_string_literals() -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    guarded = (
-        "src/theforge/config/defaults.py",
-        "src/theforge/config/bridge.py",
-        "src/theforge/config/profiles.py",
-        "src/theforge/config/load.py",
-        "src/theforge/config/types.py",
-        "src/theforge/coordinator/preflight.py",
-        "src/theforge/coordinator/plan_flow.py",
-        "src/theforge/coordinator/escalation_advisor_flow.py",
-        "src/theforge/coordinator/diagnose_flow.py",
-        "src/theforge/coordinator/knowledge_summary_flow.py",
-        "src/theforge/cli/provider_readiness.py",
-        "src/theforge/assignment.py",
-    )
     violations: list[str] = []
 
-    for relative_path in guarded:
-        path = repo_root / relative_path
+    for path in sorted((repo_root / "src/theforge").rglob("*.py")):
+        relative_path = path.relative_to(repo_root).as_posix()
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
@@ -112,6 +107,8 @@ def test_model_profile_phase_sites_do_not_introduce_new_string_literals() -> Non
             elif isinstance(func, ast.Attribute):
                 func_name = func.attr
             if func_name not in {"ModelProfile", "model_ref_to_profile", "replace"}:
+                continue
+            if phase_kw.value.value.upper() == phase_kw.value.value:
                 continue
             violations.append(f"{relative_path}:{node.lineno}:{phase_kw.value.value}")
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -678,8 +678,11 @@ class TestProjectDeclarationsAreAsExpressiveAsShipped:
             },
         )
 
-        with pytest.raises(ValueError, match="only supports"):
+        with pytest.raises(ValueError, match="only supports") as excinfo:
             load_config(path)
+        message = str(excinfo.value)
+        assert "diagnose" not in message
+        assert "knowledge_summary" in message
 
     def test_phase_eligibility_closed_phase_names_the_deliberate_closure(self, tmp_path):
         path = _write(

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -43,6 +43,7 @@ from theforge.config.model_catalog import (
     resolve_packaged,
     resolve_project,
 )
+from theforge.config.model_identity import DEFAULT_PHASE_ELIGIBILITY, PHASE_DIAGNOSE
 from theforge.config.models import AGENT_REGISTRY, RETIRED_MODEL_REGISTRY, transport_for
 from theforge.config.pricing import (
     COST_BAND_BASIS_DECLARED_POLICY,
@@ -137,7 +138,7 @@ class TestLayering:
 # no test change, while re-tiering one of these fails until the expectation is
 # updated in the same commit. A silent re-tier is the failure #2217 was about,
 # and moving the set into YAML is what made it a one-line edit.
-_ALL_PHASES = ("advisor", "dev", "plan", "preflight", "review")
+_ALL_PHASES = tuple(sorted(DEFAULT_PHASE_ELIGIBILITY))
 _SHIPPED_ROUTING: dict[str, tuple[str, int, int, bool, tuple[str, ...]]] = {
     "anthropic/opus/cli": ("strong", 10, 3, True, _ALL_PHASES),
     "anthropic/sonnet/cli": ("fast", 7, 1, True, _ALL_PHASES),
@@ -615,6 +616,102 @@ class TestProjectDeclarationsAreAsExpressiveAsShipped:
         )
         spec = (load_config(path).model_registry or {})["google/gemini-4-pro/api"]
         assert spec.phase_eligibility == frozenset(_ALL_PHASES)
+
+    def test_phase_eligibility_accepts_knowledge_summary_in_forge_yaml(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        {
+                            "provider": "google",
+                            "model": "gemini-4-pro",
+                            "transport": {"kind": "api"},
+                            "routing": {
+                                "tier": "strong",
+                                "capability": 10,
+                                "cost_rank": 3,
+                                "phase_eligibility": ["knowledge_summary", "plan_review"],
+                            },
+                            "cost": {
+                                "input_per_mtok": 2.0,
+                                "output_per_mtok": 12.0,
+                                "pricing_provenance": "gemini-4-pro-2026-08",
+                            },
+                        }
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+
+        spec = (load_config(path).model_registry or {})["google/gemini-4-pro/api"]
+        assert spec.phase_eligibility == frozenset({"knowledge_summary", "plan_review"})
+
+    def test_phase_eligibility_unknown_phase_still_fails_at_load(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        {
+                            "provider": "google",
+                            "model": "gemini-4-pro",
+                            "transport": {"kind": "api"},
+                            "routing": {
+                                "tier": "strong",
+                                "capability": 10,
+                                "cost_rank": 3,
+                                "phase_eligibility": ["launch"],
+                            },
+                            "cost": {
+                                "input_per_mtok": 2.0,
+                                "output_per_mtok": 12.0,
+                                "pricing_provenance": "gemini-4-pro-2026-08",
+                            },
+                        }
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+
+        with pytest.raises(ValueError, match="only supports"):
+            load_config(path)
+
+    def test_phase_eligibility_closed_phase_names_the_deliberate_closure(self, tmp_path):
+        path = _write(
+            tmp_path,
+            {
+                "project": "p",
+                "models": {
+                    "enabled": [
+                        {
+                            "provider": "google",
+                            "model": "gemini-4-pro",
+                            "transport": {"kind": "api"},
+                            "routing": {
+                                "tier": "strong",
+                                "capability": 10,
+                                "cost_rank": 3,
+                                "phase_eligibility": [PHASE_DIAGNOSE],
+                            },
+                            "cost": {
+                                "input_per_mtok": 2.0,
+                                "output_per_mtok": 12.0,
+                                "pricing_provenance": "gemini-4-pro-2026-08",
+                            },
+                        }
+                    ]
+                },
+                "budget_usd": 30.0,
+            },
+        )
+
+        with pytest.raises(ValueError, match="deliberately closed"):
+            load_config(path)
 
     def test_models_custom_accepts_the_canonical_schema(self, tmp_path):
         """A reusable declaration is as expressive as an inline one.


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The prior CLI-pool transport_fallback regression is fixed, knowledge_summary is now operator-constrainable, and targeted tests passed. | [anthropic-opus-cli] All prior findings are resolved and verified at HEAD 4c3ceca6 — the CLI-pool transport_fallback regression, the plan-envelope budget/timeout/name preservation, the unknown-phase message now listing only operator-constrainable phases (diagnose absent), and the AST guard now scanning all of src/theforge with the casing escape hatch removed; 67 tests in the three touched modules pass and the coordinator gate verdict for this commit is PASS.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $13.32
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

_No findings._

## Story

Each dispatchable phase added to forge needs a separate source edit before an operator can constrain it, so the newest phase is always the one that cannot be restricted (GitHub Issue #2500)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2500