### PR TITLE
The review prompt tells reviewers to use injected repository context without restating that only the spec decides story compliance

### DIFF
--- a/src/theforge/task/review_prompts.py
+++ b/src/theforge/task/review_prompts.py
@@ -331,6 +331,12 @@ def build_review_prompt(
           suggestion: ""
         ```
 
+        Only the `## Spec` section (and its `## Acceptance criteria`, if present)
+        is authoritative for `story_compliance.matches_spec` and
+        `ac_verification`. The Repository Context Pack, including any injected
+        prior-run summaries, is advisory background — never cite it as the
+        reason an AC failed or `matches_spec` is false.
+
         ```yaml
         verdict: APPROVE | REQUEST_CHANGES
         summary: "<one-line summary of your review>"
@@ -409,6 +415,13 @@ def build_review_prompt(
               (failure branch)"
 
               suggestion: ""
+
+            Only the `## Spec` section (and its `## Acceptance criteria`, if
+            present) is authoritative for `story_compliance.matches_spec` and
+            `ac_verification` in the submit_review call. The Repository Context
+            Pack, including any injected prior-run summaries, is advisory
+            background — never cite it as the reason an AC failed or
+            `matches_spec` is false.
         """)
 
     # Distinguish mechanical containment from native-flag / prompt-only runs so
@@ -576,6 +589,15 @@ def build_review_prompt(
           flags such bodies as `implementation_plan_in_body`; if you see a
           body that should have been flagged but slipped through, note it
           in `summary` so the operator can re-shape the issue.
+        - **Only `## Spec` decides compliance**: `story_compliance.matches_spec`
+          and every `ac_verification` entry must be judged solely against the
+          `## Spec` section (its `## Acceptance criteria`, if present). The
+          Repository Context Pack — including any injected prior-run
+          summaries — is advisory background for orienting your investigation,
+          never a source of truth for what the story requires. Do NOT mark an
+          AC `NOT_VERIFIED`/`PARTIAL` or set `matches_spec: false` because the
+          implementation diverges from something stated only in the Repository
+          Context Pack.
         - **Spec-to-runtime traceability**: For each AC in the spec, verify
           BOTH layers: (a) the logic exists in the codebase, AND (b) it is
           actually invoked at runtime by the calling code. Code that produces

--- a/tests/test_task_review.py
+++ b/tests/test_task_review.py
@@ -720,3 +720,22 @@ def test_review_prompt_includes_repository_context_pack(review_task):
 
     assert "Repository Context Pack" in prompt
     assert "review the touched modules first" in prompt
+
+
+def test_review_prompt_asserts_spec_authority_near_compliance_judgment(review_task):
+    """The prompt must restate spec authority adjacent to where compliance is
+    judged (Output Format schema and Rules), not only where context is
+    introduced — so the reviewer sees it last, right before judging."""
+    prompt = build_review_prompt(review_task, **_REVIEW_COMMON_KWARGS)
+
+    output_format_idx = prompt.index("## Output Format")
+    rules_idx = prompt.index("## Rules")
+
+    output_format_section = prompt[output_format_idx:rules_idx]
+    rules_section = prompt[rules_idx:]
+
+    assert "authoritative for" in output_format_section
+    assert "matches_spec" in output_format_section
+
+    assert "Only `## Spec` decides compliance" in rules_section
+    assert "Repository Context Pack" in rules_section


### PR DESCRIPTION
## Summary

The review prompt now restates Spec authority beside the compliance schema and Rules, with focused regression coverage.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $0.98
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

The review prompt tells reviewers to use injected repository context without restating that only the spec decides story compliance (GitHub Issue #2548)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2548