### PR TITLE
The model that authors durable knowledge is derived from the key declaring rate-limit failure behaviour, and can be configured no other way

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -1047,10 +1047,12 @@ Two properties are worth knowing before enabling it:
   actually exists in that run's audit record. A citation that does not resolve
   rejects the whole summary rather than persisting an unverifiable claim.
 
-Generation dispatches a bounded, tool-free agent over an API transport derived
-from the plan model (via its `transport_fallback` when the plan model is a CLI).
-A plan model with no API transport available skips generation with a warning.
-Its cost is recorded on the artifact under `generation.cost_usd`, because it is
+Generation dispatches a bounded, tool-free agent over an API transport.
+`knowledge.ref` chooses the summary model explicitly; when omitted, summaries
+inherit `plan.ref` only if planning already dispatches over API transport. A
+CLI plan model with no explicit `knowledge.ref` skips generation with a
+warning. `transport_fallback` does not choose the durable-knowledge author. Its
+cost is recorded on the artifact under `generation.cost_usd`, because it is
 spent after the run's own cost accounting has closed.
 
 `knowledge.prior_run_context` enables Layer 3 consumption: context assembly may

--- a/src/theforge/config/defaults.py
+++ b/src/theforge/config/defaults.py
@@ -222,9 +222,16 @@ retry:
 # evidence-backed summary to .forge/knowledge/summaries/{run_id}.yaml. Every
 # learned claim must cite a finding, plan step, review cycle, file, or diff ref
 # from that run — unevidenced summaries are rejected, not persisted. Generation
-# is a post-DONE side effect: it never changes a run's outcome. Ships disabled.
+# is a post-DONE side effect: it never changes a run's outcome. ``knowledge.ref``
+# directly names the API model that authors summaries; when omitted, summaries
+# inherit ``plan.ref`` only if planning already dispatches over API transport.
+# CLI plan refs do not consult ``transport_fallback`` for summary authoring.
+# Ships disabled.
 # knowledge:
 #   run_summaries: true
+#   ref:
+#     provider: openai
+#     model: o4-mini
 
 context:
   preflight_budget: 200
@@ -236,7 +243,9 @@ context:
 # unavailable. The provider never changes — only the transport. For any CLI
 # model in models: whose same-provider API variant is registered, TheForge wires
 # the fallback automatically. Set auto_transport_fallback: false to disable
-# auto-pairing, or declare transport_fallback to override it.
+# auto-pairing, or declare transport_fallback to override it. This key does not
+# choose the durable-knowledge summary model; configure ``knowledge.ref`` for
+# that role.
 # transport_fallback:
 #   openai:
 #     model: o4-mini

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -81,6 +81,7 @@ from .types import (
     KnowledgeConfig,
     LogConfig,
     ModelProfile,
+    ModelRef,
     PlanAgentReviewConfig,
     PlanConfig,
     PlanReviewConfig,
@@ -1648,8 +1649,96 @@ def load_config(config_path: Path) -> ForgeConfig:
                 "forge.yaml 'knowledge.invariant_sources' items must be non-empty strings,"
                 f" got {_glob!r}"
             )
+    _knowledge_ref_raw = knowledge_data.get("ref")
+    _knowledge_ref: ModelRef | None = None
+    if _knowledge_ref_raw is not None:
+        if not isinstance(_knowledge_ref_raw, dict):
+            raise ValueError(
+                "forge.yaml 'knowledge.ref' must be a mapping when present, "
+                f"got {_knowledge_ref_raw!r}"
+            )
+        if "cli" in _knowledge_ref_raw:
+            raise ValueError(
+                "forge.yaml 'knowledge.ref' must dispatch over API transport; "
+                "remove 'cli' and set 'provider' instead"
+            )
+        _provider = _knowledge_ref_raw.get("provider")
+        if not isinstance(_provider, str) or not _provider.strip():
+            raise ValueError(
+                "forge.yaml 'knowledge.ref.provider' must be a non-empty string when "
+                "knowledge.ref is configured"
+            )
+        if _provider.strip() not in SUPPORTED_PROVIDERS:
+            raise ValueError(
+                f"Unsupported provider {_provider!r} in knowledge.ref. "
+                f"Supported: {sorted(SUPPORTED_PROVIDERS)}"
+            )
+        _model = _knowledge_ref_raw.get("model")
+        if not isinstance(_model, str) or not _model.strip():
+            raise ValueError(
+                "forge.yaml 'knowledge.ref.model' must be a non-empty string when "
+                "knowledge.ref is configured"
+            )
+        _fallback_models_raw = _knowledge_ref_raw.get("fallback_models", ())
+        if not isinstance(_fallback_models_raw, (list, tuple)):
+            raise ValueError(
+                "forge.yaml 'knowledge.ref.fallback_models' must be a list of strings, "
+                f"got {_fallback_models_raw!r}"
+            )
+        for _fallback_model in _fallback_models_raw:
+            if not isinstance(_fallback_model, str) or not _fallback_model.strip():
+                raise ValueError(
+                    "forge.yaml 'knowledge.ref.fallback_models' items must be non-empty "
+                    f"strings, got {_fallback_model!r}"
+                )
+        if "transport" in _knowledge_ref_raw:
+            _transport_raw = _knowledge_ref_raw["transport"]
+            if not isinstance(_transport_raw, dict):
+                raise ValueError(
+                    "forge.yaml 'knowledge.ref.transport' must be a mapping, "
+                    f"got {_transport_raw!r}"
+                )
+            _transport_kind = str(_transport_raw.get("kind", "")).strip().lower()
+            if _transport_kind and _transport_kind != "api":
+                raise ValueError(
+                    "forge.yaml 'knowledge.ref.transport.kind' must be 'api' for "
+                    "knowledge summaries"
+                )
+        _knowledge_ref = ModelRef(
+            provider=_provider.strip(),
+            model=_model.strip(),
+            budget_usd=float(_knowledge_ref_raw.get("budget_usd", 0.50)),
+            timeout_seconds=int(_knowledge_ref_raw.get("timeout_seconds", 300)),
+            fallback_models=tuple(
+                _fallback_model.strip() for _fallback_model in _fallback_models_raw
+            ),
+            reasoning_effort=(
+                str(_knowledge_ref_raw["reasoning_effort"]).strip()
+                if _knowledge_ref_raw.get("reasoning_effort") is not None
+                else None
+            ),
+            thinking_budget=(
+                int(_knowledge_ref_raw["thinking_budget"])
+                if _knowledge_ref_raw.get("thinking_budget") is not None
+                else None
+            ),
+            base_url=(
+                str(_knowledge_ref_raw["base_url"]).strip()
+                if _knowledge_ref_raw.get("base_url") is not None
+                else None
+            ),
+            max_iterations=(
+                int(_knowledge_ref_raw["max_iterations"])
+                if _knowledge_ref_raw.get("max_iterations") is not None
+                else None
+            ),
+            max_tool_output_bytes=int(
+                _knowledge_ref_raw.get("max_tool_output_bytes", ModelRef.max_tool_output_bytes)
+            ),
+        )
     knowledge_cfg = KnowledgeConfig(
         **_knowledge_values,
+        ref=_knowledge_ref,
         invariant_sources=tuple(_glob.strip() for _glob in _invariant_sources_raw),
     )
 

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -1271,10 +1271,18 @@ class KnowledgeConfig:
     The extractor skips derived and vendored trees and only parses files that
     actually contain a marker, so the broad default costs a substring scan.
     Projects with a settled documentation layout can narrow it here.
+
+    ``ref`` directly names the tool-free API model that authors durable
+    knowledge summaries. When omitted, summaries inherit ``plan.ref`` only if
+    the planner already dispatches over API transport. CLI planner refs do not
+    consult ``transport_fallback`` for summary authoring: configure
+    ``knowledge.ref`` explicitly instead so the role's model is visible at the
+    key whose job is to declare it.
     """
 
     run_summaries: bool = False
     prior_run_context: bool = False
+    ref: ModelRef | None = None
     invariant_context: bool = False
     invariant_sources: tuple[str, ...] = ("**/*.md",)
 

--- a/src/theforge/coordinator/knowledge_summary_flow.py
+++ b/src/theforge/coordinator/knowledge_summary_flow.py
@@ -229,7 +229,7 @@ def _summary_dispatch_profile(
     summary_envelope: "ModelProfile",
     selected: "ModelProfile",
 ) -> "ModelProfile":
-    """Keep the plan role envelope while swapping in the selected model identity."""
+    """Keep the summary role envelope while swapping in the selected model identity."""
     return replace(
         summary_envelope,
         cli=selected.cli,
@@ -246,16 +246,18 @@ def _summary_dispatch_profile(
 
 
 def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str | None]:
-    """Derive a tool-free API profile for the summary agent, or None.
-
-    Built from ``config.plan.ref`` — the plan model is the cheap bounded-writing
-    role and the summary is the same kind of work. A CLI-transport ref is
-    projected onto its configured same-provider API fallback; without one there
-    is no dispatch path that is mechanically tool-free, and the caller skips.
-    """
+    """Resolve a tool-free API profile for the summary agent, or None."""
     from theforge.config.bridge import model_ref_to_profile  # noqa: PLC0415
 
-    ref = getattr(getattr(config, "plan", None), "ref", None)
+    knowledge_cfg = getattr(config, "knowledge", None)
+    ref = getattr(knowledge_cfg, "ref", None)
+    if ref is None:
+        ref = getattr(getattr(config, "plan", None), "ref", None)
+        if ref is not None and ref.mode != "api":
+            return (
+                None,
+                "knowledge summaries need knowledge.ref when plan.ref uses CLI transport",
+            )
     if ref is None:
         return (None, None)
 
@@ -266,7 +268,6 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
         phase=PHASE_KNOWLEDGE_SUMMARY,
         sandbox_mode="read-only",
     )
-    summary_envelope = _apply_summary_transport_fallback(config, summary_envelope)
     base_profile = _project_summary_api_profile(summary_envelope)
 
     agents = getattr(config, "agents", None) or []
@@ -378,8 +379,8 @@ def maybe_generate_run_summary(
         profile, profile_reason = _summary_profile(config)
         if profile is None:
             reason = profile_reason or (
-                "no tool-free API transport available for the plan model "
-                "(configure transport_fallback to enable summaries)"
+                "no tool-free API transport available for knowledge_summary "
+                "(configure knowledge.ref to enable summaries)"
             )
             _log(f"  ⚠ knowledge summary skipped: {reason}")
             return _record_summary_outcome(

--- a/src/theforge/coordinator/knowledge_summary_flow.py
+++ b/src/theforge/coordinator/knowledge_summary_flow.py
@@ -217,7 +217,8 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
 
     Model selection is authoritative from ``knowledge.ref`` when present,
     otherwise from the inherited ``plan.ref``. The configured agent pool only
-    gates whether ``knowledge_summary`` is allowed to run at all.
+    gates whether ``knowledge_summary`` is allowed to run at all; it never
+    supplies or swaps the role's identity.
     """
     from theforge.config.bridge import model_ref_to_profile  # noqa: PLC0415
 
@@ -249,12 +250,12 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
     if not agents:
         return (base_profile, None)
 
-    phase_eligible = [
-        agent
-        for agent in agents
-        if PHASE_KNOWLEDGE_SUMMARY in _agent_phase_eligibility(config, agent)
-    ]
-    if not phase_eligible:
+    # A configured pool can veto this role entirely, but it does not participate
+    # in model selection once the summary profile has been derived above.
+    any_phase_eligible = any(
+        PHASE_KNOWLEDGE_SUMMARY in _agent_phase_eligibility(config, agent) for agent in agents
+    )
+    if not any_phase_eligible:
         return (
             None,
             "routing.phase_eligibility excludes knowledge_summary for every configured candidate",

--- a/src/theforge/coordinator/knowledge_summary_flow.py
+++ b/src/theforge/coordinator/knowledge_summary_flow.py
@@ -306,6 +306,8 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
         )
         if matching is not None:
             return (base_profile, None)
+    if base_profile is not None:
+        return (base_profile, None)
     return (_summary_dispatch_profile(summary_envelope, projected[0]), None)
 
 

--- a/src/theforge/coordinator/knowledge_summary_flow.py
+++ b/src/theforge/coordinator/knowledge_summary_flow.py
@@ -42,7 +42,7 @@ from theforge.knowledge_summary import (
     validate_proposed_summary,
     write_summary,
 )
-from theforge.model_capabilities import identity_for_agent, identity_for_profile
+from theforge.model_capabilities import identity_for_agent
 from theforge.task.summary_prompts import build_run_summary_prompt
 
 from . import util as _cu
@@ -212,28 +212,13 @@ def _project_summary_api_profile(profile: "ModelProfile") -> "ModelProfile | Non
     )
 
 
-def _summary_dispatch_profile(
-    summary_envelope: "ModelProfile",
-    selected: "ModelProfile",
-) -> "ModelProfile":
-    """Keep the summary role envelope while swapping in the selected model identity."""
-    return replace(
-        summary_envelope,
-        cli=selected.cli,
-        provider=selected.provider,
-        transport=selected.transport,
-        base_url=selected.base_url,
-        model=selected.model,
-        fallback_models=selected.fallback_models,
-        api_fallback=selected.api_fallback,
-        registry_id=selected.registry_id,
-        registry_source=selected.registry_source,
-        reasoning_mode=selected.reasoning_mode,
-    )
-
-
 def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str | None]:
-    """Resolve a tool-free API profile for the summary agent, or None."""
+    """Resolve the tool-free API summary profile after eligibility checks.
+
+    Model selection is authoritative from ``knowledge.ref`` when present,
+    otherwise from the inherited ``plan.ref``. The configured agent pool only
+    gates whether ``knowledge_summary`` is allowed to run at all.
+    """
     from theforge.config.bridge import model_ref_to_profile  # noqa: PLC0415
 
     knowledge_cfg = getattr(config, "knowledge", None)
@@ -275,40 +260,7 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
             "routing.phase_eligibility excludes knowledge_summary for every configured candidate",
         )
 
-    base_identity = identity_for_profile(base_profile) if base_profile is not None else None
-    projected: list[ModelProfile] = []
-    for agent in phase_eligible:
-        candidate = replace(
-            agent.to_model_profile(allowed_tools=()),
-            phase=PHASE_KNOWLEDGE_SUMMARY,
-            sandbox_mode="read-only",
-        )
-        candidate = _project_summary_api_profile(candidate)
-        if candidate is not None:
-            projected.append(candidate)
-    if not projected:
-        if base_profile is not None:
-            return (base_profile, None)
-        return (
-            None,
-            "no phase-eligible configured model can dispatch knowledge_summary over a tool-free "
-            "API transport",
-        )
-
-    if base_identity is not None:
-        matching = next(
-            (
-                candidate
-                for candidate in projected
-                if identity_for_profile(candidate) == base_identity
-            ),
-            None,
-        )
-        if matching is not None:
-            return (base_profile, None)
-    if base_profile is not None:
-        return (base_profile, None)
-    return (_summary_dispatch_profile(summary_envelope, projected[0]), None)
+    return (base_profile, None)
 
 
 def _should_generate(config: "ForgeConfig", result: "CoordinatorResult", run_id: str) -> bool:

--- a/src/theforge/coordinator/knowledge_summary_flow.py
+++ b/src/theforge/coordinator/knowledge_summary_flow.py
@@ -192,19 +192,6 @@ def _agent_phase_eligibility(config: "ForgeConfig", agent: object) -> frozenset[
     return DEFAULT_PHASE_ELIGIBILITY
 
 
-def _apply_summary_transport_fallback(
-    config: "ForgeConfig",
-    profile: "ModelProfile",
-) -> "ModelProfile":
-    fallbacks = getattr(config, "transport_fallbacks", None) or {}
-    if not fallbacks or profile.api_fallback is not None:
-        return profile
-
-    from theforge.config.profiles import _apply_transport_fallback  # noqa: PLC0415
-
-    return _apply_transport_fallback(profile, fallbacks)
-
-
 def _project_summary_api_profile(profile: "ModelProfile") -> "ModelProfile | None":
     if profile.mode == "api":
         return profile
@@ -250,7 +237,8 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
     from theforge.config.bridge import model_ref_to_profile  # noqa: PLC0415
 
     knowledge_cfg = getattr(config, "knowledge", None)
-    ref = getattr(knowledge_cfg, "ref", None)
+    knowledge_ref = getattr(knowledge_cfg, "ref", None)
+    ref = knowledge_ref
     if ref is None:
         ref = getattr(getattr(config, "plan", None), "ref", None)
         if ref is not None and ref.mode != "api":
@@ -269,6 +257,8 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
         sandbox_mode="read-only",
     )
     base_profile = _project_summary_api_profile(summary_envelope)
+    if knowledge_ref is not None:
+        return (base_profile, None)
 
     agents = getattr(config, "agents", None) or []
     if not agents:
@@ -285,7 +275,6 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
             "routing.phase_eligibility excludes knowledge_summary for every configured candidate",
         )
 
-    summary_identity = identity_for_profile(summary_envelope)
     base_identity = identity_for_profile(base_profile) if base_profile is not None else None
     projected: list[ModelProfile] = []
     for agent in phase_eligible:
@@ -294,14 +283,12 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
             phase=PHASE_KNOWLEDGE_SUMMARY,
             sandbox_mode="read-only",
         )
-        candidate = _apply_summary_transport_fallback(config, candidate)
         candidate = _project_summary_api_profile(candidate)
         if candidate is not None:
             projected.append(candidate)
     if not projected:
-        if base_profile is not None and summary_identity is not None:
-            if any(identity_for_agent(agent) == summary_identity for agent in phase_eligible):
-                return (base_profile, None)
+        if base_profile is not None:
+            return (base_profile, None)
         return (
             None,
             "no phase-eligible configured model can dispatch knowledge_summary over a tool-free "

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -779,11 +779,51 @@ class TestKnowledgeConfig:
         assert config.knowledge.run_summaries is True
         # Layer 3 consumption stays off — the two knobs are independent.
         assert config.knowledge.prior_run_context is False
+        assert config.knowledge.ref is None
+
+    def test_knowledge_ref_can_name_the_summary_model(self, tmp_path):
+        config = load_config(
+            _write_config(
+                {
+                    "knowledge": {
+                        "run_summaries": True,
+                        "ref": {
+                            "provider": "openai",
+                            "model": "gpt-5.4-mini",
+                            "budget_usd": 0.75,
+                            "timeout_seconds": 420,
+                        },
+                    }
+                },
+                tmp_path,
+            )
+        )
+
+        assert config.knowledge.run_summaries is True
+        assert config.knowledge.ref is not None
+        assert config.knowledge.ref.provider == "openai"
+        assert config.knowledge.ref.cli is None
+        assert config.knowledge.ref.model == "gpt-5.4-mini"
+        assert config.knowledge.ref.budget_usd == 0.75
+        assert config.knowledge.ref.timeout_seconds == 420
 
     @pytest.mark.parametrize("key", ["run_summaries", "prior_run_context"])
     def test_a_non_bool_value_is_rejected(self, key, tmp_path):
         config_path = _write_config({"knowledge": {key: "yes"}}, tmp_path)
         with pytest.raises(ValueError, match=f"knowledge.{key}"):
+            load_config(config_path)
+
+    def test_knowledge_ref_rejects_cli_transport(self, tmp_path):
+        config_path = _write_config(
+            {"knowledge": {"ref": {"cli": "codex", "model": "gpt-5.4"}}},
+            tmp_path,
+        )
+        with pytest.raises(ValueError, match="knowledge.ref.*API transport"):
+            load_config(config_path)
+
+    def test_knowledge_ref_requires_provider_and_model(self, tmp_path):
+        config_path = _write_config({"knowledge": {"ref": {"provider": "openai"}}}, tmp_path)
+        with pytest.raises(ValueError, match="knowledge.ref.model"):
             load_config(config_path)
 
     def test_a_non_mapping_knowledge_block_is_rejected(self, tmp_path):

--- a/tests/test_coord_knowledge_summary.py
+++ b/tests/test_coord_knowledge_summary.py
@@ -101,6 +101,7 @@ def _make_config(
     run_summaries: bool = True,
     provider: str = "anthropic",
     model: str | None = None,
+    knowledge_ref: ModelRef | None = None,
     transport_fallbacks: dict[str, TransportFallbackConfig] | None = None,
 ) -> ForgeConfig:
     """A config whose plan model dispatches over an API transport.
@@ -136,7 +137,7 @@ def _make_config(
                 provider=provider,
             ),
         ),
-        knowledge=KnowledgeConfig(run_summaries=run_summaries),
+        knowledge=KnowledgeConfig(run_summaries=run_summaries, ref=knowledge_ref),
         transport_fallbacks=transport_fallbacks or {},
     )
 
@@ -283,29 +284,19 @@ class TestGeneration:
         assert calls[0]["profile"].timeout_seconds == 300
         assert calls[0]["profile"].phase == PHASE_KNOWLEDGE_SUMMARY
 
-    def test_provider_level_transport_fallback_keeps_cli_pool_summary_dispatchable(
+    def test_explicit_knowledge_ref_selects_the_summary_model(
         self, tmp_path: Path, calls: list[dict]
     ) -> None:
-        fallback = TransportFallbackConfig(provider="openai", model="gpt-5.4-mini")
-        config = replace(
-            _make_config(
-                tmp_path,
+        config = _make_config(
+            tmp_path,
+            provider="openai",
+            model="gpt-5.4",
+            knowledge_ref=ModelRef(
                 provider="openai",
-                model="gpt-5.4",
-                transport_fallbacks={"openai": fallback},
+                model="gpt-5.4-mini",
+                budget_usd=0.5,
+                timeout_seconds=300,
             ),
-            agents=[
-                AgentDef(
-                    name="openai-gpt-5-4",
-                    provider=None,
-                    cli="codex",
-                    model="gpt-5.4",
-                    budget_usd=3.0,
-                    timeout_seconds=900,
-                    tier="mid",
-                    transport=transport_for("openai", "cli"),
-                ),
-            ],
         )
 
         outcome = knowledge_summary_flow.maybe_generate_run_summary(
@@ -319,6 +310,33 @@ class TestGeneration:
         assert profile.name == "knowledge_summary"
         assert profile.budget_usd == 0.5
         assert profile.timeout_seconds == 300
+
+    def test_transport_fallback_does_not_choose_the_summary_model(self, tmp_path: Path) -> None:
+        fallback = TransportFallbackConfig(provider="openai", model="gpt-5.4-mini")
+        config = _make_config(
+            tmp_path,
+            provider="openai",
+            model="gpt-5.4",
+            transport_fallbacks={"openai": fallback},
+        )
+        config = replace(
+            config,
+            plan=replace(
+                config.plan,
+                ref=replace(
+                    config.plan.ref,
+                    cli="codex",
+                    provider=None,
+                    transport=transport_for("openai", "cli"),
+                    api_fallback=fallback,
+                ),
+            ),
+        )
+
+        profile, reason = knowledge_summary_flow._summary_profile(config)
+
+        assert profile is None
+        assert reason == "knowledge summaries need knowledge.ref when plan.ref uses CLI transport"
 
     def test_matching_pool_model_keeps_plan_derived_summary_limits(
         self, tmp_path: Path, calls: list[dict]
@@ -379,7 +397,7 @@ class TestGeneration:
         assert "run_summary:" in prompt
         assert single_shot_runner.call_args.kwargs == {"plain_text": True}
 
-    def test_a_cli_plan_model_without_an_api_fallback_is_not_dispatched(
+    def test_a_cli_plan_model_without_knowledge_ref_is_not_dispatched(
         self, tmp_path: Path, calls: list[dict]
     ) -> None:
         from dataclasses import replace
@@ -395,13 +413,16 @@ class TestGeneration:
         )
         assert outcome.status == "skipped"
         assert outcome.attempted is True
+        assert (
+            outcome.reason
+            == "knowledge summaries need knowledge.ref when plan.ref uses CLI transport"
+        )
         assert calls == []
         assert not summary_path(tmp_path, RUN_ID).exists()
 
-    def test_phase_eligible_matching_cli_pool_model_can_use_plan_ref_api_fallback(
+    def test_explicit_knowledge_ref_keeps_cli_plan_summary_dispatchable(
         self, tmp_path: Path, calls: list[dict]
     ) -> None:
-        fallback = TransportFallbackConfig(provider="openai", model="gpt-5.4-mini")
         config = _make_config(tmp_path, provider="openai", model="gpt-5.4")
         config = replace(
             config,
@@ -412,21 +433,17 @@ class TestGeneration:
                     cli="codex",
                     provider=None,
                     transport=transport_for("openai", "cli"),
-                    api_fallback=fallback,
                 ),
             ),
-            agents=[
-                AgentDef(
-                    name="openai-gpt-5-4",
-                    provider=None,
-                    cli="codex",
-                    model="gpt-5.4",
-                    budget_usd=3.0,
-                    timeout_seconds=900,
-                    tier="mid",
-                    transport=transport_for("openai", "cli"),
+            knowledge=KnowledgeConfig(
+                run_summaries=True,
+                ref=ModelRef(
+                    provider="openai",
+                    model="gpt-5.4-mini",
+                    budget_usd=0.5,
+                    timeout_seconds=300,
                 ),
-            ],
+            ),
         )
 
         outcome = knowledge_summary_flow.maybe_generate_run_summary(

--- a/tests/test_coord_knowledge_summary.py
+++ b/tests/test_coord_knowledge_summary.py
@@ -234,7 +234,7 @@ class TestGeneration:
         assert calls[0]["plain_text"] is True
         assert outcome.status == "written"
 
-    def test_phase_eligibility_does_not_override_the_plan_derived_summary_model(
+    def test_phase_eligibility_only_gates_the_plan_derived_summary_model(
         self, tmp_path: Path, calls: list[dict]
     ) -> None:
         excluded = replace(
@@ -283,6 +283,44 @@ class TestGeneration:
         assert calls[0]["profile"].budget_usd == 0.5
         assert calls[0]["profile"].timeout_seconds == 300
         assert calls[0]["profile"].phase == PHASE_KNOWLEDGE_SUMMARY
+
+    def test_phase_eligibility_can_block_summary_generation(
+        self, tmp_path: Path, calls: list[dict]
+    ) -> None:
+        excluded = replace(
+            AGENT_REGISTRY["openai/gpt-5.4/api"],
+            routing=replace(
+                AGENT_REGISTRY["openai/gpt-5.4/api"].routing,
+                phase_eligibility=frozenset(DEFAULT_PHASE_ELIGIBILITY - {PHASE_KNOWLEDGE_SUMMARY}),
+            ),
+        )
+        config = replace(
+            _make_config(tmp_path, provider="openai", model="gpt-5.4"),
+            agents=[
+                AgentDef(
+                    name="openai-gpt-5-4",
+                    provider="openai",
+                    model="gpt-5.4",
+                    budget_usd=1.0,
+                    timeout_seconds=120,
+                    tier="mid",
+                    transport=transport_for("openai", "api"),
+                ),
+            ],
+            model_registry={"openai/gpt-5.4/api": excluded},
+        )
+
+        outcome = knowledge_summary_flow.maybe_generate_run_summary(
+            config, _done_result(), _audit()
+        )
+
+        assert outcome.status == "skipped"
+        assert outcome.attempted is True
+        expected = (
+            "routing.phase_eligibility excludes knowledge_summary for every configured candidate"
+        )
+        assert outcome.reason == expected
+        assert calls == []
 
     def test_explicit_knowledge_ref_selects_the_summary_model(
         self, tmp_path: Path, calls: list[dict]

--- a/tests/test_coord_knowledge_summary.py
+++ b/tests/test_coord_knowledge_summary.py
@@ -311,6 +311,58 @@ class TestGeneration:
         assert profile.budget_usd == 0.5
         assert profile.timeout_seconds == 300
 
+    def test_explicit_knowledge_ref_is_authoritative_over_a_configured_pool(
+        self, tmp_path: Path, calls: list[dict]
+    ) -> None:
+        fallback = TransportFallbackConfig(provider="openai", model="gpt-5.4")
+        config = replace(
+            _make_config(
+                tmp_path,
+                provider="openai",
+                model="gpt-5.4",
+                knowledge_ref=ModelRef(
+                    provider="openai",
+                    model="o4-mini",
+                    budget_usd=0.5,
+                    timeout_seconds=300,
+                ),
+                transport_fallbacks={"anthropic": fallback},
+            ),
+            agents=[
+                AgentDef(
+                    name="anthropic-sonnet",
+                    provider=None,
+                    model="claude-sonnet-4-5",
+                    budget_usd=1.0,
+                    timeout_seconds=120,
+                    tier="mid",
+                    cli="claude",
+                    transport=transport_for("anthropic", "cli"),
+                ),
+                AgentDef(
+                    name="openai-gpt-5-4",
+                    provider="openai",
+                    model="gpt-5.4",
+                    budget_usd=1.0,
+                    timeout_seconds=120,
+                    tier="mid",
+                    transport=transport_for("openai", "api"),
+                ),
+            ],
+        )
+
+        outcome = knowledge_summary_flow.maybe_generate_run_summary(
+            config, _done_result(), _audit()
+        )
+
+        assert outcome.status == "written"
+        profile = calls[0]["profile"]
+        assert profile.mode == "api"
+        assert profile.model == "o4-mini"
+        assert profile.name == "knowledge_summary"
+        assert profile.budget_usd == 0.5
+        assert profile.timeout_seconds == 300
+
     def test_transport_fallback_does_not_choose_the_summary_model(self, tmp_path: Path) -> None:
         fallback = TransportFallbackConfig(provider="openai", model="gpt-5.4-mini")
         config = _make_config(
@@ -362,6 +414,43 @@ class TestGeneration:
 
         assert outcome.status == "written"
         profile = calls[0]["profile"]
+        assert profile.model == "gpt-5.4"
+        assert profile.name == "knowledge_summary"
+        assert profile.budget_usd == 0.5
+        assert profile.timeout_seconds == 300
+
+    def test_pool_transport_fallback_does_not_override_an_api_plan_summary_model(
+        self, tmp_path: Path, calls: list[dict]
+    ) -> None:
+        fallback = TransportFallbackConfig(provider="openai", model="gpt-5.4-mini")
+        config = replace(
+            _make_config(
+                tmp_path,
+                provider="openai",
+                model="gpt-5.4",
+                transport_fallbacks={"anthropic": fallback},
+            ),
+            agents=[
+                AgentDef(
+                    name="anthropic-sonnet",
+                    provider=None,
+                    model="claude-sonnet-4-5",
+                    budget_usd=1.0,
+                    timeout_seconds=120,
+                    tier="mid",
+                    cli="claude",
+                    transport=transport_for("anthropic", "cli"),
+                ),
+            ],
+        )
+
+        outcome = knowledge_summary_flow.maybe_generate_run_summary(
+            config, _done_result(), _audit()
+        )
+
+        assert outcome.status == "written"
+        profile = calls[0]["profile"]
+        assert profile.mode == "api"
         assert profile.model == "gpt-5.4"
         assert profile.name == "knowledge_summary"
         assert profile.budget_usd == 0.5

--- a/tests/test_coord_knowledge_summary.py
+++ b/tests/test_coord_knowledge_summary.py
@@ -234,7 +234,7 @@ class TestGeneration:
         assert calls[0]["plain_text"] is True
         assert outcome.status == "written"
 
-    def test_phase_eligibility_can_move_summary_to_another_api_candidate(
+    def test_phase_eligibility_does_not_override_the_plan_derived_summary_model(
         self, tmp_path: Path, calls: list[dict]
     ) -> None:
         excluded = replace(
@@ -278,7 +278,7 @@ class TestGeneration:
         )
 
         assert outcome.status == "written"
-        assert calls[0]["profile"].model == "gemini-2.5-pro"
+        assert calls[0]["profile"].model == "gpt-5.4"
         assert calls[0]["profile"].name == "knowledge_summary"
         assert calls[0]["profile"].budget_usd == 0.5
         assert calls[0]["profile"].timeout_seconds == 300
@@ -414,6 +414,36 @@ class TestGeneration:
 
         assert outcome.status == "written"
         profile = calls[0]["profile"]
+        assert profile.model == "gpt-5.4"
+        assert profile.name == "knowledge_summary"
+        assert profile.budget_usd == 0.5
+        assert profile.timeout_seconds == 300
+
+    def test_nonmatching_pool_model_does_not_override_an_api_plan_summary_model(
+        self, tmp_path: Path, calls: list[dict]
+    ) -> None:
+        config = replace(
+            _make_config(tmp_path, provider="openai", model="gpt-5.4"),
+            agents=[
+                AgentDef(
+                    name="google-gemini-2-5-pro",
+                    provider="google",
+                    model="gemini-2.5-pro",
+                    budget_usd=1.0,
+                    timeout_seconds=120,
+                    tier="mid",
+                    transport=transport_for("google", "api"),
+                ),
+            ],
+        )
+
+        outcome = knowledge_summary_flow.maybe_generate_run_summary(
+            config, _done_result(), _audit()
+        )
+
+        assert outcome.status == "written"
+        profile = calls[0]["profile"]
+        assert profile.mode == "api"
         assert profile.model == "gpt-5.4"
         assert profile.name == "knowledge_summary"
         assert profile.budget_usd == 0.5


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Reviewed HEAD matches the authoritative gate commit; the knowledge-summary model is now directly configurable and no P1 regressions were found. | [anthropic-opus-cli] Verified at HEAD 9aa8180b against the repo's real forge.yaml: knowledge.ref alone decides the summary author, transport_fallback no longer reaches summary dispatch on any path, and the pool-selection branch flagged last cycle is now removed rather than left unreachable; one P2 for a docstring claim about the pool veto that does not hold when knowledge.ref is set.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $5.76
- **Dev iterations:** 3
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/coordinator/knowledge_summary_flow.py:246`** When an explicit summary model is configured, the routing eligibility veto is never consulted, so a pool in which every candidate has the knowledge_summary phase excluded still produces a dispatched summary, while the same pool with no explicit summary model refuses the role — the resolver's own docstring states the pool gates whether the role is allowed to run at all.

## Story

The model that authors durable knowledge is derived from the key declaring rate-limit failure behaviour, and can be configured no other way (GitHub Issue #2508)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2508