### PR TITLE
Run summaries are written to a tracked directory that nothing stages, so a corpus meant to be shared exists only on the machine that produced it

### DIFF
--- a/src/theforge/sprint/audit_publish.py
+++ b/src/theforge/sprint/audit_publish.py
@@ -34,10 +34,11 @@ from ..log_util import _log_line
 from .audit import _write_sprint_audit, _write_sprint_summary
 from .manifest import SprintResult
 
-_STORY_RUN_AUDIT_DIR = ".forge/audits/runs"
-_STORY_RUN_AUDIT_COMMIT_CMD = (
-    f'git commit -m "chore(audit): record sprint run audits" -- {_STORY_RUN_AUDIT_DIR}'
+_STORY_RUN_ARTIFACT_DIRS = (
+    ".forge/audits/runs",
+    ".forge/knowledge/summaries",
 )
+_STORY_RUN_AUDIT_COMMIT_MESSAGE = "chore(audit): record sprint run audits"
 
 # Where the outcome of the publish step is recorded. Lives under .forge/ (which
 # .gitignore denies wholesale), so writing it never dirties the base-branch
@@ -201,31 +202,39 @@ def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: b
         _record_audit_publish_state(project_root, base_branch, exc.state, detail=str(exc))
         raise
 
-    audit_dir = Path(_STORY_RUN_AUDIT_DIR)
-    quoted_audit_dir = shlex.quote(audit_dir.as_posix())
-    ok_status, status_out = _cu._run_shell(
-        f"git status --porcelain -- {quoted_audit_dir}",
-        project_root,
-    )
-    if not ok_status:
-        raise StoryRunAuditPublishError(
-            f"Failed to inspect story run audits: {status_out}",
-            state=AUDIT_PUBLISH_COMMIT_FAILED,
+    dirty_dirs: list[str] = []
+    for artifact_dir in _STORY_RUN_ARTIFACT_DIRS:
+        artifact_path = project_root / artifact_dir
+        if not artifact_path.exists() and not artifact_path.parent.exists():
+            continue
+        quoted_artifact_dir = shlex.quote(artifact_dir)
+        ok_status, status_out = _cu._run_shell(
+            f"git status --porcelain -- {quoted_artifact_dir}",
+            project_root,
         )
-    if not status_out.strip():
+        if not ok_status:
+            raise StoryRunAuditPublishError(
+                f"Failed to inspect story run audits: {status_out}",
+                state=AUDIT_PUBLISH_COMMIT_FAILED,
+            )
+        if status_out.strip():
+            dirty_dirs.append(artifact_dir)
+    if not dirty_dirs:
         # Nothing pending. Record it so a marker from an earlier run cannot be
         # mistaken for this one's outcome.
         _record_audit_publish_state(project_root, base_branch, AUDIT_PUBLISH_CLEAN)
         return
 
-    ok_add, add_out = _cu._run_shell(f"git add -- {quoted_audit_dir}", project_root)
+    quoted_dirty_dirs = " ".join(shlex.quote(path) for path in dirty_dirs)
+    ok_add, add_out = _cu._run_shell(f"git add -- {quoted_dirty_dirs}", project_root)
     if not ok_add:
         raise StoryRunAuditPublishError(
             f"Failed to stage story run audits: {add_out}",
             state=AUDIT_PUBLISH_COMMIT_FAILED,
         )
 
-    ok_commit, commit_out = _cu._run_shell(_STORY_RUN_AUDIT_COMMIT_CMD, project_root)
+    commit_cmd = f'git commit -m "{_STORY_RUN_AUDIT_COMMIT_MESSAGE}" -- {quoted_dirty_dirs}'
+    ok_commit, commit_out = _cu._run_shell(commit_cmd, project_root)
     if not ok_commit:
         raise StoryRunAuditPublishError(
             f"Failed to commit story run audits: {commit_out}",

--- a/src/theforge/sprint/audit_publish.py
+++ b/src/theforge/sprint/audit_publish.py
@@ -76,6 +76,15 @@ def _log(msg: str) -> None:
     _log_line("[sprint]", msg)
 
 
+def _story_run_artifact_label(artifact_dir: str) -> str:
+    """Return an operator-facing label for a tracked story-run artifact tree."""
+    if artifact_dir == ".forge/audits/runs":
+        return "story run audits"
+    if artifact_dir == ".forge/knowledge/summaries":
+        return "knowledge summaries"
+    return f"story run artifacts under {artifact_dir}"
+
+
 class StoryRunAuditPublishError(RuntimeError):
     """Canonical story run audits could not be published to the base branch.
 
@@ -214,7 +223,8 @@ def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: b
         )
         if not ok_status:
             raise StoryRunAuditPublishError(
-                f"Failed to inspect story run audits: {status_out}",
+                f"Failed to inspect {_story_run_artifact_label(artifact_dir)} "
+                f"at {artifact_dir}: {status_out}",
                 state=AUDIT_PUBLISH_COMMIT_FAILED,
             )
         if status_out.strip():
@@ -228,16 +238,22 @@ def _commit_story_run_audits(project_root: Path, base_branch: str, *, publish: b
     quoted_dirty_dirs = " ".join(shlex.quote(path) for path in dirty_dirs)
     ok_add, add_out = _cu._run_shell(f"git add -- {quoted_dirty_dirs}", project_root)
     if not ok_add:
+        artifact_list = ", ".join(
+            f"{_story_run_artifact_label(path)} at {path}" for path in dirty_dirs
+        )
         raise StoryRunAuditPublishError(
-            f"Failed to stage story run audits: {add_out}",
+            f"Failed to stage {artifact_list}: {add_out}",
             state=AUDIT_PUBLISH_COMMIT_FAILED,
         )
 
     commit_cmd = f'git commit -m "{_STORY_RUN_AUDIT_COMMIT_MESSAGE}" -- {quoted_dirty_dirs}'
     ok_commit, commit_out = _cu._run_shell(commit_cmd, project_root)
     if not ok_commit:
+        artifact_list = ", ".join(
+            f"{_story_run_artifact_label(path)} at {path}" for path in dirty_dirs
+        )
         raise StoryRunAuditPublishError(
-            f"Failed to commit story run audits: {commit_out}",
+            f"Failed to commit {artifact_list}: {commit_out}",
             state=AUDIT_PUBLISH_COMMIT_FAILED,
         )
     _log("Committed canonical story run audit records to the base branch checkout.")

--- a/tests/test_sprint_audit_publish.py
+++ b/tests/test_sprint_audit_publish.py
@@ -67,6 +67,15 @@ def _write_audit(repo: Path, name: str) -> None:
     (audit_dir / name).write_text(json.dumps({"run": name}) + "\n", encoding="utf-8")
 
 
+def _write_summary(repo: Path, run_id: str) -> None:
+    summaries_dir = repo / ".forge" / "knowledge" / "summaries"
+    summaries_dir.mkdir(parents=True, exist_ok=True)
+    (summaries_dir / f"{run_id}.yaml").write_text(
+        yaml.safe_dump({"run_id": run_id}, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
 @pytest.fixture()
 def origin_and_clone(tmp_path: Path) -> tuple[Path, Path]:
     """A bare origin with ``BASE`` checked out in a clone, audits unignored."""
@@ -96,6 +105,10 @@ def _read_state(project_root: Path) -> dict:
     )
 
 
+def _tree_names(repo: Path) -> str:
+    return _git(repo, "ls-tree", "-r", "--name-only", BASE)
+
+
 def _advance_origin(tmp_path: Path, origin: Path, message: str) -> None:
     """Land an unrelated commit on origin's base branch, as a merged PR would."""
     other = tmp_path / f"other-{message}"
@@ -112,11 +125,15 @@ def test_publish_pushes_audits_when_remote_is_unchanged(
 ) -> None:
     origin, clone = origin_and_clone
     _write_audit(clone, "run-a.json")
+    _write_summary(clone, "run-a")
 
     _commit_story_run_audits(clone, BASE, publish=True)
 
-    assert "run-a.json" in _git(origin, "ls-tree", "-r", "--name-only", BASE)
+    tree = _tree_names(origin)
+    assert "run-a.json" in tree
+    assert ".forge/knowledge/summaries/run-a.yaml" in tree
     assert _read_state(clone)["state"] == AUDIT_PUBLISH_PUBLISHED
+    assert _git(clone, "status", "--short", "--", ".forge/knowledge/summaries") == ""
 
 
 def test_publish_reconciles_when_the_base_branch_advanced(
@@ -127,6 +144,7 @@ def test_publish_reconciles_when_the_base_branch_advanced(
     """The sprint's own merge landing mid-run must not strand the audit commit."""
     origin, clone = origin_and_clone
     _write_audit(clone, "run-b.json")
+    _write_summary(clone, "run-b")
     # The base branch moves after the clone's last fetch — the merge of the PR
     # for the story this sprint just landed.
     _advance_origin(tmp_path, origin, "story-merge")
@@ -147,6 +165,7 @@ def test_publish_reconciles_when_the_base_branch_advanced(
 
     tree = _git(origin, "ls-tree", "-r", "--name-only", BASE)
     assert "run-b.json" in tree
+    assert ".forge/knowledge/summaries/run-b.yaml" in tree
     # The reconcile rebased onto the mover rather than discarding it.
     assert "story-merge.txt" in tree
     assert _read_state(clone)["state"] == AUDIT_PUBLISH_PUBLISHED
@@ -265,10 +284,13 @@ def test_publish_disabled_records_local_only_state(
 ) -> None:
     origin, clone = origin_and_clone
     _write_audit(clone, "run-f.json")
+    _write_summary(clone, "run-f")
 
     _commit_story_run_audits(clone, BASE, publish=False)
 
-    assert "run-f.json" not in _git(origin, "ls-tree", "-r", "--name-only", BASE)
+    tree = _tree_names(origin)
+    assert "run-f.json" not in tree
+    assert ".forge/knowledge/summaries/run-f.yaml" not in tree
     assert _read_state(clone)["state"] == AUDIT_PUBLISH_LOCAL_ONLY
 
 
@@ -431,11 +453,14 @@ def test_publish_entry_point_publishes_for_the_state_it_is_given(
 ) -> None:
     origin, clone = origin_and_clone
     _write_audit(clone, "run-h.json")
+    _write_summary(clone, "run-h")
     state = _make_state(clone, base_branch=BASE)
 
     publish_story_run_audits(state, lands_locally=False)
 
-    assert "run-h.json" in _git(origin, "ls-tree", "-r", "--name-only", BASE)
+    tree = _tree_names(origin)
+    assert "run-h.json" in tree
+    assert ".forge/knowledge/summaries/run-h.yaml" in tree
     assert _read_state(clone)["state"] == AUDIT_PUBLISH_PUBLISHED
 
 
@@ -445,11 +470,14 @@ def test_publish_entry_point_keeps_the_commit_local_when_pushing_would_publish_m
     """auto_push off on a run that lands locally: commit, do not push, say so."""
     origin, clone = origin_and_clone
     _write_audit(clone, "run-i.json")
+    _write_summary(clone, "run-i")
     state = _make_state(clone, base_branch=BASE, auto_push=False)
 
     publish_story_run_audits(state, lands_locally=True)
 
-    assert "run-i.json" not in _git(origin, "ls-tree", "-r", "--name-only", BASE)
+    tree = _tree_names(origin)
+    assert "run-i.json" not in tree
+    assert ".forge/knowledge/summaries/run-i.yaml" not in tree
     assert _read_state(clone)["state"] == AUDIT_PUBLISH_LOCAL_ONLY
 
 

--- a/tests/test_sprint_audit_publish.py
+++ b/tests/test_sprint_audit_publish.py
@@ -28,6 +28,7 @@ from theforge.sprint.audit_publish import (
     _STORY_RUN_AUDIT_PUBLISH_STATE_PATH,
     AUDIT_PUBLISH_BRANCH_MISMATCH,
     AUDIT_PUBLISH_CLEAN,
+    AUDIT_PUBLISH_COMMIT_FAILED,
     AUDIT_PUBLISH_LOCAL_ONLY,
     AUDIT_PUBLISH_PUBLISHED,
     AUDIT_PUBLISH_PUSH_REFUSED,
@@ -133,6 +134,22 @@ def test_publish_pushes_audits_when_remote_is_unchanged(
     assert "run-a.json" in tree
     assert ".forge/knowledge/summaries/run-a.yaml" in tree
     assert _read_state(clone)["state"] == AUDIT_PUBLISH_PUBLISHED
+    assert _git(clone, "status", "--short", "--", ".forge/knowledge/summaries") == ""
+
+
+def test_publish_pushes_summary_when_audit_dir_is_clean(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    origin, clone = origin_and_clone
+    _write_summary(clone, "run-summary-only")
+
+    _commit_story_run_audits(clone, BASE, publish=True)
+
+    tree = _tree_names(origin)
+    assert ".forge/audits/runs/run-summary-only.json" not in tree
+    assert ".forge/knowledge/summaries/run-summary-only.yaml" in tree
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_PUBLISHED
+    assert _git(clone, "status", "--short", "--", ".forge/audits/runs") == ""
     assert _git(clone, "status", "--short", "--", ".forge/knowledge/summaries") == ""
 
 
@@ -251,6 +268,31 @@ def test_publish_reports_reconcile_failure_distinctly(
 
     assert excinfo.value.state == AUDIT_PUBLISH_RECONCILE_FAILED
     assert _read_state(clone)["state"] == AUDIT_PUBLISH_RECONCILE_FAILED
+
+
+def test_publish_reports_which_artifact_dir_failed_inspection(
+    monkeypatch: pytest.MonkeyPatch, origin_and_clone: tuple[Path, Path]
+) -> None:
+    _origin, clone = origin_and_clone
+    _write_summary(clone, "run-k")
+
+    from theforge.coordinator import util as _cu
+
+    real_run_shell = _cu._run_shell
+
+    def fake_run_shell(cmd: str, cwd: Path, *args: object, **kwargs: object):
+        if cmd == "git status --porcelain -- .forge/knowledge/summaries":
+            return False, "fatal: status failed"
+        return real_run_shell(cmd, cwd, *args, **kwargs)
+
+    monkeypatch.setattr(_cu, "_run_shell", fake_run_shell)
+
+    with pytest.raises(StoryRunAuditPublishError) as excinfo:
+        _commit_story_run_audits(clone, BASE, publish=True)
+
+    assert excinfo.value.state == AUDIT_PUBLISH_COMMIT_FAILED
+    assert "knowledge summaries" in str(excinfo.value)
+    assert ".forge/knowledge/summaries" in str(excinfo.value)
 
 
 def test_publish_aborts_a_conflicted_rebase_before_raising(

--- a/tests/test_sprint_parallel.py
+++ b/tests/test_sprint_parallel.py
@@ -3410,7 +3410,9 @@ class TestSprintRunAuditCommit:
         audit_shell_calls = [
             call
             for call in shell_calls
-            if ".forge/audits/runs" in call[0] or "chore(audit)" in call[0]
+            if ".forge/audits/runs" in call[0]
+            or ".forge/knowledge/summaries" in call[0]
+            or "chore(audit)" in call[0]
         ]
         assert audit_shell_calls == [("git status --porcelain -- .forge/audits/runs", tmp_path)]
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change now stages and publishes knowledge summaries through the existing story-run artifact publish path, with focused coverage for combined and summary-only runs. | [anthropic-opus-cli] Iteration 2 resolves both prior P2s (per-directory failure labels, summaries-only-dirty test) with no behavioural regression; HEAD 235a9bc5 matches the authoritative PASS gate and the touched suites pass locally (17 + 6).

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $4.04
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Run summaries are written to a tracked directory that nothing stages, so a corpus meant to be shared exists only on the machine that produced it (GitHub Issue #2546)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2546