### PR TITLE
Measure how often dev resolves an advisory plan-review finding, so the approve-with-findings policy can be decided on evidence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,11 @@ then [vision.md](vision.md) for the philosophy and reading order.
   — spike record for issue #2348: design, POC and the **defer** decision for a
   codebase-scoped structural-decay observer, with the data condition that
   reopens it.
+- [plans/2112-plan-advisory-resolution.md](plans/2112-plan-advisory-resolution.md)
+  — measurement record for issue #2112: how often dev resolves an advisory
+  plan-review finding, broken out by finding class, with the four escapes named
+  and plan-review cost as a fraction of the story it guarded. Reproduce with
+  `forge audits plan-advisory`.
 - [plans/1848-reviewer-finding-fate-spike.md](plans/1848-reviewer-finding-fate-spike.md)
   — spike record for issue #1848: finding-fate derivation from structured
   code-review records, the live Thursday, August 20, 2026 POC output, and the

--- a/docs/plans/2112-plan-advisory-resolution.md
+++ b/docs/plans/2112-plan-advisory-resolution.md
@@ -1,0 +1,157 @@
+# Measurement: how often dev resolves an advisory plan-review finding
+
+Status: record (2026-08-19, issue #2112). This is a measurement, not a policy
+change. It replaces an instinct with a number; what to do about the number is a
+separate decision this record does not pre-empt.
+
+Reproduce with `forge audits plan-advisory` (add `--verbose` for each finding's
+text and the evidence its judgment cites). The read model lives at
+`src/theforge/plan_advisory/`; the judgment corpus is
+`src/theforge/plan_advisory/judgments.json`.
+
+## The question
+
+Plan review approves a plan while holding unresolved P1-level findings and
+passes them to dev as advisory context. The policy has never been evaluated
+against outcomes. It turns on one unmeasured quantity: **how often does dev
+resolve an advisory plan finding it was handed?**
+
+## Result
+
+```
+Plan advisory resolution — 29 runs, 104 judged findings of 104 extracted (coverage 100%)
+  audit records scanned: 254
+  corpus: completed (DONE) runs carrying a plan review with P1-level plan findings
+  excluded by final_phase: 8 run(s) carrying 29 P1-level finding(s) (reached dev but did not ship)
+  P2 plan findings out of scope: 56
+  P1-level findings raised: 119; 15 resolved by plan regeneration before dev (not advisory, excluded from the rate)
+  unjudged findings excluded from every rate: 0
+  judgments carrying no citable evidence: 0
+
+overall: 100/104 advisory findings resolved (96%); 100 shipped-addressed, 4 not
+
+class                        findings  resolved  escaped   rate
+---------------------------------------------------------------
+missing failure mode               25        23        2    92%
+module/placement                   25        25        0   100%
+unspecified mechanism              19        18        1    95%
+scope / out-of-scope               16        15        1    94%
+factual error in rationale         10        10        0   100%
+contract/interface mismatch         5         5        0   100%
+test strategy gap                   3         3        0   100%
+already-implemented                 1         1        0   100%
+
+plan review cost:  median $4.97/story (n=18)   median 24% of story cost (n=17)
+  of 29 corpus run(s): 11 record no plan-review cost, 12 no story total — both omitted rather than imputed
+
+escapes by later detection point:
+  unshipped 2 · adopter run 1 · own later story 1
+
+escaped findings (4):
+  issue-2050   unspecified mechanism      not addressed  -> caught at adopter run
+  issue-2111   missing failure mode       not addressed  -> caught at own later story
+  issue-2284   scope / out-of-scope       not addressed  -> never caught (still latent)
+  issue-2347   missing failure mode       not addressed  -> never caught (still latent)
+```
+
+## What the four escapes are
+
+- **issue-2050 · unspecified mechanism · adopter run.** The plan defined a
+  request/response channel but not how the agent blocks between writing a
+  request and reading a response. `2d5bfdd1` shipped the protocol without the
+  discipline. Rediscovered when an adopter story produced no work at all;
+  shipped as #2077 at roughly $4.43 across the wasted run and two fix stories,
+  plus two days during which the adopter could not use the capability.
+- **issue-2111 · missing failure mode · own later story.** Ungating
+  `_has_base_commit_referencing_issue` let a bare `#N` mention count as merge
+  evidence. Caught by issue-2374, which needed `e82b1478` plus two further fix
+  commits (`76cf65cc`, `2c67da01`) to narrow it.
+- **issue-2284 · scope / out-of-scope · never caught.** `a96d96bc` changed what
+  `dev_cost_estimate_usd` means (score-scoped history × `BAND_HEADROOM`) without
+  touching the two consumers that read `state.adaptive_dev_cost_estimate_usd` as
+  an overrun threshold (`dev_phase.py:1666,1676`, `review_phase.py:2326`). Still
+  latent.
+- **issue-2347 · missing failure mode · never caught.** `617e1014` added
+  `CoordinatorState.changed_files` without registering it with
+  `resume_persistence.py`, which serializes explicit blocks. A resumed run drops
+  the capture silently. Still latent.
+
+## What this does and does not establish
+
+The rate is **96%**, and no class falls out of line the way the spec anticipated
+`unspecified mechanism` might: its 95% sits inside the spread of every other
+class with more than a handful of findings. On this corpus there is no class
+whose escape rate justifies an extra plan round on its own.
+
+The cost side sharpens that. Plan review is a **median 24% of story cost** —
+several times the 3.7% the story's illustrative shape assumed. An additional
+plan round is not a rounding error against what it guards; it is a quarter of
+the story again, spent on 104 findings to catch some fraction of four.
+
+Three qualifications, all of which the report renders rather than hides:
+
+1. **Escapes are cheap to detect and expensive to miss, asymmetrically.** Two of
+   four escapes were caught downstream, at real but bounded cost. The other two
+   were never caught and are still latent — they were found *by this analysis*,
+   not by any process. A 96% rate says nothing about the tail cost of the 4%.
+2. **The cost denominator is thin.** 11 of 29 corpus runs record no plan-review
+   cost and 12 no story total, so the 24% median rests on 17 runs. These are the
+   cost-unmeasured runs (#2019, #2020 and successors); the omissions are counted
+   rather than imputed.
+3. **DONE-only selection is a real bias.** 8 further runs carried 29 P1-level
+   plan findings and ended `ESCALATE`, `MERGE_FAILED` or `PLAN_REVIEW`. "Did the
+   change that shipped address it" has no answer where nothing shipped, so they
+   are excluded from the rate — but a plan finding escaping into a run that then
+   escalated is exactly the expensive shape, and it is not represented here.
+
+Two facts from the substrate also correct the story's stated census, which was
+written against nine runs and is stale:
+
+- Plan **regeneration does happen**: 15 of 119 P1-level findings (12.6%) were
+  resolved by a regenerated plan before dev saw them, across runs including
+  issue-2335 and issue-2347. The policy is not "never regenerate".
+- The corpus is 29 runs and 119 P1-level findings, not 9 and 11.
+
+## Choosing among the three options
+
+- **Keep advisory-only.** Supported by everything above: a 96% resolution rate
+  against a plan phase already costing a median 24% of the story. This is the
+  option the numbers favour.
+- **Amend plans for selected finding classes.** Not supported. The class table
+  gives no candidate — `unspecified mechanism` is 95%, and the two classes
+  carrying escapes (`missing failure mode` at 92%, `scope / out-of-scope` at
+  94%) are the two largest and most heterogeneous, so gating on them means
+  gating on most findings.
+- **Carry unresolved plan findings forward into review.** The option the escapes
+  actually point at, and the one this measurement cannot decide. All four
+  escapes are of a shape code review is positioned to catch — a consumer not
+  updated, a state field not persisted, a channel with no blocking discipline —
+  and two of them were never caught by anything. Unlike an extra plan round, it
+  costs no additional agent invocation: the findings already exist and review
+  already runs. Deciding it needs a measurement this record does not make: how
+  often review would have caught them if it had been handed them.
+
+## Corpus construction and exclusions
+
+- **Mechanical half** (read-only, from the audit substrate via `open_readonly`):
+  which P1-level findings each run carried, their registry dispositions, and
+  `plan_review.cost_usd` against `cost.total_usd`.
+- **Judged half** (`judgments.json`): finding class and whether the change that
+  shipped addressed it. No audit field records either —
+  `plan_finding_registry` entries carry only `description`, `severity`,
+  `original_severity`, `effective_severity`, `cycle_first_seen`,
+  `cycle_last_seen` and an in-run `disposition`, none of which speak to the
+  shipped diff. Every row cites a commit, a code site, or the run's own dev
+  handoff notes; the report counts rows marked `evidence unavailable` separately
+  (currently 0).
+- **Findings are keyed** by `run_id:ordinal:sha256(normalized description)[:8]`,
+  so a re-ordered registry or a repeated description in one run both survive.
+- **Coverage is validated in one direction.** A judgment naming no carried
+  finding is a hard error. An audit finding with no judgment is not: it is
+  counted as unjudged, rendered, and excluded from every rate denominator, so
+  the substrate can grow past the corpus without the rate silently narrowing.
+- **Excluded:** P2 plan findings (56); P1-level findings resolved by plan
+  regeneration before dev (15); runs that did not reach `DONE` (8 runs, 29
+  findings, enumerated in the report).
+- **Not available:** the `hdp` adopter's three plan-review runs. That repository
+  is not reachable from this workspace, so its records are in no count here.

--- a/src/theforge/cli/audits.py
+++ b/src/theforge/cli/audits.py
@@ -22,8 +22,44 @@ def cmd_audits(args: object) -> int:
         return _cmd_audits_skips(args)
     if sub == "alias-drift":
         return _cmd_audits_alias_drift(args)
+    if sub == "plan-advisory":
+        return _cmd_audits_plan_advisory(args)
     print(f"forge audits: unknown subcommand {sub!r}", file=sys.stderr)
     return 2
+
+
+def _cmd_audits_plan_advisory(args: object) -> int:
+    """Report how often dev resolved an advisory plan-review finding (issue #2112).
+
+    Plan review approves plans while still holding P1-level findings and hands
+    them to dev as advisory context. This joins those findings to a checked-in
+    judgment corpus and renders the resolution rate by finding class, the
+    enumerable resolved and escaped findings, and plan-review cost as a fraction
+    of the story it guarded.
+
+    Thin by construction (CLI CONVENTIONS): loading, joining and rendering all
+    live in ``theforge.plan_advisory``; this resolves the project root and prints.
+    """
+    from theforge.plan_advisory.analysis import CorpusMismatchError  # noqa: PLC0415
+    from theforge.plan_advisory.report import load_report, render  # noqa: PLC0415
+
+    config_path = _find_config(Path(args.config).resolve() if args.config else None)
+    if config_path is None:
+        print("[forge] forge.yaml not found. Run from a forge project root.", file=sys.stderr)
+        return 1
+    try:
+        report = load_report(config_path.parent)
+    except audit_substrate.SubstrateError as exc:
+        print(f"[forge] {exc}", file=sys.stderr)
+        return 1
+    except CorpusMismatchError as exc:
+        print(
+            f"[forge] the plan-advisory judgment corpus does not match the audit substrate: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(render(report, verbose=bool(getattr(args, "verbose", False))))
+    return 0
 
 
 def _cmd_audits_alias_drift(args: object) -> int:
@@ -525,6 +561,20 @@ def register_parser(subparsers: object) -> None:
         help="Only show configured identities that resolved to more than one model",
     )
     alias_drift_parser.add_argument(
+        "--config",
+        help="Path to forge.yaml (default: auto-detect)",
+    )
+
+    plan_advisory_parser = audits_sub.add_parser(
+        "plan-advisory",
+        help="Report how often dev resolved an advisory plan-review finding",
+    )
+    plan_advisory_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Include each finding's text and the evidence its judgment cites",
+    )
+    plan_advisory_parser.add_argument(
         "--config",
         help="Path to forge.yaml (default: auto-detect)",
     )

--- a/src/theforge/cli/audits.py
+++ b/src/theforge/cli/audits.py
@@ -53,10 +53,7 @@ def _cmd_audits_plan_advisory(args: object) -> int:
         print(f"[forge] {exc}", file=sys.stderr)
         return 1
     except CorpusMismatchError as exc:
-        print(
-            f"[forge] the plan-advisory judgment corpus does not match the audit substrate: {exc}",
-            file=sys.stderr,
-        )
+        print(f"[forge] plan-advisory judgment corpus unusable: {exc}", file=sys.stderr)
         return 1
     print(render(report, verbose=bool(getattr(args, "verbose", False))))
     return 0

--- a/src/theforge/plan_advisory/__init__.py
+++ b/src/theforge/plan_advisory/__init__.py
@@ -1,0 +1,36 @@
+"""Plan-advisory resolution measurement (#2112).
+
+Plan review approves plans while holding unresolved P1-level findings and hands
+them to dev as advisory context. This package measures the one quantity that
+policy turns on: how often the change that shipped addressed such a finding.
+
+The measurement is read-only over the audit substrate for the mechanical half
+(which findings existed, what each run cost) and a checked-in, hand-authored
+judgment corpus for the half no field records (was the finding addressed, and of
+what class). ``analysis`` is pure aggregation; ``report`` loads the substrate and
+renders.
+"""
+
+from __future__ import annotations
+
+from .analysis import (
+    ESCAPED,
+    EVIDENCE_UNAVAILABLE,
+    FINDING_CLASSES,
+    RESOLVED,
+    CorpusMismatchError,
+    analyze,
+    extract_plan_findings,
+    finding_key,
+)
+
+__all__ = [
+    "ESCAPED",
+    "EVIDENCE_UNAVAILABLE",
+    "FINDING_CLASSES",
+    "RESOLVED",
+    "CorpusMismatchError",
+    "analyze",
+    "extract_plan_findings",
+    "finding_key",
+]

--- a/src/theforge/plan_advisory/__main__.py
+++ b/src/theforge/plan_advisory/__main__.py
@@ -1,0 +1,8 @@
+"""``python -m theforge.plan_advisory`` entry point."""
+
+import sys
+
+from .report import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/theforge/plan_advisory/analysis.py
+++ b/src/theforge/plan_advisory/analysis.py
@@ -73,7 +73,12 @@ _FIXED_IN_PLAN = "fixed"
 
 
 class CorpusMismatchError(RuntimeError):
-    """The judgment corpus does not line up with the audit substrate."""
+    """The judgment corpus is unusable: unreadable, or at odds with the substrate.
+
+    Both mean the same thing to whoever is looking at the report — no rate can be
+    computed and the corpus file is what to inspect — so they are one signal
+    rather than two an operator would have to tell apart.
+    """
 
 
 @dataclass(frozen=True)

--- a/src/theforge/plan_advisory/analysis.py
+++ b/src/theforge/plan_advisory/analysis.py
@@ -1,0 +1,407 @@
+"""Pure extraction and aggregation for the plan-advisory resolution measure (#2112).
+
+Two halves meet here and the seam between them is deliberate:
+
+* **Mechanical** — which P1-level plan findings a run carried, and what the plan
+  review cost against the story it guarded. Both come straight out of audit
+  records; nothing here interprets them.
+* **Judged** — what class a finding belongs to and whether the change that
+  shipped addressed it. No audit field records either (``plan_finding_registry``
+  entries carry only description, severity, cycle window and an in-run
+  disposition), so these come from a checked-in corpus of hand-authored rows.
+
+The join between them is by stable finding key, and it is validated in one
+direction only. A judgment naming a finding that no audit record carries is a
+hard error — the corpus has drifted from the substrate and every rate computed
+from it is suspect. An audit finding with no judgment is *not* an error: the
+substrate grows faster than findings can be judged, so unjudged findings are
+counted, reported, and excluded from every rate denominator. A rate that silently
+covered only part of its corpus would be worse than one that says so.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import statistics
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+RESOLVED = "resolved"
+ESCAPED = "escaped"
+
+#: Marker a judgment sets in ``evidence`` when nothing citable was found. Counted
+#: and rendered separately so an under-evidenced corpus is visible rather than
+#: averaged in alongside evidenced rows.
+EVIDENCE_UNAVAILABLE = "evidence unavailable"
+
+#: Controlled class vocabulary, seeded from the story's example. Kept closed so
+#: classes stay comparable across judgments; a genuinely novel finding shape
+#: warrants a new entry here rather than a free-text class on one row.
+FINDING_CLASSES = (
+    "module/placement",
+    "scope / out-of-scope",
+    "unspecified mechanism",
+    "factual error in rationale",
+    "already-implemented",
+    "missing failure mode",
+    "contract/interface mismatch",
+    "test strategy gap",
+)
+
+#: Where an escaped finding was eventually caught. ``unshipped`` means it never
+#: was — the defect is still latent as far as the corpus can tell.
+DETECTION_POINTS = (
+    "own code review",
+    "own gate",
+    "own later story",
+    "adopter run",
+    "operator",
+    "unshipped",
+)
+
+_DONE = "DONE"
+_WS = re.compile(r"\s+")
+
+#: Registry disposition meaning the finding was gone by the last plan-review
+#: cycle — the plan was regenerated and the finding did not survive. Such a
+#: finding was never handed to dev as advisory context, so it cannot answer the
+#: question this measure asks. Counted, reported, and kept out of the rate.
+_FIXED_IN_PLAN = "fixed"
+
+
+class CorpusMismatchError(RuntimeError):
+    """The judgment corpus does not line up with the audit substrate."""
+
+
+@dataclass(frozen=True)
+class PlanFinding:
+    """One P1-level advisory plan finding extracted from an audit record."""
+
+    key: str
+    run_id: str
+    slug: str
+    ordinal: int
+    severity: str
+    description: str
+    disposition: str
+
+    @property
+    def carried_to_dev(self) -> bool:
+        """True when the approved plan still held this finding at dev handoff."""
+        return self.disposition != _FIXED_IN_PLAN
+
+
+@dataclass
+class RunCost:
+    """Plan-review cost against total story cost for one run."""
+
+    run_id: str
+    slug: str
+    plan_review_usd: float | None
+    total_usd: float | None
+
+    @property
+    def fraction(self) -> float | None:
+        if self.plan_review_usd is None or not self.total_usd:
+            return None
+        return self.plan_review_usd / self.total_usd
+
+
+@dataclass
+class Extraction:
+    """Everything the substrate can say on its own, before any judgment."""
+
+    findings: list[PlanFinding] = field(default_factory=list)
+    costs: list[RunCost] = field(default_factory=list)
+    runs: list[str] = field(default_factory=list)
+    excluded_runs: list[dict[str, Any]] = field(default_factory=list)
+    records_scanned: int = 0
+    p2_findings_skipped: int = 0
+
+
+def normalize_description(text: str) -> str:
+    """Collapse a finding description to its comparison form."""
+    return _WS.sub(" ", str(text or "")).strip().lower()
+
+
+def finding_key(run_id: str, ordinal: int, description: str) -> str:
+    """Return the stable identity of one plan finding.
+
+    Ordinal alone would shift if a registry were ever re-ordered, and the
+    description hash alone collides when the same reviewer raises the same
+    finding twice in one run. Together they survive both.
+    """
+    digest = hashlib.sha256(normalize_description(description).encode("utf-8")).hexdigest()[:8]
+    return f"{run_id}:{ordinal}:{digest}"
+
+
+def is_p1_level(finding: Mapping[str, Any]) -> bool:
+    """True for P1 and its sub-severities (``P1-impl``, ``P1-spec``, ...)."""
+    severity = finding.get("effective_severity") or finding.get("severity") or ""
+    return str(severity).startswith("P1")
+
+
+def _plan_registry(record: Mapping[str, Any]) -> tuple[Mapping[str, Any] | None, list]:
+    plan_review = record.get("plan_review")
+    if not isinstance(plan_review, dict) or not plan_review.get("decision"):
+        return None, []
+    registry = plan_review.get("plan_finding_registry")
+    if not isinstance(registry, list):
+        return plan_review, []
+    return plan_review, registry
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def extract_plan_findings(records: Iterable[Mapping[str, Any]]) -> Extraction:
+    """Pull P1-level advisory plan findings and plan-review cost from audit records.
+
+    Only runs that reached ``DONE`` contribute to the rate corpus: "did the change
+    that shipped address it" has no answer for a run that never shipped one. Runs
+    that carried plan findings and ended otherwise are still counted and named in
+    ``excluded_runs``, because selection bias that nobody can see is selection
+    bias nobody can weigh.
+    """
+    out = Extraction()
+    for record in records:
+        out.records_scanned += 1
+        plan_review, registry = _plan_registry(record)
+        if plan_review is None or not registry:
+            continue
+        task = record.get("task") if isinstance(record.get("task"), dict) else {}
+        outcome = record.get("outcome") if isinstance(record.get("outcome"), dict) else {}
+        run_id = str(record.get("run_id") or "")
+        slug = str(task.get("slug") or task.get("issue_id") or "?")
+        final_phase = str(outcome.get("final_phase") or "?")
+
+        p1s = [f for f in registry if isinstance(f, dict) and is_p1_level(f)]
+        if final_phase != _DONE:
+            out.excluded_runs.append(
+                {
+                    "run_id": run_id,
+                    "slug": slug,
+                    "final_phase": final_phase,
+                    "p1_findings": len(p1s),
+                }
+            )
+            continue
+
+        out.p2_findings_skipped += len(registry) - len(p1s)
+        if not p1s:
+            continue
+        out.runs.append(run_id)
+        for ordinal, finding in enumerate(p1s):
+            description = str(finding.get("description") or "")
+            out.findings.append(
+                PlanFinding(
+                    key=finding_key(run_id, ordinal, description),
+                    run_id=run_id,
+                    slug=slug,
+                    ordinal=ordinal,
+                    severity=str(
+                        finding.get("effective_severity") or finding.get("severity") or "?"
+                    ),
+                    description=description,
+                    disposition=str(finding.get("disposition") or "?"),
+                )
+            )
+        cost = record.get("cost") if isinstance(record.get("cost"), dict) else {}
+        out.costs.append(
+            RunCost(
+                run_id=run_id,
+                slug=slug,
+                plan_review_usd=_as_float(plan_review.get("cost_usd")),
+                total_usd=_as_float(cost.get("total_usd")),
+            )
+        )
+    return out
+
+
+def _cost_summary(costs: Sequence[RunCost]) -> dict[str, Any]:
+    fractions = [c.fraction for c in costs if c.fraction is not None]
+    dollars = [c.plan_review_usd for c in costs if c.plan_review_usd is not None]
+    return {
+        "runs": len(costs),
+        "runs_with_plan_review_cost": len(dollars),
+        "runs_with_both": len(fractions),
+        "median_plan_review_usd": round(statistics.median(dollars), 4) if dollars else None,
+        "median_fraction_of_story": round(statistics.median(fractions), 4) if fractions else None,
+        "omitted_missing_plan_review_cost": sum(1 for c in costs if c.plan_review_usd is None),
+        "omitted_missing_total_cost": sum(1 for c in costs if not c.total_usd),
+    }
+
+
+def _validate(
+    extraction: Extraction, judgments: Sequence[Mapping[str, Any]]
+) -> dict[str, Mapping[str, Any]]:
+    by_key = {f.key: f for f in extraction.findings if f.carried_to_dev}
+    judged: dict[str, Mapping[str, Any]] = {}
+    orphans: list[str] = []
+    duplicates: list[str] = []
+    for row in judgments:
+        key = str(row.get("finding_key") or "")
+        if key not in by_key:
+            orphans.append(key)
+            continue
+        if key in judged:
+            duplicates.append(key)
+            continue
+        judged[key] = row
+    problems = []
+    if orphans:
+        problems.append(
+            f"{len(orphans)} judgment(s) name no advisory finding carried into dev: "
+            + ", ".join(sorted(orphans)[:5])
+        )
+    if duplicates:
+        problems.append(
+            f"{len(duplicates)} finding(s) judged more than once: " + ", ".join(sorted(duplicates))
+        )
+    bad_class = sorted(
+        {
+            str(row.get("class"))
+            for row in judgments
+            if str(row.get("class")) not in FINDING_CLASSES
+        }
+    )
+    if bad_class:
+        problems.append("class outside the controlled vocabulary: " + ", ".join(bad_class))
+    bad_outcome = sorted(
+        {
+            str(row.get("advisory_outcome"))
+            for row in judgments
+            if str(row.get("advisory_outcome")) not in (RESOLVED, ESCAPED)
+        }
+    )
+    if bad_outcome:
+        problems.append("advisory_outcome must be resolved/escaped: " + ", ".join(bad_outcome))
+    bad_point = sorted(
+        {
+            str(row.get("detection_point"))
+            for row in judgments
+            if row.get("advisory_outcome") == ESCAPED
+            and str(row.get("detection_point")) not in DETECTION_POINTS
+        }
+    )
+    if bad_point:
+        problems.append("detection_point outside the vocabulary: " + ", ".join(bad_point))
+    if problems:
+        raise CorpusMismatchError("; ".join(problems))
+    return judged
+
+
+def analyze(extraction: Extraction, judgments: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Join extracted findings to the judgment corpus and aggregate the decision report.
+
+    Rates are computed over judged findings only. Both the advisory-resolution
+    outcome and the final shipped-addressed status are carried through, because
+    they are different questions: dev can leave an advisory finding untouched in
+    the run it was raised against and the eventual shipped change can still carry
+    the remedy — or not.
+    """
+    judged = _validate(extraction, judgments)
+    carried = [f for f in extraction.findings if f.carried_to_dev]
+    by_key = {f.key: f for f in carried}
+
+    per_class: dict[str, Counter] = {}
+    resolved_rows: list[dict[str, Any]] = []
+    escaped_rows: list[dict[str, Any]] = []
+    detection_points: Counter = Counter()
+    shipped_addressed = 0
+    shipped_unaddressed = 0
+    evidence_unavailable = 0
+
+    for key, row in sorted(judged.items(), key=lambda kv: (by_key[kv[0]].slug, kv[0])):
+        finding = by_key[key]
+        cls = str(row["class"])
+        outcome = str(row["advisory_outcome"])
+        counts = per_class.setdefault(cls, Counter())
+        counts["findings"] += 1
+        counts[outcome] += 1
+
+        evidence = str(row.get("evidence") or "").strip()
+        if not evidence or evidence == EVIDENCE_UNAVAILABLE:
+            evidence_unavailable += 1
+        if row.get("shipped_addressed"):
+            shipped_addressed += 1
+            counts["shipped_addressed"] += 1
+        else:
+            shipped_unaddressed += 1
+
+        entry = {
+            "finding_key": key,
+            "run_id": finding.run_id,
+            "slug": finding.slug,
+            "class": cls,
+            "severity": finding.severity,
+            "description": finding.description,
+            "shipped_addressed": bool(row.get("shipped_addressed")),
+            "detection_point": row.get("detection_point"),
+            "evidence": evidence or EVIDENCE_UNAVAILABLE,
+        }
+        if outcome == RESOLVED:
+            resolved_rows.append(entry)
+        else:
+            escaped_rows.append(entry)
+            detection_points[str(row.get("detection_point"))] += 1
+
+    classes = []
+    for cls in sorted(per_class, key=lambda c: (-per_class[c]["findings"], c)):
+        counts = per_class[cls]
+        total = counts["findings"]
+        classes.append(
+            {
+                "class": cls,
+                "findings": total,
+                "resolved": counts[RESOLVED],
+                "escaped": counts[ESCAPED],
+                "shipped_addressed": counts["shipped_addressed"],
+                "rate": round(counts[RESOLVED] / total, 4) if total else None,
+            }
+        )
+
+    judged_count = len(judged)
+    extracted = len(carried)
+    total_resolved = sum(c["resolved"] for c in classes)
+    return {
+        "corpus": {
+            "records_scanned": extraction.records_scanned,
+            "runs": len(extraction.runs),
+            "p1_findings_raised": len(extraction.findings),
+            "findings_fixed_in_plan": len(extraction.findings) - extracted,
+            "findings_extracted": extracted,
+            "findings_judged": judged_count,
+            "findings_unjudged": extracted - judged_count,
+            "coverage": round(judged_count / extracted, 4) if extracted else None,
+            "p2_findings_skipped": extraction.p2_findings_skipped,
+            "excluded_runs": extraction.excluded_runs,
+            "excluded_run_count": len(extraction.excluded_runs),
+            "excluded_run_findings": sum(int(r["p1_findings"]) for r in extraction.excluded_runs),
+            "evidence_unavailable": evidence_unavailable,
+        },
+        "overall": {
+            "findings": judged_count,
+            "resolved": total_resolved,
+            "escaped": judged_count - total_resolved,
+            "rate": round(total_resolved / judged_count, 4) if judged_count else None,
+            "shipped_addressed": shipped_addressed,
+            "shipped_unaddressed": shipped_unaddressed,
+        },
+        "classes": classes,
+        "resolved_findings": resolved_rows,
+        "escaped_findings": escaped_rows,
+        "escapes_by_detection_point": dict(detection_points.most_common()),
+        "cost": _cost_summary(extraction.costs),
+        "unjudged_findings": [
+            {"finding_key": f.key, "run_id": f.run_id, "slug": f.slug}
+            for f in carried
+            if f.key not in judged
+        ],
+    }

--- a/src/theforge/plan_advisory/judgments.json
+++ b/src/theforge/plan_advisory/judgments.json
@@ -1,0 +1,946 @@
+{
+  "corpus_version": 1,
+  "notes": "Judgments are hand-authored for every P1-level plan finding the approved plan carried into dev on a completed (DONE) local run, as of 2026-08-19. Each row was decided by reading the finding against the shipped diff, the run's own dev handoff notes, and the code as it stands. Findings whose registry disposition is 'fixed' were resolved by plan regeneration before dev ever saw them and are excluded by the analyzer, not judged here. The hdp adopter's three runs are not reachable from this repository and are not in the corpus.",
+  "judgments": [
+    {
+      "finding_key": "726945a4203a:0:04006af7",
+      "run_id": "726945a4203a",
+      "slug": "issue-1019",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "fad876d0 adds the per-axis threshold/bucket fields and updates the consumers beyond the plan's three test files: src/theforge/cli/explain.py renders them and tests/test_cli_explain.py pins that rendering."
+    },
+    {
+      "finding_key": "82b965babe1e:0:1d7cb5b2",
+      "run_id": "82b965babe1e",
+      "slug": "issue-1904",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "67b1e0d4 updates three of the four named files (tests/test_diagnosis_spec.py, tests/test_fix_readiness.py, tests/test_shape_verdict_diagnosis_split.py); test_diagnose_types.py needed no change because src/theforge/diagnose_types.py dropped the component rather than renaming it."
+    },
+    {
+      "finding_key": "82b965babe1e:1:d92c1459",
+      "run_id": "82b965babe1e",
+      "slug": "issue-1904",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "67b1e0d4 deletes _RULED_OUT_RE from src/theforge/shape_check/heuristics.py outright and rewrites _diagnosis_cause_unknown, so the misclassification path the finding described cannot arise."
+    },
+    {
+      "finding_key": "2039e6241e01:0:b89c13a2",
+      "run_id": "2039e6241e01",
+      "slug": "issue-1947",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "5bb31329 threads the preset through config/types.py and config/load.py into runners/runner_claude.py, runners/runner_gemini.py and runners/sandbox.py; runners/cli.py (the plan's named site) is untouched."
+    },
+    {
+      "finding_key": "2039e6241e01:1:96e46783",
+      "run_id": "2039e6241e01",
+      "slug": "issue-1947",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "5bb31329 writes the capability fields in src/theforge/coordinator/audit.py as well as audit_substrate.py, and ships tests/fixtures/audit_record_schema_v10.json."
+    },
+    {
+      "finding_key": "2039e6241e01:2:d3e519ca",
+      "run_id": "2039e6241e01",
+      "slug": "issue-1947",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "5bb31329 documents the forge.yaml key in docs/guides/inputs-reference.md (+56); docs/reference, which the plan named, is untouched."
+    },
+    {
+      "finding_key": "2039e6241e01:3:a2c5c869",
+      "run_id": "2039e6241e01",
+      "slug": "issue-1947",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "5bb31329 modifies src/theforge/coordinator/audit.py (+12) to carry the capability profile into the run record."
+    },
+    {
+      "finding_key": "2039e6241e01:4:34471515",
+      "run_id": "2039e6241e01",
+      "slug": "issue-1947",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same defect as the finding at ordinal 0, raised by a second reviewer; 5bb31329 wires runner_claude.py and runner_gemini.py directly."
+    },
+    {
+      "finding_key": "2039e6241e01:5:6ea24b72",
+      "run_id": "2039e6241e01",
+      "slug": "issue-1947",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same defect as the finding at ordinal 1, raised by a second reviewer; 5bb31329 changes coordinator/audit.py, not the substrate layer alone."
+    },
+    {
+      "finding_key": "94020c5a735a:0:24adc8f6",
+      "run_id": "94020c5a735a",
+      "slug": "issue-2003",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "0f271c9a changes src/theforge/coordinator/workspace.py (+24) alongside sprint/launch_guard.py and sprint/runner.py, so the sweep the finding named is covered."
+    },
+    {
+      "finding_key": "94020c5a735a:1:dd9c4521",
+      "run_id": "94020c5a735a",
+      "slug": "issue-2003",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "0f271c9a decides it explicitly: src/theforge/sprint/live_stories.py states a live worktree 'must not be re-dispatched while the inherited agent runs' and supplies await_inherited_agents / reclaim_inherited_agents."
+    },
+    {
+      "finding_key": "94020c5a735a:2:68364883",
+      "run_id": "94020c5a735a",
+      "slug": "issue-2003",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "0f271c9a rewrites the dispatch point in src/theforge/sprint/runner.py (+262) so re-exec enters continuation handling; covered by tests/test_sprint_reexec_continuation.py."
+    },
+    {
+      "finding_key": "3dcd2e32efda:0:203f7dea",
+      "run_id": "3dcd2e32efda",
+      "slug": "issue-1937",
+      "class": "already-implemented",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "b0d034e8 ships one mechanism, not two: the no-merge disposition path stays in src/theforge/sprint/sources.py (+153) and no parallel comment/close path was added."
+    },
+    {
+      "finding_key": "3dcd2e32efda:1:e5becf4d",
+      "run_id": "3dcd2e32efda",
+      "slug": "issue-1937",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "b0d034e8 does not touch coordinator/preflight_flow.py; the disposition hook lives in sprint/sources.py where the story source is in scope."
+    },
+    {
+      "finding_key": "3dcd2e32efda:2:df148cf5",
+      "run_id": "3dcd2e32efda",
+      "slug": "issue-1937",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "b0d034e8 does not touch src/theforge/operator_action_queue.py; the operator-action labelling is done in sprint/sources.py instead, so the non-existent queue API was never relied on."
+    },
+    {
+      "finding_key": "3dcd2e32efda:3:319be450",
+      "run_id": "3dcd2e32efda",
+      "slug": "issue-1937",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "b0d034e8 leaves src/theforge/sprint/rca.py alone and splits the ALREADY SATISFIED bucket in cli/sprint_digest.py (+47), so ALREADY_DONE stays in the succeeded set as the finding required."
+    },
+    {
+      "finding_key": "cd127a3e2b3c:0:611fcdca",
+      "run_id": "cd127a3e2b3c",
+      "slug": "issue-1945",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "d83ef3a0 makes gate_timeout explicitly per-leg: coordinator/gate.py passes gate_timeout into each leg runner and comments that continuing would 'spend another full gate_timeout per' leg. (The story was later reverted wholesale by 839ca5cc for unrelated reasons.)"
+    },
+    {
+      "finding_key": "cd127a3e2b3c:1:2b57eb33",
+      "run_id": "cd127a3e2b3c",
+      "slug": "issue-1945",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "d83ef3a0 changes coordinator/validate_phase.py (+29) to per-leg trace names '{iter}-gate-py{version}.txt' via a new _gate_trace_path, with tests/test_validate_phase.py (+63)."
+    },
+    {
+      "finding_key": "6f619a5997a1:0:ffcfb300",
+      "run_id": "6f619a5997a1",
+      "slug": "issue-2019",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "e98a2d8e restates the correction in the code: the _UNTRACKED_COST_CLIS comment in sprint/runner.py now says the set 'is only the pre-sprint warning, evaluated over config profiles before any run exists', and the real unblock is the measured cost in runners/runner_codex.py (+317)."
+    },
+    {
+      "finding_key": "6f619a5997a1:1:e498b9f7",
+      "run_id": "6f619a5997a1",
+      "slug": "issue-2019",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "e98a2d8e adds _agent_text_from_events / _looks_like_codex_events in runners/runner_codex.py and replaces the raw-stdout fallback, with a comment naming the JSONL-into-handoff failure the finding described."
+    },
+    {
+      "finding_key": "6f619a5997a1:2:3aee9479",
+      "run_id": "6f619a5997a1",
+      "slug": "issue-2019",
+      "class": "contract/interface mismatch",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "e98a2d8e updates tests/test_runner_api_local.py (+28) and keeps the PRICING_TABLE unpacking in runners/runner_claude.py working unchanged."
+    },
+    {
+      "finding_key": "6f619a5997a1:3:81b71185",
+      "run_id": "6f619a5997a1",
+      "slug": "issue-2019",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "e98a2d8e makes the runners/cli.py change opt-in: partial_cost_fn defaults to None and its docstring states Claude and Gemini 'behave exactly as before'."
+    },
+    {
+      "finding_key": "6f619a5997a1:4:846642e6",
+      "run_id": "6f619a5997a1",
+      "slug": "issue-2019",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "e98a2d8e keeps _estimate_cost backward-compatible \u2014 runners/adapters/{openai,google,anthropic}.py are untouched and still call it positionally."
+    },
+    {
+      "finding_key": "dc070b9d88ab:0:e4193a97",
+      "run_id": "dc070b9d88ab",
+      "slug": "issue-2050",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "escaped",
+      "shipped_addressed": false,
+      "evidence": "2d5bfdd1 defines the request/response artifact protocol in coordinator/dev_verification.py but no blocking discipline between write and read. Rediscovered when an adopter story produced no work at all and shipped as #2077; ~$4.43 across the wasted run and two fix stories.",
+      "detection_point": "adopter run"
+    },
+    {
+      "finding_key": "dc070b9d88ab:1:1bb88d38",
+      "run_id": "dc070b9d88ab",
+      "slug": "issue-2050",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "2d5bfdd1 constructs the broker once per iteration in coordinator/dev_phase.py and starts it outside the transport-retry loop, so max_requests is a defined per-iteration budget across retries."
+    },
+    {
+      "finding_key": "5564b09a9fa2:0:42224251",
+      "run_id": "5564b09a9fa2",
+      "slug": "issue-2107",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "59397a3f uses fcntl.flock on a separately-opened descriptor per acquisition and documents why: 'POSIX record locks (fcntl.lockf) are per-process' and would not serialize threads."
+    },
+    {
+      "finding_key": "5564b09a9fa2:1:c942e60a",
+      "run_id": "5564b09a9fa2",
+      "slug": "issue-2107",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "59397a3f adds the shared_infrastructure_abort rule to src/theforge/sprint/rca.py (+100) and bumps RULESET_VERSION to 6."
+    },
+    {
+      "finding_key": "5564b09a9fa2:2:1a998b09",
+      "run_id": "5564b09a9fa2",
+      "slug": "issue-2107",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "59397a3f moves _maybe_file_issue out of the locked span: advisory_conventions.py now takes the lock, releases it, calls _maybe_file_issue, then re-acquires."
+    },
+    {
+      "finding_key": "5564b09a9fa2:3:f948cf06",
+      "run_id": "5564b09a9fa2",
+      "slug": "issue-2107",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same defect as ordinal 1, raised by a second reviewer; 59397a3f adds the RCA rule so cli/sprint_digest.py renders it instead of unknown_needs_rca."
+    },
+    {
+      "finding_key": "30df162d0f7f:0:d8bbe08a",
+      "run_id": "30df162d0f7f",
+      "slug": "issue-2111",
+      "class": "missing failure mode",
+      "advisory_outcome": "escaped",
+      "shipped_addressed": false,
+      "evidence": "cbb6b0b4 ungates _has_base_commit_referencing_issue without narrowing the match, so a bare '#N' mention counted as merge evidence. Caught later by issue-2374, which shipped e82b1478 'require a closing reference for commit-message merge evidence' plus two further fix commits (76cf65cc, 2c67da01).",
+      "detection_point": "own later story"
+    },
+    {
+      "finding_key": "30df162d0f7f:1:a5bf6c64",
+      "run_id": "30df162d0f7f",
+      "slug": "issue-2111",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "cbb6b0b4 replaces the bare 'except Exception: return no_merge' in sprint/dag.py with a fall-through to the remaining evidence sources; the commit body names discarding the fallback as the defect."
+    },
+    {
+      "finding_key": "77b94cd43a39:0:584705ca",
+      "run_id": "77b94cd43a39",
+      "slug": "issue-2155",
+      "class": "contract/interface mismatch",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "43aa6cf7 commits a new tests/fixtures/audit_record_schema_v19.json rather than editing v18, and bumps the version in coordinator/audit_substrate.py."
+    },
+    {
+      "finding_key": "77b94cd43a39:1:7f8d3136",
+      "run_id": "77b94cd43a39",
+      "slug": "issue-2155",
+      "class": "contract/interface mismatch",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same schema-versioning requirement as ordinal 0, stated by a second reviewer; 43aa6cf7 performs the full bump + v19 fixture + audit.py re-export sync."
+    },
+    {
+      "finding_key": "37f96ad44eef:0:00bd15bd",
+      "run_id": "37f96ad44eef",
+      "slug": "issue-751",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "aeabe578 changes src/theforge/config/_loaders.py, the omitted construction site for PlanAgentReviewConfig."
+    },
+    {
+      "finding_key": "37f96ad44eef:1:92bf99e4",
+      "run_id": "37f96ad44eef",
+      "slug": "issue-751",
+      "class": "contract/interface mismatch",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "aeabe578 adopts the reviewer's conclusion verbatim: config/types.py states 'TransportFallbackConfig is deliberately left alone: a ModelRef *contains* one', avoiding the mutual composition and import cycle."
+    },
+    {
+      "finding_key": "37f96ad44eef:2:e3db8a3e",
+      "run_id": "37f96ad44eef",
+      "slug": "issue-751",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "aeabe578 changes src/theforge/cli/shared.py (+7) to mutate the nested ref rather than the legacy scalars."
+    },
+    {
+      "finding_key": "37f96ad44eef:3:6056a5ee",
+      "run_id": "37f96ad44eef",
+      "slug": "issue-751",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "aeabe578 changes src/theforge/config/models.py (+12), the apply_model_info site the finding named."
+    },
+    {
+      "finding_key": "37f96ad44eef:4:ec757e50",
+      "run_id": "37f96ad44eef",
+      "slug": "issue-751",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Moot by the design the reviewer's own ordinal-1 finding produced: TransportFallbackConfig keeps its scalar fields, so _build_api_fallback_profile needs no change and aeabe578 does not touch src/theforge/runners/cli.py."
+    },
+    {
+      "finding_key": "37f96ad44eef:5:eb33eb58",
+      "run_id": "37f96ad44eef",
+      "slug": "issue-751",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same omission as ordinal 0, raised by a second reviewer; aeabe578 changes config/_loaders.py."
+    },
+    {
+      "finding_key": "37f96ad44eef:6:6c92f607",
+      "run_id": "37f96ad44eef",
+      "slug": "issue-751",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "aeabe578 changes src/theforge/config/profiles.py (+18), migrating iter_plan_phase_profiles."
+    },
+    {
+      "finding_key": "e416fd364095:0:e80b4e50",
+      "run_id": "e416fd364095",
+      "slug": "issue-1587",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "9751ca98 is test-only \u2014 tests/test_assignment.py, test_check_config.py, test_config_load.py, test_coord_model_profiles_seam.py, no src/ change \u2014 so the plan's false 'forge.yaml' expectation did not become a production edit to model resolution."
+    },
+    {
+      "finding_key": "0a1bf1592dc7:0:cafe2798",
+      "run_id": "0a1bf1592dc7",
+      "slug": "issue-2189",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6321453f excludes None from UNRESOLVED_LANDING_STATUSES in sprint/prior_landing.py with a comment naming the on_approve / no-landing case the finding described."
+    },
+    {
+      "finding_key": "0a1bf1592dc7:1:75a0c367",
+      "run_id": "0a1bf1592dc7",
+      "slug": "issue-2189",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6321453f gives the record a real landing shape: prior_landing.as_prior_record accepts the full story-entry mapping and landing_settled reads landing evidence, with sprint/runner.py (+175) writing it."
+    },
+    {
+      "finding_key": "aa7b4ca2cfc1:0:c30405ce",
+      "run_id": "aa7b4ca2cfc1",
+      "slug": "issue-2284",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Dev notes on the run record state 'the plan reviewer was right that it did not exist. Added RECONCILE_NONCOMPARABLE_DEV_ESTIMATE and a matching format_reconciliation branch'; shipped in a96d96bc."
+    },
+    {
+      "finding_key": "aa7b4ca2cfc1:1:2eeb4d82",
+      "run_id": "aa7b4ca2cfc1",
+      "slug": "issue-2284",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "a96d96bc sets audit['dev_cost_estimate_basis'] on all five estimate paths in coordinator/adaptive_iterations.py, including the adaptive-disabled and no-score early returns the finding named."
+    },
+    {
+      "finding_key": "aa7b4ca2cfc1:2:0bbcfbf7",
+      "run_id": "aa7b4ca2cfc1",
+      "slug": "issue-2284",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "escaped",
+      "shipped_addressed": false,
+      "evidence": "a96d96bc changes what dev_cost_estimate_usd means (score-scoped history x BAND_HEADROOM) but touches neither coordinator/dev_phase.py nor review_phase.py. Both still read state.adaptive_dev_cost_estimate_usd as an overrun threshold (dev_phase.py:1666,1676; review_phase.py:2326) and no later commit has revisited them.",
+      "detection_point": "unshipped"
+    },
+    {
+      "finding_key": "b95f23283829:0:15b233c5",
+      "run_id": "b95f23283829",
+      "slug": "issue-2351",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "49726723 adds RESUME_SELECTION_KEY to _METADATA_KEYS in coordinator/resume_persistence.py, which is exactly the exclusion the finding said was missing."
+    },
+    {
+      "finding_key": "b95f23283829:1:8e96aada",
+      "run_id": "b95f23283829",
+      "slug": "issue-2351",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "49726723 records prior_run_id / incoming_run_id on each selection entry \u2014 the top-level ids that do exist \u2014 rather than the per-block ids the plan assumed."
+    },
+    {
+      "finding_key": "a96d23c420c0:0:ac1be4b1",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6cfcd835 makes verified_on a required ISO date in config/model_identity.py: 'a verification that cannot expire is a permanent claim about something that changes'."
+    },
+    {
+      "finding_key": "a96d23c420c0:1:7dd07e3f",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Dev notes record the design: 'Step 5's provider invocation options on ModelProfile was implemented as one typed field (reasoning_mode) plus a routing.py change to the existing reasoning-effort axis'; 6cfcd835 changes routing.py, config/types.py and config/profiles.py."
+    },
+    {
+      "finding_key": "a96d23c420c0:2:08c6fbcf",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6cfcd835 changes runners/api.py, runners/finalizers.py and runners/adapters/openai.py (+110), the real loop and finalization paths the finding named."
+    },
+    {
+      "finding_key": "a96d23c420c0:3:ef7185c3",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6cfcd835 changes runners/adapters/openai.py and runners/api.py so cache_read_tokens flow through to _estimate_cost as cached_input_tokens."
+    },
+    {
+      "finding_key": "a96d23c420c0:4:27905033",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Deferred in the first iteration (the run's deferred_items say so) and delivered under review pressure in 715ed9f2, which adds COST_ESTIMATED_UNCONFIRMED to agent_types.COST_PROVENANCE_VALUES citing #2352."
+    },
+    {
+      "finding_key": "a96d23c420c0:5:5252b97b",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6cfcd835 rewrites assignment._thinking_spend_captured to ask pricing_for instead of indexing PRICING_TABLE; the dev notes name the reviewer's flag as the reason."
+    },
+    {
+      "finding_key": "a96d23c420c0:6:f6a2a398",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6cfcd835 does not fail load on unverified entries \u2014 only a 'retired' status without a retired_reason raises, and model_catalog.py records that 'an expired check is not bad configuration, it is configuration'."
+    },
+    {
+      "finding_key": "a96d23c420c0:7:0e5d384f",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Dev notes: 'WebFetch against api-docs.deepseek.com returned the served model list, the full pricing table ... so the replacements are provider-attested rather than guessed' \u2014 the finding's demand for a source was met rather than guessed at."
+    },
+    {
+      "finding_key": "a96d23c420c0:8:9cc83b11",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6cfcd835 changes runners/adapters/openai.py (+110) to read prompt_tokens_details / completion_tokens_details."
+    },
+    {
+      "finding_key": "a96d23c420c0:9:cee20d85",
+      "run_id": "a96d23c420c0",
+      "slug": "issue-2352",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6cfcd835 updates tests/test_model_catalog.py (+14) alongside the catalog change."
+    },
+    {
+      "finding_key": "21c042885a9d:0:4329fb07",
+      "run_id": "21c042885a9d",
+      "slug": "issue-2374",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "e82b1478 updates tests/test_sprint_resume.py (+76) as well as test_sprint_runner.py; test_sprint_run_id_rollover.py needed no change for the reason the finding itself gave (it passes the reason in)."
+    },
+    {
+      "finding_key": "9b9ce2a394d0:7:a305e45f",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "4dd555c8 separates the two ideas the plan conflated: runners/rate_registry.AccountingMode distinguishes PROVIDER_REPORTED / INDEPENDENTLY_MEASURED / TOKEN_ESTIMATED / TOKEN_ESTIMATED_IF_REPORTED, so 'no static rates' no longer implies 'unaccountable'."
+    },
+    {
+      "finding_key": "9b9ce2a394d0:11:e2187479",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "4dd555c8's install contract in runners/rate_registry.py states 'installation happens only after a ForgeConfig has been fully constructed, so a load that raises during validation never leaves its partial rates active', and makes the replacement explicit and logged ('last install wins')."
+    },
+    {
+      "finding_key": "9b9ce2a394d0:14:fbc3538b",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "4dd555c8's make_identity in runners/rate_registry.py refuses a partial key at construction: 'A partial key can never match a registry entry, so it is refused at construction rather than inserted and silently missed forever.'"
+    },
+    {
+      "finding_key": "9b9ce2a394d0:16:65ddccc5",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "4dd555c8 is titled 'resolve rates once onto the dispatched identity' and adds config/dispatch_rates.py, which compiles reachable identities to rates at load rather than converting at accounting time."
+    },
+    {
+      "finding_key": "9b9ce2a394d0:17:0c3b5073",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same registry-lifetime defect as ordinal 11, raised again in a later plan cycle; answered by the same install contract in runners/rate_registry.py."
+    },
+    {
+      "finding_key": "9b9ce2a394d0:18:6901e475",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "_UNTRACKED_COST_CLIS no longer exists in src/theforge/sprint/runner.py \u2014 4dd555c8 replaced the hardcoded set with AccountingMode."
+    },
+    {
+      "finding_key": "9b9ce2a394d0:19:b0f73496",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "4dd555c8 maps 'ghaw' to AccountingMode.INDEPENDENTLY_MEASURED in runners/rate_registry.py, exempting it from static-rate diagnostics."
+    },
+    {
+      "finding_key": "9b9ce2a394d0:20:7db791a2",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same Gemini/_UNTRACKED_COST_CLIS defect as ordinal 18; the set is gone from sprint/runner.py."
+    },
+    {
+      "finding_key": "9b9ce2a394d0:21:286a04cd",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same gh-aw exemption as ordinal 19; rate_registry.py:224 classifies it INDEPENDENTLY_MEASURED."
+    },
+    {
+      "finding_key": "9b9ce2a394d0:22:a9a9554f",
+      "run_id": "9b9ce2a394d0",
+      "slug": "issue-2335",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same Gemini/_UNTRACKED_COST_CLIS defect as ordinal 18; 4dd555c8 also changes runners/runner_gemini.py (+89) to record measured cost."
+    },
+    {
+      "finding_key": "41b3bef1268f:0:8295bb09",
+      "run_id": "41b3bef1268f",
+      "slug": "issue-2373",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "2c320330 changes src/theforge/sprint/audit.py, which is where _write_story_audit lives \u2014 the upstream serialization point the finding named \u2014 so the audit carries the sprint's recorded reason."
+    },
+    {
+      "finding_key": "41b3bef1268f:1:50fe6e7f",
+      "run_id": "41b3bef1268f",
+      "slug": "issue-2373",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "2c320330 keeps final_phase as an observation ('audit_final_phase') fed into a conflict diagnostic rather than making it authoritative for the terminal outcome."
+    },
+    {
+      "finding_key": "41b3bef1268f:2:81c9b96e",
+      "run_id": "41b3bef1268f",
+      "slug": "issue-2373",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "2c320330 lands its tests flat: tests/test_sprint_rca.py and the new tests/test_sprint_rca_cost_unknown_outcome.py; no tests/cli/ or tests/sprint/ package was invented."
+    },
+    {
+      "finding_key": "41b3bef1268f:3:7535f7f7",
+      "run_id": "41b3bef1268f",
+      "slug": "issue-2373",
+      "class": "contract/interface mismatch",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "2c320330 bumps RULESET_VERSION 11 -> 12 in sprint/rca.py and updates tests/test_sprint_rca.py (+21)."
+    },
+    {
+      "finding_key": "46b5281e27d6:0:603646db",
+      "run_id": "46b5281e27d6",
+      "slug": "issue-2325",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "d5689a35 puts the tests in the mirroring module the convention requires \u2014 tests/test_sprint_runner.py (+270) for src/theforge/sprint/runner.py \u2014 rather than a new location."
+    },
+    {
+      "finding_key": "46b5281e27d6:1:47c15038",
+      "run_id": "46b5281e27d6",
+      "slug": "issue-2325",
+      "class": "factual error in rationale",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "d5689a35 rewrites run_sprint's execution state across 1076 changed lines against the frame as it actually was, not the spec's stale 16-param / 6,953-line inventory."
+    },
+    {
+      "finding_key": "36d247a95b45:2:6f775039",
+      "run_id": "36d247a95b45",
+      "slug": "issue-2347",
+      "class": "missing failure mode",
+      "advisory_outcome": "escaped",
+      "shipped_addressed": false,
+      "evidence": "617e1014 adds CoordinatorState.changed_files in coordinator/state.py but never registers it with coordinator/resume_persistence.py, which serializes explicit blocks. resume_persistence.py carries no changed_files reference to this day, so a resumed run drops the capture silently.",
+      "detection_point": "unshipped"
+    },
+    {
+      "finding_key": "36d247a95b45:3:87be06e8",
+      "run_id": "36d247a95b45",
+      "slug": "issue-2347",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "617e1014 handles it directly in coordinator/changed_files.py: 'binary = raw_ins == \"-\" and raw_del == \"-\"', recorded as a binary flag with zero counts instead of int()-parsed."
+    },
+    {
+      "finding_key": "31e0c8855436:0:2ffb2444",
+      "run_id": "31e0c8855436",
+      "slug": "issue-2434",
+      "class": "test strategy gap",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "8f84dfd5 covers both directions: test_broken_baseline_audit_reports_pre_gate_remediation_spend for the abort path and test_sprint_total_includes_intake_remediation_agent_cost / test_entry_intake_outcomes_cost_rolls_into_sprint_total for the normal fold-once path."
+    },
+    {
+      "finding_key": "31e0c8855436:1:adfa6d69",
+      "run_id": "31e0c8855436",
+      "slug": "issue-2434",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "8f84dfd5 decides it: 'a first run that does not reproduce returns through the ordinary cleanup path and leaves nothing behind', and the commit body states a non-reproduced failure leaks neither worktree nor evidence."
+    },
+    {
+      "finding_key": "cbfd089e3518:0:bbdc2239",
+      "run_id": "cbfd089e3518",
+      "slug": "issue-2380",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "f17d9fa9's _profile_for_transport in cli/provider_readiness.py sets api_fallback=None and fallback_models=(), so a probe cannot cross to another transport or model."
+    },
+    {
+      "finding_key": "cbfd089e3518:1:7dd98866",
+      "run_id": "cbfd089e3518",
+      "slug": "issue-2380",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "f17d9fa9 adds _preflight_unverified_reason and _runtime_unverified_reason in cli/provider_readiness.py, classifying missing CLI / absent credentials as unverified rather than failed."
+    },
+    {
+      "finding_key": "cbfd089e3518:2:a59c34d5",
+      "run_id": "cbfd089e3518",
+      "slug": "issue-2380",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "f17d9fa9 special-cases the CLI path: a structured result with cost_usd None on a CLI transport returns _unverified_attempt with 'not exercised: structured result returned but CLI cost is unavailable', not a transport verdict."
+    },
+    {
+      "finding_key": "4b582ddcfba0:0:3c45ff54",
+      "run_id": "4b582ddcfba0",
+      "slug": "issue-2332",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "79d0f8cb adds 'advisor' to _DEFAULT_PHASE_ELIGIBILITY in config/model_identity.py as well as KNOWN_PHASES, so default-eligible models are not rejected."
+    },
+    {
+      "finding_key": "4b582ddcfba0:1:1a46fe66",
+      "run_id": "4b582ddcfba0",
+      "slug": "issue-2332",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "79d0f8cb builds a single-role selector instead: coordinator/escalation_advisor_flow.py imports _capability_exclusions, _capability_pool and NoCapableCandidateError from assignment.py rather than routing advisor through assign_models."
+    },
+    {
+      "finding_key": "4b582ddcfba0:2:469bab38",
+      "run_id": "4b582ddcfba0",
+      "slug": "issue-2332",
+      "class": "test strategy gap",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "79d0f8cb changes escalation_advisor.parse_advisory_report to accept an empty recommendation as valid, so the regression exercises the real parser path instead of an impossible object."
+    },
+    {
+      "finding_key": "4b582ddcfba0:3:2295f19d",
+      "run_id": "4b582ddcfba0",
+      "slug": "issue-2332",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "79d0f8cb changes coordinator/state.py, resume_persistence.py and audit.py alongside escalation_advisor_flow.py, so the new advisor-unavailable reason is durable and audited."
+    },
+    {
+      "finding_key": "4b582ddcfba0:4:f2fc4f42",
+      "run_id": "4b582ddcfba0",
+      "slug": "issue-2332",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same eligibility trap as ordinal 0, stated in full; 79d0f8cb also updates the three explicit phase_eligibility lists in config/data/models.yaml to include advisor."
+    },
+    {
+      "finding_key": "4b582ddcfba0:5:a0ec8b73",
+      "run_id": "4b582ddcfba0",
+      "slug": "issue-2332",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "79d0f8cb adds 'advisor' to ROLE_REQUIRED_CAPABILITY and documents that it deliberately shares its token with routing.phase_eligibility; tests/test_capability_routing_seam.py needed no change because the extra explicit_profiles key is inert in assign_models."
+    },
+    {
+      "finding_key": "4b582ddcfba0:6:c232e5e0",
+      "run_id": "4b582ddcfba0",
+      "slug": "issue-2332",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "79d0f8cb names the entry point the plan left open by composing exactly the reusable pieces the finding listed inside coordinator/escalation_advisor_flow.py."
+    },
+    {
+      "finding_key": "364c213449ab:0:cb91552b",
+      "run_id": "364c213449ab",
+      "slug": "issue-2085",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "7537c9b2 updates tests/test_sprint_gate_timeout_scaling.py (+64) and tests/test_sprint_gate_timeout_reexec_load.py (+24) \u2014 the real old-contract sites \u2014 not the plan's named files."
+    },
+    {
+      "finding_key": "364c213449ab:1:39a2afbc",
+      "run_id": "364c213449ab",
+      "slug": "issue-2085",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "Same misnamed test targets as ordinal 0; 7537c9b2 touches neither tests/test_gate_timeout_resolver.py (which does not exist) nor tests/test_sprint_runner.py."
+    },
+    {
+      "finding_key": "364c213449ab:2:bc751ef4",
+      "run_id": "364c213449ab",
+      "slug": "issue-2085",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "7537c9b2 and be60d7ed both edit the two gate-timeout test modules, so the overcommit-field assertions the plan never listed were updated with the behaviour change."
+    },
+    {
+      "finding_key": "364c213449ab:3:7d31390c",
+      "run_id": "364c213449ab",
+      "slug": "issue-2085",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "The resolver stays pure: os.getloadavg() is called in src/theforge/sprint/runner.py:4773 and the observed load is passed into sprint/gate_timeout_resolver.py, giving the mocked-load test a seam."
+    },
+    {
+      "finding_key": "cf857907b6ed:0:f2e4137d",
+      "run_id": "cf857907b6ed",
+      "slug": "issue-2525",
+      "class": "scope / out-of-scope",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "a6f771a1 narrows the handoff itself: review_phase.py builds _dev_handoff_review by dropping ungrounded P1s from parsed_review, with a comment naming the mixed-cycle sibling case the finding described."
+    },
+    {
+      "finding_key": "cf857907b6ed:1:b89c9059",
+      "run_id": "cf857907b6ed",
+      "slug": "issue-2525",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "16b97a7c makes diff grounding a per-cycle verdict rather than a sticky disposition and changes finding_classifier.py (+20), removing the fall-through-to-unresolved reset the finding warned about."
+    },
+    {
+      "finding_key": "cf857907b6ed:2:32155a1b",
+      "run_id": "cf857907b6ed",
+      "slug": "issue-2525",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "a6f771a1's coordinator/diff_grounding.py normalizes absolute paths inside the worktree via resolve().relative_to() and treats paths outside it as ungrounded \u2014 both branches the finding asked for."
+    },
+    {
+      "finding_key": "2c7cc09417b2:0:8c610880",
+      "run_id": "2c7cc09417b2",
+      "slug": "issue-2137",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6d18ec69 scopes the downgrade in coordinator/preflight_flow.py: only a BLOCKED 'founded solely on unratified rationale' is downgraded, and 'blockers that are not policy claims (missing credentials, ...)' are explicitly exempt."
+    },
+    {
+      "finding_key": "2c7cc09417b2:1:9df21aa4",
+      "run_id": "2c7cc09417b2",
+      "slug": "issue-2137",
+      "class": "module/placement",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6d18ec69 changes coordinator/preflight_cache.py (+24) and resume_persistence.py (+24) alongside state.py, so the provenance fields survive the batch-preflight and resume paths."
+    },
+    {
+      "finding_key": "2c7cc09417b2:2:4141f590",
+      "run_id": "2c7cc09417b2",
+      "slug": "issue-2137",
+      "class": "test strategy gap",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6d18ec69 covers the prose-fallback path directly: tests/test_policy_provenance.py::test_uncited_standing_decision_claim_is_adjudicated_as_unmarked, and the adjudication surfaces 'unmarked' rather than silently demoting."
+    },
+    {
+      "finding_key": "2c7cc09417b2:3:170faf6d",
+      "run_id": "2c7cc09417b2",
+      "slug": "issue-2137",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6d18ec69's policy_provenance.policy_assertions_path takes project_root and documents that it comes from ForgeConfig.project_root 'rather than the process working directory'."
+    },
+    {
+      "finding_key": "7d7b7449225a:0:9b2b5e27",
+      "run_id": "7d7b7449225a",
+      "slug": "issue-2308",
+      "class": "missing failure mode",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "2968b61e partitions evidence by canonical identity and states the limit rather than hiding it: model_strength_report.py records contributing_keys and evidence_recency='unknown' because 'profiles carry no per-key timestamp, so no row can assert its evidence is current'."
+    },
+    {
+      "finding_key": "7d7b7449225a:1:1904bdef",
+      "run_id": "7d7b7449225a",
+      "slug": "issue-2308",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6431bdf9 defines the peer set concretely (same declared tier, same complexity band, peers that clear the evidence floor) and refuses the claim below MIN_PEERS_FOR_DISAGREEMENT = 2: 'a peer range over a single peer is not a range'."
+    },
+    {
+      "finding_key": "7d7b7449225a:2:881258ec",
+      "run_id": "7d7b7449225a",
+      "slug": "issue-2308",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6431bdf9 takes model_registry as 'the *effective* registry from a loaded config (config.model_registry), so packaged defaults and forge.yaml overlays' are both present; cli/profiles.py supplies it from load_config."
+    },
+    {
+      "finding_key": "7d7b7449225a:3:5f9e9d10",
+      "run_id": "7d7b7449225a",
+      "slug": "issue-2308",
+      "class": "unspecified mechanism",
+      "advisory_outcome": "resolved",
+      "shipped_addressed": true,
+      "evidence": "6431bdf9 returns peer_low/peer_high None when no comparable peer exists and declines the disagreement claim below MIN_PEERS_FOR_DISAGREEMENT."
+    }
+  ]
+}

--- a/src/theforge/plan_advisory/report.py
+++ b/src/theforge/plan_advisory/report.py
@@ -1,0 +1,220 @@
+"""Substrate loading and rendering for the plan-advisory resolution measure (#2112)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+from theforge.coordinator.audit_read_model import iter_records
+from theforge.coordinator.audit_storage import open_readonly
+
+from .analysis import EVIDENCE_UNAVAILABLE, analyze, extract_plan_findings
+
+JUDGMENTS_PATH = Path(__file__).with_name("judgments.json")
+
+
+def load_judgments(path: Path | None = None) -> dict[str, Any]:
+    """Read the checked-in judgment corpus."""
+    source = Path(path) if path is not None else JUDGMENTS_PATH
+    with open(source, encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if not isinstance(payload, dict) or not isinstance(payload.get("judgments"), list):
+        raise ValueError(f"{source}: expected an object with a 'judgments' list")
+    return payload
+
+
+def load_report(project_root: Path, *, judgments_path: Path | None = None) -> dict[str, Any]:
+    """Build the report from the audit substrate. Opens read-only only."""
+    project_root = Path(project_root).resolve()
+    conn = open_readonly(project_root)
+    try:
+        extraction = extract_plan_findings(iter_records(conn, order_by_started=True))
+    finally:
+        conn.close()
+    payload = load_judgments(judgments_path)
+    report = analyze(extraction, payload["judgments"])
+    report["project_root"] = str(project_root)
+    report["corpus"]["judgment_source"] = str(judgments_path or JUDGMENTS_PATH)
+    report["corpus"]["judgment_notes"] = payload.get("notes")
+    return report
+
+
+def _pct(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.0%}"
+
+
+def _usd(value: float | None) -> str:
+    return "n/a" if value is None else f"${value:,.2f}"
+
+
+def _wrap(text: str, width: int, indent: str, *, label: str = "") -> list[str]:
+    """Word-wrap ``text`` at ``width``, prefixing the first line with ``label``.
+
+    Continuation lines get ``indent``; the label is padded to the same width so
+    the block stays flush under its first line.
+    """
+    words = str(text).split()
+    chunks: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if len(candidate) > width and current:
+            chunks.append(current)
+            current = word
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    if not label:
+        return [indent + chunk for chunk in chunks]
+    head = f"{indent}{label}"
+    return [head + chunks[0]] + [" " * len(head) + chunk for chunk in chunks[1:]]
+
+
+def _finding_lines(row: dict[str, Any], *, verbose: bool) -> list[str]:
+    head = (
+        f"  {row['slug']:<12} {row['class']:<26} "
+        f"{'shipped-addressed' if row['shipped_addressed'] else 'not addressed'}"
+    )
+    point = row.get("detection_point")
+    if point == "unshipped":
+        head += "  -> never caught (still latent)"
+    elif point:
+        head += f"  -> caught at {point}"
+    lines = [head]
+    if verbose:
+        lines.extend(_wrap(row["description"], 84, "        ", label="finding:  "))
+        lines.extend(_wrap(row["evidence"], 84, "        ", label="evidence: "))
+    return lines
+
+
+def render(report: dict[str, Any], *, verbose: bool = False) -> str:
+    """Render the operator-facing decision report."""
+    corpus = report["corpus"]
+    overall = report["overall"]
+    cost = report["cost"]
+
+    lines = [
+        "PLAN ADVISORY RESOLUTION (#2112)",
+        "",
+        (
+            f"Plan advisory resolution — {corpus['runs']} runs, "
+            f"{corpus['findings_judged']} judged findings "
+            f"of {corpus['findings_extracted']} extracted "
+            f"(coverage {_pct(corpus['coverage'])})"
+        ),
+        f"  project root: {report.get('project_root', '.')}",
+        f"  audit records scanned: {corpus['records_scanned']}",
+        ("  corpus: completed (DONE) runs carrying a plan review with P1-level plan findings"),
+        (
+            f"  excluded by final_phase: {corpus['excluded_run_count']} run(s) "
+            f"carrying {corpus['excluded_run_findings']} P1-level finding(s) "
+            "(reached dev but did not ship)"
+        ),
+        f"  P2 plan findings out of scope: {corpus['p2_findings_skipped']}",
+        (
+            f"  P1-level findings raised: {corpus['p1_findings_raised']}; "
+            f"{corpus['findings_fixed_in_plan']} resolved by plan regeneration "
+            "before dev (not advisory, excluded from the rate)"
+        ),
+        (f"  unjudged findings excluded from every rate: {corpus['findings_unjudged']}"),
+        (f"  judgments carrying no citable evidence: {corpus['evidence_unavailable']}"),
+        "",
+        (
+            f"overall: {overall['resolved']}/{overall['findings']} advisory findings "
+            f"resolved ({_pct(overall['rate'])}); "
+            f"{overall['shipped_addressed']} shipped-addressed, "
+            f"{overall['shipped_unaddressed']} not"
+        ),
+        "",
+        f"{'class':<28}{'findings':>9}{'resolved':>10}{'escaped':>9}{'rate':>7}",
+        f"{'-' * 28}{'-' * 9:>9}{'-' * 10:>10}{'-' * 9:>9}{'-' * 7:>7}",
+    ]
+    for row in report["classes"]:
+        lines.append(
+            f"{row['class']:<28}{row['findings']:>9}{row['resolved']:>10}"
+            f"{row['escaped']:>9}{_pct(row['rate']):>7}"
+        )
+    if not report["classes"]:
+        lines.append("(no judged findings)")
+
+    lines.extend(
+        [
+            "",
+            (
+                f"plan review cost:  median {_usd(cost['median_plan_review_usd'])}/story "
+                f"(n={cost['runs_with_plan_review_cost']})   "
+                f"median {_pct(cost['median_fraction_of_story'])} of story cost "
+                f"(n={cost['runs_with_both']})"
+            ),
+            (
+                f"  of {cost['runs']} corpus run(s): "
+                f"{cost['omitted_missing_plan_review_cost']} record no plan-review "
+                f"cost, {cost['omitted_missing_total_cost']} no story total — "
+                "both omitted rather than imputed"
+            ),
+            "",
+            "escapes by later detection point:",
+        ]
+    )
+    points = report["escapes_by_detection_point"]
+    if points:
+        lines.append("  " + " · ".join(f"{name} {count}" for name, count in points.items()))
+    else:
+        lines.append("  (none)")
+
+    lines.extend(["", f"escaped findings ({len(report['escaped_findings'])}):"])
+    for row in report["escaped_findings"]:
+        lines.extend(_finding_lines(row, verbose=verbose))
+    if not report["escaped_findings"]:
+        lines.append("  (none)")
+
+    lines.extend(["", f"resolved findings ({len(report['resolved_findings'])}):"])
+    for row in report["resolved_findings"]:
+        lines.extend(_finding_lines(row, verbose=verbose))
+    if not report["resolved_findings"]:
+        lines.append("  (none)")
+
+    if corpus["findings_unjudged"]:
+        lines.extend(["", f"unjudged findings ({corpus['findings_unjudged']}):"])
+        for row in report["unjudged_findings"]:
+            lines.append(f"  {row['slug']:<12} {row['finding_key']}")
+
+    if corpus.get("judgment_notes"):
+        lines.extend(["", "corpus notes:", *_wrap(corpus["judgment_notes"], 86, "  ")])
+    if corpus["evidence_unavailable"]:
+        lines.append(
+            f"  NOTE: {corpus['evidence_unavailable']} judgment(s) marked "
+            f"'{EVIDENCE_UNAVAILABLE}' — treat their rows as weaker evidence."
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--project-root", default=".", type=Path)
+    parser.add_argument("--judgments", default=None, type=Path)
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--json", action="store_true", help="Emit the raw report as JSON")
+    args = parser.parse_args(argv)
+
+    from theforge.coordinator.audit_storage import SubstrateError  # noqa: PLC0415
+
+    from .analysis import CorpusMismatchError  # noqa: PLC0415
+
+    try:
+        report = load_report(args.project_root, judgments_path=args.judgments)
+    except SubstrateError as exc:
+        print(f"cannot read audit substrate: {exc}", file=sys.stderr)
+        return 2
+    except CorpusMismatchError as exc:
+        print(f"judgment corpus does not match the audit substrate: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render(report, verbose=args.verbose))
+    return 0

--- a/src/theforge/plan_advisory/report.py
+++ b/src/theforge/plan_advisory/report.py
@@ -11,13 +11,23 @@ from typing import Any, Sequence
 from theforge.coordinator.audit_read_model import iter_records
 from theforge.coordinator.audit_storage import open_readonly
 
-from .analysis import EVIDENCE_UNAVAILABLE, analyze, extract_plan_findings
+from .analysis import (
+    EVIDENCE_UNAVAILABLE,
+    CorpusMismatchError,
+    analyze,
+    extract_plan_findings,
+)
 
 JUDGMENTS_PATH = Path(__file__).with_name("judgments.json")
 
 
 def load_judgments(path: Path | None = None) -> dict[str, Any]:
-    """Read the checked-in judgment corpus."""
+    """Read the checked-in judgment corpus.
+
+    Raises ``OSError`` when the file is unreadable and ``ValueError`` (including
+    ``json.JSONDecodeError``) when its contents are not a corpus. Callers that
+    face an operator convert both — see :func:`_read_corpus`.
+    """
     source = Path(path) if path is not None else JUDGMENTS_PATH
     with open(source, encoding="utf-8") as fh:
         payload = json.load(fh)
@@ -26,15 +36,36 @@ def load_judgments(path: Path | None = None) -> dict[str, Any]:
     return payload
 
 
+def _read_corpus(judgments_path: Path | None) -> dict[str, Any]:
+    """Read the corpus, reporting an unusable file the way a mismatched one is.
+
+    An operator cannot act differently on "the corpus disagrees with the
+    substrate" and "the corpus could not be read at all" — both mean the rate is
+    not computable and the file is what to look at. Converting here keeps that
+    single failure mode at one seam, so every entry point handles it without its
+    own ``except`` clause.
+    """
+    try:
+        return load_judgments(judgments_path)
+    except (OSError, ValueError) as exc:
+        source = judgments_path or JUDGMENTS_PATH
+        raise CorpusMismatchError(f"judgment corpus at {source} is unusable: {exc}") from exc
+
+
 def load_report(project_root: Path, *, judgments_path: Path | None = None) -> dict[str, Any]:
-    """Build the report from the audit substrate. Opens read-only only."""
+    """Build the report, reading the audit substrate read-only.
+
+    Raises :class:`~theforge.plan_advisory.analysis.CorpusMismatchError` when the
+    judgment corpus cannot be read or does not line up with the substrate, and
+    ``SubstrateError`` when the substrate itself is missing or corrupt.
+    """
     project_root = Path(project_root).resolve()
     conn = open_readonly(project_root)
     try:
         extraction = extract_plan_findings(iter_records(conn, order_by_started=True))
     finally:
         conn.close()
-    payload = load_judgments(judgments_path)
+    payload = _read_corpus(judgments_path)
     report = analyze(extraction, payload["judgments"])
     report["project_root"] = str(project_root)
     report["corpus"]["judgment_source"] = str(judgments_path or JUDGMENTS_PATH)
@@ -203,15 +234,13 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     from theforge.coordinator.audit_storage import SubstrateError  # noqa: PLC0415
 
-    from .analysis import CorpusMismatchError  # noqa: PLC0415
-
     try:
         report = load_report(args.project_root, judgments_path=args.judgments)
     except SubstrateError as exc:
         print(f"cannot read audit substrate: {exc}", file=sys.stderr)
         return 2
     except CorpusMismatchError as exc:
-        print(f"judgment corpus does not match the audit substrate: {exc}", file=sys.stderr)
+        print(f"judgment corpus unusable: {exc}", file=sys.stderr)
         return 2
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/test_plan_advisory_corpus.py
+++ b/tests/test_plan_advisory_corpus.py
@@ -1,0 +1,88 @@
+"""Integrity checks on the shipped plan-advisory judgment corpus (#2112).
+
+These do not need the audit substrate — CI has no ``.forge/audits`` — so they
+check what the file can be held to on its own: the schema every judgment must
+satisfy, the controlled vocabularies, key uniqueness, and that no row is
+under-evidenced without saying so.
+"""
+
+from __future__ import annotations
+
+from theforge.plan_advisory.analysis import (
+    DETECTION_POINTS,
+    ESCAPED,
+    EVIDENCE_UNAVAILABLE,
+    FINDING_CLASSES,
+    RESOLVED,
+    finding_key,
+)
+from theforge.plan_advisory.report import load_judgments
+
+_REQUIRED = {
+    "finding_key",
+    "run_id",
+    "slug",
+    "class",
+    "advisory_outcome",
+    "shipped_addressed",
+    "evidence",
+}
+
+
+def _judgments() -> list[dict]:
+    return load_judgments()["judgments"]
+
+
+def test_the_corpus_is_non_empty_and_annotated() -> None:
+    payload = load_judgments()
+    assert payload["judgments"], "the shipped corpus must carry judgments"
+    assert payload.get("notes"), "the corpus must state how it was built and what it excludes"
+
+
+def test_every_judgment_carries_the_required_fields() -> None:
+    for row in _judgments():
+        missing = _REQUIRED - set(row)
+        assert not missing, f"{row.get('finding_key')} missing {sorted(missing)}"
+        assert isinstance(row["shipped_addressed"], bool)
+
+
+def test_classes_and_outcomes_stay_inside_the_controlled_vocabularies() -> None:
+    for row in _judgments():
+        assert row["class"] in FINDING_CLASSES, row
+        assert row["advisory_outcome"] in (RESOLVED, ESCAPED), row
+        if row["advisory_outcome"] == ESCAPED:
+            assert row.get("detection_point") in DETECTION_POINTS, row
+
+
+def test_finding_keys_are_unique_and_agree_with_their_run_id() -> None:
+    keys = [row["finding_key"] for row in _judgments()]
+    assert len(keys) == len(set(keys))
+    for row in _judgments():
+        assert row["finding_key"].startswith(f"{row['run_id']}:"), row
+
+
+def test_finding_keys_have_the_shape_the_extractor_produces() -> None:
+    # A key the extractor could never emit would silently never match, so the
+    # corpus would validate as "no orphans" while covering nothing.
+    for row in _judgments():
+        run_id, ordinal, digest = row["finding_key"].split(":")
+        assert run_id == row["run_id"]
+        assert ordinal.isdigit()
+        assert len(digest) == 8
+        assert finding_key(run_id, int(ordinal), "x").split(":")[:2] == [run_id, ordinal]
+
+
+def test_every_judgment_cites_evidence_or_says_it_has_none() -> None:
+    for row in _judgments():
+        evidence = str(row["evidence"]).strip()
+        assert evidence, f"{row['finding_key']} has an empty evidence field"
+        if evidence == EVIDENCE_UNAVAILABLE:
+            continue
+        assert len(evidence) > 40, f"{row['finding_key']} evidence is too thin to check"
+
+
+def test_escapes_name_where_they_were_eventually_caught() -> None:
+    escapes = [r for r in _judgments() if r["advisory_outcome"] == ESCAPED]
+    assert escapes, "the corpus should retain at least the known #2050 escape"
+    for row in escapes:
+        assert row["shipped_addressed"] is False or row.get("detection_point")

--- a/tests/test_plan_advisory_resolution.py
+++ b/tests/test_plan_advisory_resolution.py
@@ -481,7 +481,7 @@ class TestCliDispatch:
             verbose = False
 
         assert audits_cli.cmd_audits(Args()) == 1
-        assert "does not match the audit substrate" in capsys.readouterr().err
+        assert "judgment corpus unusable" in capsys.readouterr().err
 
     def test_load_judgments_rejects_a_malformed_corpus(self, tmp_path) -> None:
         from theforge.plan_advisory.report import load_judgments
@@ -490,3 +490,70 @@ class TestCliDispatch:
         path.write_text(json.dumps({"judgments": "not a list"}), encoding="utf-8")
         with pytest.raises(ValueError, match="expected an object with a 'judgments' list"):
             load_judgments(path)
+
+
+class TestUnusableCorpus:
+    """An unreadable corpus must reach the operator as a message, not a traceback.
+
+    ``json.JSONDecodeError`` subclasses ``ValueError`` and a missing file raises
+    ``OSError``, so all three shapes below used to escape the entry points'
+    ``except`` clauses uncaught.
+    """
+
+    def _corpus(self, tmp_path, body: str | None):
+        path = tmp_path / "judgments.json"
+        if body is not None:
+            path.write_text(body, encoding="utf-8")
+        return path
+
+    @pytest.mark.parametrize(
+        "body, why",
+        [
+            (None, "missing file"),
+            ("{not json at all", "corrupt json"),
+            ('{"judgments": "not a list"}', "wrong shape"),
+            ("[]", "not an object"),
+        ],
+    )
+    def test_read_corpus_converts_every_unusable_shape(self, tmp_path, body, why) -> None:
+        from theforge.plan_advisory.report import _read_corpus
+
+        with pytest.raises(CorpusMismatchError, match="unusable"):
+            _read_corpus(self._corpus(tmp_path, body))
+
+    def test_the_module_entry_point_reports_rather_than_tracebacks(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        from theforge.plan_advisory import report as report_mod
+
+        monkeypatch.setattr(report_mod, "open_readonly", lambda root: _FakeConn())
+        corpus = self._corpus(tmp_path, "{not json at all")
+        code = report_mod.main(["--project-root", str(tmp_path), "--judgments", str(corpus)])
+        assert code == 2
+        assert "judgment corpus unusable" in capsys.readouterr().err
+
+    def test_the_cli_reports_rather_than_tracebacks(self, tmp_path, monkeypatch, capsys) -> None:
+        from theforge.cli import audits as audits_cli
+        from theforge.plan_advisory import report as report_mod
+
+        (tmp_path / "forge.yaml").write_text("project: {}\n", encoding="utf-8")
+        monkeypatch.setattr(report_mod, "open_readonly", lambda root: _FakeConn())
+        monkeypatch.setattr(report_mod, "JUDGMENTS_PATH", self._corpus(tmp_path, "["))
+
+        class Args:
+            audits_command = "plan-advisory"
+            config = str(tmp_path / "forge.yaml")
+            verbose = False
+
+        assert audits_cli.cmd_audits(Args()) == 1
+        assert "judgment corpus unusable" in capsys.readouterr().err
+
+
+class _FakeConn:
+    """Stands in for the sqlite connection so no substrate file is needed."""
+
+    def execute(self, *_args, **_kwargs):
+        return iter(())
+
+    def close(self) -> None:
+        return None

--- a/tests/test_plan_advisory_resolution.py
+++ b/tests/test_plan_advisory_resolution.py
@@ -1,0 +1,492 @@
+"""Tests for the plan-advisory resolution measure (#2112).
+
+Synthetic audit records and judgment rows throughout: the point is the matching,
+aggregation and rendering logic, not the shipped corpus (whose own coverage is
+asserted separately in :mod:`test_plan_advisory_corpus`).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from theforge.plan_advisory.analysis import (
+    CorpusMismatchError,
+    analyze,
+    extract_plan_findings,
+    finding_key,
+)
+from theforge.plan_advisory.report import render
+
+
+def _finding(description: str, *, severity: str = "P1-impl", disposition: str = "new") -> dict:
+    return {
+        "description": description,
+        "severity": severity,
+        "effective_severity": severity,
+        "cycle_first_seen": 0,
+        "cycle_last_seen": 0,
+        "disposition": disposition,
+    }
+
+
+def _record(
+    run_id: str,
+    *,
+    slug: str = "issue-1",
+    final_phase: str = "DONE",
+    findings: list[dict] | None = None,
+    plan_review_usd: float | None = 2.0,
+    total_usd: float | None = 10.0,
+    decision: str = "approve",
+) -> dict:
+    return {
+        "run_id": run_id,
+        "task": {"slug": slug},
+        "outcome": {"final_phase": final_phase},
+        "cost": {"total_usd": total_usd},
+        "plan_review": {
+            "decision": decision,
+            "cost_usd": plan_review_usd,
+            "plan_finding_registry": findings if findings is not None else [_finding("a")],
+        },
+    }
+
+
+def _judgment(record: dict, ordinal: int, **overrides) -> dict:
+    registry = record["plan_review"]["plan_finding_registry"]
+    p1s = [
+        f
+        for f in registry
+        if str(f.get("effective_severity") or f.get("severity") or "").startswith("P1")
+    ]
+    row = {
+        "finding_key": finding_key(record["run_id"], ordinal, p1s[ordinal]["description"]),
+        "run_id": record["run_id"],
+        "slug": record["task"]["slug"],
+        "class": "module/placement",
+        "advisory_outcome": "resolved",
+        "shipped_addressed": True,
+        "evidence": "commit abc1234 touches the omitted module",
+    }
+    row.update(overrides)
+    return row
+
+
+class TestExtraction:
+    def test_only_p1_level_findings_are_extracted(self) -> None:
+        record = _record(
+            "r1",
+            findings=[
+                _finding("p1 plain", severity="P1"),
+                _finding("p1 impl", severity="P1-impl"),
+                _finding("p2 one", severity="P2"),
+                _finding("p3 one", severity="P3"),
+            ],
+        )
+        extraction = extract_plan_findings([record])
+        assert [f.severity for f in extraction.findings] == ["P1", "P1-impl"]
+        assert extraction.p2_findings_skipped == 2
+
+    def test_effective_severity_wins_over_severity(self) -> None:
+        raw = _finding("downgraded later", severity="P1-impl")
+        raw["effective_severity"] = "P2"
+        extraction = extract_plan_findings([_record("r1", findings=[raw])])
+        assert extraction.findings == []
+
+    def test_non_done_runs_are_excluded_but_counted(self) -> None:
+        done = _record("r1", slug="issue-1")
+        escalated = _record(
+            "r2",
+            slug="issue-2",
+            final_phase="ESCALATE",
+            findings=[_finding("a"), _finding("b")],
+        )
+        extraction = extract_plan_findings([done, escalated])
+        assert [f.run_id for f in extraction.findings] == ["r1"]
+        assert extraction.excluded_runs == [
+            {"run_id": "r2", "slug": "issue-2", "final_phase": "ESCALATE", "p1_findings": 2}
+        ]
+
+    def test_records_without_a_plan_review_decision_are_skipped(self) -> None:
+        record = _record("r1", decision="")
+        assert extract_plan_findings([record]).findings == []
+
+    def test_findings_fixed_in_plan_are_not_carried_to_dev(self) -> None:
+        record = _record(
+            "r1",
+            findings=[_finding("kept"), _finding("regenerated away", disposition="fixed")],
+        )
+        extraction = extract_plan_findings([record])
+        assert [f.carried_to_dev for f in extraction.findings] == [True, False]
+
+    def test_finding_key_is_stable_under_whitespace_and_case(self) -> None:
+        assert finding_key("r1", 0, "The  Broker\n blocks") == finding_key(
+            "r1", 0, "the broker blocks"
+        )
+
+    def test_finding_key_separates_identical_descriptions_in_one_run(self) -> None:
+        assert finding_key("r1", 0, "same") != finding_key("r1", 1, "same")
+
+
+class TestCoverageValidation:
+    def test_a_judgment_with_no_matching_audit_finding_fails_loudly(self) -> None:
+        record = _record("r1")
+        extraction = extract_plan_findings([record])
+        row = _judgment(record, 0, finding_key="r1:0:deadbeef")
+        with pytest.raises(CorpusMismatchError, match="no advisory finding carried into dev"):
+            analyze(extraction, [row])
+
+    def test_a_judgment_naming_a_plan_regenerated_finding_fails_loudly(self) -> None:
+        record = _record("r1", findings=[_finding("gone", disposition="fixed")])
+        extraction = extract_plan_findings([record])
+        key = finding_key("r1", 0, "gone")
+        with pytest.raises(CorpusMismatchError):
+            analyze(extraction, [{**_judgment(record, 0), "finding_key": key}])
+
+    def test_an_unjudged_audit_finding_is_counted_not_fatal(self) -> None:
+        record = _record("r1", findings=[_finding("judged"), _finding("not judged")])
+        extraction = extract_plan_findings([record])
+        report = analyze(extraction, [_judgment(record, 0)])
+        assert report["corpus"]["findings_extracted"] == 2
+        assert report["corpus"]["findings_judged"] == 1
+        assert report["corpus"]["findings_unjudged"] == 1
+        assert report["corpus"]["coverage"] == 0.5
+        # The unjudged finding is excluded from the denominator, not counted as
+        # resolved: a rate that quietly covered half its corpus would mislead.
+        assert report["overall"]["findings"] == 1
+        assert [r["finding_key"] for r in report["unjudged_findings"]] == [
+            finding_key("r1", 1, "not judged")
+        ]
+
+    def test_duplicate_judgments_fail_loudly(self) -> None:
+        record = _record("r1")
+        extraction = extract_plan_findings([record])
+        row = _judgment(record, 0)
+        with pytest.raises(CorpusMismatchError, match="judged more than once"):
+            analyze(extraction, [row, dict(row)])
+
+    def test_a_class_outside_the_vocabulary_fails_loudly(self) -> None:
+        record = _record("r1")
+        extraction = extract_plan_findings([record])
+        with pytest.raises(CorpusMismatchError, match="controlled vocabulary"):
+            analyze(extraction, [_judgment(record, 0, **{"class": "vibes"})])
+
+    def test_an_unknown_advisory_outcome_fails_loudly(self) -> None:
+        record = _record("r1")
+        extraction = extract_plan_findings([record])
+        with pytest.raises(CorpusMismatchError, match="resolved/escaped"):
+            analyze(extraction, [_judgment(record, 0, advisory_outcome="partly")])
+
+    def test_an_escape_with_an_unknown_detection_point_fails_loudly(self) -> None:
+        record = _record("r1")
+        extraction = extract_plan_findings([record])
+        with pytest.raises(CorpusMismatchError, match="detection_point"):
+            analyze(
+                extraction,
+                [
+                    _judgment(
+                        record,
+                        0,
+                        advisory_outcome="escaped",
+                        shipped_addressed=False,
+                        detection_point="someone noticed",
+                    )
+                ],
+            )
+
+    def test_missing_evidence_is_counted_rather_than_averaged_in_silently(self) -> None:
+        record = _record("r1", findings=[_finding("a"), _finding("b")])
+        extraction = extract_plan_findings([record])
+        report = analyze(
+            extraction,
+            [_judgment(record, 0), _judgment(record, 1, evidence="  ")],
+        )
+        assert report["corpus"]["evidence_unavailable"] == 1
+        assert report["resolved_findings"][1]["evidence"] == "evidence unavailable"
+
+
+class TestAggregation:
+    def test_class_breakout_math(self) -> None:
+        record = _record(
+            "r1",
+            findings=[_finding("a"), _finding("b"), _finding("c"), _finding("d")],
+        )
+        extraction = extract_plan_findings([record])
+        rows = [
+            _judgment(record, 0),
+            _judgment(record, 1),
+            _judgment(
+                record,
+                2,
+                **{"class": "unspecified mechanism"},
+                advisory_outcome="escaped",
+                shipped_addressed=False,
+                detection_point="adopter run",
+            ),
+            _judgment(record, 3, **{"class": "unspecified mechanism"}),
+        ]
+        report = analyze(extraction, rows)
+        by_class = {row["class"]: row for row in report["classes"]}
+        assert by_class["module/placement"] == {
+            "class": "module/placement",
+            "findings": 2,
+            "resolved": 2,
+            "escaped": 0,
+            "shipped_addressed": 2,
+            "rate": 1.0,
+        }
+        assert by_class["unspecified mechanism"]["rate"] == 0.5
+        assert report["overall"]["rate"] == 0.75
+
+    def test_resolved_and_escaped_are_separately_enumerable(self) -> None:
+        record = _record("r1", findings=[_finding("kept"), _finding("escaped one")])
+        extraction = extract_plan_findings([record])
+        report = analyze(
+            extraction,
+            [
+                _judgment(record, 0),
+                _judgment(
+                    record,
+                    1,
+                    advisory_outcome="escaped",
+                    shipped_addressed=False,
+                    detection_point="own gate",
+                    evidence="caught by the gate on iteration 2",
+                ),
+            ],
+        )
+        assert [r["description"] for r in report["resolved_findings"]] == ["kept"]
+        escaped = report["escaped_findings"]
+        assert [r["description"] for r in escaped] == ["escaped one"]
+        assert escaped[0]["evidence"] == "caught by the gate on iteration 2"
+        assert escaped[0]["detection_point"] == "own gate"
+
+    def test_escapes_are_counted_by_detection_point(self) -> None:
+        record = _record("r1", findings=[_finding("a"), _finding("b"), _finding("c")])
+        extraction = extract_plan_findings([record])
+        rows = [
+            _judgment(
+                record,
+                i,
+                advisory_outcome="escaped",
+                shipped_addressed=False,
+                detection_point=point,
+            )
+            for i, point in enumerate(("own gate", "adopter run", "own gate"))
+        ]
+        report = analyze(extraction, rows)
+        assert report["escapes_by_detection_point"] == {"own gate": 2, "adopter run": 1}
+
+    def test_advisory_resolution_and_shipped_status_are_reported_separately(self) -> None:
+        # A finding dev never acted on whose remedy the shipped change carried
+        # anyway is neither a clean resolution nor a clean escape; both readings
+        # stay visible rather than collapsing into one number.
+        record = _record("r1")
+        extraction = extract_plan_findings([record])
+        report = analyze(
+            extraction,
+            [
+                _judgment(
+                    record,
+                    0,
+                    advisory_outcome="escaped",
+                    shipped_addressed=True,
+                    detection_point="own code review",
+                )
+            ],
+        )
+        assert report["overall"]["resolved"] == 0
+        assert report["overall"]["escaped"] == 1
+        assert report["overall"]["shipped_addressed"] == 1
+        assert report["overall"]["shipped_unaddressed"] == 0
+
+    def test_plan_regenerated_findings_are_split_out_of_the_rate(self) -> None:
+        record = _record(
+            "r1",
+            findings=[_finding("carried"), _finding("regenerated", disposition="fixed")],
+        )
+        extraction = extract_plan_findings([record])
+        report = analyze(extraction, [_judgment(record, 0)])
+        assert report["corpus"]["p1_findings_raised"] == 2
+        assert report["corpus"]["findings_fixed_in_plan"] == 1
+        assert report["corpus"]["findings_extracted"] == 1
+        assert report["overall"]["rate"] == 1.0
+
+
+class TestCost:
+    def test_median_fraction_of_story_cost(self) -> None:
+        records = [
+            _record("r1", plan_review_usd=1.0, total_usd=10.0),
+            _record("r2", plan_review_usd=2.0, total_usd=10.0),
+            _record("r3", plan_review_usd=6.0, total_usd=10.0),
+        ]
+        report = analyze(extract_plan_findings(records), [])
+        assert report["cost"]["median_plan_review_usd"] == 2.0
+        assert report["cost"]["median_fraction_of_story"] == 0.2
+        assert report["cost"]["runs_with_both"] == 3
+
+    def test_missing_costs_are_omitted_and_accounted_not_imputed(self) -> None:
+        records = [
+            _record("r1", plan_review_usd=1.0, total_usd=10.0),
+            _record("r2", plan_review_usd=None, total_usd=10.0),
+            _record("r3", plan_review_usd=3.0, total_usd=None),
+        ]
+        report = analyze(extract_plan_findings(records), [])
+        cost = report["cost"]
+        assert cost["runs"] == 3
+        assert cost["runs_with_plan_review_cost"] == 2
+        assert cost["runs_with_both"] == 1
+        assert cost["median_plan_review_usd"] == 2.0
+        assert cost["median_fraction_of_story"] == 0.1
+        assert cost["omitted_missing_plan_review_cost"] == 1
+        assert cost["omitted_missing_total_cost"] == 1
+
+    def test_a_zero_total_never_divides(self) -> None:
+        report = analyze(
+            extract_plan_findings([_record("r1", plan_review_usd=1.0, total_usd=0.0)]),
+            [],
+        )
+        assert report["cost"]["median_fraction_of_story"] is None
+        assert report["cost"]["omitted_missing_total_cost"] == 1
+
+
+class TestRender:
+    def _report(self) -> dict:
+        record = _record("r1", findings=[_finding("kept"), _finding("got out")])
+        extraction = extract_plan_findings([record])
+        return analyze(
+            extraction,
+            [
+                _judgment(record, 0),
+                _judgment(
+                    record,
+                    1,
+                    **{"class": "unspecified mechanism"},
+                    advisory_outcome="escaped",
+                    shipped_addressed=False,
+                    detection_point="adopter run",
+                    evidence="shipped later as #2077",
+                ),
+            ],
+        )
+
+    def test_render_carries_the_decision_surface(self) -> None:
+        text = render(self._report())
+        assert "module/placement" in text
+        assert "unspecified mechanism" in text
+        assert "escaped findings (1):" in text
+        assert "resolved findings (1):" in text
+        assert "caught at adopter run" in text
+        assert "escapes by later detection point:" in text
+        assert "plan review cost:" in text
+
+    def test_verbose_renders_the_finding_text_and_its_evidence(self) -> None:
+        plain = render(self._report())
+        verbose = render(self._report(), verbose=True)
+        assert "shipped later as #2077" not in plain
+        assert "shipped later as #2077" in verbose
+        assert "got out" in verbose
+
+    def test_unshipped_escapes_do_not_read_as_caught(self) -> None:
+        record = _record("r1")
+        report = analyze(
+            extract_plan_findings([record]),
+            [
+                _judgment(
+                    record,
+                    0,
+                    advisory_outcome="escaped",
+                    shipped_addressed=False,
+                    detection_point="unshipped",
+                )
+            ],
+        )
+        text = render(report)
+        assert "never caught (still latent)" in text
+        assert "caught at unshipped" not in text
+
+    def test_unjudged_findings_are_rendered_so_coverage_is_not_overread(self) -> None:
+        record = _record("r1", findings=[_finding("judged"), _finding("not judged")])
+        report = analyze(extract_plan_findings([record]), [_judgment(record, 0)])
+        text = render(report)
+        assert "1 judged findings of 2 extracted (coverage 50%)" in text
+        assert "unjudged findings (1):" in text
+
+    def test_empty_corpus_renders_without_error(self) -> None:
+        report = analyze(extract_plan_findings([]), [])
+        text = render(report)
+        assert "(no judged findings)" in text
+        assert "escaped findings (0):" in text
+
+
+class TestCliDispatch:
+    """``forge audits plan-advisory`` delegates rather than re-deriving."""
+
+    def test_the_subcommand_is_registered(self) -> None:
+        from theforge.cli.main import build_parser
+
+        args = build_parser().parse_args(["audits", "plan-advisory", "--verbose"])
+        assert args.audits_command == "plan-advisory"
+        assert args.verbose is True
+
+    def test_cmd_audits_delegates_to_the_report_module(self, tmp_path, monkeypatch, capsys):
+        from theforge.cli import audits as audits_cli
+        from theforge.plan_advisory import report as report_mod
+
+        (tmp_path / "forge.yaml").write_text("project: {}\n", encoding="utf-8")
+        seen: dict = {}
+
+        def fake_load_report(project_root, **kwargs):
+            seen["project_root"] = project_root
+            return {"sentinel": True}
+
+        def fake_render(report, *, verbose=False):
+            seen["rendered"] = report
+            seen["verbose"] = verbose
+            return "RENDERED REPORT"
+
+        monkeypatch.setattr(report_mod, "load_report", fake_load_report)
+        monkeypatch.setattr(report_mod, "render", fake_render)
+
+        class Args:
+            audits_command = "plan-advisory"
+            config = str(tmp_path / "forge.yaml")
+            verbose = True
+
+        assert audits_cli.cmd_audits(Args()) == 0
+        assert seen["project_root"] == tmp_path
+        assert seen["rendered"] == {"sentinel": True}
+        assert seen["verbose"] is True
+        assert "RENDERED REPORT" in capsys.readouterr().out
+
+    def test_a_corpus_mismatch_surfaces_as_an_explicit_failure(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from theforge.cli import audits as audits_cli
+        from theforge.plan_advisory import report as report_mod
+        from theforge.plan_advisory.analysis import CorpusMismatchError
+
+        (tmp_path / "forge.yaml").write_text("project: {}\n", encoding="utf-8")
+
+        def boom(project_root, **kwargs):
+            raise CorpusMismatchError("2 judgments name no advisory finding")
+
+        monkeypatch.setattr(report_mod, "load_report", boom)
+
+        class Args:
+            audits_command = "plan-advisory"
+            config = str(tmp_path / "forge.yaml")
+            verbose = False
+
+        assert audits_cli.cmd_audits(Args()) == 1
+        assert "does not match the audit substrate" in capsys.readouterr().err
+
+    def test_load_judgments_rejects_a_malformed_corpus(self, tmp_path) -> None:
+        from theforge.plan_advisory.report import load_judgments
+
+        path = tmp_path / "judgments.json"
+        path.write_text(json.dumps({"judgments": "not a list"}), encoding="utf-8")
+        with pytest.raises(ValueError, match="expected an object with a 'judgments' list"):
+            load_judgments(path)


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] No blocking regressions found; the plan-advisory report satisfies the measurement criteria, targeted tests passed, and the supplied authoritative gate is PASS. | [google-gemini-3.5-flash-api] The implementation beautifully resolves issue #2112, addressing all feedback from iteration 1 with highly robust error handling and comprehensive test coverage. | [anthropic-claude-haiku-4-5-cli] Iteration 2 properly addressed both prior P2s. The _read_corpus seam centralizes error handling to convert both OSError and ValueError (including JSONDecodeError) to CorpusMismatchError, so both entry points report cleanly without duplicated exception handling. Authoritative gate is PASS.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $25.21
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

_No findings._

## Story

Measure how often dev resolves an advisory plan-review finding, so the approve-with-findings policy can be decided on evidence (GitHub Issue #2112)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2112