### PR TITLE
Run artifacts are published once per sprint but the gate that requires them committed runs once per story, so every story after the first is refused

### DIFF
--- a/src/theforge/sprint/audit_publish.py
+++ b/src/theforge/sprint/audit_publish.py
@@ -478,3 +478,36 @@ def publish_story_run_audits(
         )
         _log(f"✗ SPRINT  canonical story run audit publish failed: {exc}{state_suffix}")
         raise
+
+
+def publish_pending_story_run_audits(
+    state: Any,  # SprintExecutionState — see the module docstring on why not typed
+    *,
+    lands_locally: bool,
+) -> bool:
+    """Publish whatever canonical run artifacts are already pending, mid-sprint.
+
+    A sprint writes each story's run record and knowledge summary into the
+    project-root checkout as that story finishes, and re-evaluates the landing
+    precondition — which refuses on *any* project-root dirt, untracked files
+    included — at every later story's entry. Publishing only at sprint exit
+    therefore left a story's own artifacts standing across the window in which
+    they would refuse its successor (#2595). This is the same publish, called
+    while the run is still going, so publication keeps pace with enforcement.
+
+    It differs from :func:`publish_story_run_audits` in exactly one way: a
+    failure is reported and swallowed rather than raised. At sprint exit there
+    is nothing left to lose by raising; here, raising would abandon the stories
+    still to run over a transport problem that the terminal sweep — which does
+    raise — will retry and, if it persists, report. Returns whether the publish
+    completed.
+    """
+    try:
+        publish_story_run_audits(state, lands_locally=lands_locally)
+    except RuntimeError as exc:
+        _log(
+            "⚠ SPRINT  mid-sprint story run audit publish did not complete; deferring to "
+            f"the terminal publish: {exc}"
+        )
+        return False
+    return True

--- a/src/theforge/sprint/runner.py
+++ b/src/theforge/sprint/runner.py
@@ -85,7 +85,11 @@ from .audit import (
     preflight_degraded_row_fields,
     write_live_story_audit,
 )
-from .audit_publish import publish_story_run_audits, write_terminal_sprint_audits
+from .audit_publish import (
+    publish_pending_story_run_audits,
+    publish_story_run_audits,
+    write_terminal_sprint_audits,
+)
 from .auth_gate import enforce_sprint_auth_readiness
 from .budget import (
     budget_overrun_usd,
@@ -6914,6 +6918,39 @@ def run_sprint(context: SprintRunContext) -> SprintResult:
                 _sprint_state.dag, all_tasks, _ctx.config, _sprint_state.merged_slugs
             )
             ready = [t for t in _sprint_state.dag.ready() if t.slug not in _sprint_state.active]
+
+            # Publication keeps pace with enforcement (#2595). Every story this
+            # sprint finishes writes its canonical run record and knowledge
+            # summary into the project-root checkout, and the landing
+            # precondition — evaluated at each story's WORKSPACE entry — refuses
+            # on any project-root dirt, untracked files included. Publishing
+            # only at sprint exit meant story 1's own artifacts refused story 2.
+            #
+            # This is the one point every dispatch passes through: the loop body
+            # below is the sole place a slug is registered active, and the
+            # previous pass has already settled each finished story's terminal
+            # audit writes (including the landing-status rewrite that follows
+            # integration). So in sequential mode — where a pass with work to
+            # dispatch is always a pass with nothing in flight — no story can
+            # enter WORKSPACE between a completed story's artifact write and
+            # this publish.
+            #
+            # It is skipped while workers are in flight. Under a project-root
+            # landing workflow those workers merge into the same checkout this
+            # would be committing from, and taking the index out from under a
+            # merge would turn a bookkeeping step into a story failure. Nor
+            # would publishing there be sufficient: a sibling finishing a second
+            # after the publish dirties the root again before the next entry, so
+            # parallel dispatch cannot be made race-free from here at all. Those
+            # passes fall through to the next quiescent one, or to the terminal
+            # sweep — exactly the behaviour they have today.
+            #
+            # A failure is deferred rather than raised: the terminal publish
+            # below is the final, fatal sweep.
+            if ready and not _sprint_state.active:
+                publish_pending_story_run_audits(
+                    _sprint_state, lands_locally=_sprint_lands_locally
+                )
 
             for task in ready:
                 # ``ready`` is a snapshot taken before this pass. A batch-group

--- a/tests/test_sprint_audit_publish.py
+++ b/tests/test_sprint_audit_publish.py
@@ -24,6 +24,7 @@ import pytest
 import yaml
 from coord_test_helpers import _make_config
 
+from theforge.coordinator.workspace import project_root_dirty_status
 from theforge.sprint.audit_publish import (
     _STORY_RUN_AUDIT_PUBLISH_STATE_PATH,
     AUDIT_PUBLISH_BRANCH_MISMATCH,
@@ -35,6 +36,7 @@ from theforge.sprint.audit_publish import (
     AUDIT_PUBLISH_RECONCILE_FAILED,
     StoryRunAuditPublishError,
     _commit_story_run_audits,
+    publish_pending_story_run_audits,
     publish_story_run_audits,
     write_terminal_sprint_audits,
 )
@@ -77,6 +79,21 @@ def _write_summary(repo: Path, run_id: str) -> None:
     )
 
 
+# The re-include shape ``forge init`` generates: ``.forge/**`` denied wholesale,
+# with the two project-memory trees this module publishes carved back out. It is
+# what makes the run records tracked (and therefore publishable) while the
+# publish-state marker beside them stays local (#2595).
+_FORGE_GITIGNORE = """\
+.forge/**
+!.forge/audits/
+!.forge/audits/runs/
+!.forge/audits/runs/**
+!.forge/knowledge/
+!.forge/knowledge/summaries/
+!.forge/knowledge/summaries/**
+"""
+
+
 @pytest.fixture()
 def origin_and_clone(tmp_path: Path) -> tuple[Path, Path]:
     """A bare origin with ``BASE`` checked out in a clone, audits unignored."""
@@ -89,7 +106,8 @@ def origin_and_clone(tmp_path: Path) -> tuple[Path, Path]:
     _git(seed, "init", "--initial-branch", BASE)
     _configure(seed)
     (seed / "README.md").write_text("seed\n", encoding="utf-8")
-    _git(seed, "add", "README.md")
+    (seed / ".gitignore").write_text(_FORGE_GITIGNORE, encoding="utf-8")
+    _git(seed, "add", "README.md", ".gitignore")
     _git(seed, "commit", "-m", "seed")
     _git(seed, "remote", "add", "origin", str(origin))
     _git(seed, "push", "-u", "origin", BASE)
@@ -537,6 +555,77 @@ def test_publish_entry_point_reports_the_failure_and_re_raises(
 
     assert excinfo.value.state == AUDIT_PUBLISH_BRANCH_MISMATCH
     assert _read_state(clone)["state"] == AUDIT_PUBLISH_BRANCH_MISMATCH
+
+
+# ── called more than once per sprint (#2595) ──────────────────────────────
+#
+# Publication has to keep pace with the landing precondition, which is
+# re-evaluated at every story's entry — so the entry point is now called during
+# the run as well as at its end. These pin the properties that makes safe:
+# a second call is a no-op, a local-only commit still cleans the checkout, and
+# a mid-run failure is deferred to the terminal sweep rather than ending the
+# sprint.
+
+
+def test_a_second_publish_commits_nothing_and_records_clean(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    """The sweep after a mid-run publish must not re-commit or restage anything."""
+    _origin, clone = origin_and_clone
+    _write_audit(clone, "run-k.json")
+    _write_summary(clone, "run-k")
+    state = _make_state(clone, base_branch=BASE, auto_push=False)
+
+    publish_pending_story_run_audits(state, lands_locally=True)
+    commits_after_first = _git(clone, "rev-list", "--count", BASE)
+
+    # Operator dirt that is none of this module's business, present across the
+    # second call: a publish with nothing pending must leave it exactly there.
+    (clone / "operator-edit.txt").write_text("mid-sprint\n", encoding="utf-8")
+
+    assert publish_pending_story_run_audits(state, lands_locally=True) is True
+
+    assert _git(clone, "rev-list", "--count", BASE) == commits_after_first
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_CLEAN
+    assert _git(clone, "status", "--porcelain") == "?? operator-edit.txt"
+
+
+def test_a_local_only_commit_clears_the_project_root_dirty_status(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    """auto_push off is the configuration the reported sprint ran under (#2595).
+
+    The commit stays local there, and a local commit is still enough to make the
+    checkout clean — which is the whole condition the next story's landing
+    precondition observes.
+    """
+    _origin, clone = origin_and_clone
+    _write_audit(clone, "run-l.json")
+    _write_summary(clone, "run-l")
+    assert project_root_dirty_status(clone) != ""
+    state = _make_state(clone, base_branch=BASE, auto_push=False)
+
+    publish_pending_story_run_audits(state, lands_locally=True)
+
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_LOCAL_ONLY
+    assert project_root_dirty_status(clone) == ""
+
+
+def test_a_mid_sprint_publish_failure_is_deferred_rather_than_raised(
+    origin_and_clone: tuple[Path, Path],
+) -> None:
+    """Raising mid-run would abandon the stories still to come over a transport fault."""
+    _origin, clone = origin_and_clone
+    _git(clone, "checkout", "-b", "feature/wrong-branch")
+    _write_audit(clone, "run-m.json")
+    state = _make_state(clone, base_branch=BASE)
+
+    assert publish_pending_story_run_audits(state, lands_locally=False) is False
+    assert _read_state(clone)["state"] == AUDIT_PUBLISH_BRANCH_MISMATCH
+
+    # The terminal sweep over the same unchanged condition still ends the run.
+    with pytest.raises(StoryRunAuditPublishError):
+        publish_story_run_audits(state, lands_locally=False)
 
 
 def test_the_module_does_not_import_the_sprint_runner() -> None:

--- a/tests/test_sprint_run_artifact_publish_timing.py
+++ b/tests/test_sprint_run_artifact_publish_timing.py
@@ -1,0 +1,323 @@
+"""A story's own run artifacts must not refuse its successor (#2595).
+
+A sprint writes each story's canonical run record and knowledge summary into the
+project-root checkout as that story finishes, and both paths are *tracked* — the
+generated ``.gitignore`` denies ``.forge/**`` and re-includes them as project
+memory. The landing precondition is re-evaluated at every story's WORKSPACE
+entry and refuses on any project-root dirt, untracked files included. Publishing
+those artifacts only at sprint exit therefore left story 1's own success
+standing as the reason story 2 was refused, before any agent was dispatched.
+
+These are seam tests over the real ``run_sprint`` scheduler: only ``run_task``
+is faked, and the fake does what a story does — observe the precondition it
+would be refused by, then write its artifacts into the project root. What is
+asserted is the ordering between those two, which is a property of the
+scheduler, not of either mechanism on its own.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from sprint_test_helpers import run_sprint_ctx
+
+from theforge.config import (
+    DEFAULT_DEV_PROFILE,
+    DEFAULT_PREFLIGHT_PROFILE,
+    DEFAULT_REVIEW_PROFILE,
+    ForgeConfig,
+    RetryPolicy,
+    ValidationConfig,
+    WorkspaceConfig,
+)
+from theforge.coordinator.state import CoordinatorResult, CoordinatorState, Phase
+from theforge.coordinator.workspace import landing_precondition_error
+
+BASE = "main"
+
+# Mirrors the ``forge init`` output: ``.forge/**`` denied, the two project-memory
+# trees re-included. Without it the artifacts would be ignored and no landing
+# precondition would ever see them — the condition under test would not exist.
+_FORGE_GITIGNORE = """\
+.forge/**
+!.forge/audits/
+!.forge/audits/runs/
+!.forge/audits/runs/**
+!.forge/knowledge/
+!.forge/knowledge/summaries/
+!.forge/knowledge/summaries/**
+"""
+
+
+def _git(cwd: Path, *args: str) -> str:
+    proc = subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True)
+    return proc.stdout.strip()
+
+
+@pytest.fixture()
+def project_root(tmp_path: Path) -> Path:
+    """A clean git checkout on ``BASE`` with forge's own .gitignore in place."""
+    root = tmp_path / "project"
+    root.mkdir()
+    _git(root, "init", "--initial-branch", BASE)
+    _git(root, "config", "user.email", "forge@example.com")
+    _git(root, "config", "user.name", "Forge Test")
+    (root / "README.md").write_text("seed\n", encoding="utf-8")
+    (root / ".gitignore").write_text(_FORGE_GITIGNORE, encoding="utf-8")
+    _git(root, "add", "README.md", ".gitignore")
+    _git(root, "commit", "-m", "seed")
+    # A real (bare) origin: the sprint pulls the base branch before its first
+    # story, and a checkout with no remote fails that step for reasons that have
+    # nothing to do with what is under test.
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git(origin, "init", "--bare", "--initial-branch", BASE)
+    _git(root, "remote", "add", "origin", str(origin))
+    _git(root, "push", "-u", "origin", BASE)
+    return root
+
+
+def _make_config(root: Path) -> ForgeConfig:
+    """A landing workflow: ``on_approve: merge`` with no origin to push to.
+
+    ``auto_push`` stays at its default (off), which is the configuration the
+    reported sprint ran under — the publish commits locally and does not push,
+    and a local commit is still what cleans the checkout.
+    """
+    return ForgeConfig(
+        project="test",
+        project_root=root,
+        workspace=WorkspaceConfig(
+            create_command="mkdir -p {slug}",
+            path_pattern="{slug}",
+            branch_pattern="forge/{slug}",
+            base_branch=BASE,
+            on_approve="merge",
+        ),
+        # A gate that passes: the sprint runs its baseline gate on the merge base
+        # before dispatching, and this file is about what happens after that.
+        validation=ValidationConfig(gate_command="true"),
+        dev_profile=DEFAULT_DEV_PROFILE,
+        preflight_profile=DEFAULT_PREFLIGHT_PROFILE,
+        review_pool=[DEFAULT_REVIEW_PROFILE],
+        synthesis_profile=None,
+        retry=RetryPolicy(max_dev_iterations=2, max_review_cycles=2),
+    )
+
+
+def _make_manifest(root: Path, slugs: list[str]) -> Path:
+    for slug in slugs:
+        (root / f"{slug}.md").write_text(
+            f"---\nname: {slug}\nslug: {slug}\n---\n# {slug}\nDo the thing.",
+            encoding="utf-8",
+        )
+    manifest_path = root / "sprint.yaml"
+    manifest_path.write_text(
+        yaml.dump(
+            {
+                "name": "Landing Sprint",
+                "budget_usd": 30.0,
+                "stories": [f"{slug}.md" for slug in slugs],
+                "max_parallel": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    # The spec files and the manifest are project-root dirt of the ordinary
+    # kind; commit them so the sprint-entry precondition passes and the only
+    # dirt the run can meet afterwards is the dirt it makes itself.
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "sprint stories")
+    _git(root, "push", "origin", BASE)
+    return manifest_path
+
+
+def _result(cost: float = 1.0) -> CoordinatorResult:
+    state = CoordinatorState()
+    state.preflight_verdict = "PROCEED"
+    preflight = MagicMock()
+    preflight.cost_usd = cost
+    state.preflight_result = preflight
+    return CoordinatorResult(
+        success=True, phase=Phase.DONE, state=state, message="Done.", merge={"merged": True}
+    )
+
+
+def _write_run_artifacts(root: Path, run_id: str) -> None:
+    """What a finished story leaves behind in the project-root checkout."""
+    runs = root / ".forge" / "audits" / "runs"
+    runs.mkdir(parents=True, exist_ok=True)
+    (runs / f"{run_id}.json").write_text(json.dumps({"run_id": run_id}) + "\n", encoding="utf-8")
+    summaries = root / ".forge" / "knowledge" / "summaries"
+    summaries.mkdir(parents=True, exist_ok=True)
+    (summaries / f"{run_id}.yaml").write_text(
+        yaml.safe_dump({"run_id": run_id}, sort_keys=False), encoding="utf-8"
+    )
+
+
+def test_a_story_run_artifact_does_not_refuse_the_next_story(project_root: Path) -> None:
+    """Three sequential landing stories, each leaving only its own artifacts."""
+    config = _make_config(project_root)
+    manifest_path = _make_manifest(project_root, ["story-a", "story-b", "story-c"])
+
+    observed: list[tuple[str, str | None]] = []
+
+    def fake_run_task(_config, task, *args, **kwargs):
+        # The refusal the story would meet at its WORKSPACE entry, evaluated
+        # against the checkout as the scheduler left it.
+        observed.append(
+            (task.slug, landing_precondition_error(config, lands_in_project_root=True))
+        )
+        _write_run_artifacts(project_root, f"run-{task.slug}")
+        return _result()
+
+    with patch("theforge.sprint.runner.run_task", side_effect=fake_run_task):
+        sprint = run_sprint_ctx(config, manifest_path)
+
+    assert [slug for slug, _ in observed] == ["story-a", "story-b", "story-c"]
+    refused = [(slug, error) for slug, error in observed if error is not None]
+    assert refused == [], f"stories refused by forge's own artifacts: {refused}"
+    assert sprint.specs_succeeded == 3
+    assert sprint.specs_failed == 0
+
+    # Every story's artifacts are on the base branch by the time the run ends —
+    # publishing early is a change of timing, not of what gets published.
+    tree = _git(project_root, "ls-tree", "-r", "--name-only", BASE)
+    for slug in ("story-a", "story-b", "story-c"):
+        assert f".forge/audits/runs/run-{slug}.json" in tree
+        assert f".forge/knowledge/summaries/run-{slug}.yaml" in tree
+
+
+def test_no_story_is_dispatched_between_an_artifact_write_and_its_publish(
+    project_root: Path,
+) -> None:
+    """The ordering, asserted as a sequence rather than through its symptom.
+
+    A publish that merely happened *sometime* before the next entry would pass
+    the test above by luck of scheduling. What the fix relies on is that the
+    scheduler cannot dispatch between the two, so the interleaving itself is
+    what is recorded here.
+    """
+    config = _make_config(project_root)
+    manifest_path = _make_manifest(project_root, ["story-a", "story-b"])
+    events: list[str] = []
+
+    def fake_run_task(_config, task, *args, **kwargs):
+        events.append(f"dispatch:{task.slug}")
+        _write_run_artifacts(project_root, f"run-{task.slug}")
+        events.append(f"artifacts:{task.slug}")
+        return _result()
+
+    from theforge.sprint import runner as _runner
+
+    real_publish = _runner.publish_pending_story_run_audits
+
+    def traced_publish(state, **kwargs):
+        events.append("publish")
+        return real_publish(state, **kwargs)
+
+    with (
+        patch("theforge.sprint.runner.run_task", side_effect=fake_run_task),
+        patch("theforge.sprint.runner.publish_pending_story_run_audits", traced_publish),
+    ):
+        run_sprint_ctx(config, manifest_path)
+
+    # Between story-a's artifact write and story-b's dispatch there is a publish
+    # and nothing else — no dispatch of any story in the window.
+    write_idx = events.index("artifacts:story-a")
+    dispatch_idx = events.index("dispatch:story-b")
+    assert write_idx < dispatch_idx
+    between = events[write_idx + 1 : dispatch_idx]
+    assert "publish" in between
+    assert not [e for e in between if e.startswith("dispatch:")]
+
+
+def test_operator_dirt_still_refuses_the_next_story(project_root: Path) -> None:
+    """The gate is not weakened: only forge's own tracked artifacts are committed.
+
+    ``.forge/audit-publish-state.json`` — written by the publish itself — is
+    denied by the same .gitignore, so it is not dirt either. An unrelated file
+    left in the project root is, and must still be refused.
+    """
+    config = _make_config(project_root)
+    manifest_path = _make_manifest(project_root, ["story-a", "story-b"])
+
+    observed: dict[str, str | None] = {}
+
+    def fake_run_task(_config, task, *args, **kwargs):
+        observed[task.slug] = landing_precondition_error(config, lands_in_project_root=True)
+        _write_run_artifacts(project_root, f"run-{task.slug}")
+        if task.slug == "story-a":
+            (project_root / "operator-edit.txt").write_text("unrelated\n", encoding="utf-8")
+        return _result()
+
+    with patch("theforge.sprint.runner.run_task", side_effect=fake_run_task):
+        run_sprint_ctx(config, manifest_path)
+
+    assert observed["story-a"] is None
+    assert observed["story-b"] is not None
+    assert "operator-edit.txt" in observed["story-b"]
+    # The refusal names the operator's file and nothing forge produced.
+    assert ".forge/audits/runs" not in observed["story-b"]
+    assert ".forge/knowledge/summaries" not in observed["story-b"]
+    assert "audit-publish-state" not in observed["story-b"]
+
+
+def test_a_rewritten_run_record_is_published_before_the_next_entry(
+    project_root: Path,
+) -> None:
+    """The record a finished story is written more than once still lands in time.
+
+    ``_write_native_story_record`` is called again with ``force_replace=True``
+    after the knowledge summary is generated, and the landing status is
+    re-persisted when a pending integration resolves. The publish has to come
+    after the *last* of those rewrites, not the first.
+    """
+    config = _make_config(project_root)
+    manifest_path = _make_manifest(project_root, ["story-a", "story-b"])
+    observed: dict[str, str | None] = {}
+
+    def fake_run_task(_config, task, *args, **kwargs):
+        observed[task.slug] = landing_precondition_error(config, lands_in_project_root=True)
+        _write_run_artifacts(project_root, f"run-{task.slug}")
+        # A second, differing write of the same record — the rewrite the sprint
+        # performs once landing resolves.
+        record = project_root / ".forge" / "audits" / "runs" / f"run-{task.slug}.json"
+        record.write_text(
+            json.dumps({"run_id": f"run-{task.slug}", "landing_status": "landed"}) + "\n",
+            encoding="utf-8",
+        )
+        return _result()
+
+    with patch("theforge.sprint.runner.run_task", side_effect=fake_run_task):
+        run_sprint_ctx(config, manifest_path)
+
+    assert observed["story-b"] is None
+    committed = json.loads(
+        _git(project_root, "show", f"{BASE}:.forge/audits/runs/run-story-a.json")
+    )
+    assert committed["landing_status"] == "landed"
+
+
+def test_a_non_landing_workflow_is_unaffected(project_root: Path) -> None:
+    """Nothing changes for a run whose stories never touch the project root."""
+    config = dataclasses.replace(
+        _make_config(project_root),
+        workspace=dataclasses.replace(_make_config(project_root).workspace, on_approve="pr"),
+    )
+    manifest_path = _make_manifest(project_root, ["story-a", "story-b"])
+
+    def fake_run_task(_config, task, *args, **kwargs):
+        _write_run_artifacts(project_root, f"run-{task.slug}")
+        return _result()
+
+    with patch("theforge.sprint.runner.run_task", side_effect=fake_run_task):
+        sprint = run_sprint_ctx(config, manifest_path)
+
+    assert sprint.specs_succeeded == 2


### PR DESCRIPTION
## Summary

[openai-gpt-5.5-cli] The change satisfies the bug's sequential landing-sprint symptom, keeps the terminal fatal publish, and targeted regression tests passed. | [google-gemini-3.5-flash-api] Successfully resolved run artifact publication timing to keep pace with story landing precondition enforcement. | [anthropic-claude-haiku-4-5-cli] Fix correctly addresses the timing gap between per-story artifact writes and once-per-sprint commit, with comprehensive test coverage verifying both the primary behavior (no self-refusal) and safety properties (idempotency, late failures deferred, operator dirt still caught).

## Review

- **Verdict:** APPROVE (0 P1, 0 P2)
- **Reviewers:** anthropic-sonnet-cli, anthropic-claude-haiku-4-5-cli, google-gemini-3.5-flash-api, openai-gpt-5.4-cli, google-gemini-3.1-pro-preview-api, openai-gpt-5.6-terra-cli, anthropic-opus-cli, openai-gpt-5.5-cli, openai-gpt-5.6-sol-cli
- **Cost:** $11.69
- **Dev iterations:** 1
- **Tests:** N/A

## Findings

_No findings._

## Story

Run artifacts are published once per sprint but the gate that requires them committed runs once per story, so every story after the first is refused (GitHub Issue #2595)

---
*Created automatically by [TheForge](https://github.com/fuzzypete/theforge)*

Closes #2595