### PR TITLE
A run continues spending past its configured budget without halting or warning

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -108,7 +108,22 @@ story never gets blocked for going "over budget."
 
 - **Sprint-level governance (enforced).** The sprint `budget_usd` is the *only*
   post-hoc dollar enforcement. When cumulative sprint spend reaches it, no new
-  stories launch. This is the surviving cost-governance surface.
+  stories launch **and any story already running is cancelled at its next
+  coordinator phase boundary** — the sprint stops rather than finishing a story
+  it can no longer afford. This is the surviving cost-governance surface.
+
+  A cancelled story is recorded as *skipped*, with a reason naming the budget:
+  the sprint stopped it, nothing judged its work, and re-running it under a
+  larger cap is the whole remedy.
+
+  Enforcement is a floor, not a guarantee of the exact figure: the phase that
+  was already running when the cap was met still finishes, so a run can land
+  slightly past its budget. Where it does, `forge sprint-status` marks the
+  overrun beside the cost and budget, and `budget_status` /
+  `budget_overrun_usd` record it in `sprint-summary.yaml` and the sprint audit.
+  Spend that could not be measured is a separate case: the cap cannot be
+  evaluated against a total known to be a lower bound, so the sprint refuses to
+  dispatch further work rather than cancelling what is already running.
 
 - **Per-story dollar values (estimates, not enforced).** The per-story dollar
   value is a *cost estimate* derived from historical cost data for the model and

--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -121,9 +121,10 @@ story never gets blocked for going "over budget."
   slightly past its budget. Where it does, `forge sprint-status` marks the
   overrun beside the cost and budget, and `budget_status` /
   `budget_overrun_usd` record it in `sprint-summary.yaml` and the sprint audit.
-  Spend that could not be measured is a separate case: the cap cannot be
-  evaluated against a total known to be a lower bound, so the sprint refuses to
-  dispatch further work rather than cancelling what is already running.
+  Spend that could not be measured is a separate case: the sprint will still
+  cancel a running story if the measured lower bound already exhausts the cap,
+  but it will not cancel that story merely because the remaining spend is
+  unknown. In that unverifiable-only case, it refuses further dispatch instead.
 
 - **Per-story dollar values (estimates, not enforced).** The per-story dollar
   value is a *cost estimate* derived from historical cost data for the model and

--- a/src/theforge/cli/sprint_status.py
+++ b/src/theforge/cli/sprint_status.py
@@ -132,6 +132,12 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     # reports the measured lower bound as such instead of as the sprint cost.
     cost_complete: bool = True
     cost_measured_usd: float | None = None
+    # What the run recorded about its own standing against the cap, when it
+    # recorded one. Absent for runs that predate the field, which fall back to
+    # comparing the cost this command is about to display (#2547).
+    budget_status_recorded: str | None = None
+    budget_overrun_recorded: float | None = None
+    budget_spend_recorded: float | None = None
     duration_seconds: float | None = None
     sprint_phase: str | None = None
     sprint_phase_detail: str | None = None
@@ -152,6 +158,9 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
             base_branch = meta.get("base_branch")
             budget_usd = meta.get("budget_usd")
             max_parallel = meta.get("max_parallel")
+            budget_status_recorded = meta.get("budget_status")
+            budget_overrun_recorded = meta.get("budget_overrun_usd")
+            budget_spend_recorded = meta.get("budget_spend_usd")
         # Approximate elapsed from the process start time via detach
         try:
             from theforge import detach as _detach
@@ -214,6 +223,22 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
             _measured = sp.get("total_cost_measured_usd")
             cost_measured_usd = _measured if isinstance(_measured, (int, float)) else None
             duration_seconds = sp.get("duration_seconds")
+            # A completed sprint reports its own cap and how it finished against
+            # it. Read both: without the budget there is nothing to compare the
+            # cost to, which is how a 41%-over run once read as unremarkable
+            # (#2547).
+            _summary_budget = sp.get("budget_usd")
+            if isinstance(_summary_budget, (int, float)):
+                budget_usd = float(_summary_budget)
+            _summary_status = sp.get("budget_status")
+            if isinstance(_summary_status, str):
+                budget_status_recorded = _summary_status
+            _summary_overrun = sp.get("budget_overrun_usd")
+            if isinstance(_summary_overrun, (int, float)):
+                budget_overrun_recorded = float(_summary_overrun)
+            _summary_verification = sp.get("budget_verification_spend_usd")
+            if isinstance(_summary_verification, (int, float)):
+                budget_spend_recorded = float(_summary_verification)
         except Exception:
             pass
 
@@ -248,15 +273,27 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     else:
         state_label = "completed"
 
+    # Cost and budget stop being two independent numbers here: whichever spend
+    # figure the header is about to show is compared against the cap, and an
+    # overrun is stated next to it rather than left for the operator to notice
+    # (#2547).
+    overrun_marker = _budget_overrun_marker(
+        budget_usd=budget_usd,
+        displayed_cost_usd=total_cost_usd if total_cost_usd is not None else cost_measured_usd,
+        recorded_status=budget_status_recorded,
+        recorded_overrun_usd=budget_overrun_recorded,
+        recorded_spend_usd=budget_spend_recorded,
+    )
+
     header_parts: list[str] = [f"Sprint: {sprint_name}  run: {run_id}  [{state_label}]"]
     if sprint_phase:
         header_parts.append(
             _format_sprint_phase(sprint_phase, sprint_phase_detail, sprint_phase_started_at)
         )
     if total_cost_usd is not None:
-        header_parts.append(f"cost: ${total_cost_usd:.2f}")
+        header_parts.append(f"cost: ${total_cost_usd:.2f}{overrun_marker}")
     elif not cost_complete:
-        header_parts.append(f"cost: {_fmt_cost_total(None, cost_measured_usd)}")
+        header_parts.append(f"cost: {_fmt_cost_total(None, cost_measured_usd)}{overrun_marker}")
     if duration_seconds is not None:
         if is_live:
             header_parts.append(f"elapsed: {int(duration_seconds // 60)}m")
@@ -271,7 +308,9 @@ def display_sprint_status(run_id: str, project_root: Path, title_cache: dict | N
     if base_branch:
         config_parts.append(f"base: {base_branch}")
     if budget_usd is not None:
-        config_parts.append(f"budget: ${float(budget_usd):.2f}")
+        config_parts.append(
+            f"budget: ${float(budget_usd):.2f}" + ("  ⚠ exceeded" if overrun_marker else "")
+        )
     if max_parallel is not None:
         config_parts.append(f"parallel: {max_parallel}")
     if config_parts:
@@ -413,7 +452,57 @@ def _read_sprint_meta_from_state(state_path: object) -> dict:
         out["budget_usd"] = float(data["budget_usd"])
     if isinstance(data.get("max_parallel"), int):
         out["max_parallel"] = data["max_parallel"]
+    # The runner's own verdict on the cap. Preferred over a comparison derived
+    # here because it accounts for spend the story rows never carry — carried
+    # cost from an earlier generation, and passes that belong to no story
+    # (#2547).
+    if isinstance(data.get("budget_status"), str):
+        out["budget_status"] = data["budget_status"]
+    if isinstance(data.get("budget_overrun_usd"), (int, float)):
+        out["budget_overrun_usd"] = float(data["budget_overrun_usd"])
+    if isinstance(data.get("budget_spend_usd"), (int, float)):
+        out["budget_spend_usd"] = float(data["budget_spend_usd"])
     return out
+
+
+def _budget_overrun_marker(
+    *,
+    budget_usd: float | None,
+    displayed_cost_usd: float | None,
+    recorded_status: str | None = None,
+    recorded_overrun_usd: float | None = None,
+    recorded_spend_usd: float | None = None,
+) -> str:
+    """Return the over-budget marker to append to the cost and budget fields.
+
+    Empty when there is no cap, or the run is inside it. The run's own recorded
+    verdict wins where it exists — it saw spend this view cannot (cost carried
+    from an earlier generation, passes that belong to no story) — and the
+    displayed cost is the fallback, so a run that recorded nothing is still
+    compared against its cap rather than printed beside it (#2547).
+    """
+    from theforge.sprint.budget import (  # noqa: PLC0415
+        BUDGET_STATUS_OVER,
+        budget_overrun_usd,
+    )
+
+    if budget_usd is None or float(budget_usd) <= 0.0:
+        return ""
+    spend_candidates = [
+        c for c in (displayed_cost_usd, recorded_spend_usd) if isinstance(c, (int, float))
+    ]
+    derived = (
+        budget_overrun_usd(budget_usd=float(budget_usd), spend_usd=max(spend_candidates))
+        if spend_candidates
+        else 0.0
+    )
+    if recorded_status == BUDGET_STATUS_OVER:
+        overrun = float(recorded_overrun_usd or 0.0) or derived
+    elif derived > 0.0:
+        overrun = derived
+    else:
+        return ""
+    return f"  ⚠ OVER BUDGET by ${overrun:.2f}"
 
 
 def _read_sprint_name_from_state(state_path: object) -> str:

--- a/src/theforge/coordinator/adaptive_iterations.py
+++ b/src/theforge/coordinator/adaptive_iterations.py
@@ -9,6 +9,10 @@ The per-story dollar value is an *estimate* derived from historical cost data �
 it informs routing, timeout scaling, and audit telemetry. It is NOT an enforced
 budget: real post-hoc dollar governance lives at the sprint level
 (``forge.yaml: budget_usd``). Nothing here caps or blocks spend after the fact.
+The sprint cap does bind mid-story — it is charged the spend of stories still
+running and cancels them at the next phase boundary once it is met (#2547) —
+but that decision is the sprint's, made against measured spend, never against
+an estimate derived here.
 
 Design:
 

--- a/src/theforge/coordinator/cancellation.py
+++ b/src/theforge/coordinator/cancellation.py
@@ -1,15 +1,65 @@
-"""Cooperative cancellation signal for sprint-driven worker timeouts.
+"""Cooperative cancellation signal for sprint-driven worker stops.
 
 Sprint workers run inside a ThreadPoolExecutor. Future.cancel() cannot stop a
 running thread, so the sprint scheduler signals cancellation via a per-story
 threading.Event. The coordinator checks the event at phase boundaries and
 raises StoryCancelled, which entry points catch to bypass end-of-run
 persistence (escalation history, model profile updates) — the scheduler's
-synthetic timeout record is the only artifact for cancelled stories.
+synthetic record is the only artifact for cancelled stories.
+
+The sprint has more than one reason to pull that lever — a worker deadline, an
+auth circuit breaker, an exhausted sprint budget — and they are not the same
+fact about the story. :class:`StopSignal` carries the reason alongside the
+signal so the cancelled result says which one it was, instead of every stop
+reading downstream as the timeout the first caller happened to be.
 """
 
 from __future__ import annotations
 
+import threading
+
+#: What a cancellation says happened when nobody said otherwise. Preserved as
+#: the default because the worker deadline was the original and only caller.
+DEFAULT_CANCEL_REASON = "Story cancelled by sprint timeout"
+DEFAULT_CANCEL_ERROR_TYPE = "StoryCancelled"
+
+#: Error type stamped on a story the sprint killed because its cap was reached.
+#: Distinct from the timeout type so no consumer reads a budget halt as an
+#: unresponsive worker, and neither reads as a judgment about the work (#2547).
+BUDGET_CANCEL_ERROR_TYPE = "SprintBudgetExhausted"
+
 
 class StoryCancelled(Exception):
     """Raised when a sprint-level stop_event signals worker cancellation."""
+
+
+class StopSignal(threading.Event):
+    """A cancellation event that also records why the sprint set it.
+
+    A plain ``set()`` keeps the historical meaning (worker deadline), so callers
+    that predate the distinction are unaffected. ``stop()`` names a different
+    cause, and the coordinator stamps that cause on the cancelled result.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reason: str = DEFAULT_CANCEL_REASON
+        self.error_type: str = DEFAULT_CANCEL_ERROR_TYPE
+
+    def stop(self, reason: str, *, error_type: str = DEFAULT_CANCEL_ERROR_TYPE) -> None:
+        """Signal cancellation with an explicit cause."""
+        self.reason = reason
+        self.error_type = error_type
+        self.set()
+
+
+def cancel_cause(stop_event: "threading.Event | None") -> tuple[str, str]:
+    """The (reason, error_type) a cancellation through *stop_event* carries.
+
+    Reads defensively rather than by type: the coordinator accepts any
+    ``threading.Event``, and a caller that passes a bare one still gets the
+    historical timeout wording.
+    """
+    reason = getattr(stop_event, "reason", None) or DEFAULT_CANCEL_REASON
+    error_type = getattr(stop_event, "error_type", None) or DEFAULT_CANCEL_ERROR_TYPE
+    return str(reason), str(error_type)

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -53,7 +53,7 @@ from theforge.task import (
 from . import live_state as _live_state
 from . import story_budget as _story_budget
 from .agent_failure import is_infrastructure_abort
-from .cancellation import StoryCancelled
+from .cancellation import StoryCancelled, cancel_cause
 from .log_tee import (  # noqa: E402
     _begin_run_log_tee,
     _end_run_log_tee,
@@ -231,22 +231,31 @@ def _run_end_outcome(result: CoordinatorResult) -> str:
     return "escalate"
 
 
-def _cancelled_result(task: TaskStory, state: CoordinatorState) -> CoordinatorResult:
+def _cancelled_result(
+    task: TaskStory,
+    state: CoordinatorState,
+    stop_event: "threading.Event | None" = None,
+) -> CoordinatorResult:
     """Build a failed CoordinatorResult for a story aborted via stop_event.
 
     Bypasses _record_run_memory() — the sprint scheduler has already written
-    the authoritative timeout audit record; writing a separate ESCALATE
+    the authoritative audit record for the stop; writing a separate ESCALATE
     record here would produce two contradictory failure narratives.
+
+    The cause comes off the signal itself (``cancel_cause``), so a story the
+    sprint killed for its budget is not reported as an unresponsive worker
+    (#2547). A bare ``threading.Event`` still yields the timeout wording.
     """
-    _log(f"INFO {task.slug}: cancelled by sprint stop_event")
+    reason, error_type = cancel_cause(stop_event)
+    _log(f"INFO {task.slug}: cancelled by sprint stop_event ({reason})")
     state.phase = Phase.ESCALATE
-    state.error = "Story cancelled by sprint timeout"
-    state.error_type = "StoryCancelled"
+    state.error = reason
+    state.error_type = error_type
     return CoordinatorResult(
         success=False,
         phase=Phase.ESCALATE,
         state=state,
-        message="Story cancelled by sprint timeout",
+        message=reason,
     )
 
 
@@ -1274,7 +1283,7 @@ def run_task(
                     stop_event=stop_event,
                 )
             except StoryCancelled:
-                return _cancelled_result(task, state)
+                return _cancelled_result(task, state, stop_event)
             _total_elapsed = time.monotonic() - _task_start
             _fire_post_run_hook(config, state, task, result, _run_id, _total_elapsed, logger)
             logger._safe_emit(
@@ -1385,7 +1394,7 @@ def run_task(
                     stop_event=stop_event,
                 )
             except StoryCancelled:
-                return _cancelled_result(task, state)
+                return _cancelled_result(task, state, stop_event)
             logger._safe_emit(
                 "run_end",
                 outcome=_run_end_outcome(result),
@@ -1462,7 +1471,7 @@ def run_task(
                 stop_event=stop_event,
             )
         except StoryCancelled:
-            return _cancelled_result(task, state)
+            return _cancelled_result(task, state, stop_event)
 
         # ── Landing (single-story path) ───────────────────────────────
         # _finalize_approve defers all git operations and sets landing_status
@@ -1819,7 +1828,7 @@ def _run_resume_coordinator(
                 stop_event=stop_event,
             )
         except StoryCancelled:
-            return _cancelled_result(task, state)
+            return _cancelled_result(task, state, stop_event)
 
         # ── Landing (single-story resume path) ───────────────────────
         # Skip when defer_landing=True (sprint worker): scheduler handles it.

--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -666,6 +666,7 @@ def _coordinator_loop(
                         "phase": "DEV",
                         "iteration": state.dev_iteration,
                         "cost_usd": state.total_cost_measured,
+                        "coordinator_state": state,
                         **live_complexity_fields(
                             state.preflight_complexity, state.preflight_complexity_score
                         ),
@@ -725,6 +726,7 @@ def _coordinator_loop(
                         "phase": "DEV",
                         "iteration": state.dev_iteration,
                         "cost_usd": state.total_cost_measured,
+                        "coordinator_state": state,
                         **live_complexity_fields(
                             state.preflight_complexity, state.preflight_complexity_score
                         ),

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -843,6 +843,7 @@ def _run_plan_phase(
                 "phase": "PLAN",
                 "iteration": 0,
                 "cost_usd": state.total_cost_measured,
+                "coordinator_state": state,
                 **_cu.live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),
@@ -905,6 +906,7 @@ def _run_plan_phase(
                 "phase": "PLAN",
                 "iteration": 0,
                 "cost_usd": state.total_cost_measured,
+                "coordinator_state": state,
                 **_cu.live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -349,6 +349,10 @@ def _run_preflight_phase(
                 "phase": "PREFLIGHT",
                 "iteration": 0,
                 "cost_usd": state.total_cost_measured,
+                "coordinator_state": state,
+                **_cu.live_complexity_fields(
+                    state.preflight_complexity, state.preflight_complexity_score
+                ),
                 "current_model": preflight_profile.model,
             }
         )
@@ -615,6 +619,7 @@ def _run_preflight_phase(
                 "phase": "PREFLIGHT",
                 "iteration": 0,
                 "cost_usd": state.total_cost_measured,
+                "coordinator_state": state,
                 # Fired before the parse step computes preflight_complexity_score,
                 # so the score may still be None. live_complexity_fields omits the
                 # key in that case, preserving any score an earlier phase set on a
@@ -1004,6 +1009,7 @@ def _run_preflight_phase(
                 "phase": "PREFLIGHT",
                 "iteration": 0,
                 "cost_usd": state.total_cost_measured,
+                "coordinator_state": state,
                 # Fired after the parse step; by now preflight_complexity_score is
                 # set whenever the agent emitted a numeric score, so the score
                 # reaches live state immediately for stories that never enter DEV.

--- a/src/theforge/coordinator/review_phase.py
+++ b/src/theforge/coordinator/review_phase.py
@@ -1434,6 +1434,7 @@ def _run_review_phase(
                 "phase": "REVIEW",
                 "iteration": state.review_cycle + 1,
                 "cost_usd": state.total_cost_measured,
+                "coordinator_state": state,
                 **live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),
@@ -1723,6 +1724,7 @@ def _run_review_phase(
                 "phase": "REVIEW",
                 "iteration": state.review_cycle,
                 "cost_usd": state.total_cost_measured,
+                "coordinator_state": state,
                 **live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),

--- a/src/theforge/coordinator/validate_phase.py
+++ b/src/theforge/coordinator/validate_phase.py
@@ -761,6 +761,7 @@ def _run_validate_phase(
                 "phase": "VALIDATE",
                 "iteration": state.dev_iteration,
                 "cost_usd": state.total_cost_measured,
+                "coordinator_state": state,
                 # Carry the story-descriptive complexity fields on VALIDATE entry
                 # so this early payload agrees with the sibling VALIDATE payload
                 # (post-gate) and every other phase. Omitting them here left the
@@ -1061,6 +1062,7 @@ def _run_validate_phase(
                 "phase": "VALIDATE",
                 "iteration": state.dev_iteration,
                 "cost_usd": state.total_cost_measured,
+                "coordinator_state": state,
                 **_cu.live_complexity_fields(
                     state.preflight_complexity, state.preflight_complexity_score
                 ),

--- a/src/theforge/sprint/audit.py
+++ b/src/theforge/sprint/audit.py
@@ -16,6 +16,7 @@ from ..coordinator.iteration_usage import dev_usage as _dev_usage
 from ..coordinator.landing_record import build_landing_record
 from ..log_util import _log_line
 from .abnormal import accumulate_failure_history, carry_failure_cause
+from .budget import budget_overrun_usd, budget_status
 from .launch_guard import REASON_RECONCILE_PRIOR_DONE, REASON_STRANDED_WORKTREE
 from .manifest import ResolvedSprint, SprintManifest, SprintResult
 
@@ -107,6 +108,46 @@ def _state_reported_cost(state: object) -> float | None:
     if hasattr(state, "total_cost_measured"):
         return _optional_cost(state.total_cost_measured)
     return _optional_cost(getattr(state, "total_cost", None))
+
+
+def _budget_cap_of(result: "SprintResult") -> float:
+    """The cap *result* ran under, ``0.0`` when it carries none.
+
+    Read defensively, like every other field these writers project: a record
+    built without a cap has nothing to be within or over, which is exactly what
+    a zero cap means to ``sprint.budget``.
+    """
+    raw = getattr(result, "budget_usd", 0.0)
+    return float(raw) if isinstance(raw, (int, float)) else 0.0
+
+
+def _budget_spend_against_cap(result: "SprintResult", spend_usd: float | None) -> float:
+    """The spend figure a cap comparison is made against for *result*."""
+    reported = getattr(result, "budget_spend_against_cap", None)
+    if not isinstance(reported, (int, float)):
+        raw_total = getattr(result, "total_cost_usd", 0.0)
+        reported = float(raw_total) if isinstance(raw_total, (int, float)) else 0.0
+    if spend_usd is None:
+        return float(reported)
+    return max(float(reported), float(spend_usd))
+
+
+def _budget_status_of(result: "SprintResult", spend_usd: float | None = None) -> str:
+    """Where the run stands against its cap: within, over, or unset (#2547)."""
+    return budget_status(
+        budget_usd=_budget_cap_of(result), spend_usd=_budget_spend_against_cap(result, spend_usd)
+    )
+
+
+def _budget_overrun_of(result: "SprintResult", spend_usd: float | None = None) -> float:
+    """How far the run passed its cap, or ``0.0`` when it did not (#2547)."""
+    return round(
+        budget_overrun_usd(
+            budget_usd=_budget_cap_of(result),
+            spend_usd=_budget_spend_against_cap(result, spend_usd),
+        ),
+        4,
+    )
 
 
 def _story_allocation_summary(
@@ -936,6 +977,14 @@ def _write_sprint_audit(
             "budget_verification_spend_usd": round(
                 float(getattr(result, "budget_verification_spend_usd", 0.0) or 0.0), 4
             ),
+            # Where the run finished relative to its cap, stated rather than left
+            # to be inferred from two numbers in the same block. A run can land
+            # over the cap legitimately — enforcement stops it at the first
+            # checkpoint past the limit, and the phase already running when that
+            # happened still finishes — so "over" is reported, not suppressed
+            # (#2547).
+            "budget_status": _budget_status_of(result),
+            "budget_overrun_usd": _budget_overrun_of(result),
             "budget_note": "Costs reflect Claude invocations only; Codex/Gemini report $0.00",
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -1419,6 +1468,12 @@ def _write_sprint_summary(
             "budget_verification_spend_usd": round(
                 float(getattr(result, "budget_verification_spend_usd", 0.0) or 0.0), 4
             ),
+            # See the audit writer: the run's standing against its cap, reported
+            # beside the cost it is a statement about (#2547). Measured against
+            # the summary's own effective cost, which can exceed the result's
+            # when per-story attribution recovered spend the ledger did not hold.
+            "budget_status": _budget_status_of(result, spend_usd=effective_cost_usd),
+            "budget_overrun_usd": _budget_overrun_of(result, spend_usd=effective_cost_usd),
             "started_at": started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "finished_at": finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "duration_seconds": round(duration, 1),

--- a/src/theforge/sprint/budget.py
+++ b/src/theforge/sprint/budget.py
@@ -1,8 +1,22 @@
 """Sprint budget enforcement decisions.
 
 Pure, stdlib-only: given what the sprint has measurably spent and which spend it
-could not measure, decide whether the next story may be dispatched. Extracted
-from ``runner.py`` so the policy is testable without a live sprint.
+could not measure, decide whether the sprint may keep spending. Extracted from
+``runner.py`` so the policy is testable without a live sprint.
+
+One decision point serves two enforcement moments (#2547). Dispatch asks it
+before a story starts; the in-flight checkpoint asks it again while a story is
+running, charging that story's measured spend so far on top of the ledger. The
+second moment exists because the first one alone bounds nothing: a sprint whose
+work is one long story never returns to a dispatch boundary, so a cap checked
+only there is a number the run passes rather than a number that binds it.
+
+The two moments differ in what they do with an *unverifiable* answer, and only
+in that. Dispatch refuses to launch new work against a total it knows is a lower
+bound. The in-flight checkpoint acts on ``exhausted`` alone: killing a story
+that has already been paid for, because some other spend was unmeasured, would
+destroy work to protect a comparison the sprint will re-run at its next dispatch
+boundary anyway.
 
 The load-bearing rule is that a cap can only be enforced against a number that
 means what it says. ``accumulated_cost`` is a sum over measured spend; when a
@@ -30,6 +44,20 @@ from dataclasses import dataclass
 #: How many unmeasured sources to name in an operator-facing message before
 #: eliding the rest. The full list lives in the sprint's structured records.
 _MAX_NAMED_SOURCES = 5
+
+#: A cap was configured and the run stayed inside it.
+BUDGET_STATUS_WITHIN = "within"
+#: A cap was configured and the run finished past it. Enforcement halts a run at
+#: the first checkpoint after the cap is met, but a phase already in flight can
+#: land beyond it, so "over" is a state an honest run can legitimately reach —
+#: which is exactly why it has to be reported rather than inferred (#2547).
+BUDGET_STATUS_OVER = "over"
+#: No positive cap was configured, so there is nothing to be within or over.
+BUDGET_STATUS_UNSET = "unset"
+
+#: Spend has to pass the cap by more than rounding noise before a run is called
+#: over budget: a story landing at exactly the cap met it, it did not breach it.
+_OVERRUN_EPSILON_USD = 0.005
 
 
 @dataclass(frozen=True)
@@ -147,6 +175,32 @@ def evaluate_budget(
             detail = f"{detail}; {rendered}"
         return BudgetBlock(kind="unverifiable", detail=detail)
     return None
+
+
+def budget_overrun_usd(*, budget_usd: float, spend_usd: float | None) -> float:
+    """How far *spend_usd* passed the cap, or ``0.0`` when it did not.
+
+    The reporting half of the same policy ``evaluate_budget`` enforces. It is
+    deliberately a separate function: enforcement decides whether more work may
+    start, reporting states what a finished or in-progress run actually did, and
+    a run can be over budget without anything having been refused (the phase
+    that crossed the cap was already running when it did).
+    """
+    if budget_usd <= 0.0 or spend_usd is None:
+        return 0.0
+    overrun = float(spend_usd) - float(budget_usd)
+    if overrun <= _OVERRUN_EPSILON_USD:
+        return 0.0
+    return round(overrun, 6)
+
+
+def budget_status(*, budget_usd: float, spend_usd: float | None) -> str:
+    """Classify a run against its cap: within, over, or no cap configured."""
+    if budget_usd <= 0.0:
+        return BUDGET_STATUS_UNSET
+    if budget_overrun_usd(budget_usd=budget_usd, spend_usd=spend_usd) > 0.0:
+        return BUDGET_STATUS_OVER
+    return BUDGET_STATUS_WITHIN
 
 
 def describe_source_origins(

--- a/src/theforge/sprint/budget.py
+++ b/src/theforge/sprint/budget.py
@@ -13,10 +13,12 @@ only there is a number the run passes rather than a number that binds it.
 
 The two moments differ in what they do with an *unverifiable* answer, and only
 in that. Dispatch refuses to launch new work against a total it knows is a lower
-bound. The in-flight checkpoint acts on ``exhausted`` alone: killing a story
-that has already been paid for, because some other spend was unmeasured, would
-destroy work to protect a comparison the sprint will re-run at its next dispatch
-boundary anyway.
+bound. The in-flight checkpoint acts on ``exhausted`` alone: a running story is
+still cancelled when its measured lower bound has definitely met the cap, but it
+is not cancelled merely because some spend was unmeasured and the comparison is
+therefore unverifiable. Killing a story that has already been paid for to
+protect only that second case would destroy work for a comparison the sprint
+will re-run at its next dispatch boundary anyway.
 
 The load-bearing rule is that a cap can only be enforced against a number that
 means what it says. ``accumulated_cost`` is a sum over measured spend; when a

--- a/src/theforge/sprint/manifest.py
+++ b/src/theforge/sprint/manifest.py
@@ -15,6 +15,7 @@ from ..task import (
     frontmatter_allows_forge_yaml_mutation,
     inspect_story_frontmatter,
 )
+from .budget import budget_overrun_usd, budget_status
 
 if TYPE_CHECKING:
     from .sources import StorySource
@@ -80,6 +81,28 @@ class SprintResult:
     budget_verification_spend_usd: float = 0.0
     results: list[tuple[str, CoordinatorResult]] = field(default_factory=list)
     stopped_reason: str | None = None  # why sprint stopped early, if it did
+
+    @property
+    def budget_spend_against_cap(self) -> float:
+        """The figure the cap is reported against.
+
+        The verification figure where one was computed (it charges accepted
+        ceilings for unmeasured spend, so it is never below the measured total),
+        falling back to the measured total for results built without it.
+        """
+        return max(float(self.budget_verification_spend_usd or 0.0), float(self.total_cost_usd))
+
+    @property
+    def budget_overrun_usd(self) -> float:
+        """How far this run passed its cap, or ``0.0`` when it did not (#2547)."""
+        return budget_overrun_usd(
+            budget_usd=self.budget_usd, spend_usd=self.budget_spend_against_cap
+        )
+
+    @property
+    def budget_status(self) -> str:
+        """``within``, ``over``, or ``unset`` — see ``sprint.budget``."""
+        return budget_status(budget_usd=self.budget_usd, spend_usd=self.budget_spend_against_cap)
 
 
 def load_sprint_manifest(manifest_path: Path) -> SprintManifest:

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -235,6 +235,11 @@ class _SkipReasonRule:
 # records at each skip site. Order is match order.
 _SKIP_REASON_RULES: tuple[_SkipReasonRule, ...] = (
     _SkipReasonRule("sprint_budget_unverifiable", ("budget unverifiable",)),
+    # Before the credential rule below, which shares the "cancelled mid-flight:"
+    # prefix: a story the sprint killed for its cap and one it killed for a
+    # rejected credential are different causes, and the more specific prefix has
+    # to be tried first or every budget halt reads as an auth outage (#2547).
+    _SkipReasonRule("sprint_budget_halted_in_flight", ("cancelled mid-flight: budget",)),
     _SkipReasonRule("sprint_budget_exhausted", ("budget exhausted",)),
     # "blocked" covers both "blocked: <ref>" (unresolved external dependency) and
     # the bare "blocked" the DAG sweep records.
@@ -429,6 +434,16 @@ RULES: tuple[RcaRule, ...] = (
         ),
     ),
     RcaRule(
+        rule_id="sprint_budget_halted_in_flight",
+        failure_class="sprint_budget_halted_in_flight",
+        role="primary",
+        description=(
+            "The sprint's spend met or passed the run's budget cap while this story "
+            "was running, so the sprint cancelled it at its next phase boundary. "
+            "Nothing judged the work — it is unfinished, not rejected."
+        ),
+    ),
+    RcaRule(
         rule_id="agent_credential_rejected",
         failure_class="agent_auth_rejected",
         role="primary",
@@ -579,6 +594,9 @@ _PRIMARY_PRIORITY: tuple[str, ...] = (
     # its depends_on list still says.
     "agent_auth_rejected",
     "sprint_budget_unverifiable",
+    # A story the sprint stopped mid-flight for its cap outranks the two
+    # never-dispatched budget classes: it ran, and what ended it was the money.
+    "sprint_budget_halted_in_flight",
     "sprint_budget_exhausted",
     "collision_stand_down",
     "dependency_skip",
@@ -2451,6 +2469,11 @@ def _recommend_actions(
             f"the sprint's budget cap was reached before {ref} was dispatched — raise the "
             f"budget or re-sprint {ref} in a new run; nothing about {ref}'s own work was "
             "judged"
+        ),
+        "sprint_budget_halted_in_flight": (
+            f"the sprint's budget cap was reached while {ref} was running, so the sprint "
+            f"cancelled it at its next phase boundary — raise the budget or re-sprint {ref} "
+            "in a new run; its work is unfinished, not rejected, and no model judged it"
         ),
         "agent_auth_rejected": (
             f"re-authenticate the agent credential the run recorded as rejected, then "

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2652,13 +2652,27 @@ def _make_worker_phase_fn(
         if budget_checkpoint is not None and not _cost_mirrored:
             _reported = updates.get("cost_usd")
             # ``None`` means the transport could not measure this story's spend.
-            # It is deliberately not a checkpoint: enforcing a cap on an
-            # unmeasured figure would either kill work over a number nobody has
-            # (#1992's lower bound) or, coerced to zero, report it as free. The
-            # unmeasured case stays where it already fails closed — the dispatch
-            # gate, which refuses to launch further work.
+            # That still advances the live sprint standing by the measured lower
+            # bound already in the coordinator state: the dispatch gate remains
+            # where unmeasured spend fails closed, but a running story should not
+            # get to bypass every later phase-boundary checkpoint once one phase
+            # went unmeasured (#1992, #2547).
             if isinstance(_reported, (int, float)) and not isinstance(_reported, bool):
                 budget_checkpoint(slug, float(_reported))
+            elif _reported is None:
+                _detail = updates.get("detail")
+                _lower_bound = None
+                if isinstance(_detail, dict):
+                    _candidate = _detail.get("cost_measured_lower_bound_usd")
+                    if isinstance(_candidate, (int, float)) and not isinstance(_candidate, bool):
+                        _lower_bound = float(_candidate)
+                if _lower_bound is None:
+                    _coordinator_state = updates.get("coordinator_state")
+                    _candidate = getattr(_coordinator_state, "total_cost_measured", None)
+                    if isinstance(_candidate, (int, float)) and not isinstance(_candidate, bool):
+                        _lower_bound = float(_candidate)
+                if _lower_bound is not None:
+                    budget_checkpoint(slug, _lower_bound)
         with phase_lock:
             phase_changed = bool(phase) and worker_phases.get(slug) != phase
             if phase:

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -34,6 +34,7 @@ from ..coordinator.agent_failure import (
     mark_infrastructure_abort,
 )
 from ..coordinator.batch_diff import BatchReviewContext, latest_dev_handoff
+from ..coordinator.cancellation import BUDGET_CANCEL_ERROR_TYPE, StopSignal
 from ..coordinator.config_snapshot import SprintConfigSnapshot, capture_or_load
 from ..coordinator.engine import run_from_dev, run_from_review, run_review_only, run_task
 from ..coordinator.gate import run_gate_full
@@ -86,7 +87,12 @@ from .audit import (
 )
 from .audit_publish import publish_story_run_audits, write_terminal_sprint_audits
 from .auth_gate import enforce_sprint_auth_readiness
-from .budget import budget_verification_spend, evaluate_budget
+from .budget import (
+    budget_overrun_usd,
+    budget_status,
+    budget_verification_spend,
+    evaluate_budget,
+)
 from .carry import (
     load_sprint_carry_budget_snapshot,
 )
@@ -2368,11 +2374,19 @@ def _run_batch_group(
 
         All members really are in DEV at that moment; showing only the leader as
         running would make the others read as idle for the length of the pass.
+
+        The cost in a mirrored update is the *group's* one spend, shown on each
+        member's row. Every mirror but the leader's is marked as such, so a
+        sprint charging in-flight spend to its cap counts that one pass once
+        rather than once per member (#2547).
         """
         for slug, fn in state_update_fns.items():
             if fn is None:
                 continue
-            fn({**update, "spec": slug})
+            mirrored = {**update, "spec": slug}
+            if slug != leader_task.slug:
+                mirrored["cost_mirrored"] = True
+            fn(mirrored)
 
     leader_task_dispatch, leader_result, leader_elapsed, leader_t0, leader_t1 = _run_single_story(
         config,
@@ -2599,6 +2613,7 @@ def _make_worker_phase_fn(
     plan_done: "dict[str, str] | None" = None,
     state_writer: "SprintStateWriter | None" = None,
     audit_flush: "Callable[[str], None] | None" = None,
+    budget_checkpoint: "Callable[[str, float], None] | None" = None,
 ) -> "Callable[[dict], None]":
     """Return a thread-safe state_update_fn wrapper for worker live state.
 
@@ -2617,10 +2632,33 @@ def _make_worker_phase_fn(
     file is the only record an outside process (``forge stop``) can finalize —
     it cannot see this one's memory (#2013). Flushing on phase changes only
     keeps the cost proportional to real progress rather than to update chatter.
+
+    When *budget_checkpoint* is provided it is called with the story's measured
+    spend every time the coordinator reports one. That report arrives at the
+    coordinator's phase boundaries, which is precisely where a sprint cap can be
+    enforced against a story that is already running: the sprint learns what the
+    story has spent at the same moment the story is between phases and can still
+    be stopped without wasting a phase's work (#2547).
     """
 
     def _update(updates: dict) -> None:
         phase = updates.get("phase", "")
+        # A mirrored cost belongs to another slug's run (a batch group's shared
+        # dev pass). It is displayed on this row and charged on that one.
+        _cost_mirrored = bool(updates.pop("cost_mirrored", False))
+        # Before the lock: the checkpoint may stop the sprint and set every
+        # in-flight story's cancellation signal, and no other worker's live
+        # update should queue behind that decision.
+        if budget_checkpoint is not None and not _cost_mirrored:
+            _reported = updates.get("cost_usd")
+            # ``None`` means the transport could not measure this story's spend.
+            # It is deliberately not a checkpoint: enforcing a cap on an
+            # unmeasured figure would either kill work over a number nobody has
+            # (#1992's lower bound) or, coerced to zero, report it as free. The
+            # unmeasured case stays where it already fails closed — the dispatch
+            # gate, which refuses to launch further work.
+            if isinstance(_reported, (int, float)) and not isinstance(_reported, bool):
+                budget_checkpoint(slug, float(_reported))
         with phase_lock:
             phase_changed = bool(phase) and worker_phases.get(slug) != phase
             if phase:
@@ -3070,6 +3108,52 @@ def _mark_story_auth_cancelled(
         _log(f"WARN: could not re-attribute auth-cancelled story: {exc}")
 
 
+def _copy_worker_signals(
+    signals: "dict[str, threading.Event]",
+) -> list[tuple[str, threading.Event]]:
+    """Copy a slug -> Event map safely from a thread that does not own it.
+
+    The scheduler owns ``stop_events`` and ``plan_gates``, adding and removing
+    entries as stories dispatch and land. Until the budget checkpoint (#2547) it
+    was their only reader, so neither needed a lock; a worker thread copying one
+    can now race a scheduler mutation, which CPython reports rather than
+    corrupts. Retrying the copy is the whole fix — the loser of the race reads a
+    moment later, and a story that landed in between no longer needs signalling.
+    """
+    for _ in range(3):
+        try:
+            return list(signals.items())
+        except RuntimeError:  # dict changed size during iteration
+            continue
+    return []
+
+
+def _budget_cancel_reason(state: SprintExecutionState) -> str:
+    """The operator-facing reason a story was cancelled for the sprint's cap."""
+    recorded = state.stop.reason or "sprint budget exhausted"
+    return f"cancelled mid-flight: {recorded}"
+
+
+def _mark_story_budget_cancelled(result: CoordinatorResult, *, reason: str) -> None:
+    """Re-attribute a mid-flight cancellation to the sprint's spending cap.
+
+    The same problem ``_mark_story_auth_cancelled`` solves, for the other reason
+    a sprint kills work it started: left alone, the generic cancellation reads
+    downstream as a story that failed. It did not fail — it was stopped, by a
+    decision about money that says nothing about the work, and the record has to
+    say which (#2547).
+
+    Deliberately NOT an infrastructure abort: nothing was broken. The story is
+    simply unfinished, and re-running it under a larger cap is the whole remedy.
+    """
+    try:
+        result.state.error = reason
+        result.state.error_type = BUDGET_CANCEL_ERROR_TYPE
+        result.message = reason
+    except Exception as exc:  # pragma: no cover - defensive
+        _log(f"WARN: could not re-attribute budget-cancelled story: {exc}")
+
+
 def _classify_and_record(
     task: TaskStory,
     result: CoordinatorResult,
@@ -3187,11 +3271,26 @@ class SprintCostSnapshot:
     prior: float
     unmeasured: tuple[str, ...]
     current_generation_unmeasured: frozenset[str]
+    # What the stories still running have measurably spent so far. Not part of
+    # ``accumulated``: it is provisional, replaced by the story's terminal figure
+    # the moment the story lands. Carried in the same read so an in-flight budget
+    # check cannot see a total from one moment and in-flight spend from another.
+    in_flight: float = 0.0
 
     @property
     def spent(self) -> float:
         """This generation's spend plus what it inherited on resume."""
         return self.accumulated + self.prior
+
+    @property
+    def spent_including_in_flight(self) -> float:
+        """Everything spent so far, counting stories that have not landed yet.
+
+        The figure a mid-story cap check has to use: a sprint that has paid for
+        work still in progress has spent that money whether or not the story it
+        belongs to has returned (#2547).
+        """
+        return self.spent + self.in_flight
 
     @property
     def measured(self) -> bool:
@@ -3220,6 +3319,11 @@ class SprintCostLedger:
         self._prior = float(prior)
         self._unmeasured: list[str] = []
         self._current_generation: set[str] = set()
+        # slug -> what that still-running story has measurably spent so far.
+        # Provisional spend the ledger owns for the same reason it owns the
+        # total: a sprint that tracked in-flight cost anywhere else would have
+        # two writers for one question again (#2547).
+        self._in_flight: dict[str, float] = {}
 
     # -- reads ----------------------------------------------------------
     @property
@@ -3260,12 +3364,17 @@ class SprintCostLedger:
     def snapshot(self) -> SprintCostSnapshot:
         """Read the whole ledger at one moment."""
         with self._lock:
-            return SprintCostSnapshot(
-                accumulated=self._accumulated,
-                prior=self._prior,
-                unmeasured=tuple(self._unmeasured),
-                current_generation_unmeasured=frozenset(self._current_generation),
-            )
+            return self._snapshot_locked()
+
+    def _snapshot_locked(self) -> SprintCostSnapshot:
+        """Build the read. Caller must hold ``self._lock``."""
+        return SprintCostSnapshot(
+            accumulated=self._accumulated,
+            prior=self._prior,
+            unmeasured=tuple(self._unmeasured),
+            current_generation_unmeasured=frozenset(self._current_generation),
+            in_flight=sum(self._in_flight.values()),
+        )
 
     # -- writes ---------------------------------------------------------
     def add(self, amount: float) -> float:
@@ -3295,6 +3404,29 @@ class SprintCostLedger:
         with self._lock:
             self._unmeasured.append(source)
 
+    def record_in_flight_cost(self, slug: str, cost: float) -> SprintCostSnapshot:
+        """Record what a *running* story has measurably spent so far.
+
+        Last-write-wins per slug, because the coordinator reports a running
+        total rather than an increment. Returns the whole ledger read taken
+        under the same lock as the write, so an in-flight budget check evaluates
+        one consistent moment instead of a total and an in-flight figure that
+        drifted apart between two reads.
+        """
+        with self._lock:
+            self._in_flight[slug] = max(0.0, float(cost))
+            return self._snapshot_locked()
+
+    def drop_in_flight_cost(self, slug: str) -> None:
+        """Forget a story's provisional spend without recording a total.
+
+        For the exits that never produce a terminal cost (a worker that raised
+        on its way out): the provisional figure must not linger in the in-flight
+        sum for the rest of the sprint.
+        """
+        with self._lock:
+            self._in_flight.pop(slug, None)
+
     def record_story_cost(self, slug: str, cost: float, *, measured: float | None) -> float:
         """Fold a finished story's spend into the total in one step.
 
@@ -3302,8 +3434,13 @@ class SprintCostLedger:
         shortfall is recorded alongside the figure rather than after it — the
         dispatch check must never see the advanced total without also seeing
         that it is a lower bound (#1992).
+
+        The story's provisional in-flight figure is dropped inside the same lock
+        that adds its terminal one, so no reader can observe the story's spend
+        counted twice — nor, in the other order, missing entirely (#2547).
         """
         with self._lock:
+            self._in_flight.pop(slug, None)
             if measured is None:
                 self._unmeasured.append(slug)
                 self._current_generation.add(slug)
@@ -3604,6 +3741,11 @@ class SprintExecutionState:
     # sprint row so both surfaces report the same accounting (#2214).
     prior_generation_work: dict[str, dict] = field(default_factory=dict)
     story_cost_adjustments: dict[str, float] = field(default_factory=dict)
+    # Stories this sprint cancelled mid-flight because its cap was reached.
+    # Their results come back through the generic cancellation path, and this is
+    # what tells the scheduler the cancellation was a spending decision rather
+    # than a judgment about the work (#2547).
+    budget_cancelled_slugs: set[str] = field(default_factory=set)
     # Stories this generation actually put through a coordinator run — and
     # therefore the ones whose seeded prior cost was overwritten.
     ran_this_generation: set[str] = field(default_factory=set)
@@ -5441,6 +5583,113 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
         if _sprint_state.state_writer is not None:
             _sprint_state.state_writer.update(slug, status="skipped")
 
+    def _publish_live_budget_status(spend_usd: float) -> None:
+        """Record how the live run stands against its cap.
+
+        ``forge status`` reads this rather than comparing two numbers it happens
+        to print next to each other — and the runner is the only party that can
+        supply it, because the live story rows do not carry spend inherited from
+        an earlier generation or spent outside any story (#2547).
+        """
+        if _sprint_state.state_writer is None:
+            return
+        _status = budget_status(budget_usd=_ctx.resolved.budget_usd, spend_usd=spend_usd)
+        _sprint_state.state_writer.set_budget_status(
+            _status,
+            overrun_usd=budget_overrun_usd(
+                budget_usd=_ctx.resolved.budget_usd, spend_usd=spend_usd
+            ),
+            spend_usd=spend_usd,
+        )
+
+    def _budget_decision_for(snapshot: SprintCostSnapshot):
+        """Evaluate the cap against one ledger read, in-flight spend included.
+
+        The sprint's single cap decision, asked from both enforcement moments:
+        before a story is dispatched and while one is running. Both charge the
+        spend of stories that have not landed yet, because the sprint has
+        already paid for it (#2547).
+        """
+        _unresolved, _applied = unmeasured_spend_policy.partition(
+            list(snapshot.unmeasured),
+            accepted_unmeasured,
+            current_generation=set(snapshot.current_generation_unmeasured),
+            occurrence_ids=carried_occurrence_ids,
+        )
+        # Origin/ceiling lookup reads per-story audits, so it runs off the
+        # snapshot — it is reporting, not accounting.
+        _details = (
+            {raw: _describe_unmeasured_source(raw).describe() for raw in _unresolved}
+            if _unresolved
+            else None
+        )
+        return evaluate_budget(
+            accumulated_cost=snapshot.accumulated + snapshot.in_flight,
+            prior_cost=snapshot.prior,
+            budget_usd=_ctx.resolved.budget_usd,
+            unmeasured_spend=_unresolved,
+            accepted_unmeasured_ceiling_usd=unmeasured_spend_policy.accepted_ceiling_total(
+                _applied
+            ),
+            source_details=_details,
+        )
+
+    def _halt_sprint_for_budget(slug: str, decision) -> None:
+        """Stop every running story because the sprint's cap has been reached.
+
+        The auth circuit breaker's shape (#1952), for the other reason a sprint
+        has to stop work it already started: cancel in-flight workers at their
+        next phase boundary and release any plan gate they are parked on, so the
+        sprint stops in seconds rather than after another full review cycle.
+
+        Which slugs WE cancelled is remembered, because their results return
+        through the generic cancellation path and would otherwise be recorded as
+        story failures — the sprint ran out of money, which is not a verdict on
+        anyone's work.
+        """
+        if not _sprint_state.stop.stop_if_unset(decision.stopped_reason, halt_slug=slug):
+            return
+        _log(f"HALT sprint: {decision.stopped_reason}")
+        _cancel_reason = f"sprint budget exhausted while running ({decision.detail})"
+        for _pending_slug, _pending_evt in _copy_worker_signals(_sprint_state.stop_events):
+            _sprint_state.budget_cancelled_slugs.add(_pending_slug)
+            _stop_fn = getattr(_pending_evt, "stop", None)
+            if callable(_stop_fn):
+                _stop_fn(_cancel_reason, error_type=BUDGET_CANCEL_ERROR_TYPE)
+            else:  # pragma: no cover - defensive: a bare Event still stops work
+                _pending_evt.set()
+        for _gate_slug, _pending_gate in _copy_worker_signals(_sprint_state.plan_gates):
+            _log(f"Releasing plan gate for {_gate_slug} (budget halt)")
+            _pending_gate.set()
+        if _ctx.notify and _ctx.config.notifications.backend not in ("ntfy", "none"):
+            from ..notify_backends import send_notifications
+
+            send_notifications(
+                _ctx.config,
+                decision.notification_title(_ctx.resolved.name),
+                f"{decision.detail} — running stories cancelled, remaining stories skipped",
+            )
+
+    def _budget_checkpoint(slug: str, measured_cost: float) -> None:
+        """Charge a running story's spend to the cap, and halt if it is met.
+
+        Called from the worker thread at every coordinator phase boundary that
+        reports a cost. Only ``exhausted`` acts here: an unverifiable answer
+        means some *other* spend was unmeasured, and killing paid-for work over
+        that would destroy a story to protect a comparison the dispatch gate
+        re-runs — and fails closed on — a moment later.
+        """
+        if _ctx.resolved.budget_usd <= 0.0:
+            return
+        _snapshot = _sprint_state.cost.record_in_flight_cost(slug, measured_cost)
+        _publish_live_budget_status(_snapshot.spent_including_in_flight)
+        if _sprint_state.stop.stopped:
+            return
+        _decision = _budget_decision_for(_snapshot)
+        if _decision is None or _decision.kind != "exhausted":
+            return
+        _halt_sprint_for_budget(slug, _decision)
+
     # Intake remediation gate: between dependency normalization and the
     # batch preflight spend, run the shared shape + grooming check on the
     # full normalized task list. When ``intake.auto_fix`` is enabled, semantic
@@ -6564,33 +6813,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 if len(_sprint_state.active) >= max_parallel:
                     break
 
-                _budget_snapshot = _sprint_state.cost.snapshot()
-                _budget_unresolved, _budget_applied = unmeasured_spend_policy.partition(
-                    list(_budget_snapshot.unmeasured),
-                    accepted_unmeasured,
-                    current_generation=set(_budget_snapshot.current_generation_unmeasured),
-                    occurrence_ids=carried_occurrence_ids,
-                )
-                # Origin/ceiling lookup reads per-story audits, so it runs off
-                # the snapshot — it is reporting, not accounting.
-                _budget_details = (
-                    {
-                        raw: _describe_unmeasured_source(raw).describe()
-                        for raw in _budget_unresolved
-                    }
-                    if _budget_unresolved
-                    else None
-                )
-                _budget_decision = evaluate_budget(
-                    accumulated_cost=_budget_snapshot.accumulated,
-                    prior_cost=_budget_snapshot.prior,
-                    budget_usd=_ctx.resolved.budget_usd,
-                    unmeasured_spend=_budget_unresolved,
-                    accepted_unmeasured_ceiling_usd=unmeasured_spend_policy.accepted_ceiling_total(
-                        _budget_applied
-                    ),
-                    source_details=_budget_details,
-                )
+                _budget_decision = _budget_decision_for(_sprint_state.cost.snapshot())
                 if _budget_decision is not None:
                     _skip_story_for_budget(task.slug, _budget_decision)
                     continue
@@ -6668,7 +6891,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                     else:
                         _batch_tasks = [_ready_by_slug[m] for m in _dispatchable]
                         _leader_task = _make_batch_leader(_batch_tasks, _batch_gid)
-                        _batch_stop_evt = threading.Event()
+                        _batch_stop_evt = StopSignal()
                         _batch_state_fns: dict[str, Callable[[dict], None] | None] = {}
                         for _member_slug, _member_task in zip(
                             _dispatchable, _batch_tasks, strict=True
@@ -6710,6 +6933,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                                     _ctx.resolved.name,
                                     sprint_id=_ctx.sprint_id,
                                 ),
+                                budget_checkpoint=_budget_checkpoint,
                             )
                             _sprint_state.stop_events[_member_slug] = _batch_stop_evt
                         # One worker runs the group, so the whole group shares one
@@ -6789,8 +7013,9 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                     audit_flush=_make_audit_flush_fn(
                         _ctx.config, task, _ctx.resolved.name, sprint_id=_ctx.sprint_id
                     ),
+                    budget_checkpoint=_budget_checkpoint,
                 )
-                stop_evt = threading.Event()
+                stop_evt = StopSignal()
                 _sprint_state.stop_events[task.slug] = stop_evt
                 _dispatch_kwargs: dict = {
                     "base_lands_locally": _sprint_lands_locally,
@@ -7098,6 +7323,11 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                     worker_budget.unregister_worker_budget(slug)
                     story_wait_started.discard(slug)
                     _sprint_state.stop_events.pop(slug, None)
+                    # No terminal cost will ever be recorded for this story, so
+                    # its provisional in-flight figure has no successor to
+                    # replace it — drop it rather than leave it charged to every
+                    # later cap check (#2547).
+                    _sprint_state.cost.drop_in_flight_cost(slug)
                     _end_collision_claim(_sprint_state, slug, "worker raised")
                     spec_str = slug_to_spec[slug]
                     failed_at = datetime.datetime.now(datetime.timezone.utc)
@@ -7143,6 +7373,12 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                         )
                         _exc_outcome = StoryOutcome.SKIPPED
                         _log(f"SKIPPED {slug} ({_cancel_reason})")
+                    elif slug in _sprint_state.budget_cancelled_slugs:
+                        _sprint_state.budget_cancelled_slugs.discard(slug)
+                        _cancel_reason = _budget_cancel_reason(_sprint_state)
+                        _mark_story_budget_cancelled(_exc_result, reason=_cancel_reason)
+                        _exc_outcome = StoryOutcome.SKIPPED
+                        _log(f"SKIPPED {slug} ({_cancel_reason})")
                     _sprint_state.results.append((spec_str, _exc_result))
                     _write_story_audit(
                         _ctx.config,
@@ -7180,6 +7416,12 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                     slug,
                     result.state.total_cost,
                     measured=result.state.total_cost_measured,
+                )
+                # The landed figure replaces this story's provisional one, so the
+                # live standing against the cap is republished from the ledger's
+                # new state rather than left at what the story last reported.
+                _publish_live_budget_status(
+                    _sprint_state.cost.snapshot().spent_including_in_flight
                 )
 
                 spec_str = slug_to_spec[slug]
@@ -7242,6 +7484,29 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                     _end_collision_claim(
                         _sprint_state, slug, "cancelled by the auth circuit breaker"
                     )
+                    _log(f"SKIPPED {slug} ({_cancel_reason})")
+                    _record_current_story_entry(slug, "SKIPPED", error=_cancel_reason)
+                    _set_outcome(_sprint_state, slug, StoryOutcome.SKIPPED, reason=_cancel_reason)
+                    if _sprint_state.state_writer is not None:
+                        _sprint_state.state_writer.update(slug, status="skipped")
+                    _sprint_state.dag.mark_skipped(slug)
+                    _write_story_audit(_ctx.config, task, result, sprint_id=_ctx.sprint_id)
+                    _print_worker_status(
+                        _sprint_state.active, worker_phases, _sprint_state.dag, total
+                    )
+                    continue
+
+                # A story the sprint cancelled because its cap was reached
+                # (#2547). Same reasoning as the auth cancellation above: the
+                # sprint stopped it, nothing judged it, so it is skipped rather
+                # than failed — and the reason names the budget so an operator
+                # reading the run afterwards sees a spending decision instead of
+                # a story that could not be made to work.
+                if slug in _sprint_state.budget_cancelled_slugs and not result.success:
+                    _sprint_state.budget_cancelled_slugs.discard(slug)
+                    _cancel_reason = _budget_cancel_reason(_sprint_state)
+                    _mark_story_budget_cancelled(result, reason=_cancel_reason)
+                    _end_collision_claim(_sprint_state, slug, "cancelled by the sprint budget")
                     _log(f"SKIPPED {slug} ({_cancel_reason})")
                     _record_current_story_entry(slug, "SKIPPED", error=_cancel_reason)
                     _set_outcome(_sprint_state, slug, StoryOutcome.SKIPPED, reason=_cancel_reason)

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -479,7 +479,22 @@ def _optional_cost(raw: object) -> float | None:
     return None
 
 
-def _budget_checkpoint_cost(updates: Mapping[str, object]) -> float | None:
+@dataclass(frozen=True)
+class SprintCostObservation:
+    """A story's latest known spend and whether it was fully measured.
+
+    ``amount`` is always a lower bound on what the story spent so far. When
+    ``measured`` is False, that lower bound came from a coordinator aggregate
+    whose true total is unknown because some contributing phase reported no
+    cost. The runner still charges the lower bound to the sprint cap, but it
+    must never certify the sprint total as complete afterwards (#1992, #2547).
+    """
+
+    amount: float
+    measured: bool = True
+
+
+def _budget_checkpoint_cost(updates: Mapping[str, object]) -> SprintCostObservation | None:
     """Best measured lower bound available in a live state update.
 
     ``cost_usd`` is the preferred signal: it is the fully measured running
@@ -491,21 +506,24 @@ def _budget_checkpoint_cost(updates: Mapping[str, object]) -> float | None:
     """
     _reported = _optional_cost(updates.get("cost_usd"))
     if _reported is not None:
-        return _reported
+        return SprintCostObservation(amount=_reported, measured=True)
 
     _detail = updates.get("detail")
     if isinstance(_detail, Mapping):
         _lower_bound = _optional_cost(_detail.get("cost_measured_lower_bound_usd"))
         if _lower_bound is not None:
-            return _lower_bound
+            return SprintCostObservation(amount=_lower_bound, measured=False)
 
     _coordinator_state = updates.get("coordinator_state")
     if _coordinator_state is None:
         return None
     _measured = _optional_cost(getattr(_coordinator_state, "total_cost_measured", None))
     if _measured is not None:
-        return _measured
-    return _optional_cost(getattr(_coordinator_state, "total_cost", None))
+        return SprintCostObservation(amount=_measured, measured=True)
+    _lower_bound = _optional_cost(getattr(_coordinator_state, "total_cost", None))
+    if _lower_bound is None:
+        return None
+    return SprintCostObservation(amount=_lower_bound, measured=False)
 
 
 def _story_reported_cost(state: object, adjustment: float = 0.0) -> float | None:
@@ -2642,8 +2660,8 @@ def _make_worker_phase_fn(
     plan_done: "dict[str, str] | None" = None,
     state_writer: "SprintStateWriter | None" = None,
     audit_flush: "Callable[[str], None] | None" = None,
-    budget_checkpoint: "Callable[[str, float | None], None] | None" = None,
-    live_cost_updates: "dict[str, float] | None" = None,
+    budget_checkpoint: "Callable[[str, SprintCostObservation | None], None] | None" = None,
+    live_cost_updates: "dict[str, SprintCostObservation] | None" = None,
 ) -> "Callable[[dict], None]":
     """Return a thread-safe state_update_fn wrapper for worker live state.
 
@@ -2674,7 +2692,7 @@ def _make_worker_phase_fn(
 
     def _update(updates: dict) -> None:
         phase = updates.get("phase", "")
-        _checkpoint_cost: float | None = None
+        _checkpoint_cost: SprintCostObservation | None = None
         # A mirrored cost belongs to another slug's run (a batch group's shared
         # dev pass). It is displayed on this row and charged on that one.
         _cost_mirrored = bool(updates.pop("cost_mirrored", False))
@@ -3359,7 +3377,7 @@ class SprintCostLedger:
         # Provisional spend the ledger owns for the same reason it owns the
         # total: a sprint that tracked in-flight cost anywhere else would have
         # two writers for one question again (#2547).
-        self._in_flight: dict[str, float] = {}
+        self._in_flight: dict[str, SprintCostObservation] = {}
 
     # -- reads ----------------------------------------------------------
     @property
@@ -3409,7 +3427,7 @@ class SprintCostLedger:
             prior=self._prior,
             unmeasured=tuple(self._unmeasured),
             current_generation_unmeasured=frozenset(self._current_generation),
-            in_flight=sum(self._in_flight.values()),
+            in_flight=sum(observation.amount for observation in self._in_flight.values()),
         )
 
     # -- writes ---------------------------------------------------------
@@ -3432,19 +3450,29 @@ class SprintCostLedger:
         occurrence of the same story (#2310).
         """
         with self._lock:
-            self._unmeasured.append(source)
-            self._current_generation.add(source)
+            self._note_unmeasured_locked(source, current_generation=True)
 
     def note_carried_unmeasured(self, source: str) -> None:
         """Record unmeasured spend inherited from an earlier generation."""
         with self._lock:
+            self._note_unmeasured_locked(source, current_generation=False)
+
+    def _note_unmeasured_locked(self, source: str, *, current_generation: bool) -> None:
+        """Record one unmeasured-spend source. Caller must hold ``self._lock``."""
+        if source not in self._unmeasured:
             self._unmeasured.append(source)
+        if current_generation:
+            self._current_generation.add(source)
 
-    def record_in_flight_cost(self, slug: str, cost: float) -> SprintCostSnapshot:
+    def record_in_flight_cost(
+        self, slug: str, cost: float, *, measured: bool = True
+    ) -> SprintCostSnapshot:
         """Record what a *running* story has measurably spent so far."""
-        return self.checkpoint_in_flight_cost(slug, cost)
+        return self.checkpoint_in_flight_cost(slug, cost, measured=measured)
 
-    def checkpoint_in_flight_cost(self, slug: str, cost: float | None) -> SprintCostSnapshot:
+    def checkpoint_in_flight_cost(
+        self, slug: str, cost: float | None, *, measured: bool = True
+    ) -> SprintCostSnapshot:
         """Return the ledger state at a phase boundary for one running story.
 
         When *cost* is numeric, last-write-wins per slug because the coordinator
@@ -3457,8 +3485,16 @@ class SprintCostLedger:
         """
         with self._lock:
             if cost is not None:
-                self._in_flight[slug] = max(0.0, float(cost))
+                self._in_flight[slug] = SprintCostObservation(
+                    amount=max(0.0, float(cost)),
+                    measured=bool(measured),
+                )
             return self._snapshot_locked()
+
+    def has_in_flight_cost(self, slug: str) -> bool:
+        """Whether ``slug`` currently owns a provisional in-flight ledger entry."""
+        with self._lock:
+            return slug in self._in_flight
 
     def drop_in_flight_cost(self, slug: str) -> None:
         """Forget a story's provisional spend without recording a total.
@@ -3471,7 +3507,11 @@ class SprintCostLedger:
             self._in_flight.pop(slug, None)
 
     def recover_in_flight_cost(
-        self, slug: str, *, fallback_cost: float | None = None
+        self,
+        slug: str,
+        *,
+        fallback_cost: float | None = None,
+        fallback_measured: bool = True,
     ) -> SprintCostSnapshot:
         """Fold a raised worker's last measured spend into the sprint total.
 
@@ -3479,15 +3519,22 @@ class SprintCostLedger:
         replace its provisional in-flight figure. Promoting that last measured
         figure into ``accumulated`` preserves money the sprint definitely spent
         instead of silently making it disappear from later cap checks and the
-        terminal total. When the in-flight ledger entry is already gone, the
-        caller's last live-state cost snapshot is the next-best lower bound.
+        terminal total. When the recovered figure is only a lower bound, the
+        sprint total must stay marked unmeasured. When the in-flight ledger
+        entry is already gone, the caller's last live-state cost snapshot is the
+        next-best lower bound.
         """
         with self._lock:
             _recovered = self._in_flight.pop(slug, None)
             if _recovered is None and fallback_cost is not None:
-                _recovered = max(0.0, float(fallback_cost))
+                _recovered = SprintCostObservation(
+                    amount=max(0.0, float(fallback_cost)),
+                    measured=bool(fallback_measured),
+                )
             if _recovered is not None:
-                self._accumulated += _recovered
+                self._accumulated += _recovered.amount
+                if not _recovered.measured:
+                    self._note_unmeasured_locked(slug, current_generation=True)
             return self._snapshot_locked()
 
     def record_story_cost(self, slug: str, cost: float, *, measured: float | None) -> float:
@@ -3505,8 +3552,7 @@ class SprintCostLedger:
         with self._lock:
             self._in_flight.pop(slug, None)
             if measured is None:
-                self._unmeasured.append(slug)
-                self._current_generation.add(slug)
+                self._note_unmeasured_locked(slug, current_generation=True)
             self._accumulated += cost
             return self._accumulated
 
@@ -3812,7 +3858,7 @@ class SprintExecutionState:
     # The latest measured lower bound each active story reported through live
     # state updates. Used to recover spend when a worker dies before it can
     # return a terminal CoordinatorResult (#2547 follow-up).
-    latest_live_cost_usd: dict[str, float] = field(default_factory=dict)
+    latest_live_costs: dict[str, SprintCostObservation] = field(default_factory=dict)
     # Stories this generation actually put through a coordinator run — and
     # therefore the ones whose seeded prior cost was overwritten.
     ran_this_generation: set[str] = field(default_factory=set)
@@ -5737,7 +5783,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 f"{decision.detail} — running stories cancelled, remaining stories skipped",
             )
 
-    def _budget_checkpoint(slug: str, measured_cost: float | None) -> None:
+    def _budget_checkpoint(slug: str, measured_cost: SprintCostObservation | None) -> None:
         """Charge a running story's spend to the cap, and halt if it is met.
 
         Called from the worker thread at every coordinator phase boundary that
@@ -5748,7 +5794,11 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
         """
         if _ctx.resolved.budget_usd <= 0.0:
             return
-        _snapshot = _sprint_state.cost.checkpoint_in_flight_cost(slug, measured_cost)
+        _snapshot = _sprint_state.cost.checkpoint_in_flight_cost(
+            slug,
+            None if measured_cost is None else measured_cost.amount,
+            measured=True if measured_cost is None else measured_cost.measured,
+        )
         _publish_live_budget_status(_snapshot.spent_including_in_flight)
         if _sprint_state.stop.stopped:
             return
@@ -7001,6 +7051,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                                     sprint_id=_ctx.sprint_id,
                                 ),
                                 budget_checkpoint=_budget_checkpoint,
+                                live_cost_updates=_sprint_state.latest_live_costs,
                             )
                             _sprint_state.stop_events[_member_slug] = _batch_stop_evt
                         # One worker runs the group, so the whole group shares one
@@ -7081,7 +7132,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                         _ctx.config, task, _ctx.resolved.name, sprint_id=_ctx.sprint_id
                     ),
                     budget_checkpoint=_budget_checkpoint,
-                    live_cost_updates=_sprint_state.latest_live_cost_usd,
+                    live_cost_updates=_sprint_state.latest_live_costs,
                 )
                 stop_evt = StopSignal()
                 _sprint_state.stop_events[task.slug] = stop_evt
@@ -7325,7 +7376,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                         source="sprint.runner:worker-deadline",
                     )
                     _timeout_result.state.abnormal_termination = _timeout_cause
-                    _sprint_state.latest_live_cost_usd.pop(slug, None)
+                    _sprint_state.latest_live_costs.pop(slug, None)
                     _sprint_state.story_times[slug] = (story_started_at, timed_out_at)
                     _sprint_state.live_telemetry_snapshots[slug] = snapshot
                     # A worker the auth breaker cancelled can also cross its
@@ -7373,6 +7424,8 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 continue
 
             for slug, fut in list(_sprint_state.active.items()):
+                if slug not in _sprint_state.active:
+                    continue
                 if fut not in done_futs:
                     continue
                 try:
@@ -7386,98 +7439,120 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                     else:
                         task, result, elapsed, t0, t1 = _fut_value  # type: ignore[misc]
                 except Exception as exc:
-                    _log(f"ERROR {slug}: worker thread raised {type(exc).__name__}: {exc}")
-                    del _sprint_state.active[slug]
-                    story_deadlines.pop(slug, None)
-                    worker_budget.unregister_worker_budget(slug)
-                    story_wait_started.discard(slug)
-                    _sprint_state.stop_events.pop(slug, None)
-                    snapshot = _snapshot_last_known(slug, _sprint_state.state_writer)
-                    _last_live_cost = _sprint_state.latest_live_cost_usd.pop(slug, None)
-                    _recovered_cost = _sprint_state.cost.recover_in_flight_cost(
-                        slug,
-                        fallback_cost=(
-                            _last_live_cost
-                            if _last_live_cost is not None
-                            else snapshot["last_cost"]
+                    _affected_slugs = [
+                        active_slug
+                        for active_slug, active_fut in _sprint_state.active.items()
+                        if active_fut is fut
+                    ]
+                    _recovery_slug = next(
+                        (
+                            active_slug
+                            for active_slug in _affected_slugs
+                            if _sprint_state.cost.has_in_flight_cost(active_slug)
                         ),
+                        _affected_slugs[0] if len(_affected_slugs) == 1 else None,
                     )
-                    _publish_live_budget_status(_recovered_cost.spent_including_in_flight)
-                    _end_collision_claim(_sprint_state, slug, "worker raised")
-                    spec_str = slug_to_spec[slug]
-                    failed_at = datetime.datetime.now(datetime.timezone.utc)
-                    last_phase = snapshot["last_phase"]
-                    if slug in _sprint_state.story_times:
-                        story_started_at = _sprint_state.story_times[slug][0]
-                    elif snapshot["last_started_at"] is not None:
-                        story_started_at = snapshot["last_started_at"]
-                    else:
-                        story_started_at = failed_at
-                    _phase_label = f" during phase {last_phase}" if last_phase else ""
-                    _exc_error = f"Worker exception{_phase_label}: {exc}"
-                    _exc_result = _abnormal_story_result(
-                        slug,
-                        config=_ctx.config,
-                        sprint_name=_ctx.resolved.name,
-                        started_at=story_started_at,
-                        error=_exc_error,
-                        error_type=type(exc).__name__,
-                        message=f"Worker thread raised {type(exc).__name__}: {exc}",
-                    )
-                    _exc_cause = build_abnormal_cause(
-                        kind=ABNORMAL_WORKER_EXCEPTION,
-                        cause=_exc_error,
-                        error_type=type(exc).__name__,
-                        phase=last_phase,
-                        run_id=_exc_result.state.run_id,
-                        source="sprint.runner:worker-exception",
-                    )
-                    _exc_result.state.abnormal_termination = _exc_cause
-                    _sprint_state.story_times[slug] = (story_started_at, failed_at)
-                    _sprint_state.live_telemetry_snapshots[slug] = snapshot
-                    # Same attribution as the other two cancellation exits: a
-                    # worker that raised on its way out of an auth-breaker
-                    # cancellation was killed by the sprint, not by the story.
-                    _exc_outcome: StoryOutcome = StoryOutcome.FAILED
-                    if slug in auth_cancelled_slugs:
-                        auth_cancelled_slugs.discard(slug)
-                        _cancel_reason = f"cancelled mid-flight: {auth_circuit_reason}"
-                        _mark_story_auth_cancelled(
-                            _exc_result, auth_circuit, reason=_cancel_reason
+                    _recovered_cost = _sprint_state.cost.snapshot()
+                    for affected_slug in _affected_slugs:
+                        _log(
+                            f"ERROR {affected_slug}: worker thread raised "
+                            f"{type(exc).__name__}: {exc}"
                         )
-                        _exc_outcome = StoryOutcome.SKIPPED
-                        _log(f"SKIPPED {slug} ({_cancel_reason})")
-                    elif slug in _sprint_state.budget_cancelled_slugs:
-                        _sprint_state.budget_cancelled_slugs.discard(slug)
-                        _cancel_reason = _budget_cancel_reason(_sprint_state)
-                        _mark_story_budget_cancelled(_exc_result, reason=_cancel_reason)
-                        _exc_outcome = StoryOutcome.SKIPPED
-                        _log(f"SKIPPED {slug} ({_cancel_reason})")
-                    _sprint_state.results.append((spec_str, _exc_result))
-                    _write_story_audit(
-                        _ctx.config,
-                        _ctx.slug_to_context[slug][0],
-                        _exc_result,
-                        sprint_id=_ctx.sprint_id,
-                        telemetry_snapshot=snapshot,
-                    )
-                    _set_outcome(
-                        _sprint_state,
-                        slug,
-                        _exc_outcome,
-                        phase="ESCALATE",
-                        last_phase=last_phase,
-                        failure_cause=_exc_cause,
-                        detail_updates={"gate_status": GATE_STATUS_INCOMPLETE},
-                    )
-                    _persist_current_story_result(
-                        _sprint_state,
-                        slug,
-                        _exc_result,
-                        started_at=story_started_at,
-                        finished_at=failed_at,
-                    )
-                    _sprint_state.dag.mark_skipped(slug)
+                        del _sprint_state.active[affected_slug]
+                        story_deadlines.pop(affected_slug, None)
+                        worker_budget.unregister_worker_budget(affected_slug)
+                        story_wait_started.discard(affected_slug)
+                        _sprint_state.stop_events.pop(affected_slug, None)
+                        snapshot = _snapshot_last_known(affected_slug, _sprint_state.state_writer)
+                        _last_live_cost = _sprint_state.latest_live_costs.pop(affected_slug, None)
+                        if affected_slug == _recovery_slug:
+                            _recovered_cost = _sprint_state.cost.recover_in_flight_cost(
+                                affected_slug,
+                                fallback_cost=(
+                                    _last_live_cost.amount
+                                    if _last_live_cost is not None
+                                    else snapshot["last_cost"]
+                                ),
+                                fallback_measured=(
+                                    True if _last_live_cost is None else _last_live_cost.measured
+                                ),
+                            )
+                        _end_collision_claim(_sprint_state, affected_slug, "worker raised")
+                        spec_str = slug_to_spec[affected_slug]
+                        failed_at = datetime.datetime.now(datetime.timezone.utc)
+                        last_phase = snapshot["last_phase"]
+                        if affected_slug in _sprint_state.story_times:
+                            story_started_at = _sprint_state.story_times[affected_slug][0]
+                        elif snapshot["last_started_at"] is not None:
+                            story_started_at = snapshot["last_started_at"]
+                        else:
+                            story_started_at = failed_at
+                        _phase_label = f" during phase {last_phase}" if last_phase else ""
+                        _exc_error = f"Worker exception{_phase_label}: {exc}"
+                        _exc_result = _abnormal_story_result(
+                            affected_slug,
+                            config=_ctx.config,
+                            sprint_name=_ctx.resolved.name,
+                            started_at=story_started_at,
+                            error=_exc_error,
+                            error_type=type(exc).__name__,
+                            message=f"Worker thread raised {type(exc).__name__}: {exc}",
+                        )
+                        _exc_cause = build_abnormal_cause(
+                            kind=ABNORMAL_WORKER_EXCEPTION,
+                            cause=_exc_error,
+                            error_type=type(exc).__name__,
+                            phase=last_phase,
+                            run_id=_exc_result.state.run_id,
+                            source="sprint.runner:worker-exception",
+                        )
+                        _exc_result.state.abnormal_termination = _exc_cause
+                        _sprint_state.story_times[affected_slug] = (story_started_at, failed_at)
+                        _sprint_state.live_telemetry_snapshots[affected_slug] = snapshot
+                        # Same attribution as the other two cancellation exits: a
+                        # worker that raised on its way out of an auth-breaker
+                        # cancellation was killed by the sprint, not by the story.
+                        _exc_outcome: StoryOutcome = StoryOutcome.FAILED
+                        if affected_slug in auth_cancelled_slugs:
+                            auth_cancelled_slugs.discard(affected_slug)
+                            _cancel_reason = f"cancelled mid-flight: {auth_circuit_reason}"
+                            _mark_story_auth_cancelled(
+                                _exc_result, auth_circuit, reason=_cancel_reason
+                            )
+                            _exc_outcome = StoryOutcome.SKIPPED
+                            _log(f"SKIPPED {affected_slug} ({_cancel_reason})")
+                        elif affected_slug in _sprint_state.budget_cancelled_slugs:
+                            _sprint_state.budget_cancelled_slugs.discard(affected_slug)
+                            _cancel_reason = _budget_cancel_reason(_sprint_state)
+                            _mark_story_budget_cancelled(_exc_result, reason=_cancel_reason)
+                            _exc_outcome = StoryOutcome.SKIPPED
+                            _log(f"SKIPPED {affected_slug} ({_cancel_reason})")
+                        _sprint_state.results.append((spec_str, _exc_result))
+                        _write_story_audit(
+                            _ctx.config,
+                            _ctx.slug_to_context[affected_slug][0],
+                            _exc_result,
+                            sprint_id=_ctx.sprint_id,
+                            telemetry_snapshot=snapshot,
+                        )
+                        _set_outcome(
+                            _sprint_state,
+                            affected_slug,
+                            _exc_outcome,
+                            phase="ESCALATE",
+                            last_phase=last_phase,
+                            failure_cause=_exc_cause,
+                            detail_updates={"gate_status": GATE_STATUS_INCOMPLETE},
+                        )
+                        _persist_current_story_result(
+                            _sprint_state,
+                            affected_slug,
+                            _exc_result,
+                            started_at=story_started_at,
+                            finished_at=failed_at,
+                        )
+                        _sprint_state.dag.mark_skipped(affected_slug)
+                    _publish_live_budget_status(_recovered_cost.spent_including_in_flight)
                     continue
                 del _sprint_state.active[slug]
                 story_deadlines.pop(slug, None)
@@ -7485,7 +7560,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 story_wait_started.discard(slug)
                 _sprint_state.stop_events.pop(slug, None)
                 _sprint_state.story_times[slug] = (t0, t1)
-                _sprint_state.latest_live_cost_usd.pop(slug, None)
+                _sprint_state.latest_live_costs.pop(slug, None)
 
                 _sprint_state.cost.record_story_cost(
                     slug,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -2693,6 +2693,7 @@ def _make_worker_phase_fn(
     audit_flush: "Callable[[str], None] | None" = None,
     budget_checkpoint: "Callable[[str, SprintCostObservation | None], None] | None" = None,
     live_cost_updates: "dict[str, SprintCostObservation] | None" = None,
+    stop_event: threading.Event | None = None,
 ) -> "Callable[[dict], None]":
     """Return a thread-safe state_update_fn wrapper for worker live state.
 
@@ -2719,9 +2720,16 @@ def _make_worker_phase_fn(
     already running: the sprint learns what the story has spent at the same
     moment the story is between phases and can still be stopped without wasting
     a phase's work (#2547).
+
+    When *stop_event* is already set the worker has been cancelled by the
+    scheduler, so any later phase update is stale: accepting it would recreate
+    provisional in-flight spend for a story the scheduler has already retired
+    and accounted for.
     """
 
     def _update(updates: dict) -> None:
+        if stop_event is not None and stop_event.is_set():
+            return
         phase = updates.get("phase", "")
         _checkpoint_cost: SprintCostObservation | None = None
         # A mirrored cost belongs to another slug's run (a batch group's shared
@@ -7083,6 +7091,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                                 ),
                                 budget_checkpoint=_budget_checkpoint,
                                 live_cost_updates=_sprint_state.latest_live_costs,
+                                stop_event=_batch_stop_evt,
                             )
                             _sprint_state.stop_events[_member_slug] = _batch_stop_evt
                         # One worker runs the group, so the whole group shares one
@@ -7152,6 +7161,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
 
                 worker_config = _ctx.config
 
+                stop_evt = StopSignal()
                 state_fn = _make_worker_phase_fn(
                     task.slug,
                     worker_phases,
@@ -7164,8 +7174,8 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                     ),
                     budget_checkpoint=_budget_checkpoint,
                     live_cost_updates=_sprint_state.latest_live_costs,
+                    stop_event=stop_evt,
                 )
-                stop_evt = StopSignal()
                 _sprint_state.stop_events[task.slug] = stop_evt
                 _dispatch_kwargs: dict = {
                     "base_lands_locally": _sprint_lands_locally,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -479,6 +479,35 @@ def _optional_cost(raw: object) -> float | None:
     return None
 
 
+def _budget_checkpoint_cost(updates: Mapping[str, object]) -> float | None:
+    """Best measured lower bound available in a live state update.
+
+    ``cost_usd`` is the preferred signal: it is the fully measured running
+    total when the transport reported one. When a phase went unmeasured, the
+    coordinator can still carry a lower bound on ``coordinator_state.total_cost``
+    (or, for older callers, ``detail.cost_measured_lower_bound_usd``). Returning
+    ``None`` means "no new lower bound arrived"; callers may still re-check the
+    budget against the last provisional spend they already hold.
+    """
+    _reported = _optional_cost(updates.get("cost_usd"))
+    if _reported is not None:
+        return _reported
+
+    _detail = updates.get("detail")
+    if isinstance(_detail, Mapping):
+        _lower_bound = _optional_cost(_detail.get("cost_measured_lower_bound_usd"))
+        if _lower_bound is not None:
+            return _lower_bound
+
+    _coordinator_state = updates.get("coordinator_state")
+    if _coordinator_state is None:
+        return None
+    _measured = _optional_cost(getattr(_coordinator_state, "total_cost_measured", None))
+    if _measured is not None:
+        return _measured
+    return _optional_cost(getattr(_coordinator_state, "total_cost", None))
+
+
 def _story_reported_cost(state: object, adjustment: float = 0.0) -> float | None:
     """Per-story reported cost: measured total plus adjustment, or ``None``.
 
@@ -2613,7 +2642,8 @@ def _make_worker_phase_fn(
     plan_done: "dict[str, str] | None" = None,
     state_writer: "SprintStateWriter | None" = None,
     audit_flush: "Callable[[str], None] | None" = None,
-    budget_checkpoint: "Callable[[str, float], None] | None" = None,
+    budget_checkpoint: "Callable[[str, float | None], None] | None" = None,
+    live_cost_updates: "dict[str, float] | None" = None,
 ) -> "Callable[[dict], None]":
     """Return a thread-safe state_update_fn wrapper for worker live state.
 
@@ -2633,50 +2663,42 @@ def _make_worker_phase_fn(
     it cannot see this one's memory (#2013). Flushing on phase changes only
     keeps the cost proportional to real progress rather than to update chatter.
 
-    When *budget_checkpoint* is provided it is called with the story's measured
-    spend every time the coordinator reports one. That report arrives at the
-    coordinator's phase boundaries, which is precisely where a sprint cap can be
-    enforced against a story that is already running: the sprint learns what the
-    story has spent at the same moment the story is between phases and can still
-    be stopped without wasting a phase's work (#2547).
+    When *budget_checkpoint* is provided it is called at coordinator phase
+    boundaries with the best measured lower bound that update carried, or
+    ``None`` when the update brought no new lower-bound data. Those boundaries
+    are precisely where a sprint cap can be enforced against a story that is
+    already running: the sprint learns what the story has spent at the same
+    moment the story is between phases and can still be stopped without wasting
+    a phase's work (#2547).
     """
 
     def _update(updates: dict) -> None:
         phase = updates.get("phase", "")
+        _checkpoint_cost: float | None = None
         # A mirrored cost belongs to another slug's run (a batch group's shared
         # dev pass). It is displayed on this row and charged on that one.
         _cost_mirrored = bool(updates.pop("cost_mirrored", False))
         # Before the lock: the checkpoint may stop the sprint and set every
         # in-flight story's cancellation signal, and no other worker's live
         # update should queue behind that decision.
-        if budget_checkpoint is not None and not _cost_mirrored:
-            _reported = updates.get("cost_usd")
-            # ``None`` means the transport could not measure this story's spend.
-            # That still advances the live sprint standing by the measured lower
-            # bound already in the coordinator state: the dispatch gate remains
-            # where unmeasured spend fails closed, but a running story should not
-            # get to bypass every later phase-boundary checkpoint once one phase
-            # went unmeasured (#1992, #2547).
-            if isinstance(_reported, (int, float)) and not isinstance(_reported, bool):
-                budget_checkpoint(slug, float(_reported))
-            elif _reported is None:
-                _detail = updates.get("detail")
-                _lower_bound = None
-                if isinstance(_detail, dict):
-                    _candidate = _detail.get("cost_measured_lower_bound_usd")
-                    if isinstance(_candidate, (int, float)) and not isinstance(_candidate, bool):
-                        _lower_bound = float(_candidate)
-                if _lower_bound is None:
-                    _coordinator_state = updates.get("coordinator_state")
-                    _candidate = getattr(_coordinator_state, "total_cost_measured", None)
-                    if isinstance(_candidate, (int, float)) and not isinstance(_candidate, bool):
-                        _lower_bound = float(_candidate)
-                if _lower_bound is not None:
-                    budget_checkpoint(slug, _lower_bound)
+        if not _cost_mirrored:
+            # ``None`` means "no new lower bound arrived", not "stop checking":
+            # once a story has gone unmeasured the sprint must keep re-checking
+            # the cap against the best lower bound it already holds (#1992, #2547).
+            _detail = updates.get("detail")
+            _has_lower_bound_detail = isinstance(_detail, Mapping) and (
+                "cost_measured_lower_bound_usd" in _detail
+            )
+            if "cost_usd" in updates or "coordinator_state" in updates or _has_lower_bound_detail:
+                _checkpoint_cost = _budget_checkpoint_cost(updates)
+                if budget_checkpoint is not None:
+                    budget_checkpoint(slug, _checkpoint_cost)
         with phase_lock:
             phase_changed = bool(phase) and worker_phases.get(slug) != phase
             if phase:
                 worker_phases[slug] = phase
+            if live_cost_updates is not None and _checkpoint_cost is not None:
+                live_cost_updates[slug] = _checkpoint_cost
             if state_writer is not None:
                 incoming_detail = updates.get("detail")
                 detail_updates: dict[str, object] = (
@@ -3419,27 +3441,54 @@ class SprintCostLedger:
             self._unmeasured.append(source)
 
     def record_in_flight_cost(self, slug: str, cost: float) -> SprintCostSnapshot:
-        """Record what a *running* story has measurably spent so far.
+        """Record what a *running* story has measurably spent so far."""
+        return self.checkpoint_in_flight_cost(slug, cost)
 
-        Last-write-wins per slug, because the coordinator reports a running
-        total rather than an increment. Returns the whole ledger read taken
-        under the same lock as the write, so an in-flight budget check evaluates
-        one consistent moment instead of a total and an in-flight figure that
-        drifted apart between two reads.
+    def checkpoint_in_flight_cost(self, slug: str, cost: float | None) -> SprintCostSnapshot:
+        """Return the ledger state at a phase boundary for one running story.
+
+        When *cost* is numeric, last-write-wins per slug because the coordinator
+        reports a running total rather than an increment. When *cost* is
+        ``None``, no new lower bound was available, so the story keeps the last
+        measured figure already on the ledger. In both cases the returned
+        snapshot is taken under the same lock as any update, so the cap check
+        evaluates one consistent moment instead of a total and an in-flight
+        figure that drifted apart between two reads.
         """
         with self._lock:
-            self._in_flight[slug] = max(0.0, float(cost))
+            if cost is not None:
+                self._in_flight[slug] = max(0.0, float(cost))
             return self._snapshot_locked()
 
     def drop_in_flight_cost(self, slug: str) -> None:
         """Forget a story's provisional spend without recording a total.
 
-        For the exits that never produce a terminal cost (a worker that raised
-        on its way out): the provisional figure must not linger in the in-flight
-        sum for the rest of the sprint.
+        For exits that intentionally abandon the story's spend rather than
+        promoting it into the sprint total: the provisional figure must not
+        linger in the in-flight sum for the rest of the sprint.
         """
         with self._lock:
             self._in_flight.pop(slug, None)
+
+    def recover_in_flight_cost(
+        self, slug: str, *, fallback_cost: float | None = None
+    ) -> SprintCostSnapshot:
+        """Fold a raised worker's last measured spend into the sprint total.
+
+        A worker exception never produces a terminal ``CoordinatorResult`` to
+        replace its provisional in-flight figure. Promoting that last measured
+        figure into ``accumulated`` preserves money the sprint definitely spent
+        instead of silently making it disappear from later cap checks and the
+        terminal total. When the in-flight ledger entry is already gone, the
+        caller's last live-state cost snapshot is the next-best lower bound.
+        """
+        with self._lock:
+            _recovered = self._in_flight.pop(slug, None)
+            if _recovered is None and fallback_cost is not None:
+                _recovered = max(0.0, float(fallback_cost))
+            if _recovered is not None:
+                self._accumulated += _recovered
+            return self._snapshot_locked()
 
     def record_story_cost(self, slug: str, cost: float, *, measured: float | None) -> float:
         """Fold a finished story's spend into the total in one step.
@@ -3760,6 +3809,10 @@ class SprintExecutionState:
     # what tells the scheduler the cancellation was a spending decision rather
     # than a judgment about the work (#2547).
     budget_cancelled_slugs: set[str] = field(default_factory=set)
+    # The latest measured lower bound each active story reported through live
+    # state updates. Used to recover spend when a worker dies before it can
+    # return a terminal CoordinatorResult (#2547 follow-up).
+    latest_live_cost_usd: dict[str, float] = field(default_factory=dict)
     # Stories this generation actually put through a coordinator run — and
     # therefore the ones whose seeded prior cost was overwritten.
     ran_this_generation: set[str] = field(default_factory=set)
@@ -5684,7 +5737,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 f"{decision.detail} — running stories cancelled, remaining stories skipped",
             )
 
-    def _budget_checkpoint(slug: str, measured_cost: float) -> None:
+    def _budget_checkpoint(slug: str, measured_cost: float | None) -> None:
         """Charge a running story's spend to the cap, and halt if it is met.
 
         Called from the worker thread at every coordinator phase boundary that
@@ -5695,7 +5748,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
         """
         if _ctx.resolved.budget_usd <= 0.0:
             return
-        _snapshot = _sprint_state.cost.record_in_flight_cost(slug, measured_cost)
+        _snapshot = _sprint_state.cost.checkpoint_in_flight_cost(slug, measured_cost)
         _publish_live_budget_status(_snapshot.spent_including_in_flight)
         if _sprint_state.stop.stopped:
             return
@@ -7028,6 +7081,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                         _ctx.config, task, _ctx.resolved.name, sprint_id=_ctx.sprint_id
                     ),
                     budget_checkpoint=_budget_checkpoint,
+                    live_cost_updates=_sprint_state.latest_live_cost_usd,
                 )
                 stop_evt = StopSignal()
                 _sprint_state.stop_events[task.slug] = stop_evt
@@ -7271,6 +7325,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                         source="sprint.runner:worker-deadline",
                     )
                     _timeout_result.state.abnormal_termination = _timeout_cause
+                    _sprint_state.latest_live_cost_usd.pop(slug, None)
                     _sprint_state.story_times[slug] = (story_started_at, timed_out_at)
                     _sprint_state.live_telemetry_snapshots[slug] = snapshot
                     # A worker the auth breaker cancelled can also cross its
@@ -7337,15 +7392,20 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                     worker_budget.unregister_worker_budget(slug)
                     story_wait_started.discard(slug)
                     _sprint_state.stop_events.pop(slug, None)
-                    # No terminal cost will ever be recorded for this story, so
-                    # its provisional in-flight figure has no successor to
-                    # replace it — drop it rather than leave it charged to every
-                    # later cap check (#2547).
-                    _sprint_state.cost.drop_in_flight_cost(slug)
+                    snapshot = _snapshot_last_known(slug, _sprint_state.state_writer)
+                    _last_live_cost = _sprint_state.latest_live_cost_usd.pop(slug, None)
+                    _recovered_cost = _sprint_state.cost.recover_in_flight_cost(
+                        slug,
+                        fallback_cost=(
+                            _last_live_cost
+                            if _last_live_cost is not None
+                            else snapshot["last_cost"]
+                        ),
+                    )
+                    _publish_live_budget_status(_recovered_cost.spent_including_in_flight)
                     _end_collision_claim(_sprint_state, slug, "worker raised")
                     spec_str = slug_to_spec[slug]
                     failed_at = datetime.datetime.now(datetime.timezone.utc)
-                    snapshot = _snapshot_last_known(slug, _sprint_state.state_writer)
                     last_phase = snapshot["last_phase"]
                     if slug in _sprint_state.story_times:
                         story_started_at = _sprint_state.story_times[slug][0]
@@ -7425,6 +7485,7 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 story_wait_started.discard(slug)
                 _sprint_state.stop_events.pop(slug, None)
                 _sprint_state.story_times[slug] = (t0, t1)
+                _sprint_state.latest_live_cost_usd.pop(slug, None)
 
                 _sprint_state.cost.record_story_cost(
                     slug,

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -34,7 +34,7 @@ from ..coordinator.agent_failure import (
     mark_infrastructure_abort,
 )
 from ..coordinator.batch_diff import BatchReviewContext, latest_dev_handoff
-from ..coordinator.cancellation import BUDGET_CANCEL_ERROR_TYPE, StopSignal
+from ..coordinator.cancellation import BUDGET_CANCEL_ERROR_TYPE, StopSignal, cancel_cause
 from ..coordinator.config_snapshot import SprintConfigSnapshot, capture_or_load
 from ..coordinator.engine import run_from_dev, run_from_review, run_review_only, run_task
 from ..coordinator.gate import run_gate_full
@@ -2498,22 +2498,42 @@ def _run_batch_group(
             f"reviews cannot attribute commits and will treat every finding as "
             f"unverifiable against the member's own change"
         )
+
+    def _cancelled_batch_member_result(
+        member: TaskStory, started_at: datetime.datetime
+    ) -> CoordinatorResult:
+        reason, error_type = cancel_cause(stop_event)
+        return _abnormal_story_result(
+            member.slug,
+            config=config,
+            sprint_name=sprint_name,
+            started_at=started_at,
+            error=reason,
+            error_type=error_type,
+            message=reason,
+        )
+
     for member in member_tasks:
         member_t0 = datetime.datetime.now(datetime.timezone.utc)
         set_worker_slug(member.slug)
         member_fn = state_update_fns.get(member.slug)
         if member_fn is not None:
             member_fn({"spec": member.slug, "phase": "REVIEW"})
+        review_started = False
         try:
-            member_result = run_review_only(
-                config,
-                member,
-                workspace_path,
-                notify=notify,
-                sprint_name=sprint_name,
-                branch_name=branch_name,
-                batch_context=batch_context,
-            )
+            if stop_event is not None and stop_event.is_set():
+                member_result = _cancelled_batch_member_result(member, member_t0)
+            else:
+                review_started = True
+                member_result = run_review_only(
+                    config,
+                    member,
+                    workspace_path,
+                    notify=notify,
+                    sprint_name=sprint_name,
+                    branch_name=branch_name,
+                    batch_context=batch_context,
+                )
         except Exception as exc:
             _log(f"ERROR {member.slug}: batch review raised {type(exc).__name__}: {exc}")
             member_result = _batch_member_failure(
@@ -2525,6 +2545,17 @@ def _run_batch_group(
             )
         finally:
             set_worker_slug("")
+        if review_started and member_fn is not None:
+            member_update: dict[str, object] = {
+                "spec": member.slug,
+                "coordinator_state": member_result.state,
+            }
+            measured_cost = _optional_cost(
+                getattr(member_result.state, "total_cost_measured", None)
+            )
+            if measured_cost is not None:
+                member_update["cost_usd"] = measured_cost
+            member_fn(member_update)
         member_result.state.preflight_batch_group = group_id
         # The gate ran once, on the shared worktree. Carry its result onto every
         # member so a batched story's audit shows the validation it actually
@@ -7294,133 +7325,173 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
 
             if expired_slugs:
                 for slug in expired_slugs:
+                    if slug not in _sprint_state.active:
+                        continue
                     if slug in _sprint_state.plan_gates:
                         _log(f"TIMEOUT releasing plan gate for {slug}")
                         _sprint_state.plan_gates[slug].set()
                         del _sprint_state.plan_gates[slug]
-                    fut = _sprint_state.active.pop(slug)
-                    story_deadlines.pop(slug, None)
-                    story_wait_started.discard(slug)
-                    # A worker killed at its deadline is not preserved work
-                    # awaiting a decision — nothing can land it, so its files
-                    # are free.
-                    _end_collision_claim(_sprint_state, slug, "worker timed out")
-                    # Set the cancellation event BEFORE cancel() so any in-flight
-                    # work stops at the next phase boundary or subprocess read.
-                    # Future.cancel() is a no-op for an already-running thread.
-                    _stop_evt = _sprint_state.stop_events.pop(slug, None)
-                    if _stop_evt is not None:
-                        _stop_evt.set()
-                    fut.cancel()
-                    # An elapsed deadline is exhausted time, not a verdict on the
-                    # work and not evidence the worker stopped responding — a
-                    # story killed here may have been converging, mid-edit, or in
-                    # a wait this system itself opened. Say which (#2333).
-                    _wait_credit = worker_budget.operator_wait_credit(slug)
-                    _was_waiting, _wait_phase, _wait_len = worker_budget.waiting_on_operator(slug)
-                    _wait_note = ""
-                    if _wait_credit > 0:
-                        _wait_note = (
-                            f"; {_fmt_duration(_wait_credit)} of operator-decision wait"
-                            " was excluded from the deadline"
+                    fut = _sprint_state.active[slug]
+                    affected_slugs = [
+                        active_slug
+                        for active_slug, active_fut in _sprint_state.active.items()
+                        if active_fut is fut
+                    ]
+                    recovered_snapshot = _sprint_state.cost.snapshot()
+                    for affected_slug in affected_slugs:
+                        del _sprint_state.active[affected_slug]
+                        story_deadlines.pop(affected_slug, None)
+                        story_wait_started.discard(affected_slug)
+                        # A worker killed at its deadline is not preserved work
+                        # awaiting a decision — nothing can land it, so its files
+                        # are free.
+                        _end_collision_claim(_sprint_state, affected_slug, "worker timed out")
+                        # Set the cancellation event BEFORE cancel() so any in-flight
+                        # work stops at the next phase boundary or subprocess read.
+                        # Future.cancel() is a no-op for an already-running thread.
+                        _stop_evt = _sprint_state.stop_events.pop(affected_slug, None)
+                        if _stop_evt is not None:
+                            _stop_evt.set()
+                        fut.cancel()
+                    for affected_slug in affected_slugs:
+                        # An elapsed deadline is exhausted time, not a verdict on the
+                        # work and not evidence the worker stopped responding — a
+                        # story killed here may have been converging, mid-edit, or in
+                        # a wait this system itself opened. Say which (#2333).
+                        _wait_credit = worker_budget.operator_wait_credit(affected_slug)
+                        _was_waiting, _wait_phase, _wait_len = worker_budget.waiting_on_operator(
+                            affected_slug
                         )
-                    if _was_waiting:
-                        _wait_note += (
-                            f"; still waiting on an operator decision"
-                            f"{f' at {_wait_phase}' if _wait_phase else ''}"
-                            f" after {_fmt_duration(_wait_len)}"
+                        _wait_note = ""
+                        if _wait_credit > 0:
+                            _wait_note = (
+                                f"; {_fmt_duration(_wait_credit)} of operator-decision wait"
+                                " was excluded from the deadline"
+                            )
+                        if _was_waiting:
+                            _wait_note += (
+                                f"; still waiting on an operator decision"
+                                f"{f' at {_wait_phase}' if _wait_phase else ''}"
+                                f" after {_fmt_duration(_wait_len)}"
+                            )
+                        _log(
+                            f"TIMEOUT {affected_slug} (story deadline exhausted after "
+                            f"{story_worker_timeouts[affected_slug]}s of working time{_wait_note}"
+                            " — marking as failed on wall clock, not on quality)"
                         )
-                    _log(
-                        f"TIMEOUT {slug} (story deadline exhausted after "
-                        f"{story_worker_timeouts[slug]}s of working time{_wait_note}"
-                        " — marking as failed on wall clock, not on quality)"
-                    )
-                    worker_budget.unregister_worker_budget(slug)
-                    spec_str = slug_to_spec[slug]
-                    timed_out_at = datetime.datetime.now(datetime.timezone.utc)
-                    snapshot = _snapshot_last_known(slug, _sprint_state.state_writer)
-                    last_phase = snapshot["last_phase"]
-                    if slug in _sprint_state.story_times:
-                        story_started_at = _sprint_state.story_times[slug][0]
-                    elif snapshot["last_started_at"] is not None:
-                        story_started_at = snapshot["last_started_at"]
-                    else:
-                        story_started_at = timed_out_at
-                    _phase_label = f" during phase {last_phase}" if last_phase else ""
-                    # Deadline exhaustion, stated as such. The operator action for
-                    # a story that ran out of wall clock is not the action for one
-                    # that produced an unacceptable result, and only the second is
-                    # evidence about the work (#2333).
-                    _timeout_error = (
-                        f"Story deadline exhausted (>{story_worker_timeouts[slug]}s of "
-                        f"working time){_phase_label}{_wait_note}"
-                    )
-                    _timeout_result = _abnormal_story_result(
-                        slug,
-                        config=_ctx.config,
-                        sprint_name=_ctx.resolved.name,
-                        started_at=story_started_at,
-                        error=_timeout_error,
-                        error_type="TimeoutError",
-                        message=(
-                            f"Story deadline exhausted after {story_worker_timeouts[slug]}s "
-                            "of working time — not a review or quality failure"
-                        ),
-                    )
-                    _timeout_cause = build_abnormal_cause(
-                        kind=ABNORMAL_WORKER_TIMEOUT,
-                        cause=_timeout_error,
-                        error_type="TimeoutError",
-                        phase=last_phase,
-                        run_id=_timeout_result.state.run_id,
-                        source="sprint.runner:worker-deadline",
-                    )
-                    _timeout_result.state.abnormal_termination = _timeout_cause
-                    _sprint_state.latest_live_costs.pop(slug, None)
-                    _sprint_state.story_times[slug] = (story_started_at, timed_out_at)
-                    _sprint_state.live_telemetry_snapshots[slug] = snapshot
-                    # A worker the auth breaker cancelled can also cross its
-                    # deadline before returning. It is still a story the sprint
-                    # killed over a dead credential, not one that failed — same
-                    # attribution as the ordinary cancellation path below.
-                    _timeout_outcome: StoryOutcome = StoryOutcome.FAILED
-                    if slug in auth_cancelled_slugs:
-                        auth_cancelled_slugs.discard(slug)
-                        _cancel_reason = f"cancelled mid-flight: {auth_circuit_reason}"
-                        _mark_story_auth_cancelled(
-                            _timeout_result, auth_circuit, reason=_cancel_reason
+                        worker_budget.unregister_worker_budget(affected_slug)
+                        spec_str = slug_to_spec[affected_slug]
+                        timed_out_at = datetime.datetime.now(datetime.timezone.utc)
+                        snapshot = _snapshot_last_known(affected_slug, _sprint_state.state_writer)
+                        last_live_cost = _sprint_state.latest_live_costs.pop(affected_slug, None)
+                        if _sprint_state.cost.has_in_flight_cost(affected_slug) or (
+                            len(affected_slugs) == 1
+                            and (last_live_cost is not None or snapshot["last_cost"] is not None)
+                        ):
+                            recovered_snapshot = _sprint_state.cost.recover_in_flight_cost(
+                                affected_slug,
+                                fallback_cost=(
+                                    last_live_cost.amount
+                                    if last_live_cost is not None
+                                    else snapshot["last_cost"]
+                                ),
+                                fallback_measured=(
+                                    True if last_live_cost is None else last_live_cost.measured
+                                ),
+                            )
+                        last_phase = snapshot["last_phase"]
+                        if affected_slug in _sprint_state.story_times:
+                            story_started_at = _sprint_state.story_times[affected_slug][0]
+                        elif snapshot["last_started_at"] is not None:
+                            story_started_at = snapshot["last_started_at"]
+                        else:
+                            story_started_at = timed_out_at
+                        _phase_label = f" during phase {last_phase}" if last_phase else ""
+                        # Deadline exhaustion, stated as such. The operator action for
+                        # a story that ran out of wall clock is not the action for one
+                        # that produced an unacceptable result, and only the second is
+                        # evidence about the work (#2333).
+                        _timeout_error = (
+                            "Story deadline exhausted (>"
+                            f"{story_worker_timeouts[affected_slug]}s of "
+                            f"working time){_phase_label}{_wait_note}"
                         )
-                        _timeout_outcome = StoryOutcome.SKIPPED
-                        _log(f"SKIPPED {slug} ({_cancel_reason})")
-                    _sprint_state.results.append((spec_str, _timeout_result))
-                    _write_story_audit(
-                        _ctx.config,
-                        _ctx.slug_to_context[slug][0],
-                        _timeout_result,
-                        sprint_id=_ctx.sprint_id,
-                        telemetry_snapshot=snapshot,
-                    )
-                    _set_outcome(
-                        _sprint_state,
-                        slug,
-                        _timeout_outcome,
-                        phase="ESCALATE",
-                        last_phase=last_phase,
-                        failure_cause=_timeout_cause,
-                        # The gate this story may have been sitting in never
-                        # reported a decision and never will; leaving the live
-                        # detail at gate_status=running is what made the state
-                        # file claim a running gate on a failed story (#2013).
-                        detail_updates={"gate_status": GATE_STATUS_TIMEOUT},
-                    )
-                    _persist_current_story_result(
-                        _sprint_state,
-                        slug,
-                        _timeout_result,
-                        started_at=story_started_at,
-                        finished_at=timed_out_at,
-                    )
-                    _sprint_state.dag.mark_skipped(slug)
+                        _timeout_result = _abnormal_story_result(
+                            affected_slug,
+                            config=_ctx.config,
+                            sprint_name=_ctx.resolved.name,
+                            started_at=story_started_at,
+                            error=_timeout_error,
+                            error_type="TimeoutError",
+                            message=(
+                                "Story deadline exhausted after "
+                                f"{story_worker_timeouts[affected_slug]}s of working time — "
+                                "not a review or quality failure"
+                            ),
+                        )
+                        _timeout_cause = build_abnormal_cause(
+                            kind=ABNORMAL_WORKER_TIMEOUT,
+                            cause=_timeout_error,
+                            error_type="TimeoutError",
+                            phase=last_phase,
+                            run_id=_timeout_result.state.run_id,
+                            source="sprint.runner:worker-deadline",
+                        )
+                        _timeout_result.state.abnormal_termination = _timeout_cause
+                        _sprint_state.story_times[affected_slug] = (
+                            story_started_at,
+                            timed_out_at,
+                        )
+                        _sprint_state.live_telemetry_snapshots[affected_slug] = snapshot
+                        # A worker the auth breaker cancelled can also cross its
+                        # deadline before returning. It is still a story the sprint
+                        # killed over a dead credential, not one that failed — same
+                        # attribution as the ordinary cancellation path below.
+                        _timeout_outcome: StoryOutcome = StoryOutcome.FAILED
+                        if affected_slug in auth_cancelled_slugs:
+                            auth_cancelled_slugs.discard(affected_slug)
+                            _cancel_reason = f"cancelled mid-flight: {auth_circuit_reason}"
+                            _mark_story_auth_cancelled(
+                                _timeout_result, auth_circuit, reason=_cancel_reason
+                            )
+                            _timeout_outcome = StoryOutcome.SKIPPED
+                            _log(f"SKIPPED {affected_slug} ({_cancel_reason})")
+                        elif affected_slug in _sprint_state.budget_cancelled_slugs:
+                            _sprint_state.budget_cancelled_slugs.discard(affected_slug)
+                            _cancel_reason = _budget_cancel_reason(_sprint_state)
+                            _mark_story_budget_cancelled(_timeout_result, reason=_cancel_reason)
+                            _timeout_outcome = StoryOutcome.SKIPPED
+                            _log(f"SKIPPED {affected_slug} ({_cancel_reason})")
+                        _sprint_state.results.append((spec_str, _timeout_result))
+                        _write_story_audit(
+                            _ctx.config,
+                            _ctx.slug_to_context[affected_slug][0],
+                            _timeout_result,
+                            sprint_id=_ctx.sprint_id,
+                            telemetry_snapshot=snapshot,
+                        )
+                        _set_outcome(
+                            _sprint_state,
+                            affected_slug,
+                            _timeout_outcome,
+                            phase="ESCALATE",
+                            last_phase=last_phase,
+                            failure_cause=_timeout_cause,
+                            # The gate this story may have been sitting in never
+                            # reported a decision and never will; leaving the live
+                            # detail at gate_status=running is what made the state
+                            # file claim a running gate on a failed story (#2013).
+                            detail_updates={"gate_status": GATE_STATUS_TIMEOUT},
+                        )
+                        _persist_current_story_result(
+                            _sprint_state,
+                            affected_slug,
+                            _timeout_result,
+                            started_at=story_started_at,
+                            finished_at=timed_out_at,
+                        )
+                        _sprint_state.dag.mark_skipped(affected_slug)
+                    _publish_live_budget_status(recovered_snapshot.spent_including_in_flight)
                 continue
 
             for slug, fut in list(_sprint_state.active.items()):

--- a/src/theforge/sprint/state_writer.py
+++ b/src/theforge/sprint/state_writer.py
@@ -78,6 +78,13 @@ class SprintStateWriter:
         self._base_branch = base_branch
         self._budget_usd = budget_usd
         self._max_parallel = max_parallel
+        # How this run stands against its cap, and by how much it passed it.
+        # Written by the runner's budget checkpoint so a live sprint's status
+        # states the relationship between cost and budget rather than leaving an
+        # operator to compare two independent numbers (#2547).
+        self._budget_status: str | None = None
+        self._budget_overrun_usd: float = 0.0
+        self._budget_spend_usd: float | None = None
         # Preserve any pre-existing top-level metadata (e.g. bootstrap state
         # written before the writer was constructed) so init() does not erase
         # base_branch / budget / parallel set by cli/sprint.py at daemonize.
@@ -151,6 +158,25 @@ class SprintStateWriter:
         except FileNotFoundError:
             pass
 
+    def set_budget_status(
+        self,
+        status: str,
+        *,
+        overrun_usd: float = 0.0,
+        spend_usd: float | None = None,
+    ) -> None:
+        """Record the run's standing against its cap and rewrite the state file."""
+        with self._lock:
+            unchanged = self._budget_status == status and round(
+                self._budget_overrun_usd, 4
+            ) == round(float(overrun_usd), 4)
+            if unchanged:
+                return
+            self._budget_status = status
+            self._budget_overrun_usd = float(overrun_usd)
+            self._budget_spend_usd = None if spend_usd is None else float(spend_usd)
+            self._write_locked()
+
     def set_phase(self, phase: str) -> None:
         """Update sprint-level phase and rewrite the state file atomically."""
         with self._lock:
@@ -215,6 +241,12 @@ class SprintStateWriter:
             self._budget_usd = float(data["budget_usd"])
         if self._max_parallel is None and isinstance(data.get("max_parallel"), int):
             self._max_parallel = data["max_parallel"]
+        if self._budget_status is None and isinstance(data.get("budget_status"), str):
+            self._budget_status = data["budget_status"]
+            if isinstance(data.get("budget_overrun_usd"), (int, float)):
+                self._budget_overrun_usd = float(data["budget_overrun_usd"])
+            if isinstance(data.get("budget_spend_usd"), (int, float)):
+                self._budget_spend_usd = float(data["budget_spend_usd"])
 
     def _write_locked(self) -> None:
         """Write the state file atomically. Caller must hold self._lock."""
@@ -224,6 +256,11 @@ class SprintStateWriter:
             "sprint_phase": self._sprint_phase,
             "base_branch": self._base_branch,
             "budget_usd": self._budget_usd,
+            "budget_status": self._budget_status,
+            "budget_overrun_usd": round(self._budget_overrun_usd, 4),
+            "budget_spend_usd": (
+                None if self._budget_spend_usd is None else round(self._budget_spend_usd, 4)
+            ),
             "max_parallel": self._max_parallel,
             "stories": self.story_state.as_dict(),
         }

--- a/tests/test_cli_sprint_status.py
+++ b/tests/test_cli_sprint_status.py
@@ -733,6 +733,108 @@ def test_display_sprint_status_header_includes_cost_and_duration(tmp_path: Path)
     assert "duration: 62m" in output
 
 
+def test_display_sprint_status_marks_a_completed_run_that_passed_its_budget(
+    tmp_path: Path,
+) -> None:
+    """The reported bug's display half: cost and budget printed as strangers.
+
+    A $70.44 run against a $50 cap rendered as two independent header fields
+    with nothing saying one had passed the other. The relationship is now
+    stated (#2547).
+    """
+    stories = [{"slug": "issue-1", "path": "Issue #1", "outcome": "DONE", "cost_usd": 70.44}]
+    _make_summary_file(tmp_path, "over-sprint", "run-over-1", stories)
+    log_dir = tmp_path / ".forge" / "logs" / "over-sprint"
+    summary_path = log_dir / "sprint-summary.yaml"
+    with open(summary_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    data["sprint"]["budget_usd"] = 50.0
+    data["sprint"]["total_cost_usd"] = 70.44
+    data["sprint"]["budget_status"] = "over"
+    data["sprint"]["budget_overrun_usd"] = 20.44
+    with open(summary_path, "w", encoding="utf-8") as f:
+        yaml.dump(data, f)
+
+    code, output = _run_sprint_status(tmp_path, "run-over-1")
+
+    assert code == 0
+    assert "cost: $70.44" in output
+    assert "budget: $50.00" in output
+    assert "OVER BUDGET by $20.44" in output
+
+
+def test_display_sprint_status_marks_an_overrun_a_summary_never_recorded(
+    tmp_path: Path,
+) -> None:
+    """A run that predates the recorded verdict is still compared to its cap."""
+    stories = [{"slug": "issue-1", "path": "Issue #1", "outcome": "DONE", "cost_usd": 12.0}]
+    _make_summary_file(tmp_path, "old-sprint", "run-old-1", stories)
+    log_dir = tmp_path / ".forge" / "logs" / "old-sprint"
+    summary_path = log_dir / "sprint-summary.yaml"
+    with open(summary_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    data["sprint"]["budget_usd"] = 10.0
+    data["sprint"]["total_cost_usd"] = 12.0
+    with open(summary_path, "w", encoding="utf-8") as f:
+        yaml.dump(data, f)
+
+    code, output = _run_sprint_status(tmp_path, "run-old-1")
+
+    assert code == 0
+    assert "OVER BUDGET by $2.00" in output
+
+
+def test_display_sprint_status_leaves_a_run_inside_its_budget_unmarked(
+    tmp_path: Path,
+) -> None:
+    """The marker has to mean something: no overrun, no warning."""
+    stories = [{"slug": "issue-1", "path": "Issue #1", "outcome": "DONE", "cost_usd": 1.5}]
+    _make_summary_file(tmp_path, "ok-sprint", "run-ok-1", stories)
+
+    code, output = _run_sprint_status(tmp_path, "run-ok-1")
+
+    assert code == 0
+    assert "budget: $10.00" in output
+    assert "OVER BUDGET" not in output
+
+
+def test_display_sprint_status_marks_a_live_run_over_its_budget(tmp_path: Path) -> None:
+    """A live run reports its standing while it is still running."""
+    runs_dir = tmp_path / ".forge" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "live-over.pid").write_text("99999\nover-sprint\n")
+    state_path = runs_dir / "live-over.state"
+    with open(state_path, "w", encoding="utf-8") as f:
+        yaml.dump(
+            {
+                "sprint_name": "over-sprint",
+                "budget_usd": 10.0,
+                "budget_status": "over",
+                "budget_overrun_usd": 4.25,
+                "budget_spend_usd": 14.25,
+                "stories": [
+                    {
+                        "slug": "issue-9",
+                        "path": "Issue #9",
+                        "status": "running",
+                        "phase": "REVIEW",
+                        "cost_usd": 14.25,
+                        "blocked_by": [],
+                        "detail": {},
+                    }
+                ],
+            },
+            f,
+        )
+
+    code, output = _run_sprint_status(tmp_path, "live-over")
+
+    assert code == 0
+    assert "[live]" in output
+    assert "OVER BUDGET by $4.25" in output
+    assert "budget: $10.00  ⚠ exceeded" in output
+
+
 def test_display_sprint_status_row_shows_status_and_detail(tmp_path: Path) -> None:
     """Sprint rows include status and detail fields."""
     stories = [

--- a/tests/test_sprint_budget_enforcement.py
+++ b/tests/test_sprint_budget_enforcement.py
@@ -40,6 +40,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
+from theforge.config.types import SprintBatchConfig, SprintConfig
 from theforge.coordinator.cancellation import (
     BUDGET_CANCEL_ERROR_TYPE,
     StopSignal,
@@ -90,6 +91,13 @@ def _make_resolved(
         budget_usd=budget_usd,
         stories=stories,
         max_parallel=max_parallel,
+    )
+
+
+def _make_batch_config(tmp_path: Path) -> ForgeConfig:
+    return replace(
+        _make_config(tmp_path),
+        sprint=SprintConfig(batch=SprintBatchConfig(max_stories=2, max_complexity_budget=2)),
     )
 
 
@@ -234,6 +242,133 @@ def test_worker_exception_recovery_promotes_the_last_measured_spend() -> None:
 
     ledger.record_story_cost("story-b", 1.5, measured=1.5)
     assert round(ledger.snapshot().spent_including_in_flight, 2) == 5.5
+
+
+def test_worker_exception_recovery_keeps_a_lower_bound_total_unmeasured() -> None:
+    """Promoting an unmeasured-phase lower bound must not certify the sprint total."""
+    ledger = SprintCostLedger()
+    ledger.record_in_flight_cost("story-a", 6.0, measured=False)
+
+    recovered = ledger.recover_in_flight_cost("story-a")
+
+    assert recovered.accumulated == 6.0
+    assert recovered.measured is False
+    assert recovered.unmeasured == ("story-a",)
+
+
+def test_batched_worker_exception_recovers_the_shared_spend_once(tmp_path: Path) -> None:
+    """A shared worker future must not charge its spend once per member slug."""
+    config = _make_batch_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a", "story-b"), budget_usd=100.0)
+    states: dict[str, CoordinatorState] = {}
+    for slug in ("story-a", "story-b"):
+        state = CoordinatorState()
+        state.preflight_verdict = "PROCEED"
+        state.preflight_complexity = "small"
+        state.preflight_work_type = "bug"
+        state.preflight_sufficiency = "implementation_ready"
+        state.preflight_likely_files = [f"src/{slug}.py"]
+        states[slug] = state
+
+    def _fake_run_batch_group(
+        _config,
+        leader_task,
+        member_tasks,
+        _sprint_run_id,
+        _sprint_name,
+        _interactive,
+        _notify,
+        _effective_auto_merge,
+        state_update_fns,
+        _no_pull,
+        _preflight_states,
+        _stop_event,
+        *,
+        base_lands_locally=None,
+        lands_in_project_root=None,
+    ):
+        del base_lands_locally, lands_in_project_root
+        state_update_fns[leader_task.slug]({"phase": "DEV", "cost_usd": 4.0})
+        for member in member_tasks:
+            state_update_fns[member.slug]({"phase": "DEV", "cost_usd": 4.0, "cost_mirrored": True})
+        raise RuntimeError("batch exploded")
+
+    with (
+        patch("theforge.sprint.runner.enforce_sprint_auth_readiness"),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value=states),
+        patch("theforge.sprint.runner._run_batch_group", side_effect=_fake_run_batch_group),
+        patch("theforge.sprint.audit_publish._write_sprint_audit"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
+        patch("theforge.sprint.runner._write_story_audit"),
+    ):
+        result = run_sprint_ctx(config, resolved)
+
+    assert result.specs_failed == 2
+    assert result.total_cost_usd == 4.0
+    assert result.cost_complete is True
+
+
+def test_worker_exception_lower_bound_recovery_keeps_sprint_cost_incomplete(
+    tmp_path: Path,
+) -> None:
+    """A raised worker cannot turn a lower bound into a measured sprint total."""
+    config = _make_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a",), budget_usd=100.0)
+    lower_bound_state = CoordinatorState()
+    lower_bound_state.preflight_result = MagicMock(cost_usd=6.0)
+    lower_bound_state.dev_results.append(MagicMock(cost_usd=None))
+    assert lower_bound_state.total_cost_measured is None
+    assert lower_bound_state.total_cost == 6.0
+
+    def _fake_run_single_story(
+        _config,
+        _task,
+        _triage,
+        _sprint_run_id,
+        _sprint_name,
+        _interactive,
+        _notify,
+        _resume,
+        _effective_auto_merge,
+        state_update_fn,
+        _no_pull=False,
+        _plan_gate=None,
+        _preflight_states=None,
+        _stop_event=None,
+        base_lands_locally=None,
+        lands_in_project_root=None,
+    ):
+        del base_lands_locally, lands_in_project_root
+        state_update_fn(
+            {
+                "phase": "REVIEW",
+                "cost_usd": None,
+                "coordinator_state": lower_bound_state,
+            }
+        )
+        raise RuntimeError("agent crashed after unmeasured phase")
+
+    with (
+        patch("theforge.sprint.runner.enforce_sprint_auth_readiness"),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner._run_single_story", side_effect=_fake_run_single_story),
+        patch("theforge.sprint.audit_publish._write_sprint_audit"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
+        patch("theforge.sprint.runner._write_story_audit"),
+    ):
+        result = run_sprint_ctx(config, resolved)
+
+    assert result.total_cost_usd == 6.0
+    assert result.cost_complete is False
+    assert result.unmeasured_spend_sources == ("story-a",)
+    assert result.budget_verification_spend_usd == 6.0
 
 
 def test_a_budget_halt_is_not_labelled_as_a_worker_timeout(tmp_path: Path) -> None:

--- a/tests/test_sprint_budget_enforcement.py
+++ b/tests/test_sprint_budget_enforcement.py
@@ -218,6 +218,24 @@ def test_two_running_stories_cross_the_cap_together(tmp_path: Path) -> None:
     assert round(result.total_cost_usd, 2) == 12.0
 
 
+def test_worker_exception_recovery_promotes_the_last_measured_spend() -> None:
+    """A raised worker's last live figure becomes terminal sprint spend.
+
+    The scheduler has no terminal ``CoordinatorResult`` to fold in on this
+    path, so it must promote the provisional in-flight amount itself or the
+    sprint silently forgets money it already spent.
+    """
+    ledger = SprintCostLedger()
+    ledger.record_in_flight_cost("story-a", 4.0)
+
+    recovered = ledger.recover_in_flight_cost("story-a")
+    assert recovered.accumulated == 4.0
+    assert recovered.in_flight == 0.0
+
+    ledger.record_story_cost("story-b", 1.5, measured=1.5)
+    assert round(ledger.snapshot().spent_including_in_flight, 2) == 5.5
+
+
 def test_a_budget_halt_is_not_labelled_as_a_worker_timeout(tmp_path: Path) -> None:
     """A cancelled story must say which lever the sprint pulled.
 
@@ -246,6 +264,48 @@ def test_a_budget_halt_is_not_labelled_as_a_worker_timeout(tmp_path: Path) -> No
     _spec, cancelled = result.results[0]
     assert cancelled.state.error_type == BUDGET_CANCEL_ERROR_TYPE
     assert "budget" in (cancelled.state.error or "").lower()
+
+
+def test_unmeasured_phase_uses_the_coordinator_lower_bound_for_budget_checks(
+    tmp_path: Path,
+) -> None:
+    """An unknown total is still charged at its measured lower bound.
+
+    Once a phase reports ``cost_usd: null``, ``total_cost_measured`` is poisoned
+    to ``None`` for the rest of the run. Mid-story enforcement must then fall
+    back to the coordinator state's measured lower bound instead of letting the
+    story bypass every later sprint-budget checkpoint.
+    """
+    config = _make_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a",), budget_usd=5.0)
+    lower_bound_state = CoordinatorState()
+    lower_bound_state.preflight_result = MagicMock(cost_usd=6.0)
+    lower_bound_state.dev_results.append(MagicMock(cost_usd=None))
+    assert lower_bound_state.total_cost_measured is None
+    assert lower_bound_state.total_cost == 6.0
+    seen: dict[str, tuple[str, str]] = {}
+
+    def _fake_run_task(_config, task, **kwargs):
+        state_update_fn = kwargs["state_update_fn"]
+        stop_event = kwargs["stop_event"]
+        state_update_fn(
+            {
+                "phase": "REVIEW",
+                "cost_usd": None,
+                "coordinator_state": lower_bound_state,
+            }
+        )
+        assert stop_event.is_set(), "lower-bound checkpoint did not stop the over-budget story"
+        seen[task.slug] = cancel_cause(stop_event)
+        return _cancelled_result(stop_event, lower_bound_state.total_cost)
+
+    result = _run(config, resolved, _fake_run_task)
+
+    reason, error_type = seen["story-a"]
+    assert error_type == BUDGET_CANCEL_ERROR_TYPE
+    assert "budget" in reason.lower()
+    assert result.stopped_reason.startswith("Budget exhausted")
+    assert round(result.total_cost_usd, 2) == 6.0
 
 
 def test_a_run_inside_its_cap_is_left_alone(tmp_path: Path) -> None:

--- a/tests/test_sprint_budget_enforcement.py
+++ b/tests/test_sprint_budget_enforcement.py
@@ -511,6 +511,44 @@ def test_a_budget_cancelled_worker_timeout_stays_skipped_and_keeps_its_spend(
     assert "timeout" not in (cancelled.state.error or "").lower()
 
 
+def test_a_timed_out_storys_late_cost_report_cannot_block_the_next_dispatch(
+    tmp_path: Path,
+) -> None:
+    """A retired worker cannot recreate in-flight spend after its timeout."""
+    config = _make_config(tmp_path)
+    resolved = replace(
+        _make_resolved(tmp_path, ("story-a", "story-b"), budget_usd=7.0),
+        worker_timeout_seconds=1,
+    )
+    late_update_sent = threading.Event()
+    dispatched: list[str] = []
+
+    def _fake_run_task(_config, task, **kwargs):
+        dispatched.append(task.slug)
+        state_update_fn = kwargs["state_update_fn"]
+        stop_event = kwargs["stop_event"]
+        if task.slug == "story-a":
+            state_update_fn({"phase": "REVIEW", "cost_usd": 4.0})
+            assert stop_event.wait(timeout=5), "worker timeout never stopped story-a"
+            state_update_fn({"phase": "REVIEW", "cost_usd": 9.0})
+            late_update_sent.set()
+            time.sleep(0.2)
+            return _cancelled_result(stop_event, 4.0)
+        assert late_update_sent.wait(timeout=5), "story-a never sent its stale post-timeout update"
+        state_update_fn({"phase": "REVIEW", "cost_usd": 2.0})
+        return _done_result(2.0)
+
+    result = _run(config, resolved, _fake_run_task)
+
+    assert dispatched == ["story-a", "story-b"]
+    assert result.stopped_reason is None
+    assert result.specs_succeeded == 1
+    assert result.specs_failed == 1
+    assert result.specs_skipped == 0
+    assert round(result.total_cost_usd, 2) == 6.0
+    assert result.budget_status == "within"
+
+
 def test_batched_member_reviews_stop_before_starting_the_next_member_when_over_budget(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_sprint_budget_enforcement.py
+++ b/tests/test_sprint_budget_enforcement.py
@@ -1,0 +1,448 @@
+"""Mid-story enforcement of the sprint's spending cap (#2547).
+
+Before this, ``budget_usd`` was checked in exactly one place: whether the *next*
+story could be dispatched. A sprint whose work is one long story never returns
+to that boundary, so the cap bounded nothing — a $50 run reached $70.44 across
+five review cycles without halting, warning, or marking the overrun anywhere.
+
+What is covered here:
+
+- a story that crosses the cap while running is cancelled at the next
+  coordinator phase boundary, before another dev/review cycle is paid for;
+- the sprint's stop reason names the budget, and the cancelled story is
+  recorded as skipped rather than judged as failed;
+- later stories are not dispatched;
+- in-flight spend is charged exactly once — never twice while a sibling's
+  terminal cost is being folded into the ledger, and never zero afterwards;
+- unmeasured spend still fails closed at dispatch rather than reading as free.
+
+Every fixture is a fake: no provider CLI is invoked, and the "coordinator" is a
+stand-in that reports costs through the same ``state_update_fn`` the real one
+uses and checks the same ``stop_event`` at the same boundaries.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+from sprint_test_helpers import run_sprint_ctx
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    DEFAULT_VALIDATION,
+    ForgeConfig,
+    RetryPolicy,
+    WorkspaceConfig,
+)
+from theforge.coordinator.cancellation import (
+    BUDGET_CANCEL_ERROR_TYPE,
+    StopSignal,
+    cancel_cause,
+)
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.sprint.manifest import ResolvedSprint
+from theforge.sprint.runner import SprintCostLedger
+from theforge.sprint.sources import FileSource
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+
+def _make_config(tmp_path: Path) -> ForgeConfig:
+    return ForgeConfig(
+        project="test",
+        project_root=tmp_path,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+            base_branch="main",
+        ),
+        validation=replace(DEFAULT_VALIDATION, gate_command="true"),
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=5),
+    )
+
+
+def _make_resolved(
+    tmp_path: Path, slugs: tuple[str, ...], *, budget_usd: float, max_parallel: int = 1
+) -> ResolvedSprint:
+    source = FileSource()
+    stories = []
+    for slug in slugs:
+        story_file = tmp_path / f"{slug}.md"
+        story_file.write_text(
+            f"---\nname: Story {slug}\nslug: {slug}\n---\n# Content\n",
+            encoding="utf-8",
+        )
+        task = source.fetch(f"{slug}.md", tmp_path)
+        stories.append((task, source, f"{slug}.md"))
+    return ResolvedSprint(
+        name="Test Sprint",
+        budget_usd=budget_usd,
+        stories=stories,
+        max_parallel=max_parallel,
+    )
+
+
+def _done_result(cost: float) -> CoordinatorResult:
+    state = CoordinatorState()
+    state.preflight_result = MagicMock(cost_usd=0.0)
+    state.dev_results.append(MagicMock(cost_usd=cost))
+    return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="ok")
+
+
+def _cancelled_result(stop_event: object, cost: float) -> CoordinatorResult:
+    """What coordinator/engine.py returns for a story killed by stop_event.
+
+    Built through the same ``cancel_cause`` seam the engine uses, so this
+    fixture cannot drift from the labelling the engine actually applies.
+    """
+    reason, error_type = cancel_cause(stop_event)  # type: ignore[arg-type]
+    state = CoordinatorState()
+    state.preflight_result = MagicMock(cost_usd=0.0)
+    state.dev_results.append(MagicMock(cost_usd=cost))
+    state.phase = Phase.ESCALATE
+    state.error = reason
+    state.error_type = error_type
+    return CoordinatorResult(success=False, phase=Phase.ESCALATE, state=state, message=reason)
+
+
+def _run(config: ForgeConfig, resolved: ResolvedSprint, fake_run_task) -> object:
+    with (
+        patch("theforge.sprint.runner.enforce_sprint_auth_readiness"),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
+        patch("theforge.sprint.audit_publish._write_sprint_audit"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
+        patch("theforge.sprint.runner._write_story_audit"),
+    ):
+        return run_sprint_ctx(config, resolved)
+
+
+# ── mid-story enforcement ────────────────────────────────────────────────
+
+
+def test_story_crossing_the_cap_is_stopped_before_another_review_cycle(
+    tmp_path: Path,
+) -> None:
+    """The reported bug: five review cycles at $50 cap, nothing halted.
+
+    The fake coordinator runs the same loop the real one does — report cost at
+    the phase boundary, then check the stop signal — and spends past the cap on
+    its third cycle. The sprint must stop it there rather than let it keep
+    buying cycles.
+    """
+    config = _make_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a", "story-b"), budget_usd=10.0)
+    dispatched: list[str] = []
+    cycles: list[int] = []
+
+    def _fake_run_task(_config, task, **kwargs):
+        dispatched.append(task.slug)
+        state_update_fn = kwargs.get("state_update_fn")
+        stop_event = kwargs.get("stop_event")
+        spent = 0.0
+        for cycle in range(1, 6):
+            spent += 4.0
+            state_update_fn({"phase": "REVIEW", "cost_usd": spent})
+            if stop_event is not None and stop_event.is_set():
+                cycles.append(cycle)
+                return _cancelled_result(stop_event, spent)
+        cycles.append(5)
+        return _done_result(spent)
+
+    result = _run(config, resolved, _fake_run_task)
+
+    # Stopped on the cycle that crossed $10, not at the cycle limit.
+    assert cycles == [3]
+    # The later story never started: the cap is exhausted.
+    assert dispatched == ["story-a"]
+    assert result.stopped_reason is not None
+    assert result.stopped_reason.startswith("Budget exhausted")
+    # Nothing judged story-a — it was stopped, not failed.
+    assert result.specs_failed == 0
+    assert result.specs_skipped == 2
+
+
+def test_two_running_stories_cross_the_cap_together(tmp_path: Path) -> None:
+    """Parallel mode: neither story exceeds the cap alone, together they do.
+
+    Both are genuinely in flight when the second one's report tips the total
+    past the cap, so both must be stopped. This is also where double-counting
+    would show: if the ledger charged either story's spend twice, the halt would
+    fire on the first report instead of the second.
+    """
+    config = _make_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a", "story-b"), budget_usd=10.0, max_parallel=2)
+    both_running = threading.Barrier(2, timeout=30)
+    a_reported = threading.Event()
+    halted: dict[str, bool] = {}
+
+    def _fake_run_task(_config, task, **kwargs):
+        state_update_fn = kwargs["state_update_fn"]
+        stop_event = kwargs["stop_event"]
+        both_running.wait()
+        if task.slug == "story-a":
+            # $6 of a $10 cap: on its own, affordable.
+            state_update_fn({"phase": "REVIEW", "cost_usd": 6.0})
+            halted["story-a-after-own-report"] = stop_event.is_set()
+            a_reported.set()
+            assert stop_event.wait(timeout=30), "sibling's spend never stopped this story"
+        else:
+            assert a_reported.wait(timeout=30)
+            # $6 + $6 = $12: the pair is not.
+            state_update_fn({"phase": "REVIEW", "cost_usd": 6.0})
+        halted[task.slug] = stop_event.is_set()
+        return _cancelled_result(stop_event, 6.0)
+
+    result = _run(config, resolved, _fake_run_task)
+
+    # story-a alone did not trip the cap — only the pair did.
+    assert halted["story-a-after-own-report"] is False
+    assert halted["story-a"] is True
+    assert halted["story-b"] is True
+    assert result.stopped_reason.startswith("Budget exhausted")
+    # $6 + $6 recorded once each, not once per in-flight report.
+    assert round(result.total_cost_usd, 2) == 12.0
+
+
+def test_a_budget_halt_is_not_labelled_as_a_worker_timeout(tmp_path: Path) -> None:
+    """A cancelled story must say which lever the sprint pulled.
+
+    The stop_event path exists for worker deadlines. Reusing it unmodified for a
+    budget halt would report an operator's spending decision as an unresponsive
+    worker — the same conflation #1951 removed for auth aborts.
+    """
+    config = _make_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a",), budget_usd=5.0)
+    seen: dict[str, tuple[str, str]] = {}
+
+    def _fake_run_task(_config, task, **kwargs):
+        state_update_fn = kwargs.get("state_update_fn")
+        stop_event = kwargs.get("stop_event")
+        state_update_fn({"phase": "REVIEW", "cost_usd": 6.0})
+        assert stop_event is not None and stop_event.is_set()
+        seen[task.slug] = cancel_cause(stop_event)
+        return _cancelled_result(stop_event, 6.0)
+
+    result = _run(config, resolved, _fake_run_task)
+
+    reason, error_type = seen["story-a"]
+    assert error_type == BUDGET_CANCEL_ERROR_TYPE
+    assert "budget" in reason.lower()
+    assert "timeout" not in reason.lower()
+    _spec, cancelled = result.results[0]
+    assert cancelled.state.error_type == BUDGET_CANCEL_ERROR_TYPE
+    assert "budget" in (cancelled.state.error or "").lower()
+
+
+def test_a_run_inside_its_cap_is_left_alone(tmp_path: Path) -> None:
+    """Enforcement must not become a new way for affordable sprints to fail."""
+    config = _make_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a", "story-b"), budget_usd=100.0)
+    dispatched: list[str] = []
+
+    def _fake_run_task(_config, task, **kwargs):
+        dispatched.append(task.slug)
+        state_update_fn = kwargs.get("state_update_fn")
+        state_update_fn({"phase": "REVIEW", "cost_usd": 2.0})
+        assert not kwargs["stop_event"].is_set()
+        return _done_result(2.0)
+
+    result = _run(config, resolved, _fake_run_task)
+
+    assert dispatched == ["story-a", "story-b"]
+    assert result.stopped_reason is None
+    assert result.specs_succeeded == 2
+    assert result.budget_status == "within"
+    assert result.budget_overrun_usd == 0.0
+
+
+def test_an_overrun_is_reported_on_the_result(tmp_path: Path) -> None:
+    """A run that finished past its cap says so where its cost is reported."""
+    config = _make_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a",), budget_usd=5.0)
+
+    def _fake_run_task(_config, task, **kwargs):
+        kwargs["state_update_fn"]({"phase": "REVIEW", "cost_usd": 8.0})
+        return _cancelled_result(kwargs["stop_event"], 8.0)
+
+    result = _run(config, resolved, _fake_run_task)
+
+    assert result.budget_status == "over"
+    assert round(result.budget_overrun_usd, 2) == 3.0
+
+
+def test_the_audit_and_summary_record_the_overrun(tmp_path: Path) -> None:
+    """An operator reading the run afterwards can tell it passed its cap.
+
+    The terminal records carry the standing, not just the two numbers: a run
+    that respected its budget and one that did not must not be distinguishable
+    only by doing the arithmetic yourself (#2547).
+    """
+    config = _make_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a",), budget_usd=5.0)
+
+    def _fake_run_task(_config, task, **kwargs):
+        kwargs["state_update_fn"]({"phase": "REVIEW", "cost_usd": 9.0})
+        return _cancelled_result(kwargs["stop_event"], 9.0)
+
+    with (
+        patch("theforge.sprint.runner.enforce_sprint_auth_readiness"),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.run_task", side_effect=_fake_run_task),
+        patch("theforge.sprint.runner._write_story_audit"),
+    ):
+        run_sprint_ctx(config, resolved)
+
+    audit = yaml.safe_load(
+        (tmp_path / ".forge" / "audits" / "sprint-audit.yaml").read_text(encoding="utf-8")
+    )["sprint"]
+    assert audit["budget_status"] == "over"
+    assert round(audit["budget_overrun_usd"], 2) == 4.0
+
+    summary = yaml.safe_load(
+        (tmp_path / ".forge" / "logs" / "Test Sprint" / "sprint-summary.yaml").read_text(
+            encoding="utf-8"
+        )
+    )["sprint"]
+    assert summary["budget_status"] == "over"
+    assert round(summary["budget_overrun_usd"], 2) == 4.0
+    assert summary["stopped_reason"].startswith("Budget exhausted")
+
+
+# ── the ledger: in-flight spend counted exactly once ──────────────────────
+
+
+def test_in_flight_spend_is_not_double_counted_when_a_sibling_lands() -> None:
+    """Two stories running; one lands while the other is still spending.
+
+    The moment ``record_story_cost`` folds a story's terminal figure in is the
+    moment its provisional figure must disappear — in that order, under one
+    lock. Either mistake corrupts the cap: counted twice it refuses affordable
+    work, dropped early it under-reports what the sprint has spent.
+    """
+    ledger = SprintCostLedger()
+    ledger.record_in_flight_cost("story-a", 4.0)
+    ledger.record_in_flight_cost("story-b", 3.0)
+
+    assert ledger.snapshot().spent_including_in_flight == 7.0
+
+    ledger.record_story_cost("story-a", 4.5, measured=4.5)
+    snapshot = ledger.snapshot()
+
+    # story-a is counted once, at its terminal figure; story-b still in flight.
+    assert snapshot.accumulated == 4.5
+    assert snapshot.in_flight == 3.0
+    assert snapshot.spent_including_in_flight == 7.5
+
+    ledger.record_story_cost("story-b", 3.25, measured=3.25)
+    assert ledger.snapshot().in_flight == 0.0
+    assert ledger.snapshot().spent_including_in_flight == 7.75
+
+
+def test_a_running_story_updates_its_own_in_flight_figure() -> None:
+    """The coordinator reports a running total, so the last word wins."""
+    ledger = SprintCostLedger()
+    ledger.record_in_flight_cost("story-a", 2.0)
+    ledger.record_in_flight_cost("story-a", 5.0)
+
+    assert ledger.snapshot().in_flight == 5.0
+
+
+def test_a_dropped_story_stops_being_charged() -> None:
+    """A worker that raised leaves no terminal cost to replace its estimate."""
+    ledger = SprintCostLedger()
+    ledger.record_in_flight_cost("story-a", 2.0)
+    ledger.drop_in_flight_cost("story-a")
+
+    assert ledger.snapshot().in_flight == 0.0
+    assert ledger.snapshot().spent_including_in_flight == 0.0
+
+
+def test_unmeasured_terminal_cost_still_poisons_the_total() -> None:
+    """Fail-closed on unmeasured spend survives the in-flight bookkeeping."""
+    ledger = SprintCostLedger()
+    ledger.record_in_flight_cost("story-a", 1.0)
+    ledger.record_story_cost("story-a", 0.0, measured=None)
+
+    snapshot = ledger.snapshot()
+    assert snapshot.unmeasured == ("story-a",)
+    assert snapshot.in_flight == 0.0
+
+
+# ── unmeasured spend keeps its dispatch-only semantics ───────────────────
+
+
+def test_unmeasured_in_flight_cost_does_not_kill_a_running_story(
+    tmp_path: Path,
+) -> None:
+    """An unmeasured phase is not a licence to destroy paid-for work.
+
+    Unknown spend still fails closed — at the dispatch gate, which refuses the
+    next story. What it must not do is cancel the story that is already running,
+    which would trade a story for a comparison the dispatch gate re-runs anyway.
+    """
+    config = _make_config(tmp_path)
+    resolved = _make_resolved(tmp_path, ("story-a", "story-b"), budget_usd=100.0)
+    dispatched: list[str] = []
+
+    def _fake_run_task(_config, task, **kwargs):
+        dispatched.append(task.slug)
+        state_update_fn = kwargs.get("state_update_fn")
+        state_update_fn({"phase": "REVIEW", "cost_usd": None})
+        assert not kwargs["stop_event"].is_set(), "unmeasured spend cancelled a running story"
+        state = CoordinatorState()
+        state.preflight_result = MagicMock(cost_usd=0.0)
+        # An unmeasured story: total_cost_measured is None, total_cost is 0.0.
+        state.dev_results.append(MagicMock(cost_usd=None))
+        return CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="ok")
+
+    result = _run(config, resolved, _fake_run_task)
+
+    # story-a ran to completion; the sprint then refused to dispatch story-b
+    # against a total it knows is a lower bound.
+    assert dispatched == ["story-a"]
+    assert result.stopped_reason is not None
+    assert "unverifiable" in result.stopped_reason.lower()
+
+
+# ── the stop signal itself ───────────────────────────────────────────────
+
+
+def test_a_bare_event_still_reads_as_a_timeout() -> None:
+    """Callers that predate the distinction keep the historical wording."""
+    reason, error_type = cancel_cause(threading.Event())
+
+    assert error_type == "StoryCancelled"
+    assert "timeout" in reason.lower()
+
+
+def test_a_stop_signal_carries_its_cause() -> None:
+    signal = StopSignal()
+    signal.stop("sprint budget exhausted", error_type=BUDGET_CANCEL_ERROR_TYPE)
+
+    assert signal.is_set()
+    assert cancel_cause(signal) == ("sprint budget exhausted", BUDGET_CANCEL_ERROR_TYPE)
+
+
+def test_a_plain_set_keeps_the_timeout_cause() -> None:
+    signal = StopSignal()
+    signal.set()
+
+    assert cancel_cause(signal)[1] == "StoryCancelled"

--- a/tests/test_sprint_budget_enforcement.py
+++ b/tests/test_sprint_budget_enforcement.py
@@ -23,7 +23,9 @@ uses and checks the same ``stop_event`` at the same boundaries.
 
 from __future__ import annotations
 
+import datetime
 import threading
+import time
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -94,10 +96,17 @@ def _make_resolved(
     )
 
 
-def _make_batch_config(tmp_path: Path) -> ForgeConfig:
+def _make_batch_config(
+    tmp_path: Path, *, max_stories: int = 2, max_complexity_budget: int = 2
+) -> ForgeConfig:
     return replace(
         _make_config(tmp_path),
-        sprint=SprintConfig(batch=SprintBatchConfig(max_stories=2, max_complexity_budget=2)),
+        sprint=SprintConfig(
+            batch=SprintBatchConfig(
+                max_stories=max_stories,
+                max_complexity_budget=max_complexity_budget,
+            )
+        ),
     )
 
 
@@ -312,6 +321,72 @@ def test_batched_worker_exception_recovers_the_shared_spend_once(tmp_path: Path)
     assert result.cost_complete is True
 
 
+def test_batched_worker_timeout_recovers_the_shared_spend_once(tmp_path: Path) -> None:
+    """The deadline recovery path must preserve the shared batch spend once."""
+    config = _make_batch_config(tmp_path)
+    resolved = replace(
+        _make_resolved(tmp_path, ("story-a", "story-b"), budget_usd=100.0),
+        worker_timeout_seconds=1,
+    )
+    states: dict[str, CoordinatorState] = {}
+    for slug in ("story-a", "story-b"):
+        state = CoordinatorState()
+        state.preflight_verdict = "PROCEED"
+        state.preflight_complexity = "small"
+        state.preflight_work_type = "bug"
+        state.preflight_sufficiency = "implementation_ready"
+        state.preflight_likely_files = [f"src/{slug}.py"]
+        states[slug] = state
+
+    def _fake_run_batch_group(
+        _config,
+        leader_task,
+        member_tasks,
+        _sprint_run_id,
+        _sprint_name,
+        _interactive,
+        _notify,
+        _effective_auto_merge,
+        state_update_fns,
+        _no_pull,
+        _preflight_states,
+        stop_event,
+        *,
+        base_lands_locally=None,
+        lands_in_project_root=None,
+    ):
+        del base_lands_locally, lands_in_project_root
+        state_update_fns[leader_task.slug]({"phase": "DEV", "cost_usd": 4.0})
+        for member in member_tasks:
+            state_update_fns[member.slug]({"phase": "DEV", "cost_usd": 4.0, "cost_mirrored": True})
+        assert stop_event.wait(timeout=10), "worker deadline never stopped the batch"
+        finished = datetime.datetime.now(datetime.timezone.utc)
+        leader_result = _cancelled_result(stop_event, 4.0)
+        member_result = _cancelled_result(stop_event, 4.0)
+        return {
+            leader_task.slug: (leader_task, leader_result, 0.0, finished, finished),
+            member_tasks[0].slug: (member_tasks[0], member_result, 0.0, finished, finished),
+        }
+
+    with (
+        patch("theforge.sprint.runner.enforce_sprint_auth_readiness"),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value=states),
+        patch("theforge.sprint.runner._run_batch_group", side_effect=_fake_run_batch_group),
+        patch("theforge.sprint.audit_publish._write_sprint_audit"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
+        patch("theforge.sprint.runner._write_story_audit"),
+    ):
+        result = run_sprint_ctx(config, resolved)
+
+    assert result.specs_failed == 2
+    assert result.total_cost_usd == 4.0
+    assert result.cost_complete is True
+
+
 def test_worker_exception_lower_bound_recovery_keeps_sprint_cost_incomplete(
     tmp_path: Path,
 ) -> None:
@@ -399,6 +474,128 @@ def test_a_budget_halt_is_not_labelled_as_a_worker_timeout(tmp_path: Path) -> No
     _spec, cancelled = result.results[0]
     assert cancelled.state.error_type == BUDGET_CANCEL_ERROR_TYPE
     assert "budget" in (cancelled.state.error or "").lower()
+
+
+def test_a_budget_cancelled_worker_timeout_stays_skipped_and_keeps_its_spend(
+    tmp_path: Path,
+) -> None:
+    """A budget halt that returns through the deadline path stays a budget halt."""
+    config = _make_config(tmp_path)
+    resolved = replace(
+        _make_resolved(tmp_path, ("story-a",), budget_usd=5.0),
+        worker_timeout_seconds=1,
+    )
+    saw_budget_stop = threading.Event()
+
+    def _fake_run_task(_config, task, **kwargs):
+        state_update_fn = kwargs["state_update_fn"]
+        stop_event = kwargs["stop_event"]
+        state_update_fn({"phase": "REVIEW", "cost_usd": 6.0})
+        assert stop_event.wait(timeout=5), "budget halt never reached the worker"
+        saw_budget_stop.set()
+        time.sleep(1.2)
+        return _cancelled_result(stop_event, 6.0)
+
+    result = _run(config, resolved, _fake_run_task)
+
+    assert saw_budget_stop.is_set()
+    assert result.stopped_reason is not None
+    assert result.stopped_reason.startswith("Budget exhausted")
+    assert result.specs_failed == 0
+    assert result.specs_skipped == 1
+    assert round(result.total_cost_usd, 2) == 6.0
+    assert result.budget_status == "over"
+    _spec, cancelled = result.results[0]
+    assert cancelled.state.error_type == BUDGET_CANCEL_ERROR_TYPE
+    assert "budget" in (cancelled.state.error or "").lower()
+    assert "timeout" not in (cancelled.state.error or "").lower()
+
+
+def test_batched_member_reviews_stop_before_starting_the_next_member_when_over_budget(
+    tmp_path: Path,
+) -> None:
+    """A member review that exhausts the cap must block later member reviews."""
+    config = _make_batch_config(tmp_path, max_stories=3, max_complexity_budget=3)
+    resolved = _make_resolved(tmp_path, ("story-a", "story-b", "story-c"), budget_usd=5.0)
+    states: dict[str, CoordinatorState] = {}
+    for slug in ("story-a", "story-b", "story-c"):
+        state = CoordinatorState()
+        state.preflight_verdict = "PROCEED"
+        state.preflight_complexity = "small"
+        state.preflight_work_type = "bug"
+        state.preflight_sufficiency = "implementation_ready"
+        state.preflight_likely_files = [f"src/{slug}.py"]
+        states[slug] = state
+    workspace = tmp_path / "batch-workspace"
+    workspace.mkdir()
+    review_calls: list[str] = []
+
+    def _fake_run_single_story(
+        _config,
+        task,
+        _triage,
+        _sprint_run_id,
+        _sprint_name,
+        _interactive,
+        _notify,
+        _resume,
+        _effective_auto_merge,
+        state_update_fn,
+        _no_pull=False,
+        _plan_gate=None,
+        _preflight_states=None,
+        _stop_event=None,
+        base_lands_locally=None,
+        lands_in_project_root=None,
+    ):
+        del base_lands_locally, lands_in_project_root
+        state_update_fn({"phase": "DEV", "cost_usd": 1.0})
+        state = CoordinatorState()
+        state.preflight_result = MagicMock(cost_usd=1.0)
+        state.workspace_path = workspace
+        state.branch_name = f"forge/{task.slug}"
+        finished = datetime.datetime.now(datetime.timezone.utc)
+        return (
+            task,
+            CoordinatorResult(success=True, phase=Phase.DONE, state=state, message="ok"),
+            0.0,
+            finished,
+            finished,
+        )
+
+    def _fake_run_review_only(_config, task, workspace_path, **kwargs):
+        del kwargs
+        assert workspace_path == workspace
+        review_calls.append(task.slug)
+        if task.slug == "story-b":
+            return _done_result(5.0)
+        raise AssertionError("story-c review started after story-b exhausted the budget")
+
+    with (
+        patch("theforge.sprint.runner.enforce_sprint_auth_readiness"),
+        patch(
+            "theforge.sprint.runner._run_baseline_gate",
+            return_value={"passed": True, "message": "ok"},
+        ),
+        patch("theforge.sprint.runner.run_batch_preflight", return_value=states),
+        patch("theforge.sprint.runner._run_single_story", side_effect=_fake_run_single_story),
+        patch("theforge.sprint.runner.run_review_only", side_effect=_fake_run_review_only),
+        patch("theforge.sprint.audit_publish._write_sprint_audit"),
+        patch("theforge.sprint.audit_publish._write_sprint_summary"),
+        patch("theforge.sprint.runner._write_story_audit"),
+    ):
+        result = run_sprint_ctx(config, resolved)
+
+    assert review_calls == ["story-b"]
+    assert result.stopped_reason is not None
+    assert result.stopped_reason.startswith("Budget exhausted")
+    assert result.specs_succeeded == 2
+    assert result.specs_failed == 0
+    assert result.specs_skipped == 1
+    assert round(result.total_cost_usd, 2) == 6.0
+    by_slug = {Path(spec).stem: story_result for spec, story_result in result.results}
+    assert by_slug["story-c"].state.error_type == BUDGET_CANCEL_ERROR_TYPE
+    assert "budget" in (by_slug["story-c"].state.error or "").lower()
 
 
 def test_unmeasured_phase_uses_the_coordinator_lower_bound_for_budget_checks(

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -533,6 +533,32 @@ def test_budget_exhausted_skip_classifies_as_budget_exhausted(tmp_path: Path) ->
     assert not any("land blocking dependencies" in a for a in entry["recommended_next_actions"])
 
 
+def test_mid_flight_budget_halt_is_not_a_credential_rejection(tmp_path: Path) -> None:
+    """A story the sprint stopped for money is not one it stopped for a token.
+
+    Both cancellations record a reason beginning "cancelled mid-flight:", so the
+    budget halt needs its own class or every capped run diagnoses as an auth
+    outage (#2547).
+    """
+    d = _sprint_dir(tmp_path)
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                _skipped_with_reason(
+                    "cancelled mid-flight: Budget exhausted (sprint $12.00 + carried "
+                    "$0.00 = $12.00 >= $10.00)",
+                    depends_on=["issue-2226"],
+                )
+            ]
+        ),
+    )
+    entry = _build(d)["stories"]["issue-2206"]
+    assert entry["primary_failure_class"] == "sprint_budget_halted_in_flight"
+    assert not any("re-authenticate" in a for a in entry["recommended_next_actions"])
+    assert any("budget" in a for a in entry["recommended_next_actions"])
+
+
 def test_auth_circuit_skip_classifies_as_credential_rejection(tmp_path: Path) -> None:
     d = _sprint_dir(tmp_path)
     _write(


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Original budget halt behavior and prior P1 fixes are covered, but the latest stale-update guard can drop measured spend from still-active cancelled workers. | [anthropic-opus-cli] All three prior P1s remain fixed (shared batch future recovers its spend once on both abnormal exits, a budget-cancelled story that crosses its deadline is recorded as a budget skip, and batch member reviews check the stop signal before starting), and this cycle's change — dropping worker live-state updates once the worker's stop signal is set (runner.py:2731) — does resolve the stale post-retirement in-flight report, verified against the diff rather than the handoff, with test_a_timed_out_storys_late_cost_report_cannot_block_the_next_dispatch covering it. Authoritative gate is PASS for cbad3462 which matches HEAD, so I did not rerun it. Note the handoff listed only 1 of the 6 branch commits.

## Review

- **Verdict:** APPROVE (1 P1, 1 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $34.84
- **Dev iterations:** 5
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/runner.py:2731`** Once a worker's stop signal is set, every live-state update from that worker is discarded rather than only its cost report, so the story's phase transitions — including the PLAN_DONE signal the scheduler's plan-gate release reads — stop reaching the scheduler, and the run avoids stalling only because each of the three sites that set a stop signal happens to release that story's plan gate itself.

## Story

A run continues spending past its configured budget without halting or warning (GitHub Issue #2547)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2547