### PR TITLE
A story held in a preserved state reports the state without naming what resolves it

### DIFF
--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -33,6 +33,21 @@ forge sprint --verbose --issues N,N,N --budget 50 --parallel 3
 - **Confirm with the operator per-invocation before launching.** Sprints spend
   money; "fix it" is not authorization to spend.
 
+### PRESERVED — escalated worktree held for re-entry
+
+A sprint can report a story as **PRESERVED** when launch triage finds an
+existing escalated worktree from a prior generation and deliberately declines to
+reschedule it in this run. On `forge status` the row stays `status=preserved`
+with phase `—`; in the run log and launch-time stderr the story is reported as:
+"escalated worktree preserved for human review; resolve with `forge run
+--resume <story-file>`."
+
+Treat this as a recoverable halt, not a silent drop. The worktree and resume
+record are still on disk; the exit is the command named in the report:
+`forge run --resume <story-file>`. That command triages the existing worktree
+and resumes from the correct phase (REVIEW, DEV, or full pipeline) instead of
+starting over.
+
 ### Auth readiness gate (issue #1952)
 
 Before any story is dispatched, a sprint inspects the credential each

--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -39,14 +39,25 @@ A sprint can report a story as **PRESERVED** when launch triage finds an
 existing escalated worktree from a prior generation and deliberately declines to
 reschedule it in this run. On `forge status` the row stays `status=preserved`
 with phase `—`; in the run log and launch-time stderr the story is reported as:
-"escalated worktree preserved for human review; resolve with `forge run
---resume <story-file>`."
+
+Issue-backed story:
+
+```text
+escalated worktree preserved for human review; resolve with `forge review --issue 2475`
+```
+
+File-backed story:
+
+```text
+escalated worktree preserved for human review; resolve with `forge review <story-file>`
+```
 
 Treat this as a recoverable halt, not a silent drop. The worktree and resume
 record are still on disk; the exit is the command named in the report:
-`forge run --resume <story-file>`. That command triages the existing worktree
-and resumes from the correct phase (REVIEW, DEV, or full pipeline) instead of
-starting over.
+`forge review --issue 2475` for issue-backed stories, or
+`forge review <story-file>` for file-backed stories. `forge review` triages the
+existing worktree and resumes from the correct phase (REVIEW, DEV, or full
+pipeline) instead of starting over.
 
 ### Auth readiness gate (issue #1952)
 

--- a/docs/guides/controller-runbook.md
+++ b/docs/guides/controller-runbook.md
@@ -55,9 +55,11 @@ escalated worktree preserved for human review; resolve with `forge review <story
 Treat this as a recoverable halt, not a silent drop. The worktree and resume
 record are still on disk; the exit is the command named in the report:
 `forge review --issue 2475` for issue-backed stories, or
-`forge review <story-file>` for file-backed stories. `forge review` triages the
-existing worktree and resumes from the correct phase (REVIEW, DEV, or full
-pipeline) instead of starting over.
+`forge review <story-file>` for file-backed stories. For file-backed reports,
+the runtime substitutes the concrete path when it already knows it; the
+placeholder above is schematic. `forge review` triages the existing worktree
+and resumes from the correct phase (REVIEW, DEV, or full pipeline) instead of
+starting over.
 
 ### Auth readiness gate (issue #1952)
 

--- a/src/theforge/cli/sprint.py
+++ b/src/theforge/cli/sprint.py
@@ -18,7 +18,7 @@ from theforge.sprint.launch_guard import acquire_launch_story_locks
 from theforge.sprint.live_stories import LivenessResolution
 from theforge.sprint.lock import release_story_locks
 from theforge.sprint.preflight import reacquire_story_locks_in_daemon
-from theforge.sprint.runner import parse_manifest_slugs
+from theforge.sprint.runner import parse_manifest_story_refs
 
 # A run's reported disposition must be derived from how it actually ended, not
 # from the absence of a record saying otherwise. ``_BACKSTOP`` carries the
@@ -35,6 +35,12 @@ _UNKNOWN_END_CAUSE = "sprint process ended before recording a completion"
 # is live and nothing is unresolved. Distinct from a failed lookup, which yields
 # an *unresolved* result (see ``_resolve_story_liveness``).
 _NO_LIVENESS = LivenessResolution()
+
+
+def parse_manifest_slugs(config: object, manifest_path: Path) -> list[str]:
+    """CLI seam for pre-launch slug parsing in manifest mode."""
+    slugs, _canonical_refs_by_slug = parse_manifest_story_refs(config, manifest_path)
+    return slugs
 
 
 def _exc_cause(exc: BaseException) -> str:
@@ -291,6 +297,7 @@ def _cmd_sprint(args: object) -> int:
         return 1
 
     slugs = parse_manifest_slugs(config, manifest_path)
+    _parsed_slugs, canonical_refs_by_slug = parse_manifest_story_refs(config, manifest_path)
     # ``reexec`` was captured at the top of cmd_sprint, before setup_detached_child
     # popped FORGE_PREV_RUN_ID — do not recompute it here (the env signal is gone).
     # On the re-exec path, resolve the prior generation's recorded outcomes so the
@@ -319,6 +326,7 @@ def _cmd_sprint(args: object) -> int:
         prior_outcomes=prior_outcomes,
         live_slugs=set(liveness.live_slugs),
         unresolved_slugs=set(liveness.unresolved_slugs),
+        canonical_refs_by_slug=canonical_refs_by_slug,
     )
     if launch_error is not None:
         return launch_error
@@ -439,6 +447,7 @@ def _acquire_launch_locks(
     prior_outcomes: dict[str, str | dict] | None = None,
     live_slugs: set[str] | None = None,
     unresolved_slugs: set[str] | None = None,
+    canonical_refs_by_slug: dict[str, str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
     return acquire_launch_story_locks(
         slugs=slugs,
@@ -449,6 +458,7 @@ def _acquire_launch_locks(
         prior_outcomes=prior_outcomes,
         live_slugs=live_slugs,
         unresolved_slugs=unresolved_slugs,
+        canonical_refs_by_slug=canonical_refs_by_slug,
     )
 
 
@@ -1244,6 +1254,9 @@ def _run_query_mode(
     # ``reexec`` is threaded in from cmd_sprint (captured before the detach
     # handoff popped FORGE_PREV_RUN_ID) — do not recompute it here.
     slugs = [task.slug for task, _src, _ref in resolved.stories]
+    canonical_refs_by_slug = {
+        task.slug: canonical_ref for task, _src, canonical_ref in resolved.stories
+    }
     # On the re-exec path, resolve the prior generation's recorded outcomes so
     # the launch guard can reconcile already-completed worktrees instead of
     # flattening them into fresh collisions. Best-effort — a miss degrades to
@@ -1261,6 +1274,7 @@ def _run_query_mode(
         prior_outcomes=prior_outcomes,
         live_slugs=set(liveness.live_slugs),
         unresolved_slugs=set(liveness.unresolved_slugs),
+        canonical_refs_by_slug=canonical_refs_by_slug,
     )
     if launch_error is not None:
         return launch_error

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -166,9 +166,9 @@ def acquire_launch_story_locks(
     dropped.update({s: REASON_PRESERVED_ESCALATED for s in escalated_slugs})
     schedulable = [s for s in slugs if s not in dropped]
 
-    if escalated_slugs:
+    for slug in escalated_slugs:
         print(
-            f"[forge] {preserved_escalated_message(', '.join(escalated_slugs))}.",
+            f"[forge] {preserved_escalated_message(slug)}.",
             file=sys.stderr,
             flush=True,
         )

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Mapping
 from typing import Any
 
 from theforge.sprint.lock import (
@@ -71,6 +72,7 @@ def acquire_launch_story_locks(
     prior_outcomes: dict[str, str | dict] | None = None,
     live_slugs: set[str] | None = None,
     unresolved_slugs: set[str] | None = None,
+    canonical_refs_by_slug: Mapping[str, str] | None = None,
 ) -> tuple[list, int | None, dict[str, str]]:
     """Acquire launch-time story locks after checking for active worktrees.
 
@@ -106,6 +108,11 @@ def acquire_launch_story_locks(
     evidence that no agent is running, and classifying such a story as a foreign
     ``REASON_ACTIVE_WORKTREE`` collision is what produced #2079 — a sprint
     dropping its own committed work and advising the operator to delete it.
+
+    ``canonical_refs_by_slug`` is best-effort operator context for launch-time
+    preserved messages only. Lock ownership and collision classification remain
+    keyed by slug; the extra ref lets file-backed and custom-slug issue stories
+    name a runnable ``forge review`` command before the full sprint resolves.
 
     Invariants the callers rely on:
 
@@ -167,8 +174,9 @@ def acquire_launch_story_locks(
     schedulable = [s for s in slugs if s not in dropped]
 
     for slug in escalated_slugs:
+        canonical_ref = (canonical_refs_by_slug or {}).get(slug)
         print(
-            f"[forge] {preserved_escalated_message(slug)}.",
+            f"[forge] {preserved_escalated_message(slug, canonical_ref=canonical_ref)}.",
             file=sys.stderr,
             flush=True,
         )

--- a/src/theforge/sprint/launch_guard.py
+++ b/src/theforge/sprint/launch_guard.py
@@ -17,6 +17,7 @@ from theforge.sprint.preflight import (
     drop_conflicting_running_stories,
     warn_for_running_stories,
 )
+from theforge.sprint.preserved_resume import preserved_escalated_message
 from theforge.sprint.prior_landing import (
     PRIOR_SUCCEEDED_OUTCOMES,
     as_prior_record,
@@ -167,8 +168,7 @@ def acquire_launch_story_locks(
 
     if escalated_slugs:
         print(
-            f"[forge] PRESERVED {', '.join(escalated_slugs)}: escalated worktree "
-            "preserved for human review; not rescheduled.",
+            f"[forge] {preserved_escalated_message(', '.join(escalated_slugs))}.",
             file=sys.stderr,
             flush=True,
         )

--- a/src/theforge/sprint/preserved_resume.py
+++ b/src/theforge/sprint/preserved_resume.py
@@ -76,9 +76,6 @@ def preserved_escalated_detail_for_story(story: Mapping[str, object]) -> str:
     )
 
 
-PRESERVED_ESCALATED_DETAIL = preserved_escalated_detail()
-
-
 def preserved_escalated_message(
     slug: str,
     *,

--- a/src/theforge/sprint/preserved_resume.py
+++ b/src/theforge/sprint/preserved_resume.py
@@ -1,0 +1,14 @@
+"""Shared operator guidance for preserved sprint stories."""
+
+from __future__ import annotations
+
+PRESERVED_RESUME_COMMAND = "forge run --resume <story-file>"
+PRESERVED_RESUME_GUIDANCE = f"resolve with `{PRESERVED_RESUME_COMMAND}`"
+PRESERVED_ESCALATED_DETAIL = (
+    f"escalated worktree preserved for human review; {PRESERVED_RESUME_GUIDANCE}"
+)
+
+
+def preserved_escalated_message(slug: str) -> str:
+    """Canonical preserved-state message for an escalated worktree."""
+    return f"PRESERVED {slug}: {PRESERVED_ESCALATED_DETAIL}"

--- a/src/theforge/sprint/preserved_resume.py
+++ b/src/theforge/sprint/preserved_resume.py
@@ -51,8 +51,11 @@ def preserved_review_command(
     issue_number = _issue_number(canonical_ref=canonical_ref, path=path, slug=slug)
     if issue_number is not None:
         return f"forge review --issue {issue_number}"
-    if path is not None:
-        return f"forge review {shlex.quote(path)}"
+    story_path = path
+    if story_path is None and canonical_ref and not canonical_ref.startswith("issue:"):
+        story_path = canonical_ref
+    if story_path is not None:
+        return f"forge review {shlex.quote(story_path)}"
     return PRESERVED_REVIEW_COMMAND
 
 

--- a/src/theforge/sprint/preserved_resume.py
+++ b/src/theforge/sprint/preserved_resume.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import re
+import shlex
 from collections.abc import Mapping
 
 PRESERVED_REVIEW_COMMAND = "forge review <story-file>"
 PRESERVED_REVIEW_GUIDANCE = f"resolve with `{PRESERVED_REVIEW_COMMAND}`"
-_GENERIC_REVIEW_COMMAND = "forge review"
 _ISSUE_PATH_RE = re.compile(r"^Issue #(?P<number>\d+)$")
 _ISSUE_SLUG_RE = re.compile(r"^issue-(?P<number>\d+)$")
 
@@ -51,8 +51,8 @@ def preserved_review_command(
     issue_number = _issue_number(canonical_ref=canonical_ref, path=path, slug=slug)
     if issue_number is not None:
         return f"forge review --issue {issue_number}"
-    if slug and "," in slug:
-        return _GENERIC_REVIEW_COMMAND
+    if path is not None:
+        return f"forge review {shlex.quote(path)}"
     return PRESERVED_REVIEW_COMMAND
 
 

--- a/src/theforge/sprint/preserved_resume.py
+++ b/src/theforge/sprint/preserved_resume.py
@@ -2,13 +2,89 @@
 
 from __future__ import annotations
 
-PRESERVED_RESUME_COMMAND = "forge run --resume <story-file>"
-PRESERVED_RESUME_GUIDANCE = f"resolve with `{PRESERVED_RESUME_COMMAND}`"
-PRESERVED_ESCALATED_DETAIL = (
-    f"escalated worktree preserved for human review; {PRESERVED_RESUME_GUIDANCE}"
-)
+import re
+from collections.abc import Mapping
+
+PRESERVED_REVIEW_COMMAND = "forge review <story-file>"
+PRESERVED_REVIEW_GUIDANCE = f"resolve with `{PRESERVED_REVIEW_COMMAND}`"
+_GENERIC_REVIEW_COMMAND = "forge review"
+_ISSUE_PATH_RE = re.compile(r"^Issue #(?P<number>\d+)$")
+_ISSUE_SLUG_RE = re.compile(r"^issue-(?P<number>\d+)$")
 
 
-def preserved_escalated_message(slug: str) -> str:
+def _story_str(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _issue_number(
+    *,
+    canonical_ref: str | None = None,
+    path: str | None = None,
+    slug: str | None = None,
+) -> str | None:
+    """Best-effort issue number extraction for issue-backed preserved stories."""
+    if canonical_ref and canonical_ref.startswith("issue:"):
+        number = canonical_ref.split(":", 1)[1].strip()
+        if number.isdigit():
+            return number
+    if path:
+        match = _ISSUE_PATH_RE.match(path)
+        if match:
+            return match.group("number")
+    if slug:
+        match = _ISSUE_SLUG_RE.match(slug)
+        if match:
+            return match.group("number")
+    return None
+
+
+def preserved_review_command(
+    *,
+    canonical_ref: str | None = None,
+    path: str | None = None,
+    slug: str | None = None,
+) -> str:
+    """Return the runnable operator command for a preserved escalated story."""
+    issue_number = _issue_number(canonical_ref=canonical_ref, path=path, slug=slug)
+    if issue_number is not None:
+        return f"forge review --issue {issue_number}"
+    if slug and "," in slug:
+        return _GENERIC_REVIEW_COMMAND
+    return PRESERVED_REVIEW_COMMAND
+
+
+def preserved_escalated_detail(
+    *,
+    canonical_ref: str | None = None,
+    path: str | None = None,
+    slug: str | None = None,
+) -> str:
+    """Canonical preserved-state detail with source-appropriate review guidance."""
+    command = preserved_review_command(canonical_ref=canonical_ref, path=path, slug=slug)
+    return f"escalated worktree preserved for human review; resolve with `{command}`"
+
+
+def preserved_escalated_detail_for_story(story: Mapping[str, object]) -> str:
+    """Canonical preserved-state detail derived from a summary/live-status row."""
+    return preserved_escalated_detail(
+        canonical_ref=_story_str(story.get("canonical_ref")),
+        path=_story_str(story.get("path")),
+        slug=_story_str(story.get("slug")),
+    )
+
+
+PRESERVED_ESCALATED_DETAIL = preserved_escalated_detail()
+
+
+def preserved_escalated_message(
+    slug: str,
+    *,
+    canonical_ref: str | None = None,
+    path: str | None = None,
+) -> str:
     """Canonical preserved-state message for an escalated worktree."""
-    return f"PRESERVED {slug}: {PRESERVED_ESCALATED_DETAIL}"
+    detail = preserved_escalated_detail(canonical_ref=canonical_ref, path=path, slug=slug)
+    return f"PRESERVED {slug}: {detail}"

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -1629,35 +1629,49 @@ def _agent_cost_tracking_warnings(config: ForgeConfig) -> list[str]:
     return warnings
 
 
-def parse_manifest_slugs(config: "ForgeConfig", manifest_path: Path) -> list[str]:
-    """Extract story slugs from a sprint manifest without full validation.
+def parse_manifest_story_refs(
+    config: "ForgeConfig", manifest_path: Path
+) -> tuple[list[str], dict[str, str]]:
+    """Extract manifest slugs plus best-effort canonical refs.
 
-    Returns an empty list if the manifest cannot be parsed or has no stories.
-    Used for pre-launch conflict detection — does not raise on invalid manifests.
+    Returns ``([], {})`` if the manifest cannot be parsed or has no stories.
+    Used for pre-launch conflict detection and operator guidance, so it stays
+    best-effort and does not raise on invalid manifests.
     """
     try:
         with open(manifest_path, encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
         if not isinstance(raw, dict):
-            return []
+            return [], {}
         stories = raw.get("stories") or raw.get("specs") or []
         if not isinstance(stories, list):
-            return []
+            return [], {}
         slugs: list[str] = []
+        canonical_refs_by_slug: dict[str, str] = {}
         for entry in stories:
             if isinstance(entry, dict) and "issue" in entry:
-                slugs.append(entry.get("slug", f"issue-{entry['issue']}"))
+                slug = entry.get("slug", f"issue-{entry['issue']}")
+                slugs.append(slug)
+                canonical_refs_by_slug[slug] = f"issue:{entry['issue']}"
             elif isinstance(entry, str):
                 story_path = (config.project_root / entry).resolve()
                 if story_path.exists():
                     task = _build_task_from_story(story_path)
-                    slugs.append(task.slug)
+                    slug = task.slug
                 else:
                     # Fallback: use file stem as slug
-                    slugs.append(Path(entry).stem)
-        return slugs
+                    slug = Path(entry).stem
+                slugs.append(slug)
+                canonical_refs_by_slug[slug] = entry
+        return slugs, canonical_refs_by_slug
     except Exception:
-        return []
+        return [], {}
+
+
+def parse_manifest_slugs(config: "ForgeConfig", manifest_path: Path) -> list[str]:
+    """Extract story slugs from a sprint manifest without full validation."""
+    slugs, _canonical_refs_by_slug = parse_manifest_story_refs(config, manifest_path)
+    return slugs
 
 
 #: A collision claim is held while its story is running past the plan gate.

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -5925,10 +5925,17 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
             reason = REASON_STRANDED_WORKTREE
             _dropped_slugs[slug] = reason
         if reason == "preserved-escalated":
-            _log(preserved_escalated_message(slug))
+            _, _, _canonical_ref = _ctx.slug_to_context[slug]
+            _log(preserved_escalated_message(slug, canonical_ref=_canonical_ref))
             _sprint_state.dag.mark_skipped(slug)
             _set_outcome(_sprint_state, slug, StoryOutcome.PRESERVED, reason=reason)
-            _record_current_story_entry(slug, "PRESERVED", error=reason, error_type="dropped")
+            _record_current_story_entry(
+                slug,
+                "PRESERVED",
+                error=reason,
+                error_type="dropped",
+                extras={"drop_reason": reason},
+            )
         elif reason == REASON_RECONCILE_PRIOR_DONE:
             # The prior generation already completed this story; its worktree
             # collision is a reconcilable success, not a fresh drop. Mark it

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -137,6 +137,7 @@ from .manifest import (
     _build_task_from_story,
     resolve_from_manifest,
 )
+from .preserved_resume import preserved_escalated_message
 from .prior_landing import landing_settled
 from .query import (
     NormalizedDependencyPlan,
@@ -5924,7 +5925,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
             reason = REASON_STRANDED_WORKTREE
             _dropped_slugs[slug] = reason
         if reason == "preserved-escalated":
-            _log(f"PRESERVED {slug} (escalated worktree held for review)")
+            _log(preserved_escalated_message(slug))
             _sprint_state.dag.mark_skipped(slug)
             _set_outcome(_sprint_state, slug, StoryOutcome.PRESERVED, reason=reason)
             _record_current_story_entry(slug, "PRESERVED", error=reason, error_type="dropped")

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -14,7 +14,7 @@ from .audit import (
     preflight_degraded_row_fields_from_audit,
     preflight_degraded_row_fields_from_row,
 )
-from .preserved_resume import PRESERVED_ESCALATED_DETAIL
+from .preserved_resume import preserved_escalated_detail_for_story
 
 
 @dataclass
@@ -279,6 +279,14 @@ def _nonempty_str(value: object) -> str | None:
         return None
     stripped = value.strip()
     return stripped or None
+
+
+def _is_preserved_escalated_story(story: dict) -> bool:
+    """Whether a live/completed row represents a preserved escalated worktree."""
+    for key in ("reason", "drop_reason", "error"):
+        if _nonempty_str(story.get(key)) == "preserved-escalated":
+            return True
+    return False
 
 
 def _parse_status_timestamp(value: object) -> datetime.datetime | None:
@@ -845,7 +853,7 @@ def _live_stage_and_detail(story: dict) -> tuple[str, str, str | None]:
             and preserved_reason == "preserved-escalated"
             and (final_outcome in {None, "PRESERVED"} or not isinstance(final_outcome, str))
         ):
-            return "", PRESERVED_ESCALATED_DETAIL, complexity
+            return "", preserved_escalated_detail_for_story(story), complexity
         if isinstance(final_outcome, str) and final_outcome:
             if final_outcome == "ALREADY_DONE":
                 return (
@@ -1067,11 +1075,8 @@ def _stage_and_detail_from_completed_story(
             detail = "APPROVE"
         elif verdict:
             detail = verdict
-        elif (
-            outcome == "PRESERVED"
-            and _nonempty_str(story.get("drop_reason")) == "preserved-escalated"
-        ):
-            detail = PRESERVED_ESCALATED_DETAIL
+        elif outcome == "PRESERVED" and _is_preserved_escalated_story(story):
+            detail = preserved_escalated_detail_for_story(story)
         elif outcome in {"SKIPPED", "DROPPED"}:
             detail = (
                 _nonempty_str(story.get("error"))

--- a/src/theforge/sprint/status_reader.py
+++ b/src/theforge/sprint/status_reader.py
@@ -14,6 +14,7 @@ from .audit import (
     preflight_degraded_row_fields_from_audit,
     preflight_degraded_row_fields_from_row,
 )
+from .preserved_resume import PRESERVED_ESCALATED_DETAIL
 
 
 @dataclass
@@ -818,6 +819,9 @@ def _live_stage_and_detail(story: dict) -> tuple[str, str, str | None]:
         if status_val in {"failed", "skipped"} and final_outcome in {"DONE", "ALREADY_DONE"}:
             canonical_outcome = _nonempty_str(story.get("outcome"))
             final_outcome = canonical_outcome.upper() if canonical_outcome else None
+        preserved_reason = (
+            _nonempty_str(story.get("reason")) if status_val == "preserved" else None
+        )
         skip_reason = _nonempty_str(story.get("reason")) if status_val == "skipped" else None
         # Intake-drop outcomes carry structured rule codes in the detail dict.
         # Surfacing them in the DETAIL column keeps operators from having to
@@ -836,6 +840,12 @@ def _live_stage_and_detail(story: dict) -> tuple[str, str, str | None]:
             and final_outcome in {"SKIPPED", "DROPPED"}
         ):
             return "", skip_reason, complexity
+        if (
+            status_val == "preserved"
+            and preserved_reason == "preserved-escalated"
+            and (final_outcome in {None, "PRESERVED"} or not isinstance(final_outcome, str))
+        ):
+            return "", PRESERVED_ESCALATED_DETAIL, complexity
         if isinstance(final_outcome, str) and final_outcome:
             if final_outcome == "ALREADY_DONE":
                 return (
@@ -1057,6 +1067,11 @@ def _stage_and_detail_from_completed_story(
             detail = "APPROVE"
         elif verdict:
             detail = verdict
+        elif (
+            outcome == "PRESERVED"
+            and _nonempty_str(story.get("drop_reason")) == "preserved-escalated"
+        ):
+            detail = PRESERVED_ESCALATED_DETAIL
         elif outcome in {"SKIPPED", "DROPPED"}:
             detail = (
                 _nonempty_str(story.get("error"))

--- a/tests/test_claude_docs.py
+++ b/tests/test_claude_docs.py
@@ -1,10 +1,5 @@
 from pathlib import Path
 
-from theforge.sprint.preserved_resume import (
-    PRESERVED_REVIEW_COMMAND,
-    preserved_review_command,
-)
-
 ROOT = Path(__file__).resolve().parents[1]
 SUBSYSTEMS = ["coordinator", "runners", "sprint", "task", "config", "cli"]
 REQUIRED_SECTIONS = ["## Purpose", "## Invariants", "## Context"]
@@ -72,15 +67,3 @@ def test_memory_migration_audit_doc_exists() -> None:
     text = (ROOT / "docs" / "memory-migration.md").read_text()
     assert "Project-level files moved into `CONVENTIONS.md`" in text
     assert "User-local files retained in user memory" in text
-
-
-def test_controller_runbook_preserved_section_matches_runtime_guidance() -> None:
-    text = (ROOT / "docs" / "guides" / "controller-runbook.md").read_text()
-    preserved_section = text.split("### PRESERVED", 1)[1].split("### Auth readiness gate", 1)[0]
-
-    assert (
-        f"resolve with `{preserved_review_command(path='Issue #2475', slug='issue-2475')}`"
-        in preserved_section
-    )
-    assert f"resolve with `{PRESERVED_REVIEW_COMMAND}`" in preserved_section
-    assert "forge run --resume <story-file>" not in preserved_section

--- a/tests/test_claude_docs.py
+++ b/tests/test_claude_docs.py
@@ -1,5 +1,10 @@
 from pathlib import Path
 
+from theforge.sprint.preserved_resume import (
+    PRESERVED_REVIEW_COMMAND,
+    preserved_review_command,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 SUBSYSTEMS = ["coordinator", "runners", "sprint", "task", "config", "cli"]
 REQUIRED_SECTIONS = ["## Purpose", "## Invariants", "## Context"]
@@ -67,3 +72,15 @@ def test_memory_migration_audit_doc_exists() -> None:
     text = (ROOT / "docs" / "memory-migration.md").read_text()
     assert "Project-level files moved into `CONVENTIONS.md`" in text
     assert "User-local files retained in user memory" in text
+
+
+def test_controller_runbook_preserved_section_matches_runtime_guidance() -> None:
+    text = (ROOT / "docs" / "guides" / "controller-runbook.md").read_text()
+    preserved_section = text.split("### PRESERVED", 1)[1].split("### Auth readiness gate", 1)[0]
+
+    assert (
+        f"resolve with `{preserved_review_command(path='Issue #2475', slug='issue-2475')}`"
+        in preserved_section
+    )
+    assert f"resolve with `{PRESERVED_REVIEW_COMMAND}`" in preserved_section
+    assert "forge run --resume <story-file>" not in preserved_section

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -1267,6 +1267,24 @@ def test_stage_and_detail_failed_with_stale_done_does_not_leak() -> None:
     assert detail in {"ESCALATED", "ESCALATE"}
 
 
+def test_stage_and_detail_preserved_names_resume_command() -> None:
+    """A preserved story should state the shipped resume command, not just PRESERVED."""
+    from theforge.sprint.preserved_resume import PRESERVED_ESCALATED_DETAIL
+    from theforge.sprint.status_reader import _stage_and_detail_from_live_story
+
+    story = {
+        "slug": "issue-2475",
+        "path": "Issue #2475",
+        "status": "preserved",
+        "outcome": "preserved",
+        "phase": None,
+        "detail": {"final_outcome": "PRESERVED"},
+        "reason": "preserved-escalated",
+    }
+    _stage, detail, _complexity = _stage_and_detail_from_live_story(story)
+    assert detail == PRESERVED_ESCALATED_DETAIL
+
+
 def test_completed_failed_story_with_stale_verdict_does_not_show_approve() -> None:
     """Completed FAILED row with stale verdict=APPROVE must not render APPROVE."""
     from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
@@ -1310,6 +1328,21 @@ def test_completed_skipped_story_with_stale_verdict_does_not_show_approve() -> N
     _stage, detail, _complexity = _stage_and_detail_from_completed_story(story, None)
     assert "APPROVE" not in detail
     assert detail == "SKIPPED"
+
+
+def test_completed_preserved_story_names_resume_command() -> None:
+    """Completed PRESERVED rows should keep the same resume guidance."""
+    from theforge.sprint.preserved_resume import PRESERVED_ESCALATED_DETAIL
+    from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
+
+    story = {
+        "slug": "issue-2475",
+        "path": "Issue #2475",
+        "outcome": "PRESERVED",
+        "drop_reason": "preserved-escalated",
+    }
+    _stage, detail, _complexity = _stage_and_detail_from_completed_story(story, None)
+    assert detail == PRESERVED_ESCALATED_DETAIL
 
 
 def test_completed_done_story_verdict_is_preserved() -> None:

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import datetime
 import io
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -1267,9 +1268,9 @@ def test_stage_and_detail_failed_with_stale_done_does_not_leak() -> None:
     assert detail in {"ESCALATED", "ESCALATE"}
 
 
-def test_stage_and_detail_preserved_names_resume_command() -> None:
-    """A preserved story should state the shipped resume command, not just PRESERVED."""
-    from theforge.sprint.preserved_resume import PRESERVED_ESCALATED_DETAIL
+def test_stage_and_detail_preserved_names_review_command() -> None:
+    """A preserved issue story should name the runnable review command."""
+    from theforge.sprint.preserved_resume import preserved_escalated_detail_for_story
     from theforge.sprint.status_reader import _stage_and_detail_from_live_story
 
     story = {
@@ -1282,7 +1283,7 @@ def test_stage_and_detail_preserved_names_resume_command() -> None:
         "reason": "preserved-escalated",
     }
     _stage, detail, _complexity = _stage_and_detail_from_live_story(story)
-    assert detail == PRESERVED_ESCALATED_DETAIL
+    assert detail == preserved_escalated_detail_for_story(story)
 
 
 def test_completed_failed_story_with_stale_verdict_does_not_show_approve() -> None:
@@ -1330,9 +1331,9 @@ def test_completed_skipped_story_with_stale_verdict_does_not_show_approve() -> N
     assert detail == "SKIPPED"
 
 
-def test_completed_preserved_story_names_resume_command() -> None:
-    """Completed PRESERVED rows should keep the same resume guidance."""
-    from theforge.sprint.preserved_resume import PRESERVED_ESCALATED_DETAIL
+def test_completed_preserved_story_names_review_command() -> None:
+    """Completed PRESERVED rows should keep the same review guidance."""
+    from theforge.sprint.preserved_resume import preserved_escalated_detail_for_story
     from theforge.sprint.status_reader import _stage_and_detail_from_completed_story
 
     story = {
@@ -1342,7 +1343,66 @@ def test_completed_preserved_story_names_resume_command() -> None:
         "drop_reason": "preserved-escalated",
     }
     _stage, detail, _complexity = _stage_and_detail_from_completed_story(story, None)
-    assert detail == PRESERVED_ESCALATED_DETAIL
+    assert detail == preserved_escalated_detail_for_story(story)
+
+
+def test_completed_preserved_story_from_current_entry_error_shape_names_review_command(
+    tmp_path: Path,
+) -> None:
+    """Completed status must render preserved current-entry rows written with only error."""
+    from theforge.sprint.audit import _write_sprint_summary
+    from theforge.sprint.manifest import SprintResult
+    from theforge.sprint.preserved_resume import preserved_escalated_detail_for_story
+    from theforge.sprint.status_reader import read_completed_status
+
+    manifest = MagicMock()
+    manifest.name = "test-sprint"
+    manifest.budget_usd = 1.0
+    manifest.max_parallel = 1
+
+    sprint_result = SprintResult(
+        name="test-sprint",
+        specs_total=1,
+        specs_succeeded=0,
+        specs_failed=1,
+        specs_skipped=0,
+        total_cost_usd=0.0,
+        budget_usd=1.0,
+        results=[],
+    )
+
+    now = datetime.datetime(2026, 8, 18, tzinfo=datetime.timezone.utc)
+    sprint_log_dir = tmp_path / ".forge" / "logs" / "test-sprint"
+    sprint_log_dir.mkdir(parents=True, exist_ok=True)
+    _write_sprint_summary(
+        manifest=manifest,
+        result=sprint_result,
+        canonical_refs=["issue:2475"],
+        started_at=now,
+        finished_at=now,
+        duration=1.0,
+        sprint_log_dir=sprint_log_dir,
+        slug_map={"issue:2475": "issue-2475"},
+        current_story_entries_by_ref={
+            "issue:2475": {
+                "slug": "issue-2475",
+                "path": "Issue #2475",
+                "outcome": "PRESERVED",
+                "error": "preserved-escalated",
+                "error_type": "dropped",
+                "cost_usd": 0.0,
+                "merge": False,
+                "batch": 0,
+                "depends_on": [],
+            }
+        },
+    )
+
+    entries = read_completed_status(sprint_log_dir / "sprint-summary.yaml")
+    assert len(entries) == 1
+    assert entries[0].detail == preserved_escalated_detail_for_story(
+        {"slug": "issue-2475", "path": "Issue #2475"}
+    )
 
 
 def test_completed_done_story_verdict_is_preserved() -> None:

--- a/tests/test_sprint_abnormal_evidence.py
+++ b/tests/test_sprint_abnormal_evidence.py
@@ -151,6 +151,32 @@ def test_preserved_drop_log_names_review_command(tmp_path: Path, capsys) -> None
     assert preserved_escalated_detail(slug="issue-2048") in capsys.readouterr().err
 
 
+def test_file_backed_preserved_drop_log_names_concrete_story_path(tmp_path: Path, capsys) -> None:
+    """The runner log uses the known file-backed story path, not a placeholder."""
+    _make_spec_file(tmp_path, "Feature A", "feature-a")
+    _make_spec_file(tmp_path, "Feature B", "feature-b")
+    manifest_path = _make_manifest(tmp_path, ["feature-a.md", "feature-b.md"])
+    config = _make_config(tmp_path)
+
+    with (
+        patch("theforge.sprint.runner._triage_spec", side_effect=_triage_full),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value={}),
+        patch("theforge.sprint.runner.run_task", return_value=_make_coordinator_result()),
+        patch("theforge.sprint.runner._run_baseline_gate") as mock_gate,
+    ):
+        mock_gate.return_value = {"passed": True, "message": "ok"}
+        run_sprint_ctx(
+            config,
+            manifest_path,
+            run_id="run-2030-file-backed",
+            dropped_slugs={"feature-a": REASON_PRESERVED_ESCALATED},
+        )
+
+    err = capsys.readouterr().err
+    assert preserved_escalated_detail(canonical_ref="feature-a.md", slug="feature-a") in err
+    assert "resolve with `forge review <story-file>`" not in err
+
+
 def test_drop_record_never_overwrites_an_existing_story_audit(tmp_path: Path) -> None:
     """A drop must not replace the audit of the generation that actually ran.
 

--- a/tests/test_sprint_abnormal_evidence.py
+++ b/tests/test_sprint_abnormal_evidence.py
@@ -36,7 +36,12 @@ from theforge.sprint.abnormal import (
     build_abnormal_cause,
     derive_failure_cause,
 )
-from theforge.sprint.launch_guard import REASON_ACTIVE_WORKTREE, REASON_STRANDED_WORKTREE
+from theforge.sprint.launch_guard import (
+    REASON_ACTIVE_WORKTREE,
+    REASON_PRESERVED_ESCALATED,
+    REASON_STRANDED_WORKTREE,
+)
+from theforge.sprint.preserved_resume import PRESERVED_ESCALATED_DETAIL
 from theforge.sprint.story_state import SprintStoryState, StoryOutcome
 
 # ── helpers ──────────────────────────────────────────────────────────
@@ -137,6 +142,13 @@ def test_stranded_worktree_drop_also_leaves_a_record(tmp_path: Path) -> None:
     abnormal = _story_audits(tmp_path)["issue-2048"]["abnormal_termination"]
     assert abnormal["kind"] == ABNORMAL_LAUNCH_GUARD_DROP
     assert REASON_STRANDED_WORKTREE in abnormal["cause"]
+
+
+def test_preserved_drop_log_names_resume_command(tmp_path: Path, capsys) -> None:
+    """The preserved runner log states how the operator exits the held state."""
+    _run_sprint_with_drop(tmp_path, reason=REASON_PRESERVED_ESCALATED)
+
+    assert PRESERVED_ESCALATED_DETAIL in capsys.readouterr().err
 
 
 def test_drop_record_never_overwrites_an_existing_story_audit(tmp_path: Path) -> None:

--- a/tests/test_sprint_abnormal_evidence.py
+++ b/tests/test_sprint_abnormal_evidence.py
@@ -41,7 +41,7 @@ from theforge.sprint.launch_guard import (
     REASON_PRESERVED_ESCALATED,
     REASON_STRANDED_WORKTREE,
 )
-from theforge.sprint.preserved_resume import PRESERVED_ESCALATED_DETAIL
+from theforge.sprint.preserved_resume import preserved_escalated_detail
 from theforge.sprint.story_state import SprintStoryState, StoryOutcome
 
 # ── helpers ──────────────────────────────────────────────────────────
@@ -144,11 +144,11 @@ def test_stranded_worktree_drop_also_leaves_a_record(tmp_path: Path) -> None:
     assert REASON_STRANDED_WORKTREE in abnormal["cause"]
 
 
-def test_preserved_drop_log_names_resume_command(tmp_path: Path, capsys) -> None:
-    """The preserved runner log states how the operator exits the held state."""
+def test_preserved_drop_log_names_review_command(tmp_path: Path, capsys) -> None:
+    """The preserved runner log states how the operator reviews the held state."""
     _run_sprint_with_drop(tmp_path, reason=REASON_PRESERVED_ESCALATED)
 
-    assert PRESERVED_ESCALATED_DETAIL in capsys.readouterr().err
+    assert preserved_escalated_detail(slug="issue-2048") in capsys.readouterr().err
 
 
 def test_drop_record_never_overwrites_an_existing_story_audit(tmp_path: Path) -> None:

--- a/tests/test_sprint_preserved_resume.py
+++ b/tests/test_sprint_preserved_resume.py
@@ -26,6 +26,12 @@ def test_preserved_review_command_names_file_backed_story_path() -> None:
     )
 
 
+def test_preserved_review_command_uses_file_backed_canonical_ref_when_path_missing() -> None:
+    assert preserved_review_command(canonical_ref="stories/my story.md", slug="my-story") == (
+        "forge review 'stories/my story.md'"
+    )
+
+
 def test_controller_runbook_preserved_section_matches_runtime_guidance() -> None:
     text = (ROOT / "docs" / "guides" / "controller-runbook.md").read_text()
     preserved_section = text.split("### PRESERVED", 1)[1].split("### Auth readiness gate", 1)[0]
@@ -35,4 +41,5 @@ def test_controller_runbook_preserved_section_matches_runtime_guidance() -> None
         in preserved_section
     )
     assert f"resolve with `{PRESERVED_REVIEW_COMMAND}`" in preserved_section
+    assert "substitutes the concrete path when it already knows it" in preserved_section
     assert "forge run --resume <story-file>" not in preserved_section

--- a/tests/test_sprint_preserved_resume.py
+++ b/tests/test_sprint_preserved_resume.py
@@ -1,0 +1,38 @@
+"""Tests for preserved-story operator guidance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from theforge.sprint.preserved_resume import (
+    PRESERVED_REVIEW_COMMAND,
+    preserved_review_command,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_preserved_review_command_names_issue_backed_story() -> None:
+    assert (
+        preserved_review_command(path="Issue #2475", slug="issue-2475")
+        == "forge review --issue 2475"
+    )
+
+
+def test_preserved_review_command_names_file_backed_story_path() -> None:
+    assert (
+        preserved_review_command(path="stories/my story.md", slug="my-story")
+        == "forge review 'stories/my story.md'"
+    )
+
+
+def test_controller_runbook_preserved_section_matches_runtime_guidance() -> None:
+    text = (ROOT / "docs" / "guides" / "controller-runbook.md").read_text()
+    preserved_section = text.split("### PRESERVED", 1)[1].split("### Auth readiness gate", 1)[0]
+
+    assert (
+        f"resolve with `{preserved_review_command(path='Issue #2475', slug='issue-2475')}`"
+        in preserved_section
+    )
+    assert f"resolve with `{PRESERVED_REVIEW_COMMAND}`" in preserved_section
+    assert "forge run --resume <story-file>" not in preserved_section

--- a/tests/test_sprint_reexec_collision.py
+++ b/tests/test_sprint_reexec_collision.py
@@ -19,7 +19,7 @@ import yaml
 
 from theforge.artifacts import ESCALATED_MARKER_PATH
 from theforge.sprint.launch_guard import acquire_launch_story_locks
-from theforge.sprint.preserved_resume import PRESERVED_ESCALATED_DETAIL
+from theforge.sprint.preserved_resume import preserved_escalated_detail
 
 
 def _mock_config(tmp_path: Path) -> MagicMock:
@@ -117,7 +117,7 @@ class TestEscalatedWorktreeNotTreatedAsCollision:
         assert dropped == {"issue-829": "preserved-escalated"}
         # No lock is held for the preserved escalated worktree.
         assert locked_fds == []
-        assert PRESERVED_ESCALATED_DETAIL in capsys.readouterr().err
+        assert preserved_escalated_detail(slug="issue-829") in capsys.readouterr().err
 
     def test_reexec_with_escalated_and_pending_story(self, tmp_path: Path) -> None:
         """Scenario from the bug: three stories, middle escalated, third must run.

--- a/tests/test_sprint_reexec_collision.py
+++ b/tests/test_sprint_reexec_collision.py
@@ -19,6 +19,7 @@ import yaml
 
 from theforge.artifacts import ESCALATED_MARKER_PATH
 from theforge.sprint.launch_guard import acquire_launch_story_locks
+from theforge.sprint.preserved_resume import PRESERVED_ESCALATED_DETAIL
 
 
 def _mock_config(tmp_path: Path) -> MagicMock:
@@ -95,7 +96,7 @@ class TestEscalatedWorktreeNotTreatedAsCollision:
 
             release_story_locks(locked_fds)
 
-    def test_escalated_worktree_is_preserved_not_scheduled(self, tmp_path: Path) -> None:
+    def test_escalated_worktree_is_preserved_not_scheduled(self, tmp_path: Path, capsys) -> None:
         """An escalated worktree is excluded from scheduling — no lock, no rerun."""
         _make_worktree_with_audit(tmp_path, "issue-829", final_phase="ESCALATE")
         config = _mock_config(tmp_path)
@@ -116,6 +117,7 @@ class TestEscalatedWorktreeNotTreatedAsCollision:
         assert dropped == {"issue-829": "preserved-escalated"}
         # No lock is held for the preserved escalated worktree.
         assert locked_fds == []
+        assert PRESERVED_ESCALATED_DETAIL in capsys.readouterr().err
 
     def test_reexec_with_escalated_and_pending_story(self, tmp_path: Path) -> None:
         """Scenario from the bug: three stories, middle escalated, third must run.

--- a/tests/test_sprint_reexec_collision.py
+++ b/tests/test_sprint_reexec_collision.py
@@ -119,6 +119,40 @@ class TestEscalatedWorktreeNotTreatedAsCollision:
         assert locked_fds == []
         assert preserved_escalated_detail(slug="issue-829") in capsys.readouterr().err
 
+    def test_multiple_preserved_escalated_worktrees_each_name_runnable_command(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Each preserved slug should render its own runnable review command."""
+        _make_worktree_with_audit(tmp_path, "issue-829", final_phase="ESCALATE")
+        _make_worktree_with_audit(tmp_path, "issue-830", final_phase="ESCALATE")
+        config = _mock_config(tmp_path)
+
+        git_results = [
+            MagicMock(returncode=0, stdout="7\n"),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout="5\n"),
+            MagicMock(returncode=0, stdout=""),
+        ]
+        with patch("theforge.sprint.lock.subprocess.run", side_effect=git_results):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["issue-829", "issue-830"],
+                config=config,
+                resume=False,
+                allow_drop=False,
+            )
+
+        assert launch_error is None
+        assert dropped == {
+            "issue-829": "preserved-escalated",
+            "issue-830": "preserved-escalated",
+        }
+        assert locked_fds == []
+        err = capsys.readouterr().err
+        assert preserved_escalated_detail(slug="issue-829") in err
+        assert preserved_escalated_detail(slug="issue-830") in err
+        assert "PRESERVED issue-829, issue-830" not in err
+        assert "resolve with `forge review`" not in err
+
     def test_reexec_with_escalated_and_pending_story(self, tmp_path: Path) -> None:
         """Scenario from the bug: three stories, middle escalated, third must run.
 

--- a/tests/test_sprint_reexec_collision.py
+++ b/tests/test_sprint_reexec_collision.py
@@ -153,6 +153,66 @@ class TestEscalatedWorktreeNotTreatedAsCollision:
         assert "PRESERVED issue-829, issue-830" not in err
         assert "resolve with `forge review`" not in err
 
+    def test_file_backed_preserved_launch_message_names_concrete_story_path(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Launch triage should name the concrete file-backed review command when known."""
+        _make_worktree_with_audit(tmp_path, "feature-a", final_phase="ESCALATE")
+        config = _mock_config(tmp_path)
+
+        git_results = [
+            MagicMock(returncode=0, stdout="4\n"),
+            MagicMock(returncode=0, stdout=""),
+        ]
+        with patch("theforge.sprint.lock.subprocess.run", side_effect=git_results):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["feature-a"],
+                config=config,
+                resume=False,
+                allow_drop=False,
+                canonical_refs_by_slug={"feature-a": "stories/feature-a.md"},
+            )
+
+        assert launch_error is None
+        assert dropped == {"feature-a": "preserved-escalated"}
+        assert locked_fds == []
+        err = capsys.readouterr().err
+        assert (
+            preserved_escalated_detail(
+                canonical_ref="stories/feature-a.md",
+                slug="feature-a",
+            )
+            in err
+        )
+        assert "resolve with `forge review <story-file>`" not in err
+
+    def test_custom_issue_slug_preserved_launch_message_names_issue_review_command(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Launch triage should keep issue-backed guidance runnable for custom slugs."""
+        _make_worktree_with_audit(tmp_path, "custom-issue", final_phase="ESCALATE")
+        config = _mock_config(tmp_path)
+
+        git_results = [
+            MagicMock(returncode=0, stdout="4\n"),
+            MagicMock(returncode=0, stdout=""),
+        ]
+        with patch("theforge.sprint.lock.subprocess.run", side_effect=git_results):
+            locked_fds, launch_error, dropped = acquire_launch_story_locks(
+                slugs=["custom-issue"],
+                config=config,
+                resume=False,
+                allow_drop=False,
+                canonical_refs_by_slug={"custom-issue": "issue:829"},
+            )
+
+        assert launch_error is None
+        assert dropped == {"custom-issue": "preserved-escalated"}
+        assert locked_fds == []
+        err = capsys.readouterr().err
+        assert preserved_escalated_detail(canonical_ref="issue:829", slug="custom-issue") in err
+        assert "resolve with `forge review <story-file>`" not in err
+
     def test_reexec_with_escalated_and_pending_story(self, tmp_path: Path) -> None:
         """Scenario from the bug: three stories, middle escalated, third must run.
 

--- a/tests/test_story_sources.py
+++ b/tests/test_story_sources.py
@@ -21,6 +21,7 @@ from theforge.sprint.runner import (
     _extract_plan_footprint,
     _run_fresh,
     parse_manifest_slugs,
+    parse_manifest_story_refs,
 )
 from theforge.sprint.sources import (
     FileSource,
@@ -886,6 +887,30 @@ class TestParseManifestSlugs:
         config.project_root = tmp_path
         slugs = parse_manifest_slugs(config, manifest_path)
         assert slugs == ["custom"]
+
+    def test_story_refs_preserve_file_paths_and_issue_refs(self, tmp_path: Path) -> None:
+        story = tmp_path / "story.md"
+        story.write_text("---\nname: Test\nslug: custom-file\n---\n# Content\n")
+        manifest_path = tmp_path / "sprint.yaml"
+        manifest_path.write_text(
+            yaml.dump(
+                {
+                    "name": "test",
+                    "budget_usd": 10.0,
+                    "stories": ["story.md", {"issue": 42, "slug": "custom-issue"}],
+                }
+            )
+        )
+        config = MagicMock()
+        config.project_root = tmp_path
+
+        slugs, canonical_refs_by_slug = parse_manifest_story_refs(config, manifest_path)
+
+        assert slugs == ["custom-file", "custom-issue"]
+        assert canonical_refs_by_slug == {
+            "custom-file": "story.md",
+            "custom-issue": "issue:42",
+        }
 
 
 # ── Completion: archive and PR body ───────────────────────────────────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] No blocking findings; the prior grouped launch message and file-backed runner-log placeholder issues are resolved, with one non-blocking custom-slug issue edge noted. | [anthropic-opus-cli] Both remaining prior P1s are resolved at b5a07050 — launch triage prints one message per preserved slug and now receives canonical refs from both manifest and query modes, so file-backed and custom-slug issue stories name a runnable forge review command at launch as well as in the runner log, status rows and runbook; the callers that patch parse_manifest_slugs still pass, and the one local test failure (TestGenuineCollisionDuringReexec multiprocessing PermissionError) is a sandbox artifact in untouched code with the authoritative gate PASS for this HEAD.

## Review

- **Verdict:** APPROVE (0 P1, 3 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $22.35
- **Dev iterations:** 6
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/preserved_resume.py:51`** When an issue-backed story was preserved under a manifest slug override, the report named forge review --issue 829, and that command selected the default issue-829 workspace rather than the preserved custom-issue workspace.
- **[P2] `src/theforge/cli/sprint.py:299`** Manifest-mode launch parses the sprint manifest twice in consecutive lines, once for slugs and once for the slug-to-canonical-ref map, and discards the slug list produced by the second parse.
- **[P2] `src/theforge/cli/sprint.py:40`** A module-level parse_manifest_slugs wrapper is defined in the CLI purely as a patch seam, duplicating the identically-named helper the sprint runner already exports.

## Story

A story held in a preserved state reports the state without naming what resolves it (GitHub Issue #2475)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2475