### PR TITLE
A story's failure is classified from an artifact belonging to a different attempt, so the summary recommends a remedy for a cause that is not the failure

### DIFF
--- a/src/theforge/coordinator/log_tee.py
+++ b/src/theforge/coordinator/log_tee.py
@@ -7,6 +7,8 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
+
 # The worker-slug thread-local now lives in the stdlib-only leaf module
 # ``theforge.log_util`` so the shared log-line emitter can prefix every line
 # (coordinator *and* runner) with it. Re-exported here for backward
@@ -56,7 +58,13 @@ def _make_story_log_dir(
         return None
 
 
-def _write_log_artifact(log_dir: "Path | None", relative_path: str, content: str) -> None:
+def _write_log_artifact(
+    log_dir: "Path | None",
+    relative_path: str,
+    content: str,
+    *,
+    owner_run_id: str | None = None,
+) -> None:
     """Write content to <log_dir>/<relative_path>. Best-effort; never raises."""
     if log_dir is None:
         return
@@ -64,6 +72,30 @@ def _write_log_artifact(log_dir: "Path | None", relative_path: str, content: str
         dest = log_dir / relative_path
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(content, encoding="utf-8")
+        if owner_run_id:
+            _record_log_artifact_owner(log_dir, relative_path, owner_run_id)
+    except Exception:
+        pass
+
+
+def _record_log_artifact_owner(log_dir: Path, relative_path: str, owner_run_id: str) -> None:
+    """Best-effort manifest recording which run last wrote a story artifact."""
+    manifest_path = log_dir / ".artifact-owners.yaml"
+    try:
+        existing = {}
+        if manifest_path.exists():
+            loaded = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                existing = loaded
+        entries = existing.get("artifacts")
+        if not isinstance(entries, dict):
+            entries = {}
+        entries[str(relative_path)] = owner_run_id
+        existing["artifacts"] = entries
+        manifest_path.write_text(
+            yaml.safe_dump(existing, sort_keys=True),
+            encoding="utf-8",
+        )
     except Exception:
         pass
 

--- a/src/theforge/coordinator/plan_flow.py
+++ b/src/theforge/coordinator/plan_flow.py
@@ -331,6 +331,7 @@ def _retry_transient_plan_review_failures(
                 state.log_dir,
                 f"plan-review/attempt-{attempt}/{profile.name}-retry{retry_count}.yaml",
                 retried.output or "",
+                owner_run_id=state.run_id,
             )
             retry_events.append(
                 {
@@ -522,6 +523,7 @@ def _retry_parse_failed_plan_reviews(
                 state.log_dir,
                 f"plan-review/attempt-{attempt}/{profile.name}-parse-retry{retry_count}.yaml",
                 retried.output or "",
+                owner_run_id=state.run_id,
             )
             retry_events.append(
                 {
@@ -967,7 +969,12 @@ def _run_plan_phase(
     state.plan_results.append(plan_result)
     state.plan_session_id = plan_result.session_id or state.plan_session_id
     write_trace(workspace_path / ".forge/traces" / "plan-attempt-0.txt", plan_result.output)
-    _write_log_artifact(state.log_dir, "plan-attempt-0.txt", plan_result.output or "")
+    _write_log_artifact(
+        state.log_dir,
+        "plan-attempt-0.txt",
+        plan_result.output or "",
+        owner_run_id=state.run_id,
+    )
     if not _plan_ok:
         state.phase = Phase.ESCALATE
         state.error = _plan_diag or "PLAN phase mutated the worktree"
@@ -1220,6 +1227,7 @@ def _run_plan_agent_review(
                 state.log_dir,
                 f"plan-review/attempt-{_attempt}/{_prof.name}.yaml",
                 _res.output or "",
+                owner_run_id=state.run_id,
             )
         pr_results, _transport_retry_events = _retry_transient_plan_review_failures(
             prompt=pr_prompt,
@@ -1589,7 +1597,12 @@ def _run_plan_agent_review(
                 _log(f"  ✓ PLAN   committed {PLAN_PATH}")
             except Exception as _commit_err:
                 _log(f"  ⚠ PLAN   could not commit {PLAN_PATH}: {_commit_err}")
-            _write_log_artifact(state.log_dir, "plan.md", plan_text)
+            _write_log_artifact(
+                state.log_dir,
+                "plan.md",
+                plan_text,
+                owner_run_id=state.run_id,
+            )
             return None  # continue to DEV
 
         # Advisory mode (refactor work type): log findings but never reject
@@ -1615,7 +1628,12 @@ def _run_plan_agent_review(
                     cost_usd=_round_cost(_total_pr_cost),
                     duration_s=round(_pr_elapsed, 2),
                 )
-            _write_log_artifact(state.log_dir, "plan.md", plan_text)
+            _write_log_artifact(
+                state.log_dir,
+                "plan.md",
+                plan_text,
+                owner_run_id=state.run_id,
+            )
             return None  # continue to DEV regardless of verdict
 
         # REJECT path
@@ -1858,6 +1876,7 @@ def _run_plan_agent_review(
             state.log_dir,
             f"plan-attempt-{state.plan_regen_count}.txt",
             plan_result.output or "",
+            owner_run_id=state.run_id,
         )
 
         if not plan_result.success:
@@ -1961,6 +1980,7 @@ def _run_human_plan_review(
                 state.log_dir,
                 f"plan-attempt-{state.plan_regen_count}-approved.txt",
                 updated,
+                owner_run_id=state.run_id,
             )
             _log(
                 "  ✓ PLAN_REVIEW   approve  "
@@ -1987,7 +2007,12 @@ def _run_human_plan_review(
                 _log(f"  ✓ PLAN   committed {PLAN_PATH}")
             except Exception as _commit_err:
                 _log(f"  ⚠ PLAN   could not commit {PLAN_PATH}: {_commit_err}")
-            _write_log_artifact(state.log_dir, "plan.md", plan_text)
+            _write_log_artifact(
+                state.log_dir,
+                "plan.md",
+                plan_text,
+                owner_run_id=state.run_id,
+            )
             return None  # continue to DEV
 
         if plan_review_decision == "regenerate":
@@ -2053,6 +2078,7 @@ def _run_human_plan_review(
                 state.log_dir,
                 f"plan-attempt-{state.plan_regen_count}.txt",
                 plan_result.output or "",
+                owner_run_id=state.run_id,
             )
 
             if not plan_result.success:

--- a/src/theforge/coordinator/preflight_flow.py
+++ b/src/theforge/coordinator/preflight_flow.py
@@ -1228,11 +1228,17 @@ def _run_preflight_phase(
         "attempts": attempts,
     }
     state.preflight_cache_snapshot = dict(_preflight_artifact["cache_snapshot"])
-    _write_log_artifact(state.log_dir, "preflight-raw.log", preflight_result.output or "")
+    _write_log_artifact(
+        state.log_dir,
+        "preflight-raw.log",
+        preflight_result.output or "",
+        owner_run_id=state.run_id,
+    )
     _write_log_artifact(
         state.log_dir,
         "preflight.yaml",
         yaml.dump(_preflight_artifact, default_flow_style=False, allow_unicode=True),
+        owner_run_id=state.run_id,
     )
     if state.preflight_partial_evidence is not None:
         _write_log_artifact(
@@ -1243,6 +1249,7 @@ def _run_preflight_phase(
                 default_flow_style=False,
                 allow_unicode=True,
             ),
+            owner_run_id=state.run_id,
         )
 
     # ── stop_phase gate ────────────────────────────────────────────────

--- a/src/theforge/coordinator/review_pool.py
+++ b/src/theforge/coordinator/review_pool.py
@@ -430,6 +430,7 @@ def _retry_transient_review_failures(
                 state.log_dir,
                 f"review-cycle-{cycle_num}/{profile.name}-transport-retry{retry_count}.yaml",
                 retried.output or "",
+                owner_run_id=state.run_id,
             )
             # ``current`` is being superseded by ``retried`` — it was a distinct
             # (failed) reviewer invocation and must be recorded before it is
@@ -872,6 +873,7 @@ def _run_review_pool(
             state.log_dir,
             f"review-cycle-{_cycle_num}/{r.profile_name}.yaml",
             r.output or "",
+            owner_run_id=state.run_id,
         )
 
     # ── Transient transport retry ─────────────────────────────────────
@@ -1271,5 +1273,6 @@ def _run_review_pool(
         state.log_dir,
         f"review-cycle-{_cycle_num}/synthesized.yaml",
         _synthesis_content,
+        owner_run_id=state.run_id,
     )
     return successful, failed_results, merged, individual_parsed, named_parsed

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -35,6 +35,7 @@ set. Grep it to see everything the mechanical classifier knows.
 
 from __future__ import annotations
 
+import datetime
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -1150,8 +1151,12 @@ def _collect_text_sources(
         sources.append(_TextSource(summary_rel, summary_text, "structured"))
 
     # Per-story log directory: scan every readable text file (dev/review
-    # iteration logs, captured agent output yaml, etc.).
+    # iteration logs, captured agent output yaml, etc.) that falls within this
+    # attempt's recorded time window. The story directory persists across
+    # attempts of the same story in one sprint; without attempt scoping, stale
+    # artifacts from an earlier attempt can misclassify the current failure.
     story_dir = sprint_log_dir / slug
+    attempt_started_at = _story_attempt_started_at(story, audit)
     if story_dir.is_dir():
         for path in sorted(story_dir.rglob("*")):
             if not path.is_file():
@@ -1159,6 +1164,8 @@ def _collect_text_sources(
             if path.suffix.lower() not in {".log", ".txt", ".yaml", ".yml", ".md", ".json"}:
                 continue
             if path.name == "audit.yaml":
+                continue
+            if not _path_in_attempt_window(path, attempt_started_at):
                 continue
             # Strip numeric telemetry lines (cost/duration/token values) so a
             # coincidental digit run inside a float cannot feed context-free
@@ -1184,6 +1191,55 @@ def _collect_text_sources(
             sources.append(_TextSource(_rel(run_log, logs_root), "\n".join(matched_lines), "log"))
 
     return sources
+
+
+def _story_attempt_started_at(story: dict, audit: dict) -> datetime.datetime | None:
+    """Return the current attempt's recorded start time, if present.
+
+    The summary row and per-story audit are the run's own records for this
+    attempt. When either supplies a start time, use it to exclude older leftover
+    files from prior attempts in the same per-story directory. Legacy fixtures
+    without timing keep the historical "scan everything" behavior.
+    """
+    summary_started = _parse_attempt_timestamp(story.get("started_at"))
+    timing = audit.get("timing") if isinstance(audit, dict) else None
+    audit_started = (
+        _parse_attempt_timestamp(timing.get("started_at")) if isinstance(timing, dict) else None
+    )
+    starts = [ts for ts in (summary_started, audit_started) if ts is not None]
+    return min(starts) if starts else None
+
+
+def _parse_attempt_timestamp(value: object) -> datetime.datetime | None:
+    """Parse an ISO-8601 timestamp emitted by sprint/audit records."""
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed.astimezone(datetime.timezone.utc)
+
+
+def _path_in_attempt_window(path: Path, started_at: datetime.datetime | None) -> bool:
+    """Return whether *path* was written after the current attempt began."""
+    if started_at is None:
+        return True
+    try:
+        modified_at = datetime.datetime.fromtimestamp(path.stat().st_mtime, datetime.timezone.utc)
+    except OSError:
+        return False
+    tolerance = datetime.timedelta(seconds=1)
+    if modified_at + tolerance < started_at:
+        return False
+    return True
 
 
 def _pattern_matches(pattern: str, lowered: str) -> bool:

--- a/src/theforge/sprint/rca.py
+++ b/src/theforge/sprint/rca.py
@@ -1157,15 +1157,21 @@ def _collect_text_sources(
     # artifacts from an earlier attempt can misclassify the current failure.
     story_dir = sprint_log_dir / slug
     attempt_started_at = _story_attempt_started_at(story, audit)
+    attempt_run_ids = _story_attempt_run_ids(story, audit)
     if story_dir.is_dir():
         for path in sorted(story_dir.rglob("*")):
             if not path.is_file():
                 continue
             if path.suffix.lower() not in {".log", ".txt", ".yaml", ".yml", ".md", ".json"}:
                 continue
-            if path.name == "audit.yaml":
+            if path.name in {"audit.yaml", ".artifact-owners.yaml"}:
                 continue
-            if not _path_in_attempt_window(path, attempt_started_at):
+            if not _artifact_belongs_to_attempt(
+                path,
+                story_dir=story_dir,
+                attempt_run_ids=attempt_run_ids,
+                started_at=attempt_started_at,
+            ):
                 continue
             # Strip numeric telemetry lines (cost/duration/token values) so a
             # coincidental digit run inside a float cannot feed context-free
@@ -1210,6 +1216,20 @@ def _story_attempt_started_at(story: dict, audit: dict) -> datetime.datetime | N
     return min(starts) if starts else None
 
 
+def _story_attempt_run_ids(story: dict, audit: dict) -> set[str]:
+    """Return the current attempt's recorded run identities, if present."""
+    ids: set[str] = set()
+    candidates = [story.get("story_run_id")]
+    if isinstance(audit, dict):
+        candidates.append(audit.get("run_id"))
+    for value in candidates:
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                ids.add(text)
+    return ids
+
+
 def _parse_attempt_timestamp(value: object) -> datetime.datetime | None:
     """Parse an ISO-8601 timestamp emitted by sprint/audit records."""
     if not isinstance(value, str):
@@ -1226,6 +1246,32 @@ def _parse_attempt_timestamp(value: object) -> datetime.datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=datetime.timezone.utc)
     return parsed.astimezone(datetime.timezone.utc)
+
+
+def _artifact_belongs_to_attempt(
+    path: Path,
+    *,
+    story_dir: Path,
+    attempt_run_ids: set[str],
+    started_at: datetime.datetime | None,
+) -> bool:
+    """Return whether *path* belongs to the current story attempt."""
+    owner_run_id = _artifact_owner_run_id(story_dir, path)
+    if owner_run_id is not None:
+        return bool(attempt_run_ids) and owner_run_id in attempt_run_ids
+    return _path_in_attempt_window(path, started_at)
+
+
+def _artifact_owner_run_id(story_dir: Path, path: Path) -> str | None:
+    """Return the run id recorded for *path* in the story artifact manifest."""
+    manifest = _load_yaml(story_dir / ".artifact-owners.yaml")
+    if not isinstance(manifest, dict):
+        return None
+    entries = manifest.get("artifacts")
+    if not isinstance(entries, dict):
+        return None
+    owner = entries.get(_rel(path, story_dir))
+    return owner.strip() if isinstance(owner, str) and owner.strip() else None
 
 
 def _path_in_attempt_window(path: Path, started_at: datetime.datetime | None) -> bool:

--- a/tests/test_coord_logging.py
+++ b/tests/test_coord_logging.py
@@ -497,6 +497,25 @@ class TestProjectLocalLogDir:
             assert _yaml.safe_load(artifact.read_text()) == {"slug": slug}
             assert list(log_dir.glob("run-*.log")) == []
 
+    def test_write_log_artifact_records_owner_run_id_manifest(self, tmp_path):
+        """Per-story artifacts can record stable run ownership for later readers."""
+        import yaml as _yaml
+
+        from theforge.coordinator.log_tee import _write_log_artifact
+
+        log_dir = tmp_path / ".forge" / "logs" / "parallel-sprint" / "story-a"
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        _write_log_artifact(
+            log_dir,
+            "review-cycle-1/openai-gpt.yaml",
+            "output: ok\n",
+            owner_run_id="run-current",
+        )
+
+        manifest = _yaml.safe_load((log_dir / ".artifact-owners.yaml").read_text(encoding="utf-8"))
+        assert manifest == {"artifacts": {"review-cycle-1/openai-gpt.yaml": "run-current"}}
+
 
 class TestSigtermHandler:
     """Tests for _make_sigterm_handler crash diagnostics."""

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -9,6 +9,7 @@ classification (primary + contributing factors), evidence sourcing, the
 from __future__ import annotations
 
 import datetime
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1315,6 +1316,105 @@ def test_survived_quota_blip_is_not_promoted_to_root_cause(tmp_path: Path) -> No
     for slug in ("issue-312", "issue-313"):
         assert stories[slug]["primary_failure_class"] == UNKNOWN_CLASS
         assert "provider_usage_limit" not in {ev["rule_id"] for ev in stories[slug]["evidence"]}
+
+
+def test_prior_attempt_review_artifact_before_current_attempt_window_is_excluded(
+    tmp_path: Path,
+) -> None:
+    """A stale prior-attempt review file must not classify the current failure."""
+    d = _sprint_dir(tmp_path, name="stale-attempt")
+    started_at = "2026-05-08T02:10:00Z"
+    finished_at = "2026-05-08T02:11:00Z"
+    rebase_error = "pre-dev rebase onto release/v0.15 failed — conflicts must be resolved manually"
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-2038",
+                    "outcome": "ESCALATE",
+                    "error": rebase_error,
+                    "started_at": started_at,
+                    "finished_at": finished_at,
+                }
+            ]
+        ),
+    )
+    _write(
+        d / "issue-2038" / "audit.yaml",
+        {
+            "timing": {"started_at": started_at, "finished_at": finished_at},
+            "outcome": {
+                "final_phase": "ESCALATE",
+                "message": rebase_error,
+            },
+            "error": (
+                "could not apply d7ad2974... feat(sandbox): support additive capability grants"
+            ),
+        },
+    )
+    stale_review = d / "issue-2038" / "review-cycle-1" / "anthropic-opus-cli.yaml"
+    stale_review.parent.mkdir(parents=True, exist_ok=True)
+    stale_review.write_text(
+        "observed: with a retryable provider error such as a rate limit, the transport\n",
+        encoding="utf-8",
+    )
+    os.utime(
+        stale_review,
+        (
+            datetime.datetime(2026, 5, 8, 2, 5, 0, tzinfo=datetime.timezone.utc).timestamp(),
+            datetime.datetime(2026, 5, 8, 2, 5, 0, tzinfo=datetime.timezone.utc).timestamp(),
+        ),
+    )
+
+    entry = _build(d)["stories"]["issue-2038"]
+    assert entry["primary_failure_class"] != "provider_quota"
+    assert not any("quota reset" in action for action in entry["recommended_next_actions"])
+    assert not any(ev["source"].endswith("anthropic-opus-cli.yaml") for ev in entry["evidence"])
+
+
+def test_current_attempt_review_artifact_within_attempt_window_still_classifies(
+    tmp_path: Path,
+) -> None:
+    """Attempt scoping keeps same-attempt review evidence available."""
+    d = _sprint_dir(tmp_path, name="current-attempt-window")
+    started_at = "2026-05-08T02:10:00Z"
+    finished_at = "2026-05-08T02:11:00Z"
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-1324",
+                    "outcome": "ESCALATE",
+                    "error": "story escalated",
+                    "started_at": started_at,
+                    "finished_at": finished_at,
+                }
+            ]
+        ),
+    )
+    _write(
+        d / "issue-1324" / "audit.yaml",
+        {"timing": {"started_at": started_at, "finished_at": finished_at}},
+    )
+    review_artifact = d / "issue-1324" / "review-cycle-2" / "openai-gpt.yaml"
+    review_artifact.parent.mkdir(parents=True, exist_ok=True)
+    review_artifact.write_text(
+        "output: |\n  ERROR: You've hit your usage limit. Try again at 6:57 PM.\n",
+        encoding="utf-8",
+    )
+    os.utime(
+        review_artifact,
+        (
+            datetime.datetime(2026, 5, 8, 2, 10, 30, tzinfo=datetime.timezone.utc).timestamp(),
+            datetime.datetime(2026, 5, 8, 2, 10, 30, tzinfo=datetime.timezone.utc).timestamp(),
+        ),
+    )
+
+    entry = _build(d)["stories"]["issue-1324"]
+    assert entry["primary_failure_class"] == "provider_quota"
+    assert any(ev["source"].endswith("openai-gpt.yaml") for ev in entry["evidence"])
 
 
 # ── Engine: determinism / regenerability ──────────────────────────────────────

--- a/tests/test_sprint_rca.py
+++ b/tests/test_sprint_rca.py
@@ -1417,6 +1417,110 @@ def test_current_attempt_review_artifact_within_attempt_window_still_classifies(
     assert any(ev["source"].endswith("openai-gpt.yaml") for ev in entry["evidence"])
 
 
+def test_prior_attempt_review_artifact_with_stale_owner_run_id_is_excluded_after_copy(
+    tmp_path: Path,
+) -> None:
+    """Manifest ownership beats copied-tree mtimes when they disagree."""
+    d = _sprint_dir(tmp_path, name="copied-attempt")
+    started_at = "2026-05-08T02:10:00Z"
+    finished_at = "2026-05-08T02:11:00Z"
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-2038",
+                    "story_run_id": "run-current",
+                    "outcome": "ESCALATE",
+                    "error": "story escalated",
+                    "started_at": started_at,
+                    "finished_at": finished_at,
+                }
+            ]
+        ),
+    )
+    _write(
+        d / "issue-2038" / "audit.yaml",
+        {
+            "run_id": "run-current",
+            "timing": {"started_at": started_at, "finished_at": finished_at},
+        },
+    )
+    stale_review = d / "issue-2038" / "review-cycle-1" / "anthropic-opus-cli.yaml"
+    stale_review.parent.mkdir(parents=True, exist_ok=True)
+    stale_review.write_text(
+        "observed: with a retryable provider error such as a rate limit, the transport\n",
+        encoding="utf-8",
+    )
+    _write(
+        d / "issue-2038" / ".artifact-owners.yaml",
+        {"artifacts": {"review-cycle-1/anthropic-opus-cli.yaml": "run-prior"}},
+    )
+    os.utime(
+        stale_review,
+        (
+            datetime.datetime(2026, 5, 8, 2, 10, 30, tzinfo=datetime.timezone.utc).timestamp(),
+            datetime.datetime(2026, 5, 8, 2, 10, 30, tzinfo=datetime.timezone.utc).timestamp(),
+        ),
+    )
+
+    entry = _build(d)["stories"]["issue-2038"]
+    assert entry["primary_failure_class"] != "provider_quota"
+    assert not any(ev["source"].endswith("anthropic-opus-cli.yaml") for ev in entry["evidence"])
+
+
+def test_current_attempt_review_artifact_with_current_owner_run_id_survives_stale_mtime(
+    tmp_path: Path,
+) -> None:
+    """Manifest ownership keeps same-attempt evidence when mtimes are not durable."""
+    d = _sprint_dir(tmp_path, name="manifest-owned-attempt")
+    started_at = "2026-05-08T02:10:00Z"
+    finished_at = "2026-05-08T02:11:00Z"
+    _write(
+        d / "sprint-summary.yaml",
+        _summary(
+            [
+                {
+                    "slug": "issue-1324",
+                    "story_run_id": "run-current",
+                    "outcome": "ESCALATE",
+                    "error": "story escalated",
+                    "started_at": started_at,
+                    "finished_at": finished_at,
+                }
+            ]
+        ),
+    )
+    _write(
+        d / "issue-1324" / "audit.yaml",
+        {
+            "run_id": "run-current",
+            "timing": {"started_at": started_at, "finished_at": finished_at},
+        },
+    )
+    review_artifact = d / "issue-1324" / "review-cycle-2" / "openai-gpt.yaml"
+    review_artifact.parent.mkdir(parents=True, exist_ok=True)
+    review_artifact.write_text(
+        "output: |\n  ERROR: You've hit your usage limit. Try again at 6:57 PM.\n",
+        encoding="utf-8",
+    )
+    _write(
+        d / "issue-1324" / ".artifact-owners.yaml",
+        {"artifacts": {"review-cycle-2/openai-gpt.yaml": "run-current"}},
+    )
+    os.utime(
+        review_artifact,
+        (
+            datetime.datetime(2026, 5, 8, 2, 5, 0, tzinfo=datetime.timezone.utc).timestamp(),
+            datetime.datetime(2026, 5, 8, 2, 5, 0, tzinfo=datetime.timezone.utc).timestamp(),
+        ),
+    )
+
+    entry = _build(d)["stories"]["issue-1324"]
+    assert entry["primary_failure_class"] == "provider_quota"
+    assert any(ev["source"].endswith("openai-gpt.yaml") for ev in entry["evidence"])
+
+
 # ── Engine: determinism / regenerability ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] No P1 findings; stale per-story artifacts are now scoped out by attempt time/run ownership and covered by symptom tests. | [anthropic-opus-cli] Cycle 2 adds a run-id ownership manifest atop the mtime window; verified against 143 historical sprints (5 classification changes, all correct removals of cross-attempt contamination including the target issue-2038 case, zero same-attempt artifacts wrongly dropped), 914 tests pass at the gate-PASS HEAD; two non-blocking P2s on the manifest's fail-closed branch and fixture fidelity.

## Review

- **Verdict:** APPROVE (0 P1, 2 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $6.03
- **Dev iterations:** 2
- **Tests:** N/A

## Findings

- **[P2] `src/theforge/sprint/rca.py:1259`** When a story's per-story audit record is missing or unreadable, the only run identity available to the classifier is the sprint-level identifier from the summary row, which never equals the identifier recorded in the artifact ownership manifest, so every manifest-owned artifact the current attempt actually produced is discarded and the failure is classified with no per-story evidence at all.
- **[P2] `tests/test_sprint_rca.py:1443`** The manifest-ownership regression fixtures set the summary row's story_run_id and the audit's run_id to the same value, whereas in real sprint records these are two different identifiers (the sprint-level id and the per-story coordinator run id), so the tests pass whichever of the two the matcher happens to consult and cannot distinguish a matcher wired to the wrong one.

## Story

A story's failure is classified from an artifact belonging to a different attempt, so the summary recommends a remedy for a cause that is not the failure (GitHub Issue #2579)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2579