### PR TITLE
A story whose pre-dev rebase conflicts leaves the conflicting worktree in place, so every later run of that story fails the same way

### DIFF
--- a/src/theforge/coordinator/engine.py
+++ b/src/theforge/coordinator/engine.py
@@ -95,7 +95,7 @@ from .workspace import (
     pull_base_branch,
 )
 from .workspace_scrub import _scrub_forge_history
-from .worktree_drift import is_drift_classification
+from .worktree_drift import classify_rebase_conflict, is_drift_classification
 from .worktree_provenance import inherited_work_note, last_worktree_provenance
 
 # ── Lazy runner symbols ───────────────────────────────────────────────
@@ -1818,9 +1818,11 @@ def _run_resume_coordinator(
         rebase_ok, rebase_err = _rebase_onto_main(str(state.workspace_path), base_branch, logger)
         if not rebase_ok:
             state.phase = Phase.ESCALATE
-            state.escalate_reason = (
-                f"pre-dev rebase onto {base_branch} failed — conflicts must be resolved manually: "
-                f"{rebase_err}"
+            state.escalate_reason = classify_rebase_conflict(
+                state.workspace_path, base_branch, rebase_err
+            ) or (
+                f"pre-dev rebase onto {base_branch} failed — conflicts must be resolved "
+                f"manually: {rebase_err}"
             )
             state.error = state.escalate_reason
             logger._safe_emit("escalate", reason=state.escalate_reason, phase="RESUME_REBASE")

--- a/tests/test_coord_worktree_drift.py
+++ b/tests/test_coord_worktree_drift.py
@@ -27,7 +27,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from coord_test_helpers import _make_config, _make_task
+from coord_test_helpers import _make_config, _make_task, patch_gate_shell
 
 from theforge.artifacts import ESCALATED_MARKER_PATH
 from theforge.config import (
@@ -40,7 +40,7 @@ from theforge.config import (
     RetryPolicy,
     WorkspaceConfig,
 )
-from theforge.coordinator.engine import run_task
+from theforge.coordinator.engine import run_from_dev, run_from_review, run_task
 from theforge.coordinator.state import Phase
 from theforge.coordinator.workspace import _create_workspace
 from theforge.coordinator.worktree_drift import (
@@ -305,6 +305,85 @@ class TestRunTaskSeam:
         result = run_task(config, _make_task(tmp_path))
 
         assert result.message.startswith("Workspace creation failed:")
+
+
+# ── The resume rebase seam ────────────────────────────────────────────
+
+
+def _resume_shell(cmd: str, cwd, **kwargs):
+    if "git rev-parse --abbrev-ref HEAD" in cmd:
+        return (True, "forge/test-task", 0, False)
+    return (True, "", 0, False)
+
+
+class TestResumeRebaseSeam:
+    @patch("theforge.coordinator.engine.classify_rebase_conflict")
+    @patch("theforge.coordinator.engine._rebase_onto_main", return_value=(False, REBASE_STDERR))
+    @patch_gate_shell(side_effect=_resume_shell)
+    def test_run_from_review_forwards_classification(
+        self, _mock_shell, _mock_rebase, mock_classify, tmp_path
+    ):
+        classification = f"{DRIFT_HEADER} on main\n\nFiles changed on both sides:\n  - src/foo.py"
+        mock_classify.return_value = classification
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        result = run_from_review(config, task, workspace, no_pull=True)
+
+        assert result.success is False
+        assert result.phase is Phase.ESCALATE
+        assert result.message == classification
+        assert result.state.error == classification
+        mock_classify.assert_called_once_with(
+            workspace,
+            config.workspace.base_branch,
+            REBASE_STDERR,
+        )
+
+    @patch("theforge.coordinator.engine.classify_rebase_conflict")
+    @patch("theforge.coordinator.engine._rebase_onto_main", return_value=(False, REBASE_STDERR))
+    @patch_gate_shell(side_effect=_resume_shell)
+    def test_run_from_dev_forwards_classification(
+        self, _mock_shell, _mock_rebase, mock_classify, tmp_path
+    ):
+        classification = f"{DRIFT_HEADER} on main\n\nFiles changed on both sides:\n  - src/foo.py"
+        mock_classify.return_value = classification
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        result = run_from_dev(config, task, workspace, no_pull=True)
+
+        assert result.success is False
+        assert result.phase is Phase.ESCALATE
+        assert result.message == classification
+        assert result.state.error == classification
+        mock_classify.assert_called_once_with(
+            workspace,
+            config.workspace.base_branch,
+            REBASE_STDERR,
+        )
+
+    @patch("theforge.coordinator.engine.classify_rebase_conflict", return_value=None)
+    @patch("theforge.coordinator.engine._rebase_onto_main", return_value=(False, REBASE_STDERR))
+    @patch_gate_shell(side_effect=_resume_shell)
+    def test_resume_rebase_falls_back_to_raw_error_when_unclassifiable(
+        self, _mock_shell, _mock_rebase, _mock_classify, tmp_path
+    ):
+        config = _make_config(tmp_path)
+        task = _make_task(tmp_path)
+        workspace = tmp_path / task.slug
+        workspace.mkdir()
+
+        result = run_from_review(config, task, workspace, no_pull=True)
+
+        assert result.success is False
+        assert result.phase is Phase.ESCALATE
+        assert result.message.startswith("pre-dev rebase onto main failed")
+        assert not is_drift_classification(result.message)
 
 
 # ── The sprint-log surface ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] Resume rebase failures now forward the existing drift classification for both resume entry points, with seam coverage and passing targeted tests. | [anthropic-opus-cli] Resume rebase seam now forwards the #1993 drift classification for both run_from_review and run_from_dev with seam tests and a raw-error fallback; authoritative gate is PASS at the reviewed HEAD (the handoff's BLOCKED gate_result is superseded), and tests/test_coord_worktree_drift.py passes 16/16 locally.

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $1.62
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

A story whose pre-dev rebase conflicts leaves the conflicting worktree in place, so every later run of that story fails the same way (GitHub Issue #2569)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2569