### PR TITLE
A project cannot extend a sandbox capability preset, so a toolchain need the shipped presets do not anticipate has no configuration path

### DIFF
--- a/docs/guides/inputs-reference.md
+++ b/docs/guides/inputs-reference.md
@@ -979,11 +979,15 @@ intake:
 knowledge:
   run_summaries: false        # emit an evidence-backed summary after a run reaches DONE
 
-# ── Sandbox capability profile (optional) ─────────────────
+# ── Sandbox capabilities (optional) ───────────────────────
 # Omit entirely for default write containment. See "Sandbox capability
 # profiles" below.
 sandbox:
   capability_profile: xcode   # forge-owned preset name; omit for the default
+  write_roots:                # project grants ADDED to the preset's (optional)
+    - ~/Library/Preferences
+  mach_services:              # macOS only; refused on other backends (optional)
+    - com.example.toolchaind
 
 # ── Secrets (optional) ────────────────────────────────────
 # API keys are read from .forge/.env (run `forge secrets-init` to create)
@@ -1158,7 +1162,7 @@ must be numbers in `[0.0, 1.0]`, min-runs must be integers at or above the
 minimum, enable flags must be actual booleans. Out-of-range values are a config
 error, never a silent clamp.
 
-### Sandbox capability profiles (`sandbox.capability_profile`)
+### Sandbox capability profiles (`sandbox`)
 
 The dev agent runs under a mechanical write-containment sandbox: writes are
 confined to the story worktree plus a fixed allow-set. Some stacks cannot
@@ -1167,45 +1171,69 @@ needs writes under `~/Library/Developer` and mach services for the simulator, so
 `xcodegen`/`xcodebuild` fail with `Operation not permitted` and the agent cannot
 build well enough to verify its own work.
 
-`sandbox.capability_profile` names a **forge-owned preset** that widens the
-sandbox by a bounded, declared amount:
+The `sandbox` block widens the sandbox by a bounded, declared amount. It has
+three keys, all optional and all additive:
 
 ```yaml
 sandbox:
-  capability_profile: xcode
+  capability_profile: xcode        # a forge-owned preset, selected by name
+  write_roots:                     # project grants, ADDED to the preset's
+    - ~/Library/Preferences
+    - /opt/toolchain
+  mach_services:                   # macOS only
+    - com.example.toolchaind
 ```
 
 | Preset | Platform | Grants |
 |--------|----------|--------|
 | `xcode` | macOS only | Xcode/SwiftPM state roots (`~/Library/Developer`, DerivedData caches, `/private/var/folders`) and the CoreSimulator / launch-services mach services. |
 
+`write_roots` and `mach_services` exist because the shipped presets cannot
+anticipate every toolchain: what a real stack needs is not knowable in advance
+from inside TheForge. They stand alone as well — a project may declare grants
+with no `capability_profile` at all.
+
 Rules that make this safe to adopt:
 
-- **Presets are forge-owned.** A project selects one *by name*. It cannot
-  author a preset, extend one, or override its contents; there is no inline
-  `write_roots`/`mach_services` key, and supplying one is a config error.
-- **Widening is always bounded.** No value disables the sandbox or grants
-  `allow default`. The granted set is exactly the preset's declared list — a
-  write to an out-of-worktree path the preset does not declare still fails.
-- **Unknown names fail at config load**, so a typo cannot silently fall back to
-  default containment.
-- **Unexpressible presets fail closed.** Declaring `xcode` on Linux refuses the
-  run with a clear reason (bwrap has no mach-service axis) rather than running
-  with the declared capability missing.
+- **Project grants are additive, never subtractive.** Presets stay forge-owned:
+  a project may add write roots and mach services alongside a preset, but it
+  cannot author a preset, override one, or remove anything one grants. The
+  applied set is the preset's list plus the project's, de-duplicated.
+- **Widening is always bounded.** No key disables the sandbox or grants
+  `allow default` — `allow_default`, `disabled`, and `mode` are config errors.
+  The granted set is exactly the declared list; a write to an out-of-worktree
+  path nobody declared still fails.
+- **A grant may not be an escape.** A `write_roots` entry that resolves to `/`
+  or to the invoking user's home directory is refused by name, rather than
+  widened into a whole-filesystem grant.
+- **Unknown preset names fail at config load**, and a malformed grant list (not
+  a list of non-empty strings) is a load error too — a silently dropped grant
+  is a capability the run believes it has and does not.
+- **Unexpressible capabilities fail closed.** Declaring `xcode` — or any
+  `mach_services` — on Linux refuses the run with a clear reason (bwrap has no
+  mach-service axis) rather than running with the declared capability missing.
+  The same applies per transport: a dev transport that does not apply forge's
+  host sandbox (codex, gh-aw, the API tool runtime) refuses a run that declares
+  capabilities, instead of dropping them silently. Use a transport that applies
+  the host sandbox (claude, gemini) for a project that declares grants.
 - **Grants are audited.** The resolved profile name, write roots, and mach
   services are recorded in the run audit record under `workspace` and per dev
-  iteration. A run with no preset records an explicit null profile with empty
-  grants, so default containment is distinguishable from missing audit data.
+  iteration, with project-declared grants listed separately under
+  `project_write_roots`/`project_mach_services`. A run with no declaration
+  records an explicit null profile with empty grants, so default containment is
+  distinguishable from missing audit data. A refused declaration records zero
+  grants plus `requested_*` and `unsupported_reason`, so a fail-closed run never
+  audits as though the capability was applied.
 
-**To adopt a preset**, an operator adds the two-line `sandbox` block above to
-`forge.yaml` and re-runs. There is no default and no auto-detection: a project
-that says nothing keeps today's containment exactly. To inspect what a preset
-grants without running an agent — on any host, whether or not the toolchain is
+**To adopt this**, an operator adds the `sandbox` block above to `forge.yaml`
+and re-runs. There is no default and no auto-detection: a project that says
+nothing keeps today's containment exactly. To inspect what a declaration grants
+without running an agent — on any host, whether or not the toolchain is
 installed:
 
 ```bash
 python -c "from theforge.config.sandbox_capabilities import resolve_capabilities; \
-print(resolve_capabilities('xcode').audit_payload())"
+print(resolve_capabilities('xcode', write_roots=('/opt/toolchain',)).audit_payload())"
 ```
 
 ### Validation profiles (`validation.profiles`)

--- a/src/theforge/config/load.py
+++ b/src/theforge/config/load.py
@@ -98,10 +98,11 @@ from .types import (
 
 log = logging.getLogger("theforge.config")
 _VALID_DEV_P2_POLICIES = frozenset({"in_scope", "all", "p1_only"})
-_VALID_SANDBOX_KEYS = frozenset({"capability_profile"})
-_REJECTED_INLINE_SANDBOX_KEYS = frozenset(
-    {"write_roots", "mach_services", "allow_default", "disabled", "mode"}
-)
+_VALID_SANDBOX_KEYS = frozenset({"capability_profile", "write_roots", "mach_services"})
+# Keys that would let a project *weaken* containment rather than enumerate a
+# bounded addition to it. Additive grants are supported (#2038); switching the
+# sandbox off, or opening it wholesale, never is.
+_REJECTED_INLINE_SANDBOX_KEYS = frozenset({"allow_default", "disabled", "mode"})
 
 
 def _parse_dev_config(dev_raw: Any) -> DevConfig:
@@ -132,18 +133,21 @@ def _parse_sandbox_config(sandbox_raw: Any) -> SandboxConfig:
     rejected = sorted(_REJECTED_INLINE_SANDBOX_KEYS & sandbox_raw.keys())
     if rejected:
         raise ValueError(
-            "forge.yaml 'sandbox' supports only forge-owned named presets; "
-            f"remove inline capability key(s): {rejected}"
+            "forge.yaml 'sandbox' grants are additive only — a project may add "
+            "'write_roots'/'mach_services' but may not weaken containment; "
+            f"remove key(s): {rejected}"
         )
     unknown = sorted(set(sandbox_raw) - _VALID_SANDBOX_KEYS)
     if unknown:
         raise ValueError(
-            "forge.yaml 'sandbox' mapping only supports 'capability_profile'; "
-            f"unknown key(s): {unknown}"
+            "forge.yaml 'sandbox' mapping supports "
+            f"{sorted(_VALID_SANDBOX_KEYS)}; unknown key(s): {unknown}"
         )
+    write_roots = _parse_sandbox_grant_list(sandbox_raw.get("write_roots"), "write_roots")
+    mach_services = _parse_sandbox_grant_list(sandbox_raw.get("mach_services"), "mach_services")
     profile = sandbox_raw.get("capability_profile")
     if profile is None:
-        return SandboxConfig()
+        return SandboxConfig(write_roots=write_roots, mach_services=mach_services)
     if not isinstance(profile, str) or not profile.strip():
         raise ValueError(
             "forge.yaml 'sandbox.capability_profile' must be a non-empty string when set"
@@ -152,7 +156,35 @@ def _parse_sandbox_config(sandbox_raw: Any) -> SandboxConfig:
     # Reject unknown preset names at load time rather than at dev-run time —
     # a typo'd profile must not silently resolve to default containment.
     get_preset(name)
-    return SandboxConfig(capability_profile=name)
+    return SandboxConfig(
+        capability_profile=name,
+        write_roots=write_roots,
+        mach_services=mach_services,
+    )
+
+
+def _parse_sandbox_grant_list(raw: Any, key: str) -> tuple[str, ...]:
+    """Normalize an additive ``sandbox.<key>`` grant list from forge.yaml.
+
+    Malformed shapes are an error rather than a coercion: a grant silently
+    dropped at load time is a capability the run believes it has and does not,
+    which is the exact failure this surface exists to remove.
+    """
+    if raw is None:
+        return ()
+    if isinstance(raw, str) or not isinstance(raw, (list, tuple)):
+        raise ValueError(
+            f"forge.yaml 'sandbox.{key}' must be a list of strings when set, "
+            f"got {type(raw).__name__}"
+        )
+    values: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            raise ValueError(
+                f"forge.yaml 'sandbox.{key}' entries must be non-empty strings; got {entry!r}"
+            )
+        values.append(entry.strip())
+    return tuple(dict.fromkeys(values))
 
 
 def _parse_models_section(

--- a/src/theforge/config/sandbox_capabilities.py
+++ b/src/theforge/config/sandbox_capabilities.py
@@ -7,22 +7,34 @@ mach-lookups for the simulator/toolchain; inside the default profile those
 return ``Operation not permitted``, so the agent cannot build and therefore
 cannot verify its own work (#1947).
 
-A project widens the sandbox by *selecting a preset by name* in ``forge.yaml``:
+A project widens the sandbox by *selecting a preset by name* in ``forge.yaml``,
+and may add its own bounded grants alongside it:
 
 .. code-block:: yaml
 
     sandbox:
       capability_profile: xcode
+      write_roots:
+        - ~/Library/Preferences
+      mach_services:
+        - com.apple.dt.Xcode.something
 
-Presets are forge-owned. A project cannot author, extend, or override the
-contents of one, and there is deliberately no value that disables the sandbox
-or grants ``allow default`` — widening is always a named, bounded capability
-set. Selecting nothing keeps today's behavior exactly.
+Presets stay forge-owned: a project cannot author, override or subtract from
+the contents of one. What a project *can* do is add write roots and mach
+services of its own, because the set of things a real toolchain needs is not
+knowable in advance from inside this repository (#2038). Project grants are
+strictly **additive** to the selected preset — there is deliberately no value
+that disables the sandbox or grants ``allow default``, so widening is always a
+bounded, enumerated capability set. Declaring nothing keeps today's behavior
+exactly.
 
 The declared capability set is pure data: :func:`resolve_capabilities` expands
-it without probing the host for an installed toolchain, so a preset resolves
-identically on any machine. That is what makes "what does ``xcode`` grant?"
-answerable without running an agent.
+it without probing the host for an installed toolchain, so a declaration
+resolves identically on any machine. That is what makes "what does ``xcode``
+grant?" answerable without running an agent. What it will *not* do is resolve
+quietly when an axis cannot be expressed: a mach service on a ``bwrap`` host,
+or a write root that resolves to ``/`` or the invoking home, raises
+:class:`UnsupportedCapabilityProfileError` naming exactly what was denied.
 
 This module is stdlib-only and dependency-free by design: ``config.load``
 validates preset names at load time and ``runners.sandbox`` consumes the
@@ -31,6 +43,7 @@ resolved capabilities, and neither should have to import the other.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -85,34 +98,53 @@ class SandboxCapabilityPreset:
 
 @dataclass(frozen=True)
 class ResolvedSandboxCapabilities:
-    """The concrete capability set a selected preset expands to.
+    """The concrete capability set a declaration expands to.
 
-    ``profile`` is ``None`` for the default (no preset selected) case, which
-    resolves to no extra write roots and no extra services — byte-for-byte the
-    containment boundary forge has always applied.
+    ``write_roots`` and ``mach_services`` are the *merged* set actually applied:
+    the selected preset's grants plus any the project declared inline.
+    ``project_write_roots``/``project_mach_services`` carry the project-declared
+    subset separately so an audit reader can tell a forge-owned grant from one
+    the project added.
+
+    ``profile`` is ``None`` when no preset was selected. With no project grants
+    either, that is the default case — no extra write roots and no extra
+    services, byte-for-byte the containment boundary forge has always applied.
     """
 
     profile: str | None
     write_roots: tuple[Path, ...] = ()
     mach_services: tuple[str, ...] = ()
+    project_write_roots: tuple[Path, ...] = ()
+    project_mach_services: tuple[str, ...] = ()
 
     @property
     def is_default(self) -> bool:
-        """True when no preset was selected (default containment)."""
-        return self.profile is None
+        """True when nothing was declared at all (default containment)."""
+        return self.profile is None and not self.write_roots and not self.mach_services
 
     def audit_payload(self) -> dict:
         """Serialise for the run audit record.
 
-        Always emits every key — an explicit ``None``/empty value records
+        Always emits the applied set — an explicit ``None``/empty value records
         "default containment" rather than "capability data omitted", so a
         reviewer can tell the two apart in an audit log.
+
+        The ``project_*`` provenance keys appear only when the project actually
+        declared a grant. A record without them is a run whose capabilities were
+        entirely forge-owned, which is what every record said before project
+        grants existed — so the base shape is unchanged and no reader has to
+        migrate across this addition.
         """
-        return {
+        payload: dict = {
             "profile": self.profile,
             "write_roots": [str(path) for path in self.write_roots],
             "mach_services": list(self.mach_services),
         }
+        if self.project_write_roots:
+            payload["project_write_roots"] = [str(path) for path in self.project_write_roots]
+        if self.project_mach_services:
+            payload["project_mach_services"] = list(self.project_mach_services)
+        return payload
 
 
 # ── Preset table ──────────────────────────────────────────────────────────
@@ -182,35 +214,80 @@ def _expand(template: str, home: Path) -> Path:
     return Path(template).resolve()
 
 
+def _expand_write_roots(
+    templates: Iterable[str],
+    *,
+    home: Path,
+    source: str,
+    into: list[Path],
+    seen: set[Path],
+) -> list[Path]:
+    """Expand *templates*, appending newly-seen paths to *into*.
+
+    Returns the expanded paths from *templates* alone (before de-duplication
+    against *seen*), so a caller can record provenance separately from the
+    merged set.
+
+    A grant that resolves to a filesystem or home root is a wholesale sandbox
+    escape wearing a grant's name, whatever declared it — so the guard applies
+    to forge's own preset table and to project declarations alike.
+    """
+    expanded: list[Path] = []
+    for template in templates:
+        path = _expand(template, home)
+        if path in (Path("/"), home):
+            raise UnsupportedCapabilityProfileError(
+                f"{source} declares write root {template!r} which resolves to "
+                f"{path} — a sandbox grant may not include a filesystem or home root."
+            )
+        expanded.append(path)
+        if path in seen:
+            continue
+        seen.add(path)
+        into.append(path)
+    return expanded
+
+
 def resolve_capabilities(
     profile: str | None,
     *,
     home: Path | None = None,
     system: str | None = None,
+    write_roots: Iterable[str] = (),
+    mach_services: Iterable[str] = (),
 ) -> ResolvedSandboxCapabilities:
-    """Expand a selected preset name into its concrete capability set.
+    """Expand a capability declaration into its concrete capability set.
 
     Resolution is pure: it expands ``~`` and normalises paths, and never probes
-    the host for an installed toolchain or an existing directory. The result is
-    therefore exactly the preset's declared set and nothing more, on any host.
+    the host for an installed toolchain, an existing directory, or a registered
+    mach service. The result is therefore exactly the declared set and nothing
+    more, on any host.
 
     Args:
-        profile: preset name, or ``None`` for default containment.
+        profile: preset name, or ``None`` when no preset is selected.
         home: home directory used to expand ``~``; defaults to the real one.
-        system: ``platform.system()`` value to validate the preset against.
+        system: ``platform.system()`` value to validate the declaration against.
             ``None`` (the default) skips the platform check, which is what
-            makes inspection possible on a host that could not run the preset.
+            makes inspection possible on a host that could not run it.
+        write_roots: project-declared write-root templates, added to whatever
+            the selected preset grants. Keyword-only with an empty default so
+            every existing caller keeps resolving exactly the preset.
+        mach_services: project-declared mach services, likewise additive.
 
     Raises:
         UnknownCapabilityProfileError: *profile* names no forge-owned preset.
         UnsupportedCapabilityProfileError: *system* is given and that platform's
-            sandbox backend cannot express the preset.
+            sandbox backend cannot express the declaration, or a declared write
+            root resolves to a filesystem or home root.
     """
-    if profile is None:
+    project_root_templates = tuple(write_roots)
+    project_services = tuple(dict.fromkeys(mach_services))
+
+    if profile is None and not project_root_templates and not project_services:
         return ResolvedSandboxCapabilities(profile=None)
 
-    preset = get_preset(profile)
-    if system is not None and system not in preset.supported_platforms:
+    preset = get_preset(profile) if profile is not None else None
+    if preset is not None and system is not None and system not in preset.supported_platforms:
         raise UnsupportedCapabilityProfileError(
             f"sandbox capability profile {preset.name!r} is not supported on "
             f"{system} — it declares capabilities "
@@ -219,28 +296,43 @@ def resolve_capabilities(
             f"express. Supported platforms: {sorted(preset.supported_platforms)}. "
             "Refusing to run with the declared capability absent."
         )
+    # A project may declare a mach service without selecting a preset, so the
+    # preset's supported_platforms check above does not cover it. Only Darwin's
+    # sandbox backend has a mach-lookup axis; bwrap has none, so a declaration
+    # there must refuse rather than resolve with the service silently absent.
+    if project_services and system is not None and system != "Darwin":
+        raise UnsupportedCapabilityProfileError(
+            f"forge.yaml 'sandbox.mach_services' declares {list(project_services)}, "
+            f"which the {system} sandbox backend (bwrap) cannot express — it has no "
+            "mach-lookup axis. Refusing to run with the declared capability absent."
+        )
 
     resolved_home = (home or Path.home()).resolve()
-    write_roots: list[Path] = []
+    merged_roots: list[Path] = []
     seen: set[Path] = set()
-    for template in preset.write_roots:
-        path = _expand(template, resolved_home)
-        # A preset that resolves to a filesystem or home root would be a
-        # wholesale sandbox escape wearing a preset's name. Presets are
-        # forge-owned, so this is a guard against our own table, not user input.
-        if path in (Path("/"), resolved_home):
-            raise UnsupportedCapabilityProfileError(
-                f"sandbox capability profile {preset.name!r} declares write root "
-                f"{template!r} which resolves to {path} — presets may not grant "
-                "a filesystem or home root."
-            )
-        if path in seen:
-            continue
-        seen.add(path)
-        write_roots.append(path)
+    if preset is not None:
+        _expand_write_roots(
+            preset.write_roots,
+            home=resolved_home,
+            source=f"sandbox capability profile {preset.name!r}",
+            into=merged_roots,
+            seen=seen,
+        )
+    project_roots = _expand_write_roots(
+        project_root_templates,
+        home=resolved_home,
+        source="forge.yaml 'sandbox.write_roots'",
+        into=merged_roots,
+        seen=seen,
+    )
+
+    preset_services = preset.mach_services if preset is not None else ()
+    merged_services = tuple(dict.fromkeys((*preset_services, *project_services)))
 
     return ResolvedSandboxCapabilities(
-        profile=preset.name,
-        write_roots=tuple(write_roots),
-        mach_services=preset.mach_services,
+        profile=preset.name if preset is not None else None,
+        write_roots=tuple(merged_roots),
+        mach_services=merged_services,
+        project_write_roots=tuple(dict.fromkeys(project_roots)),
+        project_mach_services=project_services,
     )

--- a/src/theforge/config/types.py
+++ b/src/theforge/config/types.py
@@ -393,6 +393,11 @@ class ModelProfile:
     # containment. Stamped by the coordinator from ForgeConfig.sandbox; None
     # means default containment (#1947).
     sandbox_capability_profile: str | None = None
+    # Project-declared additive grants, stamped from ForgeConfig.sandbox next to
+    # the preset above. Empty tuples mean "preset only", so a profile built
+    # anywhere else keeps exactly today's capability set (#2038).
+    sandbox_write_roots: tuple[str, ...] = ()
+    sandbox_mach_services: tuple[str, ...] = ()
     registry_id: str | None = None  # canonical model registry key, when sourced from a registry
     registry_source: str = "builtin"  # "builtin" | "forge.yaml"
     # The canonical TransportSpec. Populated at construction (explicitly, or
@@ -1159,9 +1164,19 @@ class DevConfig:
 
 @dataclass(frozen=True)
 class SandboxConfig:
-    """Project-selected forge-owned sandbox capability profile."""
+    """The project's sandbox capability declaration.
+
+    ``capability_profile`` selects a forge-owned preset by name. ``write_roots``
+    and ``mach_services`` are project-authored grants **added** to whatever that
+    preset grants (or granted on their own, with no preset selected), because
+    the shipped presets cannot anticipate every toolchain (#2038). There is no
+    field here that subtracts from a preset, disables containment, or grants
+    allow-default — the declaration only ever enumerates.
+    """
 
     capability_profile: str | None = None
+    write_roots: tuple[str, ...] = ()
+    mach_services: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/theforge/coordinator/dev_phase.py
+++ b/src/theforge/coordinator/dev_phase.py
@@ -856,27 +856,41 @@ def _pending_dev_transport_retry_failure_extra(state: CoordinatorState) -> dict:
 
 
 def _resolve_dev_sandbox_capabilities(config: ForgeConfig) -> dict:
-    """Resolve the project's sandbox capability profile for audit + logging (#1947).
+    """Resolve the project's sandbox capability declaration for audit + logging.
 
-    Returns the audit payload for the capabilities the dev run will be granted.
-    With no profile selected this is an explicit null/empty payload — default
+    Returns the audit payload for the capabilities the dev run will be granted:
+    the selected preset (#1947) merged with the project's own additive
+    ``sandbox.write_roots``/``sandbox.mach_services`` grants (#2038). With
+    nothing declared this is an explicit null/empty payload — default
     containment, recorded rather than omitted.
 
-    A profile this host's sandbox backend cannot express resolves to *empty*
+    A declaration this host's sandbox backend cannot express resolves to *empty*
     grants (the runner refuses the run), so the audit trail never claims a
-    capability that was not actually applied. The declared name is kept under
-    ``requested_profile`` so the refusal is diagnosable.
+    capability that was not actually applied. What was asked for is kept under
+    ``requested_profile``/``requested_write_roots``/``requested_mach_services``
+    so the refusal is diagnosable from the audit record alone.
     """
     requested = config.sandbox.capability_profile
+    requested_roots = config.sandbox.write_roots
+    requested_services = config.sandbox.mach_services
     try:
-        return resolve_capabilities(requested, system=platform.system()).audit_payload()
+        return resolve_capabilities(
+            requested,
+            system=platform.system(),
+            write_roots=requested_roots,
+            mach_services=requested_services,
+        ).audit_payload()
     except SandboxCapabilityError as exc:
         _log(
-            f"  WARNING: sandbox capability profile {requested!r} is not usable on this "
-            f"host — the dev run will fail closed. {exc}"
+            f"  WARNING: the declared sandbox capabilities (profile {requested!r}, "
+            f"write_roots {list(requested_roots)}, mach_services "
+            f"{list(requested_services)}) are not usable on this host — the dev run "
+            f"will fail closed. {exc}"
         )
         payload = resolve_capabilities(None).audit_payload()
         payload["requested_profile"] = requested
+        payload["requested_write_roots"] = list(requested_roots)
+        payload["requested_mach_services"] = list(requested_services)
         payload["unsupported_reason"] = str(exc)
         return payload
 
@@ -938,11 +952,24 @@ def _run_dev_phase(
         )
     elif state.dev_containment == "mechanical":
         _log("  dev write containment: mechanical (host sandbox wrapper)")
-    if state.dev_sandbox_capabilities.get("profile"):
+    _capabilities = state.dev_sandbox_capabilities
+    # Log whenever *anything* was declared — a project's inline grants apply
+    # with no preset selected, so keying the log on 'profile' alone would hide
+    # the inline-only case from the operator entirely (#2038).
+    _declared = any(_capabilities.get(key) for key in ("profile", "write_roots", "mach_services"))
+    if _declared:
         _log(
-            f"  sandbox capability profile: {state.dev_sandbox_capabilities['profile']} "
-            f"({len(state.dev_sandbox_capabilities['write_roots'])} extra write roots, "
-            f"{len(state.dev_sandbox_capabilities['mach_services'])} mach services)"
+            f"  sandbox capability profile: {_capabilities['profile'] or '(none)'} "
+            f"({len(_capabilities['write_roots'])} extra write roots, "
+            f"{len(_capabilities['mach_services'])} mach services; "
+            f"{len(_capabilities.get('project_write_roots', []))} roots and "
+            f"{len(_capabilities.get('project_mach_services', []))} services "
+            "declared by the project)"
+        )
+    elif _capabilities.get("unsupported_reason"):
+        _log(
+            "  sandbox capability declaration refused on this host: "
+            f"{_capabilities['unsupported_reason']}"
         )
     _preserve_error_type = state.error_type == "max_iterations_no_submit"
     if not _preserve_error_type:
@@ -1362,6 +1389,8 @@ def _run_dev_phase(
         max_iterations=state.adaptive_dev_max or config.dev_profile.max_iterations,
         stuck_detection=_scaled_stuck,
         sandbox_capability_profile=config.sandbox.capability_profile,
+        sandbox_write_roots=config.sandbox.write_roots,
+        sandbox_mach_services=config.sandbox.mach_services,
     )
 
     _dev_total_start = time.monotonic()

--- a/src/theforge/runners/cli.py
+++ b/src/theforge/runners/cli.py
@@ -25,6 +25,7 @@ from theforge.log_util import _log_line
 
 from ..config import ModelProfile
 from ..config.models import model_fallback_transport
+from .sandbox import capability_transport_refusal
 
 # ── Logging helpers ───────────────────────────────────────────────────
 
@@ -202,6 +203,29 @@ def _parse_quota_reset(output: str) -> str | None:
     return None
 
 
+def _capability_refusal_result(
+    profile: ModelProfile, transport_label: str, refusal: str
+) -> AgentResult:
+    """Fail-closed startup failure for a transport that cannot express a declaration.
+
+    Uses the same ``SANDBOX_CAPABILITY_PROFILE_UNSUPPORTED`` marker the CLI
+    runners emit, so the coordinator's existing failure classification
+    (``agent_failure``, ``sprint.rca``) sees one capability-gap signal
+    regardless of which transport refused.
+    """
+    _log(f"✗ {transport_label}: {refusal}")
+    return AgentResult(
+        success=False,
+        output=f"SANDBOX_CAPABILITY_PROFILE_UNSUPPORTED: {refusal}",
+        session_id=None,
+        cost_usd=None,
+        exit_code=-1,
+        raw={},
+        profile_name=profile.name,
+        startup_failure=True,
+    )
+
+
 def _fallback_unavailable_reason(profile: ModelProfile) -> str:
     """Explain why no transport fallback could be attempted for ``profile``."""
     provider = profile.provider_family or profile.provider or "unknown"
@@ -362,7 +386,9 @@ def _maybe_run_api_fallback(
 
     reason = decision.reason
 
-    def _annotate_cli_result(cli_result: AgentResult) -> AgentResult:
+    def _annotate_cli_result(
+        cli_result: AgentResult, not_applied: str | None = None
+    ) -> AgentResult:
         """Annotate a failure for which no fallback was ever attempted.
 
         The failure was classified as fallback-eligible, so recording only the
@@ -371,7 +397,7 @@ def _maybe_run_api_fallback(
         carry that time forward so the coordinator can tell a failure certain to
         repeat from one merely likely to (#2298).
         """
-        not_applied = _fallback_unavailable_reason(profile)
+        not_applied = not_applied or _fallback_unavailable_reason(profile)
         reset_at = (
             _parse_quota_reset(cli_result.output or "")
             if decision.cli_quota_error_observed
@@ -403,6 +429,13 @@ def _maybe_run_api_fallback(
             transport_fallback_reason=reason,
             transport_used="api",
         )
+
+    # A CLI that declared sandbox capabilities must not fall back to a transport
+    # that cannot express them — that would turn a fail-closed capability
+    # refusal into a quiet run without the capability (#2038).
+    capability_refusal = capability_transport_refusal(profile, "api")
+    if capability_refusal is not None:
+        return _annotate_cli_result(result, not_applied=capability_refusal)
 
     if session_id is not None:
         _log(
@@ -598,6 +631,14 @@ def run_agent(
     its own stdout stream. Codex and Gemini are affected.
     """
     if _profile_transport_kind(profile) == "api":
+        # The API tool runtime confines writes by path check, not by host
+        # sandbox, so it has no axis for a declared write root or mach service.
+        # Refuse before dispatch rather than run with the capability absent.
+        refusal = capability_transport_refusal(profile, "api")
+        if refusal is not None:
+            return _stamp_configured_identity(
+                _capability_refusal_result(profile, "api", refusal), profile
+            )
         from theforge.runners import api as runner_api  # noqa: PLC0415
 
         api_result = runner_api.run_api_agent(
@@ -641,6 +682,14 @@ def run_agent(
         return _fill_invocation_identity(result, profile)
 
     if cli == "codex":
+        # Codex brings its own `--sandbox` containment and never goes through
+        # workspace_effect_sandbox_command, so a declared grant would be
+        # silently dropped. Refuse instead (#2038).
+        refusal = capability_transport_refusal(profile, "codex")
+        if refusal is not None:
+            return _stamp_configured_identity(
+                _capability_refusal_result(profile, "codex", refusal), profile
+            )
         from .runner_codex import _run_codex  # noqa: PLC0415
 
         result = _run_codex(
@@ -691,6 +740,13 @@ def run_agent(
         return _fill_invocation_identity(result, profile)
 
     if cli == "ghaw":
+        # gh-aw runs the work on a GitHub Actions runner, not under this host's
+        # sandbox, so a host write root or mach service cannot be granted there.
+        refusal = capability_transport_refusal(profile, "ghaw")
+        if refusal is not None:
+            return _stamp_configured_identity(
+                _capability_refusal_result(profile, "ghaw", refusal), profile
+            )
         from .runner_ghaw import _run_ghaw  # noqa: PLC0415
 
         # No API fallback on this transport: gh-aw failures (dispatch, Actions

--- a/src/theforge/runners/runner_claude.py
+++ b/src/theforge/runners/runner_claude.py
@@ -749,6 +749,8 @@ def _run_claude(
                 extra_write_roots=_claude_state_write_roots(),
                 allow_credential_services=True,
                 capability_profile=profile.sandbox_capability_profile,
+                capability_write_roots=profile.sandbox_write_roots,
+                capability_mach_services=profile.sandbox_mach_services,
             )
         except SandboxCapabilityError as exc:
             # Fail closed: a declared capability profile this host cannot express

--- a/src/theforge/runners/runner_gemini.py
+++ b/src/theforge/runners/runner_gemini.py
@@ -194,6 +194,8 @@ def _run_gemini(
                 cmd,
                 working_dir,
                 capability_profile=profile.sandbox_capability_profile,
+                capability_write_roots=profile.sandbox_write_roots,
+                capability_mach_services=profile.sandbox_mach_services,
             )
         except SandboxCapabilityError as exc:
             # Fail closed: a declared capability profile this host cannot express

--- a/src/theforge/runners/sandbox.py
+++ b/src/theforge/runners/sandbox.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 from functools import lru_cache
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from theforge.config.sandbox_capabilities import (
     ResolvedSandboxCapabilities,
@@ -15,8 +16,12 @@ from theforge.config.sandbox_capabilities import (
     resolve_capabilities,
 )
 
+if TYPE_CHECKING:  # import-cost only — this module stays dependency-light at runtime
+    from theforge.config.types import ModelProfile
+
 __all__ = [
     "SandboxCapabilityError",
+    "capability_transport_refusal",
     "sandbox_command",
     "workspace_effect_sandbox_command",
 ]
@@ -469,21 +474,31 @@ def _linux_command(
     return wrapped
 
 
-def _resolve_capability_profile(profile: str | None) -> ResolvedSandboxCapabilities:
-    """Resolve *profile* against the running host, failing closed if unexpressible.
+def _resolve_capability_profile(
+    profile: str | None,
+    *,
+    write_roots: tuple[str, ...] | list[str] = (),
+    mach_services: tuple[str, ...] | list[str] = (),
+) -> ResolvedSandboxCapabilities:
+    """Resolve a capability declaration against the running host, failing closed.
 
     The platform check happens here, before the command is built, so a project
-    that declares a preset this backend cannot express gets a clear refusal
+    that declares a capability this backend cannot express gets a clear refusal
     rather than a run that silently proceeds with the capability absent. The
     per-axis check is belt-and-braces behind the preset's own
-    ``supported_platforms``: it catches a future preset whose platform metadata
-    and declared axes disagree.
+    ``supported_platforms`` and the resolver's own mach-service guard: it
+    catches a future preset whose platform metadata and declared axes disagree.
     """
-    capabilities = resolve_capabilities(profile, system=_SYSTEM)
+    capabilities = resolve_capabilities(
+        profile,
+        system=_SYSTEM,
+        write_roots=write_roots,
+        mach_services=mach_services,
+    )
     if capabilities.mach_services and _SYSTEM != "Darwin":
         raise UnsupportedCapabilityProfileError(
-            f"sandbox capability profile {capabilities.profile!r} declares mach "
-            f"services {list(capabilities.mach_services)}, which the {_SYSTEM} "
+            f"sandbox capability declaration (profile {capabilities.profile!r}) grants "
+            f"mach services {list(capabilities.mach_services)}, which the {_SYSTEM} "
             "sandbox backend (bwrap) cannot express. Refusing to run with the "
             "declared capability absent."
         )
@@ -497,6 +512,8 @@ def workspace_effect_sandbox_command(
     extra_write_roots: tuple[Path, ...] | list[Path] = (),
     allow_credential_services: bool = False,
     capability_profile: str | None = None,
+    capability_write_roots: tuple[str, ...] | list[str] = (),
+    capability_mach_services: tuple[str, ...] | list[str] = (),
 ) -> list[str]:
     """Wrap *cmd* so filesystem writes are confined to *allowed_root*.
 
@@ -514,6 +531,13 @@ def workspace_effect_sandbox_command(
     always a bounded named set: there is no value here that grants
     ``allow default`` or disables the sandbox (#1947).
 
+    ``capability_write_roots`` and ``capability_mach_services`` are the project's
+    own additive grants (``sandbox.write_roots``/``sandbox.mach_services`` in
+    ``forge.yaml``), merged with the preset's before the profile is built. They
+    are additive only, and fail closed on the same terms as a preset: a root
+    resolving to ``/`` or the invoking home, or a mach service on a backend with
+    no mach-lookup axis, raises rather than resolving without it (#2038).
+
     The worktree's own git internals (private gitdir, shared object store, and
     its own branch-ref namespace) are granted automatically so ``git commit``
     from the correctly-scoped worktree works, while the main checkout and other
@@ -525,10 +549,14 @@ def workspace_effect_sandbox_command(
 
     Raises:
         SandboxCapabilityError: *capability_profile* names no forge-owned preset,
-            or this host's sandbox backend cannot express it.
+            or this host's sandbox backend cannot express the declared set.
     """
     root = allowed_root.resolve()
-    capabilities = _resolve_capability_profile(capability_profile)
+    capabilities = _resolve_capability_profile(
+        capability_profile,
+        write_roots=capability_write_roots,
+        mach_services=capability_mach_services,
+    )
     extra_write_roots = tuple(extra_write_roots) + _git_worktree_write_roots(root)
     extra_write_roots += capabilities.write_roots
     blocked_worktrees = _blocked_worktree_roots(root)
@@ -563,3 +591,45 @@ def workspace_effect_sandbox_command(
 
 def sandbox_command(cmd: list[str], allowed_root: Path) -> list[str]:
     return workspace_effect_sandbox_command(cmd, allowed_root)
+
+
+def capability_transport_refusal(profile: ModelProfile, transport_label: str) -> str | None:
+    """Explain why *transport_label* cannot honor *profile*'s capability declaration.
+
+    Only the transports whose invocation goes through
+    :func:`workspace_effect_sandbox_command` (claude, gemini) can apply a
+    declaration at all. Every other transport either brings its own sandbox
+    (codex's ``--sandbox``), runs the work off-host (gh-aw), or confines tools
+    by path check rather than by host sandbox (the API tool runtime) — none has
+    a write-root or mach-service axis forge can widen. Those call this before
+    dispatching and refuse when it returns a message.
+
+    Returns ``None`` when there is nothing to honor (no declaration) or nothing
+    to contain (``sandbox_mode: none``, an explicit opt-out of containment
+    altogether, under which no grant is meaningful).
+
+    This is the fail-closed half of the project-extensible capability model:
+    a declaration the invoked transport cannot express must refuse *before*
+    dispatch, because the alternative is a run whose audit record claims a
+    capability the agent never had — exactly the gap that let a capability
+    failure reach the operator as a code-quality verdict (#2038).
+    """
+    if profile.sandbox_mode == "none":
+        return None
+    declared: list[str] = []
+    if profile.sandbox_capability_profile:
+        declared.append(f"capability_profile={profile.sandbox_capability_profile!r}")
+    if profile.sandbox_write_roots:
+        declared.append(f"write_roots={list(profile.sandbox_write_roots)}")
+    if profile.sandbox_mach_services:
+        declared.append(f"mach_services={list(profile.sandbox_mach_services)}")
+    if not declared:
+        return None
+    return (
+        f"forge.yaml declares sandbox capabilities ({', '.join(declared)}) that the "
+        f"{transport_label} transport cannot express — it does not apply forge's host "
+        "sandbox, so the declared write roots and mach services would be absent. "
+        "Refusing to run rather than record a capability the agent never had. "
+        "Assign a dev transport that applies the host sandbox (claude, gemini), or "
+        "remove the declaration."
+    )

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -83,6 +83,35 @@ class TestLoadConfig:
         config_path = _write_config({"sandbox": {"capability_profile": "xcode"}}, tmp_path)
         config = load_config(config_path)
         assert config.sandbox.capability_profile == "xcode"
+        assert config.sandbox.write_roots == ()
+        assert config.sandbox.mach_services == ()
+
+    def test_sandbox_project_grants_load_alongside_a_preset(self, tmp_path):
+        """A project extends the selected preset with grants of its own (#2038)."""
+        config_path = _write_config(
+            {
+                "sandbox": {
+                    "capability_profile": "xcode",
+                    "write_roots": ["~/Library/Preferences", " /opt/toolchain "],
+                    "mach_services": ["com.example.toolchaind"],
+                }
+            },
+            tmp_path,
+        )
+        config = load_config(config_path)
+        assert config.sandbox.capability_profile == "xcode"
+        assert config.sandbox.write_roots == ("~/Library/Preferences", "/opt/toolchain")
+        assert config.sandbox.mach_services == ("com.example.toolchaind",)
+
+    def test_sandbox_project_grants_load_without_a_preset(self, tmp_path):
+        """Grants stand alone — selecting a preset is not a precondition."""
+        config_path = _write_config(
+            {"sandbox": {"write_roots": ["/opt/toolchain", "/opt/toolchain"]}}, tmp_path
+        )
+        config = load_config(config_path)
+        assert config.sandbox.capability_profile is None
+        # Duplicates collapse at load so the declaration reads as a set.
+        assert config.sandbox.write_roots == ("/opt/toolchain",)
 
     @pytest.mark.parametrize(
         ("sandbox", "message"),
@@ -90,11 +119,16 @@ class TestLoadConfig:
             (["xcode"], "sandbox' section must be a mapping"),
             ({"capability_profile": ""}, "sandbox.capability_profile' must be a non-empty string"),
             ({"capability_profile": 3}, "sandbox.capability_profile' must be a non-empty string"),
-            ({"write_roots": ["~/x"]}, "remove inline capability key"),
-            ({"mach_services": ["svc"]}, "remove inline capability key"),
-            ({"allow_default": True}, "remove inline capability key"),
-            ({"disabled": True}, "remove inline capability key"),
-            ({"mode": "none"}, "remove inline capability key"),
+            # Additive grants are supported; weakening containment never is.
+            ({"allow_default": True}, "may not weaken containment"),
+            ({"disabled": True}, "may not weaken containment"),
+            ({"mode": "none"}, "may not weaken containment"),
+            # A grant list that is not a list of non-empty strings is an error,
+            # never a silently-dropped capability.
+            ({"write_roots": "~/x"}, "sandbox.write_roots' must be a list of strings"),
+            ({"write_roots": ["~/x", ""]}, "sandbox.write_roots' entries must be non-empty"),
+            ({"mach_services": {"a": 1}}, "sandbox.mach_services' must be a list of strings"),
+            ({"mach_services": [3]}, "sandbox.mach_services' entries must be non-empty"),
             ({"capability_profile": "xcode", "extra": True}, "unknown key"),
             # A typo'd preset must fail at load, not resolve to default containment.
             ({"capability_profile": "xcodee"}, "unknown sandbox capability profile"),

--- a/tests/test_coord_sandbox_capabilities.py
+++ b/tests/test_coord_sandbox_capabilities.py
@@ -169,3 +169,135 @@ class TestCapabilityProfileReachesRunnerAndAudit:
 
         log = generate_audit_log(config, task, result)
         assert log["workspace"]["sandbox_capabilities"]["requested_profile"] == "xcode"
+
+
+class TestProjectGrantsReachRunnerAndAudit:
+    """Project-authored additive grants cross the same seam as a preset (#2038)."""
+
+    @patch("theforge.coordinator.dev_phase.platform.system", return_value="Darwin")
+    @patch("theforge.coordinator.dev_phase.sandbox_containment_mode", return_value="mechanical")
+    @patch("theforge.coordinator.dev_phase.sandbox_available_for_profile", return_value=True)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_inline_grants_reach_runner_and_audit_with_a_preset(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        mock_probe,
+        mock_mode,
+        mock_system,
+        tmp_path: Path,
+    ) -> None:
+        mocks = {
+            "shell": mock_shell,
+            "dev": mock_dev,
+            "preflight": mock_preflight,
+            "pool": mock_pool,
+        }
+        sandbox = SandboxConfig(
+            capability_profile="xcode",
+            write_roots=("/opt/toolchain",),
+            mach_services=("com.example.toolchaind",),
+        )
+        config, task, result = _run(tmp_path, mocks, sandbox=sandbox)
+
+        # Seam 1: config → the profile the runner is actually invoked with.
+        dev_profile = mock_dev.call_args.kwargs["profile"]
+        assert dev_profile.sandbox_capability_profile == "xcode"
+        assert dev_profile.sandbox_write_roots == ("/opt/toolchain",)
+        assert dev_profile.sandbox_mach_services == ("com.example.toolchaind",)
+
+        # Seam 2: merged grants → state → audit.
+        expected = resolve_capabilities(
+            "xcode",
+            write_roots=sandbox.write_roots,
+            mach_services=sandbox.mach_services,
+        ).audit_payload()
+        assert result.state.dev_sandbox_capabilities == expected
+        assert "/opt/toolchain" in expected["write_roots"]
+        assert expected["project_mach_services"] == ["com.example.toolchaind"]
+
+        log = generate_audit_log(config, task, result)
+        assert log["workspace"]["sandbox_capabilities"] == expected
+        for iteration in log["iterations"]["dev_loop"]:
+            assert iteration["sandbox_capabilities"] == expected
+
+    @patch("theforge.coordinator.dev_phase.platform.system", return_value="Darwin")
+    @patch("theforge.coordinator.dev_phase.sandbox_containment_mode", return_value="mechanical")
+    @patch("theforge.coordinator.dev_phase.sandbox_available_for_profile", return_value=True)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_inline_only_grants_are_audited_without_a_preset(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        mock_probe,
+        mock_mode,
+        mock_system,
+        tmp_path: Path,
+    ) -> None:
+        """No preset selected is not "no capabilities" once a project declares its own."""
+        mocks = {
+            "shell": mock_shell,
+            "dev": mock_dev,
+            "preflight": mock_preflight,
+            "pool": mock_pool,
+        }
+        config, task, result = _run(
+            tmp_path, mocks, sandbox=SandboxConfig(write_roots=("/opt/toolchain",))
+        )
+
+        assert mock_dev.call_args.kwargs["profile"].sandbox_write_roots == ("/opt/toolchain",)
+        recorded = result.state.dev_sandbox_capabilities
+        assert recorded["profile"] is None
+        assert recorded["write_roots"] == ["/opt/toolchain"]
+        assert recorded["project_write_roots"] == ["/opt/toolchain"]
+
+        log = generate_audit_log(config, task, result)
+        assert log["workspace"]["sandbox_capabilities"] == recorded
+
+    @patch("theforge.coordinator.dev_phase.platform.system", return_value="Linux")
+    @patch("theforge.coordinator.dev_phase.sandbox_containment_mode", return_value="mechanical")
+    @patch("theforge.coordinator.dev_phase.sandbox_available_for_profile", return_value=True)
+    @patch("theforge.coordinator.review_pool.run_agent_pool")
+    @patch("theforge.coordinator.preflight_flow.run_agent")
+    @patch("theforge.coordinator.dev_phase.run_agent")
+    @patch_gate_shell()
+    def test_unexpressible_inline_grant_audits_the_request_and_the_reason(
+        self,
+        mock_shell,
+        mock_dev,
+        mock_preflight,
+        mock_pool,
+        mock_probe,
+        mock_mode,
+        mock_system,
+        tmp_path: Path,
+    ) -> None:
+        """An inline mach service on bwrap: zero grants recorded, request still visible."""
+        mocks = {
+            "shell": mock_shell,
+            "dev": mock_dev,
+            "preflight": mock_preflight,
+            "pool": mock_pool,
+        }
+        config, task, result = _run(
+            tmp_path, mocks, sandbox=SandboxConfig(mach_services=("com.example.toolchaind",))
+        )
+
+        recorded = result.state.dev_sandbox_capabilities
+        assert recorded["mach_services"] == []
+        assert recorded["requested_mach_services"] == ["com.example.toolchaind"]
+        assert "com.example.toolchaind" in recorded["unsupported_reason"]
+
+        log = generate_audit_log(config, task, result)
+        audited = log["workspace"]["sandbox_capabilities"]
+        assert audited["requested_mach_services"] == ["com.example.toolchaind"]

--- a/tests/test_sandbox_capabilities.py
+++ b/tests/test_sandbox_capabilities.py
@@ -273,3 +273,173 @@ def test_environment_is_not_consulted_for_capability_resolution(tmp_path: Path) 
     """No env var can widen the sandbox — selection is config-only."""
     with patch.dict(os.environ, {"FORGE_SANDBOX_CAPABILITY_PROFILE": "xcode"}, clear=False):
         assert resolve_capabilities(None).is_default
+
+
+# ── Project-authored additive grants (#2038) ──────────────────────────────
+
+
+def test_project_grants_are_added_to_the_selected_preset(tmp_path: Path) -> None:
+    """The fix-success criterion: a root and a service the presets never anticipated."""
+    preset = get_preset("xcode")
+    resolved = resolve_capabilities(
+        "xcode",
+        home=tmp_path,
+        write_roots=("~/Library/Preferences", "/opt/toolchain"),
+        mach_services=("com.example.toolchaind",),
+    )
+
+    assert resolved.profile == "xcode"
+    # The preset's own grants survive intact — project grants extend, never replace.
+    assert len(resolved.write_roots) == len(preset.write_roots) + 2
+    assert (tmp_path.resolve() / "Library/Preferences") in resolved.write_roots
+    assert Path("/opt/toolchain") in resolved.write_roots
+    assert resolved.mach_services == (*preset.mach_services, "com.example.toolchaind")
+    # Provenance is preserved: which grants came from the project is answerable.
+    assert resolved.project_write_roots == (
+        (tmp_path.resolve() / "Library/Preferences"),
+        Path("/opt/toolchain"),
+    )
+    assert resolved.project_mach_services == ("com.example.toolchaind",)
+
+
+def test_project_grants_resolve_with_no_preset_selected(tmp_path: Path) -> None:
+    """Selecting a preset is not a precondition for declaring a capability."""
+    resolved = resolve_capabilities(
+        None,
+        home=tmp_path,
+        write_roots=("~/.cache/toolchain",),
+        mach_services=("com.example.toolchaind",),
+        system="Darwin",
+    )
+
+    assert resolved.profile is None
+    assert not resolved.is_default
+    assert resolved.write_roots == ((tmp_path.resolve() / ".cache/toolchain"),)
+    assert resolved.mach_services == ("com.example.toolchaind",)
+
+
+def test_project_grants_deduplicate_against_the_preset(tmp_path: Path) -> None:
+    """Re-declaring what the preset already grants is a no-op, not a duplicate."""
+    plain = resolve_capabilities("xcode", home=tmp_path)
+    with_dupes = resolve_capabilities(
+        "xcode",
+        home=tmp_path,
+        write_roots=("~/Library/Developer", "~/Library/Developer"),
+        mach_services=("com.apple.lsd.mapdb", "com.apple.lsd.mapdb"),
+    )
+    assert with_dupes.write_roots == plain.write_roots
+    assert with_dupes.mach_services == plain.mach_services
+
+
+@pytest.mark.parametrize("template", ["/", "~"])
+def test_project_write_root_at_a_filesystem_or_home_root_is_denied_by_name(
+    tmp_path: Path, template: str
+) -> None:
+    """A project may extend the sandbox; it may not turn it inside out."""
+    with pytest.raises(UnsupportedCapabilityProfileError) as excinfo:
+        resolve_capabilities(None, home=tmp_path, write_roots=(template,))
+    message = str(excinfo.value)
+    # The refusal names the denied root, so the operator knows what to remove.
+    assert template in message
+    assert "may not include a filesystem or home root" in message
+
+
+def test_project_mach_service_on_linux_fails_closed_naming_the_services(
+    tmp_path: Path,
+) -> None:
+    """bwrap has no mach-lookup axis — declaring one there must refuse, not drop it."""
+    with pytest.raises(UnsupportedCapabilityProfileError) as excinfo:
+        resolve_capabilities(
+            None, home=tmp_path, system="Linux", mach_services=("com.example.toolchaind",)
+        )
+    message = str(excinfo.value)
+    assert "com.example.toolchaind" in message
+    assert "Linux" in message
+
+
+def test_project_write_roots_alone_resolve_on_linux(tmp_path: Path) -> None:
+    """A write root has a bwrap expression, so it must not be refused there."""
+    resolved = resolve_capabilities(
+        None, home=tmp_path, system="Linux", write_roots=("/opt/toolchain",)
+    )
+    assert resolved.write_roots == (Path("/opt/toolchain"),)
+
+
+def test_audit_payload_names_project_declared_grants(tmp_path: Path) -> None:
+    """Convention: the values that drove the run are visible in the audit trail."""
+    payload = resolve_capabilities(
+        "xcode", home=tmp_path, write_roots=("/opt/toolchain",)
+    ).audit_payload()
+    assert "/opt/toolchain" in payload["write_roots"]
+    assert payload["project_write_roots"] == ["/opt/toolchain"]
+    # Absent — not empty — when nothing was project-declared, so the shape a
+    # reader saw before project grants existed is unchanged.
+    preset_only = resolve_capabilities("xcode", home=tmp_path).audit_payload()
+    assert "project_write_roots" not in preset_only
+
+
+def test_macos_profile_grants_project_roots_and_services(tmp_path: Path) -> None:
+    """The declared grants reach the generated Seatbelt profile, deny-default intact."""
+    extra_root = tmp_path / "toolchain-state"
+    with (
+        patch("theforge.runners.sandbox._SYSTEM", "Darwin"),
+        patch("theforge.runners.sandbox._sandbox_available", return_value=True),
+    ):
+        wrapped = workspace_effect_sandbox_command(
+            ["true"],
+            tmp_path,
+            capability_profile="xcode",
+            capability_write_roots=(str(extra_root),),
+            capability_mach_services=("com.example.toolchaind",),
+        )
+    profile_text = wrapped[2]
+    assert str(extra_root.resolve()) in profile_text
+    assert '(allow mach-lookup (global-name "com.example.toolchaind"))' in profile_text
+    # The preset's own grants are still there, and containment still denies by default.
+    assert '(allow mach-lookup (global-name "com.apple.lsd.mapdb"))' in profile_text
+    assert "(deny default)" in profile_text
+    assert "(allow default)" not in profile_text
+
+
+def test_project_grants_apply_with_no_preset_selected(tmp_path: Path) -> None:
+    """Inline-only grants must reach the profile — not require a preset to carry them."""
+    extra_root = tmp_path / "toolchain-state"
+    with (
+        patch("theforge.runners.sandbox._SYSTEM", "Darwin"),
+        patch("theforge.runners.sandbox._sandbox_available", return_value=True),
+    ):
+        baseline = workspace_effect_sandbox_command(["true"], tmp_path)[2]
+        widened = workspace_effect_sandbox_command(
+            ["true"], tmp_path, capability_write_roots=(str(extra_root),)
+        )[2]
+    assert str(extra_root.resolve()) not in baseline
+    assert str(extra_root.resolve()) in widened
+
+
+def test_project_mach_service_refused_by_the_linux_backend(tmp_path: Path) -> None:
+    with (
+        patch("theforge.runners.sandbox._SYSTEM", "Linux"),
+        patch("theforge.runners.sandbox._sandbox_available", return_value=True),
+        pytest.raises(SandboxCapabilityError, match="com.example.toolchaind"),
+    ):
+        workspace_effect_sandbox_command(
+            ["true"], tmp_path, capability_mach_services=("com.example.toolchaind",)
+        )
+
+
+def test_generated_profile_with_project_grants_is_accepted_by_sandbox_exec() -> None:
+    """A project-declared grant must produce valid Seatbelt, not just plausible text."""
+    _require_usable_sandbox_exec()
+    with tempfile.TemporaryDirectory(dir="/private/var/tmp") as tmp:
+        worktree = Path(tmp).resolve()
+        extra_root = worktree / "toolchain-state"
+        extra_root.mkdir()
+        cmd = workspace_effect_sandbox_command(
+            ["/usr/bin/true"],
+            worktree,
+            capability_write_roots=(str(extra_root),),
+            capability_mach_services=("com.example.toolchaind",),
+        )
+        assert cmd[0] == "sandbox-exec"
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+        assert result.returncode == 0, result.stderr

--- a/tests/test_sandbox_capability_transports.py
+++ b/tests/test_sandbox_capability_transports.py
@@ -1,0 +1,200 @@
+"""Every dev transport either applies a capability declaration or refuses it (#2038).
+
+Project-authored sandbox grants are only trustworthy if the transport that ran
+the work actually applied them. Two transports do (claude, gemini — both wrap
+their invocation in forge's host sandbox); the rest either bring their own
+containment (codex), run the work off-host (gh-aw), or confine tools by path
+check rather than by host sandbox (the API tool runtime). For those, the run
+must fail closed *before* dispatch, or the audit record ends up claiming a
+capability the agent never had — the exact disguise that let a capability gap
+reach the operator as a code-quality verdict.
+
+No real provider CLI is launched here: each runner entry point is patched, and
+the assertions are about whether it was called at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from theforge.agent_types import AgentResult
+from theforge.config import ModelProfile, TransportFallbackConfig
+from theforge.runners.cli import run_agent
+
+_MARKER = "SANDBOX_CAPABILITY_PROFILE_UNSUPPORTED"
+
+_DECLARATION = {
+    "sandbox_capability_profile": "xcode",
+    "sandbox_write_roots": ("/opt/toolchain",),
+    "sandbox_mach_services": ("com.example.toolchaind",),
+}
+
+
+def _profile(**kwargs) -> ModelProfile:
+    defaults = dict(
+        name="dev-profile",
+        cli="codex",
+        model="gpt-5.4",
+        budget_usd=5.0,
+        timeout_seconds=900,
+        allowed_tools=("Read",),
+        phase="dev",
+    )
+    defaults.update(kwargs)
+    return ModelProfile(**defaults)
+
+
+def _success(profile: ModelProfile) -> AgentResult:
+    return AgentResult(
+        success=True,
+        output="done",
+        session_id=None,
+        cost_usd=0.01,
+        exit_code=0,
+        raw={},
+        profile_name=profile.name,
+    )
+
+
+# ── Transports that cannot express a declaration must refuse ──────────────
+
+
+@pytest.mark.parametrize(
+    ("cli", "runner_path"),
+    [
+        ("codex", "theforge.runners.runner_codex._run_codex"),
+        ("ghaw", "theforge.runners.runner_ghaw._run_ghaw"),
+    ],
+)
+def test_cli_transport_without_a_capability_axis_refuses_before_dispatch(
+    tmp_path: Path, cli: str, runner_path: str
+) -> None:
+    profile = _profile(cli=cli, **_DECLARATION)
+    runner = MagicMock(return_value=_success(profile))
+
+    with patch(runner_path, runner):
+        result = run_agent(prompt="work", profile=profile, working_dir=tmp_path, quiet=True)
+
+    runner.assert_not_called()
+    assert result.success is False
+    assert result.startup_failure is True
+    assert _MARKER in result.output
+    # The refusal names what was asked for, so the operator can act on it.
+    assert "xcode" in result.output
+    assert "/opt/toolchain" in result.output
+    assert "com.example.toolchaind" in result.output
+
+
+def test_api_transport_refuses_before_dispatch(tmp_path: Path) -> None:
+    """The API tool runtime has no write-root or mach-service axis to widen."""
+    profile = _profile(cli=None, provider="anthropic", **_DECLARATION)
+    api_runner = MagicMock(return_value=_success(profile))
+
+    with patch("theforge.runners.api.run_api_agent", api_runner):
+        result = run_agent(prompt="work", profile=profile, working_dir=tmp_path, quiet=True)
+
+    api_runner.assert_not_called()
+    assert result.success is False
+    assert _MARKER in result.output
+
+
+def test_api_fallback_from_a_declaring_cli_profile_does_not_fire(tmp_path: Path) -> None:
+    """A fail-closed CLI must not be rescued by a transport that drops the grants."""
+    profile = _profile(
+        cli="claude",
+        provider="anthropic",
+        api_fallback=TransportFallbackConfig(
+            provider="anthropic", model="claude-opus-5", timeout_seconds=900
+        ),
+        **_DECLARATION,
+    )
+    cli_failure = AgentResult(
+        success=False,
+        output="You've hit your usage limit.",
+        session_id=None,
+        cost_usd=0.0,
+        exit_code=1,
+        raw={},
+        profile_name=profile.name,
+    )
+    api_runner = MagicMock(return_value=_success(profile))
+
+    with (
+        patch("theforge.runners.runner_claude._run_claude", return_value=cli_failure),
+        patch("theforge.runners.api.run_api_agent", api_runner),
+    ):
+        result = run_agent(prompt="work", profile=profile, working_dir=tmp_path, quiet=True)
+
+    api_runner.assert_not_called()
+    assert result.transport_fallback_fired is False
+    # Why the fallback was withheld is recorded, not merely implied.
+    assert result.transport_fallback_not_applied_reason is not None
+    assert "cannot express" in result.transport_fallback_not_applied_reason
+
+
+# ── Nothing declared, or containment opted out: unchanged behaviour ───────
+
+
+def test_transport_without_a_declaration_dispatches_normally(tmp_path: Path) -> None:
+    profile = _profile(cli="codex")
+    runner = MagicMock(return_value=_success(profile))
+
+    with patch("theforge.runners.runner_codex._run_codex", runner):
+        result = run_agent(prompt="work", profile=profile, working_dir=tmp_path, quiet=True)
+
+    runner.assert_called_once()
+    assert result.success is True
+
+
+def test_sandbox_mode_none_is_an_explicit_opt_out_not_a_refusal(tmp_path: Path) -> None:
+    """With containment off there is no boundary to widen, so nothing is denied."""
+    profile = _profile(cli="codex", sandbox_mode="none", **_DECLARATION)
+    runner = MagicMock(return_value=_success(profile))
+
+    with patch("theforge.runners.runner_codex._run_codex", runner):
+        result = run_agent(prompt="work", profile=profile, working_dir=tmp_path, quiet=True)
+
+    runner.assert_called_once()
+    assert result.success is True
+
+
+# ── Transports that CAN express it pass the declaration through ───────────
+
+
+def test_claude_runner_passes_the_declaration_to_the_sandbox_wrapper(tmp_path: Path) -> None:
+    from theforge.runners import runner_claude
+
+    profile = _profile(cli="claude", provider="anthropic", **_DECLARATION)
+    wrapper = MagicMock(side_effect=RuntimeError("stop after wrapping"))
+
+    with (
+        patch.object(runner_claude, "workspace_effect_sandbox_command", wrapper),
+        pytest.raises(RuntimeError, match="stop after wrapping"),
+    ):
+        runner_claude._run_claude(prompt="work", profile=profile, working_dir=tmp_path, quiet=True)
+
+    kwargs = wrapper.call_args.kwargs
+    assert kwargs["capability_profile"] == "xcode"
+    assert kwargs["capability_write_roots"] == ("/opt/toolchain",)
+    assert kwargs["capability_mach_services"] == ("com.example.toolchaind",)
+
+
+def test_gemini_runner_passes_the_declaration_to_the_sandbox_wrapper(tmp_path: Path) -> None:
+    from theforge.runners import runner_gemini
+
+    profile = _profile(cli="gemini", provider="google", **_DECLARATION)
+    wrapper = MagicMock(side_effect=RuntimeError("stop after wrapping"))
+
+    with (
+        patch.object(runner_gemini, "workspace_effect_sandbox_command", wrapper),
+        pytest.raises(RuntimeError, match="stop after wrapping"),
+    ):
+        runner_gemini._run_gemini(prompt="work", profile=profile, working_dir=tmp_path, quiet=True)
+
+    kwargs = wrapper.call_args.kwargs
+    assert kwargs["capability_profile"] == "xcode"
+    assert kwargs["capability_write_roots"] == ("/opt/toolchain",)
+    assert kwargs["capability_mach_services"] == ("com.example.toolchaind",)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Targeted review found the project-extensible sandbox grants wired through config, coordinator audit, supported runners, and fail-closed refusal paths. | [google-gemini-3.5-flash-api] The project-extensible sandbox capability model has been cleanly implemented, thoroughly tested at both unit and integration levels, and is fully ready to merge.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $11.72
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A project cannot extend a sandbox capability preset, so a toolchain need the shipped presets do not anticipate has no configuration path (GitHub Issue #2038)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2038