### PR TITLE
A summary skipped for a missing credential reports a configuration cause, so the operator is sent to change a setting that is already correct

### DIFF
--- a/src/theforge/coordinator/knowledge_summary_flow.py
+++ b/src/theforge/coordinator/knowledge_summary_flow.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from theforge.config.auth import check_agent_auth
 from theforge.config.model_identity import DEFAULT_PHASE_ELIGIBILITY, PHASE_KNOWLEDGE_SUMMARY
 from theforge.knowledge_summary import (
     SummaryValidationError,
@@ -212,6 +213,18 @@ def _project_summary_api_profile(profile: "ModelProfile") -> "ModelProfile | Non
     )
 
 
+def _summary_auth_reason(config: "ForgeConfig", profile: "ModelProfile") -> str | None:
+    """Return the missing-auth reason for ``profile``, if any."""
+    ready, reason = check_agent_auth(
+        profile,
+        config.secrets,
+        include_sandbox_readiness=False,
+    )
+    if ready:
+        return None
+    return reason
+
+
 def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str | None]:
     """Resolve the tool-free API summary profile after eligibility checks.
 
@@ -227,11 +240,6 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
     ref = knowledge_ref
     if ref is None:
         ref = getattr(getattr(config, "plan", None), "ref", None)
-        if ref is not None and ref.mode != "api":
-            return (
-                None,
-                "knowledge summaries need knowledge.ref when plan.ref uses CLI transport",
-            )
     if ref is None:
         return (None, None)
 
@@ -243,6 +251,12 @@ def _summary_profile(config: "ForgeConfig") -> tuple["ModelProfile | None", str 
         sandbox_mode="read-only",
     )
     base_profile = _project_summary_api_profile(summary_envelope)
+    if knowledge_ref is None and ref.mode != "api" and base_profile is None:
+        return (
+            None,
+            "knowledge summaries need knowledge.ref or transport_fallback "
+            "when plan.ref uses CLI transport",
+        )
     if knowledge_ref is not None:
         return (base_profile, None)
 
@@ -324,6 +338,19 @@ def maybe_generate_run_summary(
                 "no tool-free API transport available for knowledge_summary "
                 "(configure knowledge.ref to enable summaries)"
             )
+            _log(f"  ⚠ knowledge summary skipped: {reason}")
+            return _record_summary_outcome(
+                audit,
+                RunSummaryOutcome(
+                    status="skipped",
+                    attempted=True,
+                    written=False,
+                    reason=reason,
+                ),
+            )
+        auth_reason = _summary_auth_reason(config, profile)
+        if auth_reason is not None:
+            reason = f"summary API credential missing: {auth_reason}"
             _log(f"  ⚠ knowledge summary skipped: {reason}")
             return _record_summary_outcome(
                 audit,

--- a/tests/test_coord_knowledge_summary.py
+++ b/tests/test_coord_knowledge_summary.py
@@ -103,6 +103,7 @@ def _make_config(
     model: str | None = None,
     knowledge_ref: ModelRef | None = None,
     transport_fallbacks: dict[str, TransportFallbackConfig] | None = None,
+    secrets: dict[str, str] | None = None,
 ) -> ForgeConfig:
     """A config whose plan model dispatches over an API transport.
 
@@ -139,6 +140,12 @@ def _make_config(
         ),
         knowledge=KnowledgeConfig(run_summaries=run_summaries, ref=knowledge_ref),
         transport_fallbacks=transport_fallbacks or {},
+        secrets=secrets
+        or {
+            "ANTHROPIC_API_KEY": "test-key",
+            "OPENAI_API_KEY": "test-key",
+            "GOOGLE_API_KEY": "test-key",
+        },
     )
 
 
@@ -465,8 +472,10 @@ class TestGeneration:
 
         profile, reason = knowledge_summary_flow._summary_profile(config)
 
-        assert profile is None
-        assert reason == "knowledge summaries need knowledge.ref when plan.ref uses CLI transport"
+        assert profile is not None
+        assert profile.mode == "api"
+        assert profile.model == "gpt-5.4-mini"
+        assert reason is None
 
     def test_matching_pool_model_keeps_plan_derived_summary_limits(
         self, tmp_path: Path, calls: list[dict]
@@ -611,9 +620,44 @@ class TestGeneration:
         assert outcome.status == "skipped"
         assert outcome.attempted is True
         assert (
-            outcome.reason
-            == "knowledge summaries need knowledge.ref when plan.ref uses CLI transport"
+            outcome.reason == "knowledge summaries need knowledge.ref or transport_fallback "
+            "when plan.ref uses CLI transport"
         )
+        assert calls == []
+        assert not summary_path(tmp_path, RUN_ID).exists()
+
+    def test_a_cli_plan_with_transport_fallback_but_no_api_credential_names_the_missing_key(
+        self, tmp_path: Path, calls: list[dict]
+    ) -> None:
+        fallback = TransportFallbackConfig(provider="openai", model="gpt-5.4-mini")
+        config = _make_config(
+            tmp_path,
+            provider="openai",
+            model="gpt-5.4",
+            transport_fallbacks={"openai": fallback},
+        )
+        config = replace(
+            config,
+            plan=replace(
+                config.plan,
+                ref=replace(
+                    config.plan.ref,
+                    cli="codex",
+                    provider=None,
+                    transport=transport_for("openai", "cli"),
+                    api_fallback=fallback,
+                ),
+            ),
+            secrets={},
+        )
+
+        outcome = knowledge_summary_flow.maybe_generate_run_summary(
+            config, _done_result(), _audit()
+        )
+
+        assert outcome.status == "skipped"
+        assert outcome.attempted is True
+        assert outcome.reason == "summary API credential missing: OPENAI_API_KEY not set"
         assert calls == []
         assert not summary_path(tmp_path, RUN_ID).exists()
 


### PR DESCRIPTION
## Summary

The change distinguishes missing summary API credentials from missing summary transport configuration and has focused seam coverage for both paths.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $0.89
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A summary skipped for a missing credential reports a configuration cause, so the operator is sent to change a setting that is already correct (GitHub Issue #2550)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2550