### PR TITLE
An agent process inherited across a sprint re-exec is waited on until timeout after it has already exited

### DIFF
--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -977,9 +977,10 @@ def group_has_running_members(pgid: int) -> bool:
     than "alive", so callers that need a definite answer can surface that
     uncertainty instead of waiting on a process they can no longer observe.
     """
-    members, enumerated = group_members_checked(pgid)
-    if enumerated:
-        return bool(members)
+    for _attempt in range(3):
+        members, enumerated = group_members_checked(pgid)
+        if enumerated:
+            return bool(members)
     if not group_is_alive(pgid):
         return False
     raise OSError(f"process group {pgid} could not be enumerated")

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -59,6 +59,7 @@ import signal
 import struct
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -1067,11 +1068,35 @@ def register_agent_group(
     }
     try:
         agents_dir.mkdir(parents=True, exist_ok=True)
-        _sidecar_path(agents_dir, owner_pid, pgid).write_text(
-            json.dumps(payload), encoding="utf-8"
-        )
+        _write_sidecar_json(_sidecar_path(agents_dir, owner_pid, pgid), payload)
     except OSError:
         pass
+
+
+def _write_sidecar_json(path: Path, payload: dict[str, object]) -> None:
+    """Atomically replace a sidecar JSON record in-place.
+
+    Sidecar readers treat a malformed ``*.json`` as unresolved liveness. Writing
+    via a same-directory temp file keeps that failure mode reserved for truly
+    broken records rather than our own partial writes.
+    """
+    encoded = json.dumps(payload)
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
+            handle.write(encoded)
+        Path(tmp_name).replace(path)
+    except Exception:
+        try:
+            Path(tmp_name).unlink()
+        except OSError:
+            pass
+        raise
 
 
 def _update_sidecar(pgid: int, field: str, value: dict[str, str]) -> None:
@@ -1094,7 +1119,7 @@ def _update_sidecar(pgid: int, field: str, value: dict[str, str]) -> None:
         return
     data[field] = value
     try:
-        path.write_text(json.dumps(data), encoding="utf-8")
+        _write_sidecar_json(path, data)
     except OSError:
         pass
 

--- a/src/theforge/process_group.py
+++ b/src/theforge/process_group.py
@@ -968,6 +968,23 @@ def group_members_checked(pgid: int) -> tuple[dict[int, str], bool]:
     return {}, False
 
 
+def group_has_running_members(pgid: int) -> bool:
+    """True when *pgid* still has non-zombie members; false when it is settled.
+
+    Unlike :func:`group_is_alive`, this asks the kernel for current membership so
+    an unreaped corpse does not count as live work. When the group cannot be
+    enumerated but still answers a signal-0 probe, the result is unknown rather
+    than "alive", so callers that need a definite answer can surface that
+    uncertainty instead of waiting on a process they can no longer observe.
+    """
+    members, enumerated = group_members_checked(pgid)
+    if enumerated:
+        return bool(members)
+    if not group_is_alive(pgid):
+        return False
+    raise OSError(f"process group {pgid} could not be enumerated")
+
+
 def _enumerate_group_linux(pgid: int) -> tuple[dict[int, str], bool]:
     """Linux: one ``/proc/<pid>/stat`` read per process gives group and state."""
     try:

--- a/src/theforge/sprint/live_stories.py
+++ b/src/theforge/sprint/live_stories.py
@@ -33,7 +33,10 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-from theforge.process_group import group_is_alive, kill_agent_group
+from theforge.process_group import (
+    group_has_running_members,
+    kill_agent_group,
+)
 
 __all__ = [
     "InheritedAgentGroup",
@@ -207,7 +210,7 @@ def resolve_inherited_agents(
     path_pattern: str,
     owner_pid: int | None = None,
     only_live: bool = True,
-    is_group_alive: Callable[[int], bool] = group_is_alive,
+    is_group_alive: Callable[[int], bool] = group_has_running_members,
 ) -> list[InheritedAgentGroup]:
     """Agent groups spawned by this process for any of *slugs*.
 
@@ -253,7 +256,7 @@ def resolve_liveness(
     project_root: Path,
     path_pattern: str,
     owner_pid: int | None = None,
-    is_group_alive: Callable[[int], bool] = group_is_alive,
+    is_group_alive: Callable[[int], bool] = group_has_running_members,
 ) -> LivenessResolution:
     """Establish, per slug, whether this process still has an agent running for it.
 
@@ -300,7 +303,7 @@ def resolve_live_story_slugs(
     project_root: Path,
     path_pattern: str,
     owner_pid: int | None = None,
-    is_group_alive: Callable[[int], bool] = group_is_alive,
+    is_group_alive: Callable[[int], bool] = group_has_running_members,
 ) -> set[str]:
     """The subset of *slugs* whose inherited agent group is confirmed running.
 
@@ -340,7 +343,7 @@ def await_inherited_agents(
     timeout: float,
     poll_interval: float = 2.0,
     owner_pid: int | None = None,
-    is_group_alive: Callable[[int], bool] = group_is_alive,
+    is_group_alive: Callable[[int], bool] = group_has_running_members,
     stop_event=None,
     log: Callable[[str], None] | None = None,
 ) -> bool:
@@ -365,18 +368,17 @@ def await_inherited_agents(
             is_group_alive=is_group_alive,
         )
         if not groups:
-            if waited and log is not None:
-                log(f"IN-FLIGHT {slug}: inherited agent finished; resuming the story")
-            _discard_records(
-                resolve_inherited_agents(
-                    [slug],
-                    project_root=project_root,
-                    path_pattern=path_pattern,
-                    owner_pid=owner_pid,
-                    only_live=False,
-                    is_group_alive=is_group_alive,
-                )
+            settled = resolve_inherited_agents(
+                [slug],
+                project_root=project_root,
+                path_pattern=path_pattern,
+                owner_pid=owner_pid,
+                only_live=False,
+                is_group_alive=is_group_alive,
             )
+            if (waited or settled) and log is not None:
+                log(f"IN-FLIGHT {slug}: inherited agent finished; resuming the story")
+            _discard_records(settled)
             return True
         if stop_event is not None and stop_event.is_set():
             return False
@@ -399,7 +401,7 @@ def reclaim_inherited_agents(
     project_root: Path,
     path_pattern: str,
     owner_pid: int | None = None,
-    is_group_alive: Callable[[int], bool] = group_is_alive,
+    is_group_alive: Callable[[int], bool] = group_has_running_members,
     kill_group: Callable[[int], bool] = kill_agent_group,
 ) -> list[int]:
     """Kill any still-live inherited groups for *slug*; return the pgids killed.

--- a/src/theforge/sprint/live_stories.py
+++ b/src/theforge/sprint/live_stories.py
@@ -360,14 +360,14 @@ def await_inherited_agents(
     deadline = time.monotonic() + max(0.0, float(timeout))
     waited = False
     while True:
-        groups = resolve_inherited_agents(
+        resolution = resolve_liveness(
             [slug],
             project_root=project_root,
             path_pattern=path_pattern,
             owner_pid=owner_pid,
             is_group_alive=is_group_alive,
         )
-        if not groups:
+        if slug not in resolution.deferred_slugs:
             settled = resolve_inherited_agents(
                 [slug],
                 project_root=project_root,
@@ -386,11 +386,25 @@ def await_inherited_agents(
         if remaining <= 0:
             return False
         if not waited and log is not None:
-            pgids = ", ".join(str(g.pgid) for g in groups)
-            log(
-                f"IN-FLIGHT {slug}: waiting up to {int(timeout)}s for the agent process "
-                f"group(s) {pgids} inherited across the re-exec to finish before resuming"
-            )
+            if slug in resolution.live_slugs:
+                groups = resolve_inherited_agents(
+                    [slug],
+                    project_root=project_root,
+                    path_pattern=path_pattern,
+                    owner_pid=owner_pid,
+                    is_group_alive=is_group_alive,
+                )
+                pgids = ", ".join(str(g.pgid) for g in groups)
+                log(
+                    f"IN-FLIGHT {slug}: waiting up to {int(timeout)}s for the agent process "
+                    f"group(s) {pgids} inherited across the re-exec to finish before resuming"
+                )
+            else:
+                log(
+                    f"IN-FLIGHT {slug}: waiting up to {int(timeout)}s because inherited "
+                    "agent liveness is temporarily unobservable; retaining its sidecar "
+                    "until it is confirmed finished or the wait times out"
+                )
         waited = True
         time.sleep(min(max(0.01, poll_interval), remaining))
 

--- a/src/theforge/sprint/live_stories.py
+++ b/src/theforge/sprint/live_stories.py
@@ -321,6 +321,28 @@ def resolve_live_story_slugs(
     )
 
 
+def _classify_groups(
+    groups: Iterable[InheritedAgentGroup],
+    *,
+    is_group_alive: Callable[[int], bool],
+) -> tuple[list[InheritedAgentGroup], list[InheritedAgentGroup], list[InheritedAgentGroup]]:
+    """Split groups into live, settled, and unresolved liveness buckets."""
+    live: list[InheritedAgentGroup] = []
+    settled: list[InheritedAgentGroup] = []
+    unresolved: list[InheritedAgentGroup] = []
+    for group in groups:
+        try:
+            alive = is_group_alive(group.pgid)
+        except Exception:  # noqa: BLE001 - unresolved is distinct from "settled"
+            unresolved.append(group)
+            continue
+        if alive:
+            live.append(group)
+        else:
+            settled.append(group)
+    return live, settled, unresolved
+
+
 def _discard_records(groups: Iterable[InheritedAgentGroup]) -> None:
     """Drop sidecars for groups that are finished with.
 
@@ -394,11 +416,18 @@ def await_inherited_agents(
                     owner_pid=owner_pid,
                     is_group_alive=is_group_alive,
                 )
-                pgids = ", ".join(str(g.pgid) for g in groups)
-                log(
-                    f"IN-FLIGHT {slug}: waiting up to {int(timeout)}s for the agent process "
-                    f"group(s) {pgids} inherited across the re-exec to finish before resuming"
-                )
+                if groups:
+                    pgids = ", ".join(str(g.pgid) for g in groups)
+                    log(
+                        f"IN-FLIGHT {slug}: waiting up to {int(timeout)}s for the agent process "
+                        f"group(s) {pgids} inherited across the re-exec to finish before resuming"
+                    )
+                else:
+                    log(
+                        f"IN-FLIGHT {slug}: waiting up to {int(timeout)}s because inherited "
+                        "agent liveness is temporarily unobservable; retaining its sidecar "
+                        "until it is confirmed finished or the wait times out"
+                    )
             else:
                 log(
                     f"IN-FLIGHT {slug}: waiting up to {int(timeout)}s because inherited "
@@ -424,23 +453,22 @@ def reclaim_inherited_agents(
     resumed while another agent is writing to its worktree, and leaving the group
     running would hand it to the next invocation's orphan reaper anyway.
     """
-    live = resolve_inherited_agents(
+    groups = resolve_inherited_agents(
         [slug],
         project_root=project_root,
         path_pattern=path_pattern,
         owner_pid=owner_pid,
+        only_live=False,
         is_group_alive=is_group_alive,
     )
-    for group in live:
-        kill_group(group.pgid)
-    _discard_records(
-        resolve_inherited_agents(
-            [slug],
-            project_root=project_root,
-            path_pattern=path_pattern,
-            owner_pid=owner_pid,
-            only_live=False,
-            is_group_alive=is_group_alive,
-        )
-    )
-    return [group.pgid for group in live]
+    live, settled, unresolved = _classify_groups(groups, is_group_alive=is_group_alive)
+
+    killed: list[int] = []
+    discarded: list[InheritedAgentGroup] = list(settled)
+    for group in [*live, *unresolved]:
+        if kill_group(group.pgid):
+            killed.append(group.pgid)
+            discarded.append(group)
+
+    _discard_records(discarded)
+    return killed

--- a/tests/test_process_group.py
+++ b/tests/test_process_group.py
@@ -593,6 +593,36 @@ class TestGroupMembers:
             os.kill(proc.pid, signal.SIGKILL)
             proc.wait(timeout=5)
 
+    def test_group_has_running_members_retries_a_transient_unreadable_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = iter([({}, False), ({1234: "started"}, True)])
+
+        monkeypatch.setattr(
+            process_group,
+            "group_members_checked",
+            lambda _pgid: next(calls),
+        )
+        monkeypatch.setattr(process_group, "group_is_alive", lambda _pgid: True)
+
+        assert process_group.group_has_running_members(4242) is True
+
+    def test_group_has_running_members_treats_a_zombie_only_group_as_settled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(process_group, "group_members_checked", lambda _pgid: ({}, True))
+
+        assert process_group.group_has_running_members(4242) is False
+
+    def test_group_has_running_members_raises_when_a_live_group_stays_unreadable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(process_group, "group_members_checked", lambda _pgid: ({}, False))
+        monkeypatch.setattr(process_group, "group_is_alive", lambda _pgid: True)
+
+        with pytest.raises(OSError, match="could not be enumerated"):
+            process_group.group_has_running_members(4242)
+
     def test_a_group_holding_only_a_zombie_settles_immediately(self) -> None:
         """The liveness wait must not sit out its grace period for a corpse.
 

--- a/tests/test_sprint_launch_liveness.py
+++ b/tests/test_sprint_launch_liveness.py
@@ -234,6 +234,31 @@ def test_clean_scan_resolves_confirmed_live_and_nothing_else(tmp_path: Path) -> 
     assert resolution.resolved is True
 
 
+def test_temp_sidecar_does_not_taint_liveness_scan(tmp_path: Path) -> None:
+    """A writer temp file is not a sidecar and must not defer unrelated stories."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-2048").mkdir(parents=True)
+    agents_dir = tmp_path / ".forge" / "runs" / "agents"
+    agents_dir.mkdir(parents=True)
+    _write_agent_sidecar(
+        tmp_path,
+        owner_pid=os.getpid(),
+        pgid=os.getpgrp(),
+        sandbox_dir=worktrees / "issue-2048",
+    )
+    (agents_dir / ".broken.json.tmp").write_text("{not json", encoding="utf-8")
+
+    resolution = resolve_liveness(
+        ["issue-2048"],
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+    )
+
+    assert resolution.live_slugs == {"issue-2048"}
+    assert resolution.unresolved_slugs == frozenset()
+    assert resolution.resolved is True
+
+
 def test_failed_liveness_probe_is_unresolved_not_dead(tmp_path: Path) -> None:
     """A probe that raises says nothing about the group — least of all that it exited."""
     worktrees = tmp_path / ".forge" / "worktrees"

--- a/tests/test_sprint_reexec_continuation.py
+++ b/tests/test_sprint_reexec_continuation.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 import json
 import os
+import signal
+import subprocess
+import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -220,6 +224,46 @@ def test_await_inherited_agents_returns_when_group_exits(tmp_path: Path) -> None
     assert quiesced is True
     # The image that registered it is gone, so nothing else would ever clear it.
     assert not sidecar.exists()
+
+
+def test_await_inherited_agents_treats_an_unreaped_zombie_as_finished(
+    tmp_path: Path,
+) -> None:
+    """A zombie inherited across re-exec is finished work, not running work."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    proc = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    sidecar = _write_agent_sidecar(
+        tmp_path,
+        owner_pid=os.getpid(),
+        pgid=os.getpgid(proc.pid),
+        sandbox_dir=worktrees / "issue-1945",
+    )
+    logs: list[str] = []
+    try:
+        os.kill(proc.pid, signal.SIGKILL)
+        started = time.monotonic()
+
+        quiesced = await_inherited_agents(
+            "issue-1945",
+            project_root=tmp_path,
+            path_pattern=".forge/worktrees/{slug}",
+            timeout=30,
+            poll_interval=0.01,
+            log=logs.append,
+        )
+
+        assert quiesced is True
+        assert time.monotonic() - started < 1.0
+        assert logs == ["IN-FLIGHT issue-1945: inherited agent finished; resuming the story"]
+        assert not sidecar.exists()
+    finally:
+        proc.wait(timeout=5)
 
 
 def test_await_inherited_agents_reports_overrun_without_killing(tmp_path: Path) -> None:

--- a/tests/test_sprint_reexec_continuation.py
+++ b/tests/test_sprint_reexec_continuation.py
@@ -319,6 +319,42 @@ def test_await_inherited_agents_keeps_waiting_when_liveness_is_unresolved(
     ]
 
 
+def test_await_inherited_agents_logs_unobservable_wait_when_followup_probe_loses_the_group(
+    tmp_path: Path,
+) -> None:
+    """The wait log must not claim blank pgids if the follow-up probe cannot re-read them."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    sidecar = _write_agent_sidecar(
+        tmp_path, owner_pid=os.getpid(), pgid=4242, sandbox_dir=worktrees / "issue-1945"
+    )
+    calls = iter([True, OSError("transient scan failure"), OSError("transient scan failure")])
+    logs: list[str] = []
+
+    def _probe(_pgid: int) -> bool:
+        result = next(calls)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    quiesced = await_inherited_agents(
+        "issue-1945",
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+        timeout=0.05,
+        poll_interval=0.01,
+        is_group_alive=_probe,
+        log=logs.append,
+    )
+
+    assert quiesced is False
+    assert sidecar.exists()
+    assert logs == [
+        "IN-FLIGHT issue-1945: waiting up to 0s because inherited agent liveness is temporarily "
+        "unobservable; retaining its sidecar until it is confirmed finished or the wait times out"
+    ]
+
+
 def test_reclaim_inherited_agents_kills_survivor_and_clears_record(tmp_path: Path) -> None:
     """An agent that overruns is terminated, so no second agent shares its
     worktree and no later reaper inherits the pgid."""
@@ -340,6 +376,52 @@ def test_reclaim_inherited_agents_kills_survivor_and_clears_record(tmp_path: Pat
     assert reclaimed == [4242]
     assert killed == [4242]
     assert not sidecar.exists()
+
+
+def test_reclaim_inherited_agents_kills_unresolved_group_and_clears_record(tmp_path: Path) -> None:
+    """A timed-out inherited group that stays unobservable is still reclaimed."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    sidecar = _write_agent_sidecar(
+        tmp_path, owner_pid=os.getpid(), pgid=4242, sandbox_dir=worktrees / "issue-1945"
+    )
+    killed: list[int] = []
+
+    reclaimed = reclaim_inherited_agents(
+        "issue-1945",
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+        is_group_alive=lambda _pgid: (_ for _ in ()).throw(OSError("transient scan failure")),
+        kill_group=lambda pgid: (killed.append(pgid), True)[1],
+    )
+
+    assert reclaimed == [4242]
+    assert killed == [4242]
+    assert not sidecar.exists()
+
+
+def test_reclaim_inherited_agents_keeps_sidecar_when_unresolved_kill_is_refused(
+    tmp_path: Path,
+) -> None:
+    """A possibly-live inherited group must stay registered if the reclaim kill fails."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    sidecar = _write_agent_sidecar(
+        tmp_path, owner_pid=os.getpid(), pgid=4242, sandbox_dir=worktrees / "issue-1945"
+    )
+    killed: list[int] = []
+
+    reclaimed = reclaim_inherited_agents(
+        "issue-1945",
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+        is_group_alive=lambda _pgid: (_ for _ in ()).throw(OSError("transient scan failure")),
+        kill_group=lambda pgid: (killed.append(pgid), False)[1],
+    )
+
+    assert reclaimed == []
+    assert killed == [4242]
+    assert sidecar.exists()
 
 
 # ── launch-guard classification ──────────────────────────────────────

--- a/tests/test_sprint_reexec_continuation.py
+++ b/tests/test_sprint_reexec_continuation.py
@@ -290,6 +290,35 @@ def test_await_inherited_agents_reports_overrun_without_killing(tmp_path: Path) 
     assert sidecar.exists()
 
 
+def test_await_inherited_agents_keeps_waiting_when_liveness_is_unresolved(
+    tmp_path: Path,
+) -> None:
+    """An unobservable inherited group is not finished work."""
+    worktrees = tmp_path / ".forge" / "worktrees"
+    (worktrees / "issue-1945").mkdir(parents=True)
+    sidecar = _write_agent_sidecar(
+        tmp_path, owner_pid=os.getpid(), pgid=4242, sandbox_dir=worktrees / "issue-1945"
+    )
+    logs: list[str] = []
+
+    quiesced = await_inherited_agents(
+        "issue-1945",
+        project_root=tmp_path,
+        path_pattern=".forge/worktrees/{slug}",
+        timeout=0.05,
+        poll_interval=0.01,
+        is_group_alive=lambda _pgid: (_ for _ in ()).throw(OSError("transient scan failure")),
+        log=logs.append,
+    )
+
+    assert quiesced is False
+    assert sidecar.exists()
+    assert logs == [
+        "IN-FLIGHT issue-1945: waiting up to 0s because inherited agent liveness is temporarily "
+        "unobservable; retaining its sidecar until it is confirmed finished or the wait times out"
+    ]
+
+
 def test_reclaim_inherited_agents_kills_survivor_and_clears_record(tmp_path: Path) -> None:
     """An agent that overruns is terminated, so no second agent shares its
     worktree and no later reaper inherits the pgid."""


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Prior P1s are resolved; zombie inherited agents settle promptly, transient scan failures stay unresolved, and reclaim no longer drops unobservable groups without a successful kill. | [anthropic-opus-cli] All three prior P1s are resolved (retrying zombie-aware probe, wait defers on unresolved liveness, reclaim signals live-and-unresolved groups and discards only settled or kill-confirmed sidecars) and the carried P2 is addressed by atomic temp-file-plus-replace sidecar writes whose .tmp names are invisible to every reader's *.json glob; gate PASS at the reviewed HEAD. Note for the operator: the dev handoff listed only 852b2770 while the branch carries four commits.

## Review

- **Verdict:** APPROVE (0 P1, 1 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $7.24
- **Dev iterations:** 4
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/process_group.py:1078`** A sidecar write that is interrupted between creating its temp file and renaming it into place leaves the temp file behind in the agents directory, and no sweep or reaper ever removes it because every consumer of that directory matches only the .json suffix.

## Story

An agent process inherited across a sprint re-exec is waited on until timeout after it has already exited (GitHub Issue #2553)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2553